### PR TITLE
Add npm publish workflow (Trusted Publisher / OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — publishes to npm via GitHub Actions OIDC using npm Trusted Publisher. No `NPM_TOKEN` secret needed.
- Triggers on GitHub Release publish, plus `workflow_dispatch` for manual runs.
- Runs build + tests before publishing; uses `--provenance` so the tarball is signed with an attestation.

## Prerequisite
Trusted Publisher already registered at https://www.npmjs.com/package/recon-crypto-mcp/access (repo `szhygulin/recon-crypto-mcp`, workflow `publish.yml`).

## Test plan
- [ ] Merge PR
- [ ] Manual `workflow_dispatch` to publish v0.1.1
- [ ] Verify tarball on npm shows provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)