### PR TITLE
Embed per-chain exposure in ledger account status

### DIFF
--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -1,13 +1,28 @@
 import {
-  getConnectedAccounts,
+  getConnectedAccountsDetailed,
   getCurrentSession,
   getSignClient,
   isPeerUnreachable,
 } from "./walletconnect.js";
+import type { SupportedChain } from "../types/index.js";
+
+export interface SessionAccount {
+  address: `0x${string}`;
+  /** Supported chains this address is exposed on (mapped from chainIds). */
+  chains: SupportedChain[];
+  /** Every eip155 chainId advertised for this address, including ones the server does not support. */
+  chainIds: number[];
+}
 
 export interface SessionStatus {
   paired: boolean;
+  /**
+   * Deduplicated list of addresses. An address that appears on multiple chains
+   * shows up once here; use `accountDetails` for the per-chain breakdown.
+   */
   accounts: `0x${string}`[];
+  /** Per-address chain exposure — addresses paired with the networks they're advertised on. */
+  accountDetails: SessionAccount[];
   topic?: string;
   expiresAt?: number;
   /** Peer-advertised app name (e.g. "Ledger Live"). Self-reported — NOT a trusted identity. */
@@ -42,13 +57,20 @@ export async function getSessionStatus(): Promise<SessionStatus> {
   await getSignClient(); // triggers restore + liveness check
   const session = getCurrentSession();
   if (!session)
-    return { paired: false, accounts: [], peerTrustWarning: PEER_TRUST_WARNING };
-  const accounts = await getConnectedAccounts();
+    return {
+      paired: false,
+      accounts: [],
+      accountDetails: [],
+      peerTrustWarning: PEER_TRUST_WARNING,
+    };
+  const accountDetails = await getConnectedAccountsDetailed();
+  const accounts = accountDetails.map((a) => a.address);
   const meta = session.peer?.metadata;
   const unreachable = isPeerUnreachable();
   return {
     paired: true,
     accounts,
+    accountDetails,
     topic: session.topic,
     expiresAt: session.expiry * 1000,
     ...(meta?.name ? { wallet: meta.name } : {}),

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -2,7 +2,7 @@ import { SignClient } from "@walletconnect/sign-client";
 import type { SessionTypes } from "@walletconnect/types";
 import { getSdkError } from "@walletconnect/utils";
 import { join } from "node:path";
-import { CHAIN_IDS, type SupportedChain, type UnsignedTx } from "../types/index.js";
+import { CHAIN_IDS, CHAIN_ID_TO_NAME, type SupportedChain, type UnsignedTx } from "../types/index.js";
 import {
   readUserConfig,
   patchUserConfig,
@@ -189,21 +189,54 @@ export function getCurrentSession(): SessionTypes.Struct | null {
   return currentSession;
 }
 
-/** Return the list of EVM accounts exposed by the connected wallet (across all namespaces). */
+/**
+ * Return the deduplicated list of EVM addresses exposed by the connected
+ * wallet across all chain namespaces. WalletConnect advertises accounts as
+ * `eip155:<chainId>:<address>` — the same address typically appears once per
+ * chain the wallet has exposed, so a flat list of raw entries looks like
+ * duplicates from the agent's perspective. Callers that care which chains an
+ * address is exposed on should use `getConnectedAccountsDetailed`.
+ */
 export async function getConnectedAccounts(): Promise<`0x${string}`[]> {
+  const detailed = await getConnectedAccountsDetailed();
+  return detailed.map((a) => a.address);
+}
+
+/**
+ * Return per-address chain exposure. Addresses are deduplicated; `chainIds`
+ * lists every eip155 chainId the address was advertised for, and `chains`
+ * maps those to the server's SupportedChain names where recognized.
+ */
+export async function getConnectedAccountsDetailed(): Promise<
+  { address: `0x${string}`; chainIds: number[]; chains: SupportedChain[] }[]
+> {
   if (!currentSession) await getSignClient(); // ensure restoration attempted
   if (!currentSession) return [];
-  const accounts: `0x${string}`[] = [];
   const ns = currentSession.namespaces.eip155;
   if (!ns) return [];
+
+  // Preserve the first-seen order of addresses so the list is deterministic
+  // across calls — a Map iterates in insertion order.
+  const byAddress = new Map<`0x${string}`, Set<number>>();
   for (const entry of ns.accounts) {
-    // format: "eip155:1:0xabc..."
     const parts = entry.split(":");
-    if (parts.length === 3 && /^0x[a-fA-F0-9]{40}$/.test(parts[2])) {
-      accounts.push(parts[2] as `0x${string}`);
-    }
+    if (parts.length !== 3) continue;
+    const chainId = Number(parts[1]);
+    const addr = parts[2];
+    if (!Number.isFinite(chainId) || !/^0x[a-fA-F0-9]{40}$/.test(addr)) continue;
+    const address = addr as `0x${string}`;
+    const existing = byAddress.get(address);
+    if (existing) existing.add(chainId);
+    else byAddress.set(address, new Set([chainId]));
   }
-  return accounts;
+
+  return Array.from(byAddress.entries()).map(([address, chainIdSet]) => {
+    const chainIds = Array.from(chainIdSet).sort((a, b) => a - b);
+    const chains = chainIds
+      .map((id) => CHAIN_ID_TO_NAME[id])
+      .filter((c): c is SupportedChain => c !== undefined);
+    return { address, chainIds, chains };
+  });
 }
 
 /** Send an `eth_sendTransaction` request. Ledger Live shows it, user signs on device, we get tx hash back. */


### PR DESCRIPTION
## Summary
- WalletConnect advertises accounts as `eip155:<chainId>:<address>`, so one address exposed on Ethereum + Arbitrum + Polygon surfaces as three raw entries. `get_ledger_status` was passing them through unchanged, which looked like duplicates to agents (e.g. "5 entries with 1/4 and 2/5 as duplicates") and forced a manual "same address on different chains" explanation.
- `getConnectedAccounts()` now deduplicates by address — callers doing membership checks (pre-sign guard, default-from resolution) keep working but no longer see redundant entries.
- Adds `getConnectedAccountsDetailed()` returning `{ address, chainIds, chains }` per unique address, preserving first-seen order.
- `SessionStatus` gains `accountDetails: SessionAccount[]` with the per-address chain breakdown. Each entry maps `chainIds` to the server's `SupportedChain` names (ethereum / arbitrum / polygon); unsupported chainIds are preserved in `chainIds[]` with an empty `chains[]` slot.
- `accounts` stays as a deduped flat list for backward compat with agents that already parse it.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 209 tests pass
- [ ] Manual: call `get_ledger_status` with a Ledger session exposing the same address on multiple chains; verify `accounts` is deduped and `accountDetails` shows each address with its `chains` array populated.
- [ ] Manual: send a transaction and confirm the pre-sign check still passes (it consumes `getConnectedAccounts()` which now returns deduped addresses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)