### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump to v0.2.0. Merge this, then cut a GitHub release tagged `v0.2.0` to trigger the npm publish workflow.

Contents (merged on main since v0.1.1):
- `simulate_transaction` MCP tool — generic `eth_call` with viem-decoded revert reasons
- `enrichTx` runs `eth_call` on every prepared tx and attaches the result to the preview
- `send_transaction` re-simulates right before signing and refuses when the tx would revert
- Fix: Compound V3 rendering dust when base token's `decimals()` read transiently fails

## Test plan

- [x] `npm test` — 209 tests passing
- [x] `npm run build` — clean typecheck
- [ ] After merge: create GitHub release `v0.2.0` → verify `Publish to npm` workflow succeeds
- [ ] Verify `recon-crypto-mcp@0.2.0` visible on npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)