### PR TITLE
v0.2.3: document approval→wait→main-tx pattern to all agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "mcpName": "io.github.szhygulin/recon-crypto-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/recon-crypto-mcp",
   "title": "Recon Crypto MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "websiteUrl": "https://github.com/szhygulin/recon-crypto-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/recon-crypto-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "recon-crypto-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,13 @@ async function main() {
         "   prompt the user to review and physically sign on the device.",
         "6. Optionally poll `get_transaction_status` for inclusion.",
         "",
+        "TWO-STEP ALLOWANCE FLOWS: when a `prepare_*` tool returns an approval tx alongside",
+        "the main tx (supply, repay, swap, etc.), submit the approval via `send_transaction`",
+        "FIRST, then POLL `get_transaction_status` until the approval is included (status",
+        "`confirmed`). Only AFTER that, simulate or send the main tx. Simulating the main tx",
+        "against pre-approval state fails with \"insufficient allowance\" / ERC20 reverts and",
+        "looks like a builder bug — it is not, the allowance just isn't on-chain yet.",
+        "",
         "READ-ONLY TOOLS need no pairing and can be called freely: get_lending_positions,",
         "get_lp_positions, get_compound_positions, get_morpho_positions, get_staking_positions,",
         "get_staking_rewards, estimate_staking_yield, get_portfolio_summary, get_swap_quote,",
@@ -512,7 +519,10 @@ async function main() {
         "a contract call does what you expect — e.g. does wrapping ETH by sending to WETH9's fallback succeed, " +
         "does a custom calldata revert, what selector gets hit. For state-dependent calls (WETH deposit credits " +
         "msg.sender, ERC-20 transfer debits msg.sender), pass the user's wallet as `from`. Prepared transactions " +
-        "are also re-simulated automatically at send_transaction time — this tool lets the agent check ahead.",
+        "are also re-simulated automatically at send_transaction time — this tool lets the agent check ahead. " +
+        "NEVER call this on a tx that depends on an approval you just submitted but haven't yet waited on: " +
+        "the approval must be included on-chain (poll get_transaction_status until confirmed) before the " +
+        "dependent tx will simulate correctly — otherwise you get a misleading 'insufficient allowance' revert.",
       inputSchema: simulateTransactionInput.shape,
     },
     handler(simulateTransaction)


### PR DESCRIPTION
## Summary
Bakes the approval-then-wait guidance into the MCP server itself so every agent — not just ones with Claude's memory — learns the pattern.

- **Server \`instructions\`**: adds a TWO-STEP ALLOWANCE FLOWS section. Tells agents to submit approval first, poll \`get_transaction_status\` until confirmed, and only then simulate / send the dependent main tx.
- **\`simulate_transaction\` description**: explicit warning against simulating a tx whose approval is still pending (avoids the misleading \"insufficient allowance\" revert).
- Version bumped to 0.2.3; \`server.json\` updated accordingly.

## Test plan
- [x] \`npm run build\`
- [x] \`npm test\`
- [ ] Merge, trigger workflow_dispatch, verify v0.2.3 publishes to both npm and MCP Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)