### PR TITLE
Add CI workflow: typecheck + tests on Node 20/22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build & Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck & build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` running `npm ci` → `npm run build` → `npm test` on every push to `main` and every PR against `main`.
- Matrix across Node 20 and 22 (current LTS lines).
- `concurrency` block cancels in-progress runs when a new commit lands on the same ref, so the queue doesn't stack up.

This is the first PR exercising the new branch-protection rule that blocks direct pushes to `main`.

## Test plan

- [ ] CI workflow runs on this PR — both `Build & Test (Node 20)` and `Build & Test (Node 22)` pass
- [ ] Branch protection gates the merge on both checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)