### PR TITLE
v0.1.1: fix setup CLI hang + tighten .gitignore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -283,4 +283,9 @@ async function main() {
   }
 }
 
-main();
+main().then(() => {
+  // WalletConnect's SignClient keeps websocket/relay handles open that prevent
+  // a natural event-loop exit. Force-exit so the CLI returns control to the
+  // shell; process.exitCode (set on error) is honored.
+  process.exit();
+});


### PR DESCRIPTION
## Summary
- Fix `recon-crypto-mcp-setup` hanging after Ledger pairing — WalletConnect SignClient kept relay websocket handles open, blocking event-loop exit. Force-exit when `main()` resolves so the CLI returns control to the shell.
- Broaden `.gitignore` to catch all `.env` variants (from earlier commit on this branch).
- Bump to v0.1.1.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 202/202 passing
- [ ] Post-merge: tag v0.1.1, create GitHub release, `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)