### PR TITLE
Add Dockerfile for Glama MCP inspection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.git
+.github
+test
+*.md
+recon-mcp-requirements.md
+vitest.config.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Add multi-stage `Dockerfile` (Node 20 Alpine) so Glama can build the image and introspect tools for the MCP directory listing.
- Add `.dockerignore` to keep the build context slim.

## Test plan
- [x] `docker build .` succeeds
- [x] `docker run --rm -i <image>` responds to `initialize` + `tools/list` over stdio
- [ ] Re-run Glama score evaluation after merge to confirm inspection passes