### PR TITLE
Upgrade npm in publish workflow (Trusted Publisher OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
+      - name: Upgrade npm to support Trusted Publishers
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Installs latest npm before publish so OIDC token exchange works. Node 22's bundled npm 10.x predates this feature; npm >= 11.5.1 is required.