### PR TITLE
Declare @walletconnect/types as explicit dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recon-crypto-mcp",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@walletconnect/sign-client": "^2.17.0",
+        "@walletconnect/types": "^2.17.0",
         "@walletconnect/utils": "^2.17.0",
         "qrcode-terminal": "^0.12.0",
         "viem": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@lifi/sdk": "^3.16.3",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@walletconnect/sign-client": "^2.17.0",
+    "@walletconnect/types": "^2.17.0",
     "@walletconnect/utils": "^2.17.0",
     "qrcode-terminal": "^0.12.0",
     "viem": "^2.21.0",


### PR DESCRIPTION
## Summary
- `src/signing/walletconnect.ts` imports `SessionTypes` from `@walletconnect/types`, but the package was only resolved transitively via `@walletconnect/sign-client` / `@walletconnect/utils`.
- npm hoisting made this work locally, but Glama's auto-generated build uses pnpm, which enforces strict module layout — build failed with `TS2307: Cannot find module '@walletconnect/types'`.
- Declare `@walletconnect/types@^2.17.0` explicitly so both npm and pnpm resolve it.

## Test plan
- [x] `npm run build` still succeeds
- [x] `pnpm install && pnpm run build` succeeds (reproduces Glama's env)
- [ ] After merge, re-trigger Glama Deploy from the admin page