### PR TITLE
Broaden .gitignore to catch all .env variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ node_modules/
 dist/
 *.log
 .env
-.env.local
+.env.*
+!.env.example
 .DS_Store
 coverage/
 .vitest-cache/


### PR DESCRIPTION
## Summary

Replaces the explicit `.env` + `.env.local` pair in `.gitignore` with a wildcard + negation:

```
.env
.env.*
!.env.example
```

One rule catches `.env.production`, `.env.staging`, `.env.test`, `.env.<anything>`, while keeping the committed `.env.example` template tracked.

Belt-and-suspenders — no active leak; just reduces the odds that a future sibling env file slips in.

## Test plan

- [ ] CI green (Node 20 + 22)
- [ ] `git check-ignore -v .env.production` returns the new wildcard line
- [ ] `.env.example` remains tracked (`git ls-files | grep env.example`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)