### PR TITLE
Release 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-crypto-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "mcpName": "io.github.szhygulin/recon-crypto-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/recon-crypto-mcp",
   "title": "Recon Crypto MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "websiteUrl": "https://github.com/szhygulin/recon-crypto-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/recon-crypto-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "recon-crypto-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary
Bump version to 0.3.1 in `package.json` and both `server.json` version fields.

## Included since 0.3.0
- #16 Dockerfile for Glama MCP directory inspection
- #17 Glama score badge in README
- #18 Declare `@walletconnect/types` as explicit dep (fixes pnpm builds on Glama)
- `glama.json` metadata (commit `4c37b0a`, direct to main before PR-flow was adopted)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — all 235 tests pass
- [ ] Merge, tag `v0.3.1`, create GitHub Release — publish workflow fires and ships to npm + MCP Registry