### PR TITLE
Use npx npm@latest in publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
-      - name: Upgrade npm to support Trusted Publishers
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 
@@ -42,4 +39,6 @@ jobs:
         run: npm test
 
       - name: Publish
-        run: npm publish --provenance --access public
+        # Node 22 ships npm 10.x; Trusted Publisher OIDC token exchange
+        # needs npm >= 11.5.1, so invoke latest npm via npx just for this step.
+        run: npx --yes npm@latest publish --provenance --access public


### PR DESCRIPTION
Globally upgrading npm broke the runner install. Switching to npx keeps the base env intact and still picks up npm 11+ for the OIDC publish.