### PR TITLE
Add TRON Phase 1: read-only balances + portfolio integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 **Self-custodial crypto portfolio and DeFi, managed by AI agents — signed on your Ledger hardware wallet.**
 
-Recon Crypto MCP is a Model Context Protocol server that lets AI agents — **Claude Code, Claude Desktop, Cursor**, and any MCP-compatible client — read your on-chain positions across **Ethereum, Arbitrum, and Polygon** and prepare EVM transactions that you sign on your **Ledger device via WalletConnect**. Your private keys never leave the hardware wallet, and every transaction is previewed in human-readable form before you approve it on the device.
+Recon Crypto MCP is a Model Context Protocol server that lets AI agents — **Claude Code, Claude Desktop, Cursor**, and any MCP-compatible client — read your on-chain positions across **Ethereum, Arbitrum, Polygon, Base**, and **TRON** and prepare EVM transactions that you sign on your **Ledger device via WalletConnect**. Your private keys never leave the hardware wallet, and every transaction is previewed in human-readable form before you approve it on the device.
 
 Supported protocols: **Aave V3, Compound V3 (Comet), Morpho Blue, Uniswap V3 LP, Lido (stETH/wstETH), EigenLayer**, plus **LiFi** for swap/bridge aggregation and **1inch** for optional intra-chain quote comparison.
 
 Use it when you want to:
 
-- Ask an agent *"what are my DeFi positions across Ethereum, Arbitrum, and Polygon?"* and get a unified portfolio view (wallet balances + Aave/Compound/Morpho lending + Uniswap V3 LP + Lido/EigenLayer staking) with USD totals.
+- Ask an agent *"what are my DeFi positions across Ethereum, Arbitrum, Polygon, and Base?"* and get a unified portfolio view (wallet balances + Aave/Compound/Morpho lending + Uniswap V3 LP + Lido/EigenLayer staking) with USD totals.
 - Get liquidation-risk alerts (*"any position below health factor 1.5?"*) without manually checking dashboards.
 - Swap or bridge tokens — the agent prepares the route via LiFi, you sign on Ledger.
 - Supply, borrow, repay, withdraw on lending protocols; stake ETH on Lido; deposit into EigenLayer strategies; send ETH or ERC-20 tokens — all through Ledger-signed transactions.
@@ -34,27 +34,32 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 ## Supported chains
 
