### PR TITLE
v0.2.1: publish to official MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,17 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Publish
+      - name: Publish to npm
         # Node 22 ships npm 10.x; Trusted Publisher OIDC token exchange
         # needs npm >= 11.5.1, so invoke latest npm via npx just for this step.
         run: npx --yes npm@latest publish --provenance --access public
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
+  "mcpName": "io.github.szhygulin/recon-crypto-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.szhygulin/recon-crypto-mcp",
+  "title": "Recon Crypto MCP",
+  "description": "MCP server for AI agents (Claude, Cursor) to manage a self-custodial crypto portfolio on Ethereum/Arbitrum/Polygon via Ledger + WalletConnect. Reads on-chain DeFi positions (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido, EigenLayer), surfaces liquidation/health-factor alerts, and prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, LiFi-routed swaps and bridges) that the user signs on their Ledger device. Private keys never leave the hardware wallet.",
+  "version": "0.2.1",
+  "websiteUrl": "https://github.com/szhygulin/recon-crypto-mcp",
+  "repository": {
+    "url": "https://github.com/szhygulin/recon-crypto-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "recon-crypto-mcp",
+      "version": "0.2.1",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "ETHEREUM_RPC_URL",
+          "description": "Custom Ethereum RPC endpoint (alternative to RPC_PROVIDER + RPC_API_KEY).",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "ARBITRUM_RPC_URL",
+          "description": "Custom Arbitrum RPC endpoint.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "POLYGON_RPC_URL",
+          "description": "Custom Polygon RPC endpoint.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "RPC_PROVIDER",
+          "description": "RPC provider name: 'infura' or 'alchemy'. Used together with RPC_API_KEY.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "RPC_API_KEY",
+          "description": "API key for the chosen RPC_PROVIDER.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "ETHERSCAN_API_KEY",
+          "description": "Etherscan API key for contract verification lookups.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "ONEINCH_API_KEY",
+          "description": "1inch Developer Portal API key. Enables 1inch quote comparison in get_swap_quote.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "WALLETCONNECT_PROJECT_ID",
+          "description": "WalletConnect Cloud project ID. Required for Ledger Live signing via WalletConnect.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Bumps to **0.2.1** so the npm-published `package.json` carries the new `mcpName` field that the MCP Registry validates against `server.json`.
- Adds **`server.json`** at repo root — the registry manifest. Name `io.github.szhygulin/recon-crypto-mcp`, stdio transport, optional env vars documented.
- Extends **`.github/workflows/publish.yml`** with three steps after `npm publish`: install `mcp-publisher`, `mcp-publisher login github-oidc`, `mcp-publisher publish`. No new secret needed; the existing `id-token: write` permission covers OIDC auth.

Why bother: PulseMCP, Glama, and others ingest from the official registry, so this single submission cascades downstream.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — all passing
- [ ] Merge PR
- [ ] `workflow_dispatch` to publish v0.2.1 to npm + register on MCP Registry
- [ ] Verify: `curl https://registry.modelcontextprotocol.io/v0/servers?search=recon-crypto-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)