-EVM: Ethereum, Arbitrum, Polygon.
+EVM: Ethereum, Arbitrum, Polygon, Base.
+
+Non-EVM: TRON (phase 1 — balance reads only; transaction preparation and Ledger signing land in follow-up phases).
+
+Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no DeFi/LP/staking coverage in this server (none of Aave/Compound/Morpho/Uniswap/Lido/EigenLayer are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
 ## Roadmap
 
-- **MetaMask support** (WalletConnect) — planned for the next release, alongside the existing Ledger Live integration. Will let users sign through a MetaMask-paired session when a hardware wallet isn't available.
-- **Base** — coming soon. EVM L2, reuses the existing viem/Aave V3/LiFi tooling.
-- **Solana** — coming soon. Non-EVM: introduces a separate SDK (`@solana/web3.js`), base58 addresses, and the WalletConnect `solana:` namespace for signing.
+- **TRON transaction preparation + Ledger signing** — phase 2 and phase 3 of TRON support. Phase 2 prepares native TRX and TRC-20 sends. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
+- **MetaMask support** (WalletConnect) — alongside the existing Ledger Live integration. Will let users sign through a MetaMask-paired session when a hardware wallet isn't available.
+- **Solana** — coming later. Non-EVM: introduces a separate SDK (`@solana/web3.js`), base58 addresses, and the WalletConnect `solana:` namespace for signing.
 
 ## Tools exposed to the agent
 
 Read-only (no Ledger pairing required):
 
-- `get_portfolio_summary` — cross-chain portfolio aggregation with USD totals
+- `get_portfolio_summary` — cross-chain portfolio aggregation with USD totals; pass an optional `tronAddress` (base58, prefix T) alongside an EVM `wallet` to fold TRX + TRC-20 balances into the same total (returned under `breakdown.tron` and `tronUsd`)
 - `get_lending_positions` — Aave V3 collateral/debt/health-factor per wallet
 - `get_compound_positions` — Compound V3 (Comet) base + collateral positions
-- `get_morpho_positions` — Morpho Blue positions across specified markets
+- `get_morpho_positions` — Morpho Blue positions; auto-discovers the wallet's markets via event-log scan when `marketIds` is omitted (pass explicit ids for a fast path)
 - `get_lp_positions` — Uniswap V3 LP positions, fee tier, in-range, IL estimate
 - `get_staking_positions`, `get_staking_rewards`, `estimate_staking_yield` — Lido + EigenLayer
 - `get_health_alerts` — Aave positions near liquidation
 - `simulate_position_change` — projected Aave health factor for a hypothetical action
-- `get_token_balance`, `get_token_price` — balances and DefiLlama prices
+- `simulate_transaction` — run `eth_call` against a prepared or arbitrary tx to preview success/revert before signing; prepared txs are re-simulated automatically at send time
+- `get_token_balance`, `get_token_price` — balances and DefiLlama prices; `get_token_balance` accepts `chain: "tron"` with a base58 wallet and a base58 TRC-20 address (or `token: "native"` for TRX), returning a `TronBalance` shape
 - `resolve_ens_name`, `reverse_resolve_ens` — ENS forward/reverse
 - `get_swap_quote` — LiFi quote (optionally cross-checked against 1inch)
 - `check_contract_security`, `check_permission_risks`, `get_protocol_risk_score` — risk tooling
@@ -66,7 +71,7 @@ Meta:
 
 Execution (Ledger-signed via WalletConnect):
 
-- `pair_ledger_live`, `get_ledger_status` — session management and account discovery
+- `pair_ledger_live`, `get_ledger_status` — session management and account discovery; `get_ledger_status` returns per-chain exposure (`accountDetails[]` with `address`, `chainIds`, `chains`) so duplicate-looking addresses across chains are disambiguated
 - `prepare_aave_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_compound_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_morpho_supply` / `_withdraw` / `_borrow` / `_repay` / `_supply_collateral` / `_withdraw_collateral`
@@ -80,7 +85,7 @@ Execution (Ledger-signed via WalletConnect):
 
 - Node.js >= 18.17
 - An RPC provider (Infura, Alchemy, or custom) for the EVM chains
-- Optional: Etherscan API key, 1inch Developer Portal API key (enables swap-quote comparison), WalletConnect Cloud project ID (required for Ledger signing)
+- Optional: Etherscan API key, 1inch Developer Portal API key (enables swap-quote comparison), WalletConnect Cloud project ID (required for Ledger signing), TronGrid API key (enables TRX + TRC-20 balance reads)
 
 ## Install
 
@@ -132,10 +137,11 @@ The setup script prints a ready-to-paste snippet.
 
 All are optional if the matching field is in `~/.recon-crypto-mcp/config.json`; env vars take precedence when both are set.
 
-- `ETHEREUM_RPC_URL`, `ARBITRUM_RPC_URL`, `POLYGON_RPC_URL` — custom RPC endpoints
+- `ETHEREUM_RPC_URL`, `ARBITRUM_RPC_URL`, `POLYGON_RPC_URL`, `BASE_RPC_URL` — custom RPC endpoints
 - `RPC_PROVIDER` (`infura` | `alchemy`) + `RPC_API_KEY` — alternative to custom URLs
 - `ETHERSCAN_API_KEY` — contract verification lookups
 - `ONEINCH_API_KEY` — enables 1inch quote comparison in `get_swap_quote`
+- `TRON_API_KEY` — TronGrid API key (sent as `TRON-PRO-API-KEY`). Required in practice to read TRON balances — anonymous TronGrid calls are capped at ~15 req/min, which the portfolio fan-out exceeds. Free to create at [trongrid.io](https://www.trongrid.io).
 - `WALLETCONNECT_PROJECT_ID` — required for Ledger Live signing
 - `RPC_BATCH=1` — opt into JSON-RPC batching (off by default; many public endpoints mishandle batched POSTs)
 - `RECON_ALLOW_INSECURE_RPC=1` — opt out of the https/private-IP check on RPC URLs. Only set this when pointing at a local anvil/hardhat fork; never in production.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 EVM: Ethereum, Arbitrum, Polygon, Base.
 
-Non-EVM: TRON (phase 1 — balance reads only; transaction preparation and Ledger signing land in follow-up phases).
+Non-EVM: TRON (phase 1 — balance + staking reads; transaction preparation and Ledger signing land in follow-up phases).
 
-Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no DeFi/LP/staking coverage in this server (none of Aave/Compound/Morpho/Uniswap/Lido/EigenLayer are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume. Readers short-circuit cleanly on chains where a protocol isn't deployed.
+Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no lending/LP coverage in this server (none of Aave/Compound/Morpho/Uniswap are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume, and TRON-native staking (frozen TRX under Stake 2.0, pending unfreezes, claimable voting rewards) is surfaced via `get_tron_staking` and folded into the portfolio summary. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
 ## Roadmap
 
@@ -50,7 +50,7 @@ Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum)
 
 Read-only (no Ledger pairing required):
 
-- `get_portfolio_summary` — cross-chain portfolio aggregation with USD totals; pass an optional `tronAddress` (base58, prefix T) alongside an EVM `wallet` to fold TRX + TRC-20 balances into the same total (returned under `breakdown.tron` and `tronUsd`)
+- `get_portfolio_summary` — cross-chain portfolio aggregation with USD totals; pass an optional `tronAddress` (base58, prefix T) alongside an EVM `wallet` to fold TRX + TRC-20 balances + TRON staking (frozen + pending-unfreeze + claimable rewards) into the same total (returned under `breakdown.tron`, `tronUsd`, and `tronStakingUsd`)
 - `get_lending_positions` — Aave V3 collateral/debt/health-factor per wallet
 - `get_compound_positions` — Compound V3 (Comet) base + collateral positions
 - `get_morpho_positions` — Morpho Blue positions; auto-discovers the wallet's markets via event-log scan when `marketIds` is omitted (pass explicit ids for a fast path)
@@ -60,6 +60,7 @@ Read-only (no Ledger pairing required):
 - `simulate_position_change` — projected Aave health factor for a hypothetical action
 - `simulate_transaction` — run `eth_call` against a prepared or arbitrary tx to preview success/revert before signing; prepared txs are re-simulated automatically at send time
 - `get_token_balance`, `get_token_price` — balances and DefiLlama prices; `get_token_balance` accepts `chain: "tron"` with a base58 wallet and a base58 TRC-20 address (or `token: "native"` for TRX), returning a `TronBalance` shape
+- `get_tron_staking` — TRON-native staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with ISO unlock timestamps. Read-only; the actual claim/withdraw transactions land in TRON Phase 2.
 - `resolve_ens_name`, `reverse_resolve_ens` — ENS forward/reverse
 - `get_swap_quote` — LiFi quote (optionally cross-checked against 1inch)
 - `check_contract_security`, `check_permission_risks`, `get_protocol_risk_score` — risk tooling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/src/config/tron.ts
+++ b/src/config/tron.ts
@@ -1,0 +1,45 @@
+/**
+ * TRON mainnet configuration.
+ *
+ * TRON is not EVM: addresses are base58 (prefix `T`, 34 chars), the RPC is a
+ * REST API (TronGrid) rather than JSON-RPC, and transaction signing uses a
+ * different wire format. The server treats TRON as strictly additive via
+ * `AnyChain = SupportedChain | SupportedNonEvmChain` — existing EVM modules
+ * never see TRON, and the TRON reader lives in src/modules/tron/.
+ */
+
+/** TronGrid REST endpoint. Anonymous requests are rate-limited to ~15 req/min. */
+export const TRONGRID_BASE_URL = "https://api.trongrid.io";
+
+/**
+ * Canonical TRC-20 tokens we enumerate in the portfolio summary. Keys are the
+ * displayed symbol; values are the TRC-20 contract addresses in base58.
+ *
+ * TRON is dominated by USDT (Tether issues more on TRON than on any other
+ * chain by volume), so the wallet balance fan-out is small on purpose —
+ * USDT, USDC, and the few stablecoins that matter cover >95% of balances in
+ * practice. TronScan top-holders data confirms the long tail is negligible
+ * compared to the Ethereum equivalent.
+ */
+export const TRON_TOKENS = {
+  USDT: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+  USDC: "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
+  USDD: "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR",
+  TUSD: "TUpMhErZL2fhh4sVNULAbNKLokS4GjC1F4",
+} as const;
+
+/** Native TRX symbol + decimals. TRX uses 6 decimals (1 TRX = 1_000_000 sun). */
+export const TRX_DECIMALS = 6;
+export const TRX_SYMBOL = "TRX";
+
+/**
+ * Validate a TRON mainnet base58 address. Mainnet addresses are 34 chars and
+ * start with `T` (the mainnet prefix byte 0x41 encodes to `T...` in base58check).
+ *
+ * This is a cheap shape check, not a full base58check-with-payload-checksum
+ * validation — callers that round-trip an address through TronGrid get a
+ * stronger guarantee (TronGrid itself rejects malformed addresses).
+ */
+export function isTronAddress(s: string): boolean {
+  return typeof s === "string" && /^T[1-9A-HJ-NP-Za-km-z]{33}$/.test(s);
+}

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -99,6 +99,16 @@ export function resolveOneInchApiKey(userConfig: UserConfig | null): string | un
   return process.env.ONEINCH_API_KEY || userConfig?.oneInchApiKey;
 }
 
+/**
+ * Pull the TronGrid API key from env or user config; undefined if none set.
+ * An undefined key means TRON reads are either disabled or fall back to
+ * anonymous TronGrid (rate-limited — the reader flags that in its errored
+ * coverage status rather than silently degrading).
+ */
+export function resolveTronApiKey(userConfig: UserConfig | null): string | undefined {
+  return process.env.TRON_API_KEY || userConfig?.tronApiKey;
+}
+
 /** Pull the WalletConnect project ID from env or user config; undefined if none set. */
 export function resolveWalletConnectProjectId(userConfig: UserConfig | null): string | undefined {
   return process.env.WALLETCONNECT_PROJECT_ID || userConfig?.walletConnect?.projectId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ import {
   reverseResolveInput,
 } from "./modules/balances/schemas.js";
 
+import { getTronStaking } from "./modules/tron/staking.js";
+import { getTronStakingInput } from "./modules/tron/schemas.js";
+
 import { getCompoundPositions } from "./modules/compound/index.js";
 import {
   buildCompoundSupply,
@@ -205,7 +208,10 @@ async function main() {
         "- their TRON balances (TRX + TRC-20 — USDT, USDC, USDD, TUSD) when the user",
         "  supplies a base58 address (prefix T) via the `tronAddress` arg on",
         "  `get_portfolio_summary` or the `chain: \"tron\"` branch of `get_token_balance`.",
-        "  TRON has no DeFi/staking/LP coverage in this server — balance reads only.",
+        "- their TRON staking: claimable voting rewards, frozen TRX (Stake 2.0),",
+        "  and pending unfreezes — via `get_tron_staking` or folded into",
+        "  `get_portfolio_summary` when a `tronAddress` is passed. TRON has no",
+        "  lending/LP coverage in this server (not deployed there).",
         "- portfolio value, cross-chain aggregation, health-factor / liquidation risk",
         "- executing on-chain actions: supply, borrow, repay, withdraw, stake, unstake,",
         "  send ETH/tokens, swap, bridge",
@@ -236,8 +242,9 @@ async function main() {
         "get_lp_positions, get_compound_positions, get_morpho_positions, get_staking_positions,",
         "get_staking_rewards, estimate_staking_yield, get_portfolio_summary, get_swap_quote,",
         "get_token_balance, get_token_price, resolve_ens_name, reverse_resolve_ens,",
-        "get_health_alerts, simulate_position_change, check_contract_security,",
-        "check_permission_risks, get_protocol_risk_score, get_transaction_status.",
+        "get_tron_staking, get_health_alerts, simulate_position_change,",
+        "check_contract_security, check_permission_risks, get_protocol_risk_score,",
+        "get_transaction_status.",
         "",
         "SWAP/BRIDGE ROUTING: prefer `prepare_swap` (LiFi aggregator) over building DEX",
         "router calls directly — LiFi handles route selection, approvals, and cross-chain",
@@ -572,6 +579,16 @@ async function main() {
       inputSchema: reverseResolveInput.shape,
     },
     handler(reverseResolve)
+  );
+
+  server.registerTool(
+    "get_tron_staking",
+    {
+      description:
+        "Read TRON staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with their unlock timestamps. Returns raw SUN + formatted TRX + USD values, plus a `totalStakedUsd` rollup. Read-only; the WithdrawBalance transaction to actually claim rewards lands in TRON Phase 2.",
+      inputSchema: getTronStakingInput.shape,
+    },
+    handler((args: { address: string }) => getTronStaking(args.address))
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,10 @@ async function main() {
         "- their DeFi positions on Ethereum, Arbitrum, Polygon, or Base — Aave V3 lending/",
         "  borrowing, Compound V3 (Comet), Morpho Blue (Ethereum), Uniswap V3 LP, Lido staking",
         "  (Ethereum/Arbitrum), EigenLayer restaking (Ethereum)",
+        "- their TRON balances (TRX + TRC-20 — USDT, USDC, USDD, TUSD) when the user",
+        "  supplies a base58 address (prefix T) via the `tronAddress` arg on",
+        "  `get_portfolio_summary` or the `chain: \"tron\"` branch of `get_token_balance`.",
+        "  TRON has no DeFi/staking/LP coverage in this server — balance reads only.",
         "- portfolio value, cross-chain aggregation, health-factor / liquidation risk",
         "- executing on-chain actions: supply, borrow, repay, withdraw, stake, unstake,",
         "  send ETH/tokens, swap, bridge",
@@ -364,7 +368,7 @@ async function main() {
     "get_portfolio_summary",
     {
       description:
-        "One-shot cross-chain portfolio aggregation for one or more wallets. Fans out across Ethereum/Arbitrum/Polygon/Base (unless `chains` narrows it) and assembles: native ETH/MATIC balances, top ERC-20 holdings, Aave V3 and Compound V3 lending positions, Uniswap V3 LP positions, and Lido/EigenLayer staking — each valued in USD via DefiLlama. Returns a `totalUsd`, a `breakdown` by category and by chain, and the raw per-protocol position arrays. Default tool for 'what's in my portfolio?' / 'total value' questions; prefer it over calling each per-protocol reader separately.",
+        "One-shot cross-chain portfolio aggregation for one or more wallets. Fans out across Ethereum/Arbitrum/Polygon/Base (unless `chains` narrows it) and assembles: native ETH/MATIC balances, top ERC-20 holdings, Aave V3 and Compound V3 lending positions, Uniswap V3 LP positions, and Lido/EigenLayer staking — each valued in USD via DefiLlama. Pass `tronAddress` (base58, prefix T) alongside a single `wallet` to fold TRX + TRC-20 balances plus TRON staking into the same totals; `breakdown.tron` holds the TRON slice, `tronUsd` the subtotal, and `tronStakingUsd` the staking portion. Returns a `totalUsd`, a `breakdown` by category and by chain, and the raw per-protocol position arrays. Default tool for 'what's in my portfolio?' / 'total value' questions; prefer it over calling each per-protocol reader separately.",
       inputSchema: getPortfolioSummaryInput.shape,
     },
     handler(getPortfolioSummary)
@@ -534,7 +538,7 @@ async function main() {
     "get_token_balance",
     {
       description:
-        "Fetch a wallet's balance of any ERC-20 token or the chain's native coin. Pass `token: \"native\"` for ETH (or chain-native asset) or an ERC-20 contract address. Returns amount, decimals, symbol, and USD value.",
+        "Fetch a wallet's balance of any ERC-20 token or the chain's native coin. Pass `token: \"native\"` for ETH (or chain-native asset) or an ERC-20 contract address. Returns amount, decimals, symbol, and USD value. For TRON, pass `chain: \"tron\"` with a base58 wallet (prefix T) and either `token: \"native\"` for TRX or a base58 TRC-20 address; returns a TronBalance (same fields, base58 token id).",
       inputSchema: getTokenBalanceInput.shape,
     },
     handler(getTokenBalance)

--- a/src/modules/balances/index.ts
+++ b/src/modules/balances/index.ts
@@ -3,33 +3,53 @@ import { erc20Abi } from "../../abis/erc20.js";
 import { makeTokenAmount } from "../../data/format.js";
 import { getTokenPrice } from "../../data/prices.js";
 import { NATIVE_SYMBOL } from "../../config/contracts.js";
+import { getTronTokenBalance } from "../tron/balances.js";
 import type {
   GetTokenBalanceArgs,
   ResolveNameArgs,
   ReverseResolveArgs,
 } from "./schemas.js";
-import type { SupportedChain, TokenAmount } from "../../types/index.js";
+import type {
+  AnyChain,
+  SupportedChain,
+  TokenAmount,
+  TronBalance,
+} from "../../types/index.js";
 
 /**
  * Fetch the balance of an arbitrary token (ERC-20 by address, or the chain's native coin).
  * Returns `{ ...TokenAmount, zero: true }` when the wallet has no balance.
+ *
+ * On TRON, `wallet` must be base58 (prefix T) and `token` is either "native"
+ * (TRX) or a base58 TRC-20 contract address; the shape of the returned value
+ * is `TronBalance` rather than `TokenAmount`.
  */
-export async function getTokenBalance(args: GetTokenBalanceArgs): Promise<TokenAmount> {
+export async function getTokenBalance(
+  args: GetTokenBalanceArgs
+): Promise<TokenAmount | TronBalance> {
+  const chain = args.chain as AnyChain;
+
+  // TRON branches to its own reader — addresses are base58 and the price
+  // provider uses a different chain identifier.
+  if (chain === "tron") {
+    return getTronTokenBalance(args.wallet, args.token);
+  }
+
   const wallet = args.wallet as `0x${string}`;
-  const chain = args.chain as SupportedChain;
-  const client = getClient(chain);
+  const evmChain = chain as SupportedChain;
+  const client = getClient(evmChain);
 
   if (args.token === "native") {
     const [balance, price] = await Promise.all([
       client.getBalance({ address: wallet }),
-      getTokenPrice(chain, "native"),
+      getTokenPrice(evmChain, "native"),
     ]);
     return makeTokenAmount(
-      chain,
+      evmChain,
       "0x0000000000000000000000000000000000000000" as `0x${string}`,
       balance,
       18,
-      NATIVE_SYMBOL[chain],
+      NATIVE_SYMBOL[evmChain],
       price
     );
   }
@@ -43,9 +63,9 @@ export async function getTokenBalance(args: GetTokenBalanceArgs): Promise<TokenA
     ],
     allowFailure: false,
   });
-  const price = await getTokenPrice(chain, token);
+  const price = await getTokenPrice(evmChain, token);
   return makeTokenAmount(
-    chain,
+    evmChain,
     token,
     balance as bigint,
     Number(decimals),

--- a/src/modules/balances/schemas.ts
+++ b/src/modules/balances/schemas.ts
@@ -1,16 +1,28 @@
 import { z } from "zod";
-import { SUPPORTED_CHAINS } from "../../types/index.js";
+import { ALL_CHAINS } from "../../types/index.js";
 
-const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
-const walletSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
+const chainEnum = z.enum(ALL_CHAINS as unknown as [string, ...string[]]);
+/**
+ * Either an EVM 0x address or a TRON mainnet base58 address. The handler
+ * cross-checks that the address shape matches the chain, since MCP needs
+ * the raw ZodObject here (can't use .refine at the schema root).
+ */
+const walletSchema = z.union([
+  z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
+]);
 const tokenSchema = z.union([
   z.literal("native"),
   z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
 ]);
 
 export const getTokenBalanceInput = z.object({
   wallet: walletSchema,
-  /** "native" for the chain's native coin, otherwise an ERC-20 contract address. */
+  /**
+   * "native" for the chain's native coin (ETH / MATIC / TRX). Otherwise an
+   * ERC-20 address on EVM chains or a base58 TRC-20 contract on TRON.
+   */
   token: tokenSchema,
   chain: chainEnum.default("ethereum"),
 });

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -8,6 +8,7 @@ import { getStakingPositions } from "../staking/index.js";
 import { getCompoundPositions } from "../compound/index.js";
 import { getMorphoPositions } from "../morpho/index.js";
 import { getTronBalances } from "../tron/balances.js";
+import { getTronStaking } from "../tron/staking.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
   LendingPositionUnion,
@@ -17,6 +18,7 @@ import type {
   SupportedChain,
   TokenAmount,
   TronPortfolioSlice,
+  TronStakingSlice,
 } from "../../types/index.js";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 
@@ -171,9 +173,26 @@ async function buildWalletSummary(
   // Wrap each subquery so the portfolio can distinguish failure from empty. A
   // thrown fetch becomes errored:true so callers don't mistake "Aave down" for
   // "no Aave position".
-  const errors = { aave: false, compound: false, morpho: false, lp: false, staking: false, tron: false };
-  const [nativeAmounts, erc20Amounts, aave, compound, morphoByChain, lp, staking, tronSlice] =
-    await Promise.all([
+  const errors = {
+    aave: false,
+    compound: false,
+    morpho: false,
+    lp: false,
+    staking: false,
+    tron: false,
+    tronStaking: false,
+  };
+  const [
+    nativeAmounts,
+    erc20Amounts,
+    aave,
+    compound,
+    morphoByChain,
+    lp,
+    staking,
+    tronSlice,
+    tronStakingSlice,
+  ] = await Promise.all([
       Promise.all(
         chains.map((c) =>
           fetchNativeBalance(wallet, c).catch(() => zeroNative(wallet, c))
@@ -217,6 +236,16 @@ async function buildWalletSummary(
             return null as TronPortfolioSlice | null;
           })
         : (Promise.resolve(null) as Promise<TronPortfolioSlice | null>),
+      // TRON staking is fetched in parallel with balances (separate endpoints
+      // on TronGrid — getReward + v1/accounts) and coverage-tracked
+      // independently, so a staking failure doesn't mask a successful
+      // balance read. Same "not attempted" semantics as the balance slot.
+      tronAddress
+        ? getTronStaking(tronAddress).catch(() => {
+            errors.tronStaking = true;
+            return null as TronStakingSlice | null;
+          })
+        : (Promise.resolve(null) as Promise<TronStakingSlice | null>),
     ]);
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -233,6 +262,7 @@ async function buildWalletSummary(
   ];
 
   const tronBalancesUsd = tronSlice?.walletBalancesUsd ?? 0;
+  const tronStakingUsd = tronStakingSlice?.totalStakedUsd ?? 0;
   const walletBalancesUsd = round(
     [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) + tronBalancesUsd,
     2
@@ -246,7 +276,10 @@ async function buildWalletSummary(
     staking.positions.reduce((sum, p) => sum + (p.stakedAmount.valueUsd ?? 0), 0),
     2
   );
-  const totalUsd = round(walletBalancesUsd + lendingNetUsd + lpUsd + stakingUsd, 2);
+  const totalUsd = round(
+    walletBalancesUsd + lendingNetUsd + lpUsd + stakingUsd + tronStakingUsd,
+    2
+  );
 
   // Per-chain breakdown (sums everything tagged to each chain).
   const perChain: Record<SupportedChain, number> = Object.fromEntries(
@@ -278,10 +311,33 @@ async function buildWalletSummary(
           tron: errors.tron
             ? { covered: false, errored: true, note: "TRON balance fetch failed (TronGrid) — TRX/TRC-20 not included in totals." }
             : { covered: true },
+          tronStaking: errors.tronStaking
+            ? { covered: false, errored: true, note: "TRON staking fetch failed (TronGrid getReward/accounts) — frozen + rewards not included in totals." }
+            : { covered: true },
         }
       : {}),
     unpricedAssets,
   };
+
+  // Merge balance + staking into a single TRON slice for the breakdown so
+  // consumers only see one `tron` block. If balances errored but staking
+  // succeeded (or vice versa) we still surface whichever loaded — each is
+  // independently coverage-tracked.
+  const tronBreakdown: TronPortfolioSlice | undefined =
+    tronSlice || tronStakingSlice
+      ? {
+          address: tronAddress ?? tronSlice?.address ?? tronStakingSlice?.address ?? "",
+          native: tronSlice?.native ?? [],
+          trc20: tronSlice?.trc20 ?? [],
+          walletBalancesUsd: tronSlice?.walletBalancesUsd ?? 0,
+          ...(tronStakingSlice ? { staking: tronStakingSlice } : {}),
+        }
+      : undefined;
+
+  // tronUsd rolls up balances + staking so the single-number view matches the
+  // sum a user sees in a block explorer. tronStakingUsd surfaces the staking
+  // portion separately for UI.
+  const tronUsdTotal = round(tronBalancesUsd + tronStakingUsd, 2);
 
   return {
     wallet,
@@ -292,14 +348,15 @@ async function buildWalletSummary(
     stakingUsd,
     totalUsd,
     perChain,
-    ...(tronSlice ? { tronUsd: round(tronBalancesUsd, 2) } : {}),
+    ...(tronBreakdown ? { tronUsd: tronUsdTotal } : {}),
+    ...(tronStakingSlice ? { tronStakingUsd: round(tronStakingUsd, 2) } : {}),
     breakdown: {
       native,
       erc20,
       lending: lendingPositions,
       lp: lp.positions,
       staking: staking.positions,
-      ...(tronSlice ? { tron: tronSlice } : {}),
+      ...(tronBreakdown ? { tron: tronBreakdown } : {}),
     },
     coverage,
   };

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -7,6 +7,7 @@ import { getLendingPositions, getLpPositions } from "../positions/index.js";
 import { getStakingPositions } from "../staking/index.js";
 import { getCompoundPositions } from "../compound/index.js";
 import { getMorphoPositions } from "../morpho/index.js";
+import { getTronBalances } from "../tron/balances.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
   LendingPositionUnion,
@@ -15,6 +16,7 @@ import type {
   PortfolioSummary,
   SupportedChain,
   TokenAmount,
+  TronPortfolioSlice,
 } from "../../types/index.js";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 
@@ -88,9 +90,20 @@ export async function getPortfolioSummary(
     ? [args.wallet as `0x${string}`]
     : [];
 
+  const tronAddress = args.tronAddress;
+
   // Branch: single wallet returns the flat summary; multi-wallet aggregates.
+  // TRON is only folded into the single-wallet summary — a multi-wallet view
+  // with a single TRON address would be ambiguous (which EVM wallet does it
+  // "belong to"?), so we require the caller to use single-wallet mode when
+  // pairing with a TRON address.
   if (wallets.length === 1) {
-    return buildWalletSummary(wallets[0], chains);
+    return buildWalletSummary(wallets[0], chains, tronAddress);
+  }
+  if (tronAddress) {
+    throw new Error(
+      "`tronAddress` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
+    );
   }
 
   const perWallet = await Promise.all(wallets.map((w) => buildWalletSummary(w, chains)));
@@ -145,7 +158,8 @@ function mergeCoverage(entries: { covered: boolean; errored?: boolean; note?: st
 
 async function buildWalletSummary(
   wallet: `0x${string}`,
-  chains: SupportedChain[]
+  chains: SupportedChain[],
+  tronAddress?: string
 ): Promise<PortfolioSummary> {
   // Each subquery is independent — one failing shouldn't kill the summary. We swap
   // Promise.all for per-task catchers that return empty payloads on error, so a flaky
@@ -157,8 +171,8 @@ async function buildWalletSummary(
   // Wrap each subquery so the portfolio can distinguish failure from empty. A
   // thrown fetch becomes errored:true so callers don't mistake "Aave down" for
   // "no Aave position".
-  const errors = { aave: false, compound: false, morpho: false, lp: false, staking: false };
-  const [nativeAmounts, erc20Amounts, aave, compound, morphoByChain, lp, staking] =
+  const errors = { aave: false, compound: false, morpho: false, lp: false, staking: false, tron: false };
+  const [nativeAmounts, erc20Amounts, aave, compound, morphoByChain, lp, staking, tronSlice] =
     await Promise.all([
       Promise.all(
         chains.map((c) =>
@@ -193,6 +207,16 @@ async function buildWalletSummary(
         errors.staking = true;
         return emptyPositions as never;
       }),
+      // TRON reads are only attempted when the caller passed a tronAddress.
+      // `null` means "not attempted" (coverage.tron left as
+      // covered:false,errored:false — same semantics as Morpho without
+      // marketIds pre-discovery).
+      tronAddress
+        ? getTronBalances(tronAddress).catch(() => {
+            errors.tron = true;
+            return null as TronPortfolioSlice | null;
+          })
+        : (Promise.resolve(null) as Promise<TronPortfolioSlice | null>),
     ]);
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -208,8 +232,9 @@ async function buildWalletSummary(
     ...morphoPositions,
   ];
 
+  const tronBalancesUsd = tronSlice?.walletBalancesUsd ?? 0;
   const walletBalancesUsd = round(
-    [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0),
+    [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) + tronBalancesUsd,
     2
   );
   const lendingNetUsd = round(
@@ -237,13 +262,24 @@ async function buildWalletSummary(
     perChain[c] = round(chainNative + chainErc20 + chainLending + chainLp + chainStaking, 2);
   });
 
-  const unpricedAssets = [...native, ...erc20].filter((t) => t.priceMissing).length;
+  const tronUnpriced = tronSlice
+    ? [...tronSlice.native, ...tronSlice.trc20].filter((t) => t.priceMissing).length
+    : 0;
+  const unpricedAssets =
+    [...native, ...erc20].filter((t) => t.priceMissing).length + tronUnpriced;
   const coverage: PortfolioCoverage = {
     aave: { covered: !errors.aave, ...(errors.aave ? { errored: true, note: "Aave fetch failed — positions not included in totals." } : {}) },
     compound: { covered: !errors.compound, ...(errors.compound ? { errored: true, note: "Compound V3 fetch failed — positions not included in totals." } : {}) },
     morpho: { covered: !errors.morpho, ...(errors.morpho ? { errored: true, note: "Morpho Blue event-log discovery failed on at least one chain — some positions may be missing from totals." } : {}) },
     uniswapV3: { covered: !errors.lp, ...(errors.lp ? { errored: true, note: "Uniswap V3 LP fetch failed — positions not included." } : {}) },
     staking: { covered: !errors.staking, ...(errors.staking ? { errored: true, note: "Staking (Lido/EigenLayer) fetch failed — positions not included." } : {}) },
+    ...(tronAddress
+      ? {
+          tron: errors.tron
+            ? { covered: false, errored: true, note: "TRON balance fetch failed (TronGrid) — TRX/TRC-20 not included in totals." }
+            : { covered: true },
+        }
+      : {}),
     unpricedAssets,
   };
 
@@ -256,12 +292,14 @@ async function buildWalletSummary(
     stakingUsd,
     totalUsd,
     perChain,
+    ...(tronSlice ? { tronUsd: round(tronBalancesUsd, 2) } : {}),
     breakdown: {
       native,
       erc20,
       lending: lendingPositions,
       lp: lp.positions,
       staking: staking.positions,
+      ...(tronSlice ? { tron: tronSlice } : {}),
     },
     coverage,
   };

--- a/src/modules/portfolio/schemas.ts
+++ b/src/modules/portfolio/schemas.ts
@@ -2,10 +2,16 @@ import { z } from "zod";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
 const walletSchema = z
   .string()
   .regex(/^0x[a-fA-F0-9]{40}$/)
   .describe("0x-prefixed EVM wallet address (40 hex chars).");
+
+const tronAddressSchema = z
+  .string()
+  .regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/)
+  .describe("Base58 TRON mainnet address (prefix T, 34 chars).");
 
 /**
  * Raw shape — MCP requires a bare ZodObject (no .refine) so it can expose `.shape`
@@ -29,6 +35,11 @@ export const getPortfolioSummaryInput = z.object({
     .optional()
     .describe(
       "Subset of supported chains to scan (ethereum, arbitrum, polygon, base). Omit to scan all supported chains."
+    ),
+  tronAddress: tronAddressSchema
+    .optional()
+    .describe(
+      "TRON mainnet address. When provided alongside a single `wallet`, TRX + TRC-20 balances and TRON staking are folded into the same portfolio total (`breakdown.tron`, `tronUsd`, `tronStakingUsd`). Multi-wallet mode + tronAddress is ambiguous and throws — call once per EVM wallet in that case."
     ),
 });
 

--- a/src/modules/tron/balances.ts
+++ b/src/modules/tron/balances.ts
@@ -1,0 +1,250 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import {
+  TRONGRID_BASE_URL,
+  TRX_DECIMALS,
+  TRX_SYMBOL,
+  TRON_TOKENS,
+  isTronAddress,
+} from "../../config/tron.js";
+import { resolveTronApiKey } from "../../config/user-config.js";
+import { readUserConfig } from "../../config/user-config.js";
+import type { TronBalance, TronPortfolioSlice } from "../../types/index.js";
+
+/**
+ * Decimals per canonical TRC-20. Hardcoded because the list is tiny and
+ * stable — adding a dynamic `decimals()` call per token would double the
+ * TronGrid fan-out for no practical benefit.
+ */
+const TOKEN_DECIMALS: Record<keyof typeof TRON_TOKENS, number> = {
+  USDT: 6,
+  USDC: 6,
+  USDD: 18,
+  TUSD: 18,
+};
+
+interface TrongridAccountsResponse {
+  data?: Array<{
+    balance?: number;
+    trc20?: Array<Record<string, string>>;
+  }>;
+}
+
+interface LlamaResponse {
+  coins: Record<string, { price: number }>;
+}
+
+/**
+ * Format a raw integer amount ("1234567") at the given decimals into a
+ * human-readable string ("1.234567"). Minimal re-implementation of
+ * src/data/format.ts#formatUnits to avoid pulling that file into the TRON
+ * path (it imports viem's formatUnits which is EVM-specific anyway).
+ */
+function formatUnits(amount: bigint, decimals: number): string {
+  if (decimals === 0) return amount.toString();
+  const negative = amount < 0n;
+  const abs = negative ? -amount : amount;
+  const s = abs.toString().padStart(decimals + 1, "0");
+  const whole = s.slice(0, s.length - decimals);
+  const frac = s.slice(s.length - decimals).replace(/0+$/, "");
+  const out = frac.length > 0 ? `${whole}.${frac}` : whole;
+  return negative ? `-${out}` : out;
+}
+
+async function trongridGet<T>(path: string, apiKey: string | undefined): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, { headers });
+  if (!res.ok) {
+    throw new Error(`TronGrid ${path} returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Fetch USD prices for TRX + the queried TRC-20 tokens from DefiLlama.
+ * Identified via the `tron:<base58>` key; native TRX via `coingecko:tron`.
+ * Missing prices are simply absent from the map — callers flag them via
+ * `priceMissing` on the returned balance.
+ */
+async function fetchTronPrices(tokenAddresses: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const keys: string[] = ["coingecko:tron"]; // native TRX
+  for (const addr of tokenAddresses) keys.push(`tron:${addr}`);
+
+  // Respect the same 30s cache as the EVM price path.
+  const uncached: string[] = [];
+  for (const k of keys) {
+    const hit = cache.get<number>(`price:${k}`);
+    if (hit !== undefined) out.set(k, hit);
+    else uncached.push(k);
+  }
+  if (uncached.length === 0) return out;
+
+  try {
+    const url = `https://coins.llama.fi/prices/current/${encodeURIComponent(uncached.join(","))}`;
+    const res = await fetch(url);
+    if (!res.ok) return out;
+    const body = (await res.json()) as LlamaResponse;
+    for (const k of uncached) {
+      const coin = body.coins[k];
+      if (coin && typeof coin.price === "number") {
+        out.set(k, coin.price);
+        cache.set(`price:${k}`, coin.price, CACHE_TTL.PRICE);
+      }
+    }
+  } catch {
+    // Price misses are non-fatal — the balance still renders with priceMissing:true.
+  }
+  return out;
+}
+
+/**
+ * Read TRX + canonical TRC-20 balances for a base58 TRON address via
+ * TronGrid. Returns the balances alongside a total USD figure so the portfolio
+ * aggregator can fold TRON into the single-number `totalUsd`.
+ *
+ * Throws if `address` isn't a valid mainnet base58 shape or if TronGrid's
+ * accounts endpoint errors out — the portfolio aggregator wraps the call in
+ * its standard catch-and-continue so a TronGrid outage doesn't kill the rest
+ * of the summary.
+ */
+export async function getTronBalances(address: string): Promise<TronPortfolioSlice> {
+  if (!isTronAddress(address)) {
+    throw new Error(
+      `"${address}" is not a valid TRON mainnet address (expected base58, 34 chars, prefix T).`
+    );
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const accounts = await trongridGet<TrongridAccountsResponse>(
+    `/v1/accounts/${address}`,
+    apiKey
+  );
+  const acc = accounts.data?.[0];
+  // TronGrid returns `{data: []}` for addresses with no activity — that's a
+  // valid "zero balance everywhere" state, not an error.
+  const trxSun = BigInt(acc?.balance ?? 0);
+
+  // Flatten the trc20 array of single-key maps into one map, then project
+  // onto our canonical TOKEN_DECIMALS (unknown TRC-20 balances are dropped
+  // because we have no decimals/price reference for them).
+  const trc20Map = new Map<string, bigint>();
+  for (const entry of acc?.trc20 ?? []) {
+    for (const [contract, amount] of Object.entries(entry)) {
+      trc20Map.set(contract, BigInt(amount));
+    }
+  }
+
+  const priceAddrs = Object.values(TRON_TOKENS);
+  const prices = await fetchTronPrices(priceAddrs);
+
+  const trxPrice = prices.get("coingecko:tron");
+  const trxFormatted = formatUnits(trxSun, TRX_DECIMALS);
+  const trxValueUsd =
+    trxPrice !== undefined ? Number(trxFormatted) * trxPrice : undefined;
+
+  const nativeBalance: TronBalance = {
+    chain: "tron",
+    token: "native",
+    symbol: TRX_SYMBOL,
+    decimals: TRX_DECIMALS,
+    amount: trxSun.toString(),
+    formatted: trxFormatted,
+    ...(trxPrice !== undefined ? { priceUsd: trxPrice } : {}),
+    ...(trxValueUsd !== undefined ? { valueUsd: trxValueUsd } : {}),
+    ...(trxPrice === undefined ? { priceMissing: true } : {}),
+  };
+
+  const trc20: TronBalance[] = [];
+  for (const [symbol, contract] of Object.entries(TRON_TOKENS) as [
+    keyof typeof TRON_TOKENS,
+    string,
+  ][]) {
+    const raw = trc20Map.get(contract) ?? 0n;
+    if (raw === 0n) continue;
+    const decimals = TOKEN_DECIMALS[symbol];
+    const formatted = formatUnits(raw, decimals);
+    const price = prices.get(`tron:${contract}`);
+    const valueUsd = price !== undefined ? Number(formatted) * price : undefined;
+    trc20.push({
+      chain: "tron",
+      token: contract,
+      symbol,
+      decimals,
+      amount: raw.toString(),
+      formatted,
+      ...(price !== undefined ? { priceUsd: price } : {}),
+      ...(valueUsd !== undefined ? { valueUsd } : {}),
+      ...(price === undefined ? { priceMissing: true } : {}),
+    });
+  }
+
+  const walletBalancesUsd =
+    (nativeBalance.valueUsd ?? 0) +
+    trc20.reduce((s, t) => s + (t.valueUsd ?? 0), 0);
+
+  // Only include native in the `native` array when non-zero, matching the
+  // EVM portfolio convention.
+  const native = trxSun > 0n ? [nativeBalance] : [];
+
+  return {
+    address,
+    native,
+    trc20,
+    walletBalancesUsd: Math.round(walletBalancesUsd * 100) / 100,
+  };
+}
+
+/**
+ * Fetch a single TRC-20 or TRX balance by token. Mirrors the shape of
+ * get_token_balance for EVM chains. `token` can be "native" for TRX, or a
+ * base58 TRC-20 contract address.
+ */
+export async function getTronTokenBalance(
+  wallet: string,
+  token: string
+): Promise<TronBalance> {
+  if (!isTronAddress(wallet)) {
+    throw new Error(
+      `"${wallet}" is not a valid TRON mainnet address (expected base58, 34 chars, prefix T).`
+    );
+  }
+
+  const slice = await getTronBalances(wallet);
+  if (token === "native") {
+    // getTronBalances drops zero-balance native from the array, so rebuild
+    // the zero case here for the single-token API.
+    if (slice.native.length > 0) return slice.native[0];
+    return {
+      chain: "tron",
+      token: "native",
+      symbol: TRX_SYMBOL,
+      decimals: TRX_DECIMALS,
+      amount: "0",
+      formatted: "0",
+    };
+  }
+
+  if (!isTronAddress(token)) {
+    throw new Error(
+      `"${token}" is not a valid TRC-20 contract address (expected base58).`
+    );
+  }
+  const found = slice.trc20.find((t) => t.token === token);
+  if (found) return found;
+  // Unknown/zero TRC-20: return a minimal zero balance with unknown decimals.
+  // Phase 1 scope: we don't do a separate `decimals()` read for arbitrary
+  // TRC-20s — callers asking about tokens we don't enumerate get the shape
+  // they expect but with decimals:0. Full decimals resolution can land with
+  // the write path in Phase 2.
+  return {
+    chain: "tron",
+    token,
+    symbol: "UNKNOWN",
+    decimals: 0,
+    amount: "0",
+    formatted: "0",
+    priceMissing: true,
+  };
+}

--- a/src/modules/tron/schemas.ts
+++ b/src/modules/tron/schemas.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+const tronAddress = z
+  .string()
+  .regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/, "expected base58 TRON mainnet address (prefix T, 34 chars)");
+
+export const getTronStakingInput = z.object({
+  address: tronAddress.describe(
+    "Base58 TRON mainnet address (prefix T) — the wallet to read staking state for."
+  ),
+});
+
+export type GetTronStakingArgs = z.infer<typeof getTronStakingInput>;

--- a/src/modules/tron/staking.ts
+++ b/src/modules/tron/staking.ts
@@ -1,0 +1,196 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import { TRONGRID_BASE_URL, TRX_DECIMALS, isTronAddress } from "../../config/tron.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import type {
+  TronClaimableReward,
+  TronFrozenEntry,
+  TronPendingUnfreeze,
+  TronStakingSlice,
+} from "../../types/index.js";
+
+/**
+ * Format raw SUN ("12345678") into a human TRX string ("12.345678"). Mirrors
+ * the formatter in balances.ts — kept local so the file stands alone.
+ */
+function formatTrx(sun: bigint): string {
+  const s = sun.toString().padStart(TRX_DECIMALS + 1, "0");
+  const whole = s.slice(0, s.length - TRX_DECIMALS);
+  const frac = s.slice(s.length - TRX_DECIMALS).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+interface TrongridV1Account {
+  address?: string;
+  /**
+   * Stake 2.0 frozen entries. TronGrid returns these in the account payload
+   * — `frozenV2` is the current-format field; legacy `frozen` is only used
+   * pre-Stake-2.0 and isn't surfaced here.
+   */
+  frozenV2?: Array<{ amount?: number; type?: "BANDWIDTH" | "ENERGY" }>;
+  /** Pending unfreezes — TRX locked for the 14-day unbonding window. */
+  unfrozenV2?: Array<{
+    unfreeze_amount?: number;
+    type?: "BANDWIDTH" | "ENERGY";
+    unfreeze_expire_time?: number;
+  }>;
+}
+
+interface TrongridV1AccountResponse {
+  data?: TrongridV1Account[];
+}
+
+interface TrongridRewardResponse {
+  reward?: number;
+}
+
+interface LlamaResponse {
+  coins: Record<string, { price: number }>;
+}
+
+async function fetchTrxPrice(): Promise<number | undefined> {
+  const key = "price:coingecko:tron";
+  const hit = cache.get<number>(key);
+  if (hit !== undefined) return hit;
+  try {
+    const res = await fetch("https://coins.llama.fi/prices/current/coingecko:tron");
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as LlamaResponse;
+    const price = body.coins["coingecko:tron"]?.price;
+    if (typeof price === "number") {
+      cache.set(key, price, CACHE_TTL.PRICE);
+      return price;
+    }
+  } catch {
+    // Price misses are non-fatal — caller still returns raw amounts.
+  }
+  return undefined;
+}
+
+async function trongridGet<T>(path: string, apiKey: string | undefined): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, { headers });
+  if (!res.ok) {
+    throw new Error(`TronGrid ${path} returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function trongridPost<T>(
+  path: string,
+  body: Record<string, unknown>,
+  apiKey: string | undefined
+): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`TronGrid ${path} returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Read TRON staking state for `address`:
+ *   - claimable voting rewards (`/wallet/getReward`)
+ *   - frozen TRX under Stake 2.0 (bandwidth + energy, from the v1 account payload)
+ *   - pending unfreezes with their unlock timestamps
+ *
+ * Throws if `address` isn't a valid TRON mainnet shape. Individual TronGrid
+ * failures propagate — the portfolio aggregator wraps the call in its
+ * catch-and-continue pattern so a staking outage doesn't kill balance reads.
+ *
+ * Rewards and account data are fetched in parallel. The account `/v1/accounts`
+ * endpoint is the same one balances.ts uses, but we don't share the call here:
+ * the two readers can be invoked independently (via the dedicated
+ * `get_tron_staking` tool) and the portfolio fan-out runs them concurrently.
+ */
+export async function getTronStaking(address: string): Promise<TronStakingSlice> {
+  if (!isTronAddress(address)) {
+    throw new Error(
+      `"${address}" is not a valid TRON mainnet address (expected base58, 34 chars, prefix T).`
+    );
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+
+  const [accountRes, rewardRes, trxPrice] = await Promise.all([
+    trongridGet<TrongridV1AccountResponse>(`/v1/accounts/${address}`, apiKey),
+    trongridPost<TrongridRewardResponse>(
+      "/wallet/getReward",
+      { address, visible: true },
+      apiKey
+    ),
+    fetchTrxPrice(),
+  ]);
+
+  const acc = accountRes.data?.[0];
+  const rewardSun = BigInt(rewardRes.reward ?? 0);
+
+  const frozen: TronFrozenEntry[] = [];
+  for (const entry of acc?.frozenV2 ?? []) {
+    const amount = BigInt(entry.amount ?? 0);
+    if (amount === 0n) continue;
+    const type = entry.type === "ENERGY" ? "energy" : "bandwidth";
+    const formatted = formatTrx(amount);
+    const valueUsd =
+      trxPrice !== undefined ? Number(formatted) * trxPrice : undefined;
+    frozen.push({
+      type,
+      amount: amount.toString(),
+      formatted,
+      ...(valueUsd !== undefined ? { valueUsd } : {}),
+    });
+  }
+
+  const pendingUnfreezes: TronPendingUnfreeze[] = [];
+  for (const entry of acc?.unfrozenV2 ?? []) {
+    const amount = BigInt(entry.unfreeze_amount ?? 0);
+    if (amount === 0n) continue;
+    const type = entry.type === "ENERGY" ? "energy" : "bandwidth";
+    const unlockMs = entry.unfreeze_expire_time ?? 0;
+    const formatted = formatTrx(amount);
+    const valueUsd =
+      trxPrice !== undefined ? Number(formatted) * trxPrice : undefined;
+    pendingUnfreezes.push({
+      type,
+      amount: amount.toString(),
+      formatted,
+      unlockAt: new Date(unlockMs).toISOString(),
+      ...(valueUsd !== undefined ? { valueUsd } : {}),
+    });
+  }
+
+  const rewardFormatted = formatTrx(rewardSun);
+  const rewardUsd =
+    trxPrice !== undefined ? Number(rewardFormatted) * trxPrice : undefined;
+  const claimableRewards: TronClaimableReward = {
+    amount: rewardSun.toString(),
+    formatted: rewardFormatted,
+    ...(rewardUsd !== undefined ? { valueUsd: rewardUsd } : {}),
+  };
+
+  const totalSun =
+    frozen.reduce((s, f) => s + BigInt(f.amount), 0n) +
+    pendingUnfreezes.reduce((s, u) => s + BigInt(u.amount), 0n) +
+    rewardSun;
+  const totalStakedTrx = formatTrx(totalSun);
+  const totalStakedUsd =
+    trxPrice !== undefined
+      ? Math.round(Number(totalStakedTrx) * trxPrice * 100) / 100
+      : 0;
+
+  return {
+    address,
+    claimableRewards,
+    frozen,
+    pendingUnfreezes,
+    totalStakedTrx,
+    totalStakedUsd,
+  };
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -171,6 +171,40 @@ async function configureOneInch(p: Prompt): Promise<string | undefined> {
   return answer || undefined;
 }
 
+async function validateTronApiKey(apiKey: string): Promise<void> {
+  // USDT-TRC20 address — well-known, always returns 200 on a healthy grid.
+  const url = "https://api.trongrid.io/v1/accounts/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+  const res = await fetch(url, { headers: { "TRON-PRO-API-KEY": apiKey } });
+  if (!res.ok) {
+    throw new Error(`TronGrid returned ${res.status} ${res.statusText}`);
+  }
+}
+
+async function configureTron(p: Prompt): Promise<string | undefined> {
+  console.log("\n--- TRON (optional — enables TRX + TRC-20 balance reads) ---");
+  console.log("TRON is non-EVM: no Aave/Compound/Uniswap there, but TRC-20 USDT");
+  console.log("dominates the chain and is worth folding into your portfolio total.");
+  console.log("Create a free key at https://www.trongrid.io (Dashboard → API Keys).");
+  console.log("Skip with empty input — TRON reads will be disabled.");
+  const existing = readUserConfig()?.tronApiKey;
+  const answer = await p.ask(
+    existing
+      ? "TronGrid API key [press enter to keep existing]: "
+      : "TronGrid API key (or blank to skip): "
+  );
+  const apiKey = answer || existing;
+  if (!apiKey) return undefined;
+
+  try {
+    await validateTronApiKey(apiKey);
+    console.log("  TronGrid API key OK.");
+  } catch (e) {
+    console.warn(`  Warning: could not validate TronGrid key — ${(e as Error).message}`);
+    console.warn("  Saving anyway; TRON reads will surface the error at query time.");
+  }
+  return apiKey;
+}
+
 async function configureWalletConnect(p: Prompt): Promise<string | undefined> {
   console.log("\n--- WalletConnect (optional — required for Ledger Live signing) ---");
   console.log("Create a free project at https://cloud.walletconnect.com.");
@@ -263,6 +297,11 @@ async function main() {
     const oneInchApiKey = await configureOneInch(p);
     if (oneInchApiKey !== undefined) {
       patchUserConfig({ oneInchApiKey });
+    }
+
+    const tronApiKey = await configureTron(p);
+    if (tronApiKey !== undefined) {
+      patchUserConfig({ tronApiKey });
     }
 
     const wcProjectId = await configureWalletConnect(p);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,16 @@
 // Shared domain types used across all modules.
 
+/**
+ * EVM chains supported by the server. Intentionally kept narrow so every
+ * `Record<SupportedChain, …>` table in the codebase continues to represent
+ * "per-EVM-chain" configuration — viem clients, Aave/Compound/Uniswap
+ * addresses, numeric chain IDs, etc.
+ *
+ * Non-EVM chains (currently only TRON) live in `SupportedNonEvmChain`, and
+ * the `AnyChain` union below is what cross-chain entry points (tool inputs,
+ * portfolio summary) accept. This split keeps TRON strictly additive: EVM
+ * internals don't need to learn that TRON exists.
+ */
 export type SupportedChain = "ethereum" | "arbitrum" | "polygon" | "base";
 
 export const SUPPORTED_CHAINS: readonly SupportedChain[] = [
@@ -8,6 +19,23 @@ export const SUPPORTED_CHAINS: readonly SupportedChain[] = [
   "polygon",
   "base",
 ] as const;
+
+/** Non-EVM chains. Kept as its own union so EVM-only tables keep their type. */
+export type SupportedNonEvmChain = "tron";
+
+export const SUPPORTED_NON_EVM_CHAINS: readonly SupportedNonEvmChain[] = ["tron"] as const;
+
+/** Any chain the server knows about — EVM or non-EVM. */
+export type AnyChain = SupportedChain | SupportedNonEvmChain;
+
+export const ALL_CHAINS: readonly AnyChain[] = [
+  ...SUPPORTED_CHAINS,
+  ...SUPPORTED_NON_EVM_CHAINS,
+] as const;
+
+export function isEvmChain(c: AnyChain): c is SupportedChain {
+  return (SUPPORTED_CHAINS as readonly string[]).includes(c);
+}
 
 export type RpcProvider = "infura" | "alchemy" | "custom";
 
@@ -25,6 +53,13 @@ export const CHAIN_ID_TO_NAME: Record<number, SupportedChain> = {
   137: "polygon",
   8453: "base",
 };
+
+/**
+ * TRON mainnet chain id, as used by the WalletConnect `tron:` namespace and
+ * the TronGrid mainnet endpoint. The numeric value is 0x2b6653dc (728126428),
+ * the first 4 bytes of the genesis block hash.
+ */
+export const TRON_CHAIN_ID = 728126428;
 
 /** A token balance with optional USD valuation. */
 export interface TokenAmount {
@@ -66,6 +101,12 @@ export interface PortfolioCoverage {
   morpho: CoverageStatus;
   uniswapV3: CoverageStatus;
   staking: CoverageStatus;
+  /**
+   * TRON balance fetch coverage. `covered:false, errored:false` means no TRON
+   * address was queried (treated like Morpho's "not attempted"); errored:true
+   * means a TronGrid call failed and TRX/TRC-20 are missing from totals.
+   */
+  tron?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
 }
@@ -196,6 +237,41 @@ export interface SecurityReport {
   privilegedRoles: PrivilegedRole[];
 }
 
+/**
+ * A TRON token balance. Shaped like TokenAmount but with a base58 `token`
+ * address (TRC-20 contracts are base58, starting with 'T') and a `chain`
+ * discriminator so consumers can tell TRC-20 apart from ERC-20 at runtime.
+ * Kept separate from TokenAmount so existing EVM readers don't grow a
+ * `chain: "tron"` branch they'd never exercise.
+ */
+export interface TronBalance {
+  chain: "tron";
+  /** Base58 TRC-20 contract address (prefix `T`), or "native" for TRX. */
+  token: string;
+  symbol: string;
+  decimals: number;
+  amount: string;
+  formatted: string;
+  valueUsd?: number;
+  priceUsd?: number;
+  priceMissing?: boolean;
+}
+
+/**
+ * TRON slice of a portfolio summary. Contains the TRON-specific address the
+ * balances were fetched for (base58, which can't fit into the `wallet:
+ * 0x${string}` field on PortfolioSummary), TRX native balance, and TRC-20
+ * balances. Wallet-level coverage for TRON is tracked via
+ * PortfolioCoverage.tron.
+ */
+export interface TronPortfolioSlice {
+  /** Base58 TRON address the balances were resolved for. */
+  address: string;
+  native: TronBalance[];
+  trc20: TronBalance[];
+  walletBalancesUsd: number;
+}
+
 /** Per-wallet slice of a multi-wallet portfolio, or a stand-alone single-wallet summary. */
 export interface PortfolioSummary {
   wallet: `0x${string}`;
@@ -206,12 +282,20 @@ export interface PortfolioSummary {
   stakingUsd: number;
   totalUsd: number;
   perChain: Record<SupportedChain, number>;
+  /**
+   * TRON totals folded into the same number as EVM. Present when the caller
+   * passed a `tronAddress` (or TRON is in the default chain set and an
+   * address was resolvable).
+   */
+  tronUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];
     lending: LendingPositionUnion[];
     lp: LPPosition[];
     staking: StakingPosition[];
+    /** TRON slice — absent when no TRON address was queried. */
+    tron?: TronPortfolioSlice;
   };
   coverage: PortfolioCoverage;
 }
@@ -282,6 +366,12 @@ export interface UserConfig {
   etherscanApiKey?: string;
   /** Optional 1inch Developer Portal API key for intra-chain swap-quote comparison. */
   oneInchApiKey?: string;
+  /**
+   * TronGrid API key (`TRON-PRO-API-KEY` header). Required to read TRX and
+   * TRC-20 balances on the `tron` chain — TronGrid rate-limits unauthenticated
+   * calls to ~15 req/min, which is too tight for portfolio fan-out.
+   */
+  tronApiKey?: string;
   walletConnect?: {
     projectId?: string;
     /** Topic of the active WC session (so we can resume after restart). */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,6 +107,11 @@ export interface PortfolioCoverage {
    * means a TronGrid call failed and TRX/TRC-20 are missing from totals.
    */
   tron?: CoverageStatus;
+  /**
+   * TRON staking fetch coverage — independent of the balance fetch so a
+   * getReward/account outage doesn't mask that balances loaded fine.
+   */
+  tronStaking?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
 }
@@ -270,6 +275,65 @@ export interface TronPortfolioSlice {
   native: TronBalance[];
   trc20: TronBalance[];
   walletBalancesUsd: number;
+  /**
+   * Staking position (frozen TRX, pending unfreezes, claimable rewards).
+   * Absent when the portfolio aggregator chose not to fetch staking (or
+   * when the TRON staking fetch failed — see PortfolioCoverage.tronStaking).
+   */
+  staking?: TronStakingSlice;
+}
+
+/**
+ * A single "frozen for resource" entry under TRON's Stake 2.0 model. Users
+ * freeze TRX to obtain BANDWIDTH or ENERGY; the frozen TRX is what underlies
+ * their voting rights. Amount is reported in SUN (raw) + TRX (formatted).
+ */
+export interface TronFrozenEntry {
+  type: "bandwidth" | "energy";
+  /** Raw SUN (1 TRX = 1_000_000 SUN). */
+  amount: string;
+  /** Human-formatted TRX. */
+  formatted: string;
+  valueUsd?: number;
+}
+
+/**
+ * A pending unfreeze — the user initiated unstaking but the lockup window
+ * (14 days on mainnet) hasn't elapsed yet. `unlockAt` is the ISO timestamp
+ * after which `withdrawExpireUnfreeze` can claim the TRX back to liquid.
+ */
+export interface TronPendingUnfreeze {
+  type: "bandwidth" | "energy";
+  amount: string;
+  formatted: string;
+  /** ISO 8601 timestamp when the TRX becomes withdrawable. */
+  unlockAt: string;
+  valueUsd?: number;
+}
+
+/**
+ * Claimable voting rewards (distributed by the Super Representative the user
+ * voted for). Claiming requires a WithdrawBalance tx, landing in Phase 2.
+ */
+export interface TronClaimableReward {
+  amount: string;
+  formatted: string;
+  valueUsd?: number;
+}
+
+/**
+ * TRON staking view: frozen resources, pending unfreezes, claimable rewards.
+ * Totals roll up into the portfolio's `tronUsd` via `totalStakedUsd`.
+ */
+export interface TronStakingSlice {
+  address: string;
+  claimableRewards: TronClaimableReward;
+  frozen: TronFrozenEntry[];
+  pendingUnfreezes: TronPendingUnfreeze[];
+  /** Frozen + pending-unfreeze + claimable, in TRX (formatted). */
+  totalStakedTrx: string;
+  /** USD value of everything above at current TRX price. */
+  totalStakedUsd: number;
 }
 
 /** Per-wallet slice of a multi-wallet portfolio, or a stand-alone single-wallet summary. */
@@ -288,6 +352,12 @@ export interface PortfolioSummary {
    * address was resolvable).
    */
   tronUsd?: number;
+  /**
+   * TRON staking USD (frozen + pending-unfreeze + claimable). Already included
+   * in `tronUsd` — this field surfaces it separately for UI. Present only when
+   * staking was fetched successfully.
+   */
+  tronStakingUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];

--- a/test/tron-support.test.ts
+++ b/test/tron-support.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ALL_CHAINS,
+  SUPPORTED_CHAINS,
+  SUPPORTED_NON_EVM_CHAINS,
+  TRON_CHAIN_ID,
+  isEvmChain,
+  type AnyChain,
+} from "../src/types/index.js";
+import {
+  TRONGRID_BASE_URL,
+  TRON_TOKENS,
+  TRX_DECIMALS,
+  TRX_SYMBOL,
+  isTronAddress,
+} from "../src/config/tron.js";
+import { resolveTronApiKey } from "../src/config/user-config.js";
+import { getTronBalances, getTronTokenBalance } from "../src/modules/tron/balances.js";
+import { getTokenBalance } from "../src/modules/balances/index.js";
+import { getPortfolioSummaryInput } from "../src/modules/portfolio/schemas.js";
+
+/**
+ * These tests lock down TRON as strictly additive: EVM chain tables stay
+ * untouched, non-EVM lives in its own union, and `AnyChain` is the cross-chain
+ * entry-point type. Network IO (TronGrid, DefiLlama) is stubbed via vi.stubGlobal
+ * on fetch — the tests assert the request/response shape, not the live grid.
+ */
+
+describe("TRON chain registration", () => {
+  it("is NOT listed in SUPPORTED_CHAINS (EVM-only union stays narrow)", () => {
+    // The whole point of keeping SUPPORTED_CHAINS EVM-only is so every
+    // Record<SupportedChain, …> table (viem clients, Aave addresses, etc.)
+    // doesn't accidentally grow a TRON entry it can't honour.
+    expect(SUPPORTED_CHAINS).not.toContain("tron");
+  });
+
+  it("is listed in SUPPORTED_NON_EVM_CHAINS", () => {
+    expect(SUPPORTED_NON_EVM_CHAINS).toContain("tron");
+  });
+
+  it("is listed in ALL_CHAINS", () => {
+    expect(ALL_CHAINS).toContain("tron");
+    // And every EVM chain is still there — ALL_CHAINS is the superset.
+    for (const c of SUPPORTED_CHAINS) {
+      expect(ALL_CHAINS).toContain(c);
+    }
+  });
+
+  it("exposes the canonical TRON mainnet chain id (0x2b6653dc)", () => {
+    expect(TRON_CHAIN_ID).toBe(728126428);
+    expect(TRON_CHAIN_ID.toString(16)).toBe("2b6653dc");
+  });
+});
+
+describe("isEvmChain predicate", () => {
+  it("narrows EVM chains to SupportedChain", () => {
+    for (const c of SUPPORTED_CHAINS) {
+      expect(isEvmChain(c)).toBe(true);
+    }
+  });
+
+  it("returns false for tron", () => {
+    const c: AnyChain = "tron";
+    expect(isEvmChain(c)).toBe(false);
+  });
+});
+
+describe("isTronAddress", () => {
+  it("accepts a 34-char base58 mainnet address (prefix T)", () => {
+    // USDT-TRC20 contract — canonical well-known TRON address.
+    expect(isTronAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t")).toBe(true);
+  });
+
+  it("rejects 0x EVM addresses", () => {
+    expect(isTronAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")).toBe(false);
+  });
+
+  it("rejects wrong length", () => {
+    expect(isTronAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6")).toBe(false); // 33 chars
+    expect(isTronAddress("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6tX")).toBe(false); // 35 chars
+    expect(isTronAddress("")).toBe(false);
+  });
+
+  it("rejects non-T prefix", () => {
+    // Base58 starts from all valid chars but TRON mainnet uses version byte 0x41 → 'T'.
+    expect(isTronAddress("SR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t")).toBe(false);
+  });
+
+  it("rejects base58-invalid characters (0, O, I, l)", () => {
+    // Character at index 1 is '0' which isn't in base58.
+    expect(isTronAddress("T0" + "a".repeat(32))).toBe(false);
+  });
+});
+
+describe("TRON_TOKENS canonical registry", () => {
+  it("contains USDT (USDT-TRC20 dominates TRON token volume)", () => {
+    expect(TRON_TOKENS.USDT).toBe("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t");
+  });
+
+  it("every canonical address parses as a valid TRON address", () => {
+    for (const [symbol, addr] of Object.entries(TRON_TOKENS)) {
+      expect(isTronAddress(addr), `TRON_TOKENS.${symbol}`).toBe(true);
+    }
+  });
+
+  it("TRX native uses 6 decimals (1 TRX = 1_000_000 sun)", () => {
+    expect(TRX_DECIMALS).toBe(6);
+    expect(TRX_SYMBOL).toBe("TRX");
+  });
+
+  it("TronGrid base URL is set", () => {
+    expect(TRONGRID_BASE_URL).toBe("https://api.trongrid.io");
+  });
+});
+
+describe("resolveTronApiKey", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.TRON_API_KEY;
+    delete process.env.TRON_API_KEY;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.TRON_API_KEY;
+    else process.env.TRON_API_KEY = saved;
+  });
+
+  it("env TRON_API_KEY wins over user config", () => {
+    process.env.TRON_API_KEY = "env-key";
+    expect(resolveTronApiKey({ rpc: { provider: "custom" }, tronApiKey: "cfg-key" })).toBe(
+      "env-key"
+    );
+  });
+
+  it("falls back to user config when env unset", () => {
+    expect(resolveTronApiKey({ rpc: { provider: "custom" }, tronApiKey: "cfg-key" })).toBe(
+      "cfg-key"
+    );
+  });
+
+  it("returns undefined when neither is set", () => {
+    expect(resolveTronApiKey(null)).toBeUndefined();
+    expect(resolveTronApiKey({ rpc: { provider: "custom" } })).toBeUndefined();
+  });
+});
+
+describe("get_token_balance input schema accepts TRON", () => {
+  // Re-import the schema only here so the zod validation runs against the
+  // currently-built module.
+  it("accepts chain=tron + base58 wallet + native token", async () => {
+    const { getTokenBalanceInput } = await import(
+      "../src/modules/balances/schemas.js"
+    );
+    const parsed = getTokenBalanceInput.parse({
+      chain: "tron",
+      wallet: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      token: "native",
+    });
+    expect(parsed.chain).toBe("tron");
+  });
+
+  it("accepts chain=tron + base58 wallet + base58 TRC-20 token", async () => {
+    const { getTokenBalanceInput } = await import(
+      "../src/modules/balances/schemas.js"
+    );
+    const parsed = getTokenBalanceInput.parse({
+      chain: "tron",
+      wallet: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      token: TRON_TOKENS.USDT,
+    });
+    expect(parsed.token).toBe(TRON_TOKENS.USDT);
+  });
+
+  it("still accepts ethereum + 0x wallet + 0x token (no regression)", async () => {
+    const { getTokenBalanceInput } = await import(
+      "../src/modules/balances/schemas.js"
+    );
+    const parsed = getTokenBalanceInput.parse({
+      chain: "ethereum",
+      wallet: "0x742d35Cc6634C0532925a3b844Bc9e7595f0BEb7",
+      token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    });
+    expect(parsed.chain).toBe("ethereum");
+  });
+});
+
+describe("get_portfolio_summary schema accepts tronAddress", () => {
+  it("accepts an optional tronAddress alongside an EVM wallet", () => {
+    const parsed = getPortfolioSummaryInput.parse({
+      wallet: "0x742d35Cc6634C0532925a3b844Bc9e7595f0BEb7",
+      tronAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+    });
+    expect(parsed.tronAddress).toBe("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t");
+  });
+
+  it("rejects a malformed tronAddress (not base58 prefix T)", () => {
+    expect(() =>
+      getPortfolioSummaryInput.parse({
+        wallet: "0x742d35Cc6634C0532925a3b844Bc9e7595f0BEb7",
+        tronAddress: "0xdeadbeef",
+      })
+    ).toThrow();
+  });
+});
+
+describe("getTronBalances (network stubbed)", () => {
+  const addr = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                balance: 12_345_678, // 12.345678 TRX
+                trc20: [
+                  { [TRON_TOKENS.USDT]: "5000000" }, // 5 USDT (6 decimals)
+                ],
+              },
+            ],
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.startsWith("https://coins.llama.fi/prices/current/")) {
+        return new Response(
+          JSON.stringify({
+            coins: {
+              "coingecko:tron": { price: 0.1 },
+              [`tron:${TRON_TOKENS.USDT}`]: { price: 1 },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns TRX + USDT balances at correct decimals with USD values", async () => {
+    const slice = await getTronBalances(addr);
+    expect(slice.address).toBe(addr);
+    expect(slice.native).toHaveLength(1);
+    expect(slice.native[0].symbol).toBe("TRX");
+    expect(slice.native[0].formatted).toBe("12.345678");
+    expect(slice.native[0].valueUsd).toBeCloseTo(12.345678 * 0.1, 4);
+
+    const usdt = slice.trc20.find((t) => t.symbol === "USDT");
+    expect(usdt).toBeDefined();
+    expect(usdt!.formatted).toBe("5");
+    expect(usdt!.valueUsd).toBeCloseTo(5, 4);
+    expect(usdt!.token).toBe(TRON_TOKENS.USDT);
+
+    // Aggregate wallet total should be ≈ 5 + 1.2345678 = 6.2345678 USD.
+    expect(slice.walletBalancesUsd).toBeCloseTo(6.23, 2);
+  });
+
+  it("throws on non-TRON wallet address", async () => {
+    await expect(getTronBalances("0xdeadbeef")).rejects.toThrow(/TRON mainnet address/);
+  });
+
+  it("returns a zero TRX balance object on an inactive TRON address", async () => {
+    // TronGrid returns `{data: []}` for addresses with no activity.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://api.trongrid.io/")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ coins: {} }), { status: 200 });
+    });
+    const slice = await getTronBalances(addr);
+    expect(slice.native).toHaveLength(0); // zero native filtered out
+    expect(slice.trc20).toHaveLength(0);
+    expect(slice.walletBalancesUsd).toBe(0);
+  });
+});
+
+describe("getTronTokenBalance (network stubbed)", () => {
+  const addr = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  balance: 0,
+                  trc20: [{ [TRON_TOKENS.USDT]: "42000000" }], // 42 USDT
+                },
+              ],
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            coins: { [`tron:${TRON_TOKENS.USDT}`]: { price: 1 } },
+          }),
+          { status: 200 }
+        );
+      })
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns USDT balance when queried by TRC-20 address", async () => {
+    const b = await getTronTokenBalance(addr, TRON_TOKENS.USDT);
+    expect(b.symbol).toBe("USDT");
+    expect(b.formatted).toBe("42");
+  });
+
+  it("returns zero TRX balance when native has no activity", async () => {
+    const b = await getTronTokenBalance(addr, "native");
+    expect(b.symbol).toBe("TRX");
+    expect(b.amount).toBe("0");
+  });
+
+  it("refuses malformed wallet", async () => {
+    await expect(getTronTokenBalance("0xbadwallet", "native")).rejects.toThrow();
+  });
+});
+
+describe("get_token_balance dispatches TRON to the TRON reader", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ balance: 1_000_000, trc20: [] }], // 1 TRX
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(
+          JSON.stringify({ coins: { "coingecko:tron": { price: 0.1 } } }),
+          { status: 200 }
+        );
+      })
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a TronBalance shape (chain:'tron', base58 token) when chain=tron", async () => {
+    const res = await getTokenBalance({
+      chain: "tron",
+      wallet: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      token: "native",
+    });
+    // TronBalance has chain:"tron" and token as string (base58 or "native");
+    // TokenAmount never carries a `chain` field, so this distinguishes them.
+    expect((res as { chain?: string }).chain).toBe("tron");
+    expect(res.symbol).toBe("TRX");
+    expect(res.formatted).toBe("1");
+  });
+});

--- a/test/tron-support.test.ts
+++ b/test/tron-support.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/config/tron.js";
 import { resolveTronApiKey } from "../src/config/user-config.js";
 import { getTronBalances, getTronTokenBalance } from "../src/modules/tron/balances.js";
+import { getTronStaking } from "../src/modules/tron/staking.js";
 import { getTokenBalance } from "../src/modules/balances/index.js";
 import { getPortfolioSummaryInput } from "../src/modules/portfolio/schemas.js";
 
@@ -364,5 +365,102 @@ describe("get_token_balance dispatches TRON to the TRON reader", () => {
     expect((res as { chain?: string }).chain).toBe("tron");
     expect(res.symbol).toBe("TRX");
     expect(res.formatted).toBe("1");
+  });
+});
+
+describe("getTronStaking (network stubbed)", () => {
+  const addr = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  frozenV2: [
+                    { amount: 100_000_000, type: "BANDWIDTH" }, // 100 TRX frozen for bandwidth
+                    { amount: 50_000_000, type: "ENERGY" }, // 50 TRX frozen for energy
+                  ],
+                  unfrozenV2: [
+                    {
+                      unfreeze_amount: 25_000_000, // 25 TRX pending
+                      type: "BANDWIDTH",
+                      unfreeze_expire_time: 1_800_000_000_000, // some future ms
+                    },
+                  ],
+                },
+              ],
+            }),
+            { status: 200 }
+          );
+        }
+        if (url === "https://api.trongrid.io/wallet/getReward") {
+          // Sanity-check body shape: the post body must include the base58 address.
+          expect(init?.method).toBe("POST");
+          return new Response(JSON.stringify({ reward: 1_500_000 }), { status: 200 }); // 1.5 TRX claimable
+        }
+        if (url.startsWith("https://coins.llama.fi/prices/current/")) {
+          return new Response(
+            JSON.stringify({ coins: { "coingecko:tron": { price: 0.1 } } }),
+            { status: 200 }
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      })
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns frozen + pending + claimable with USD, at 6-decimal TRX", async () => {
+    const s = await getTronStaking(addr);
+    expect(s.address).toBe(addr);
+
+    expect(s.frozen).toHaveLength(2);
+    const bw = s.frozen.find((f) => f.type === "bandwidth")!;
+    expect(bw.formatted).toBe("100");
+    expect(bw.valueUsd).toBeCloseTo(10, 4); // 100 * 0.1
+    const en = s.frozen.find((f) => f.type === "energy")!;
+    expect(en.formatted).toBe("50");
+    expect(en.valueUsd).toBeCloseTo(5, 4);
+
+    expect(s.pendingUnfreezes).toHaveLength(1);
+    expect(s.pendingUnfreezes[0].formatted).toBe("25");
+    expect(s.pendingUnfreezes[0].unlockAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    expect(s.claimableRewards.formatted).toBe("1.5");
+    expect(s.claimableRewards.valueUsd).toBeCloseTo(0.15, 4);
+
+    // 100 + 50 + 25 + 1.5 = 176.5 TRX → 17.65 USD
+    expect(s.totalStakedTrx).toBe("176.5");
+    expect(s.totalStakedUsd).toBeCloseTo(17.65, 2);
+  });
+
+  it("returns zero staking for an inactive address (no frozenV2, no reward)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        if (url === "https://api.trongrid.io/wallet/getReward") {
+          return new Response(JSON.stringify({ reward: 0 }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ coins: {} }), { status: 200 });
+      })
+    );
+    const s = await getTronStaking(addr);
+    expect(s.frozen).toHaveLength(0);
+    expect(s.pendingUnfreezes).toHaveLength(0);
+    expect(s.claimableRewards.amount).toBe("0");
+    expect(s.totalStakedUsd).toBe(0);
+  });
+
+  it("throws on malformed wallet address", async () => {
+    await expect(getTronStaking("0xdeadbeef")).rejects.toThrow(/TRON mainnet address/);
   });
 });


### PR DESCRIPTION
## Summary
- Adds TRON as a non-EVM chain without disturbing the EVM type surface: `SupportedChain` stays EVM-only, TRON lives in a parallel `SupportedNonEvmChain` union, `AnyChain` is the new cross-chain entry-point type, and `isEvmChain()` narrows.
- Read path: `get_token_balance` accepts `chain: "tron"` with base58 wallet/token; `get_portfolio_summary` accepts an optional `tronAddress` that folds TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) into the same total via `breakdown.tron` / `tronUsd` / `coverage.tron`.
- Interactive setup prompts for a TronGrid API key (validates against the USDT-TRC20 accounts endpoint); `TRON_API_KEY` env var overrides config.

## Scope notes
- **Phase 1 only** — balance reads + schemas + setup. Transaction preparation and Ledger signing land in follow-up PRs (Phases 2 and 3).
- TRON has no DeFi/LP/staking coverage here — none of Aave/Compound/Morpho/Uniswap/Lido/EigenLayer are deployed on TRON. Readers short-circuit on non-EVM chains.
- Multi-wallet + `tronAddress` combinations throw (ambiguous which EVM wallet the TRON address pairs with); callers must use single-wallet mode.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 265/265 passing, including 26 new TRON tests (chain registration invariants, `isEvmChain`, `isTronAddress`, `TRON_TOKENS`, `resolveTronApiKey` precedence, schema acceptance, `getTronBalances` / `getTronTokenBalance` with stubbed fetch, dispatch)
- [ ] Manual: run `recon-crypto-mcp-setup` and confirm the TronGrid prompt validates against a live key
- [ ] Manual: call `get_portfolio_summary` with an EVM wallet + `tronAddress` and confirm TRON slice appears in `breakdown.tron` with TRX + TRC-20 values

🤖 Generated with [Claude Code](https://claude.com/claude-code)