### PR TITLE
TRON Phase 2: transaction preparation (preview-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 EVM: Ethereum, Arbitrum, Polygon, Base.
 
-Non-EVM: TRON (phase 1 — balance + staking reads; transaction preparation and Ledger signing land in follow-up phases).
+Non-EVM: TRON (phases 1 + 2 — balance + staking reads and transaction preparation for native TRX sends, canonical TRC-20 transfers, and voting-reward claims; Ledger signing lands in a follow-up phase).
 
 Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no lending/LP coverage in this server (none of Aave/Compound/Morpho/Uniswap are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume, and TRON-native staking (frozen TRX under Stake 2.0, pending unfreezes, claimable voting rewards) is surfaced via `get_tron_staking` and folded into the portfolio summary. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
 ## Roadmap
 
-- **TRON transaction preparation + Ledger signing** — phase 2 and phase 3 of TRON support. Phase 2 prepares native TRX and TRC-20 sends. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
+- **TRON Ledger signing** — phase 3 of TRON support. TRON preparation tools (`prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`) already ship as preview-only; `send_transaction` currently refuses TRON handles. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
+- **TRON Stake 2.0 writes** — phase 2b follows phase 2: `freezeBalanceV2`, `unfreezeBalanceV2`, and `withdrawExpireUnfreeze` preparation for bandwidth/energy management.
 - **MetaMask support** (WalletConnect) — alongside the existing Ledger Live integration. Will let users sign through a MetaMask-paired session when a hardware wallet isn't available.
 - **Solana** — coming later. Non-EVM: introduces a separate SDK (`@solana/web3.js`), base58 addresses, and the WalletConnect `solana:` namespace for signing.
 
@@ -60,7 +61,7 @@ Read-only (no Ledger pairing required):
 - `simulate_position_change` — projected Aave health factor for a hypothetical action
 - `simulate_transaction` — run `eth_call` against a prepared or arbitrary tx to preview success/revert before signing; prepared txs are re-simulated automatically at send time
 - `get_token_balance`, `get_token_price` — balances and DefiLlama prices; `get_token_balance` accepts `chain: "tron"` with a base58 wallet and a base58 TRC-20 address (or `token: "native"` for TRX), returning a `TronBalance` shape
-- `get_tron_staking` — TRON-native staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with ISO unlock timestamps. Read-only; the actual claim/withdraw transactions land in TRON Phase 2.
+- `get_tron_staking` — TRON-native staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with ISO unlock timestamps. Pair with `prepare_tron_claim_rewards` to actually withdraw accumulated rewards.
 - `resolve_ens_name`, `reverse_resolve_ens` — ENS forward/reverse
 - `get_swap_quote` — LiFi quote (optionally cross-checked against 1inch)
 - `check_contract_security`, `check_permission_risks`, `get_protocol_risk_score` — risk tooling
@@ -80,7 +81,8 @@ Execution (Ledger-signed via WalletConnect):
 - `prepare_eigenlayer_deposit`
 - `prepare_swap` — LiFi-routed intra- or cross-chain swap/bridge
 - `prepare_native_send`, `prepare_token_send`
-- `send_transaction` — forwards a prepared tx to Ledger Live for user approval
+- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
+- `send_transaction` — forwards a prepared EVM tx to Ledger Live for user approval
 
 ## Requirements
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,17 @@ import {
 } from "./modules/balances/schemas.js";
 
 import { getTronStaking } from "./modules/tron/staking.js";
-import { getTronStakingInput } from "./modules/tron/schemas.js";
+import {
+  buildTronNativeSend,
+  buildTronTokenSend,
+  buildTronClaimRewards,
+} from "./modules/tron/actions.js";
+import {
+  getTronStakingInput,
+  prepareTronNativeSendInput,
+  prepareTronTokenSendInput,
+  prepareTronClaimRewardsInput,
+} from "./modules/tron/schemas.js";
 
 import { getCompoundPositions } from "./modules/compound/index.js";
 import {
@@ -585,10 +595,40 @@ async function main() {
     "get_tron_staking",
     {
       description:
-        "Read TRON staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with their unlock timestamps. Returns raw SUN + formatted TRX + USD values, plus a `totalStakedUsd` rollup. Read-only; the WithdrawBalance transaction to actually claim rewards lands in TRON Phase 2.",
+        "Read TRON staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with their unlock timestamps. Returns raw SUN + formatted TRX + USD values, plus a `totalStakedUsd` rollup. Read-only; pair with `prepare_tron_claim_rewards` to actually withdraw the accumulated reward.",
       inputSchema: getTronStakingInput.shape,
     },
     handler((args: { address: string }) => getTronStaking(args.address))
+  );
+
+  server.registerTool(
+    "prepare_tron_native_send",
+    {
+      description:
+        "Build an unsigned TRON native TRX send transaction via TronGrid's /wallet/createtransaction. Returns a human-readable preview + opaque handle. NOTE: TRON handles are PREVIEW-ONLY in this release — the physical signing path (USB HID via @ledgerhq/hw-app-trx) lands in a later phase; `send_transaction` only consumes EVM handles. Use this tool today to double-check an intended transfer (recipient, amount) against TronGrid's own tx builder before signing through Ledger Live's native TRON flow, TronLink, or another client.",
+      inputSchema: prepareTronNativeSendInput.shape,
+    },
+    handler(buildTronNativeSend)
+  );
+
+  server.registerTool(
+    "prepare_tron_token_send",
+    {
+      description:
+        "Build an unsigned TRC-20 transfer transaction (canonical set only: USDT, USDC, USDD, TUSD) via TronGrid's /wallet/triggersmartcontract. Decimals are resolved from the canonical table — unknown TRC-20s are rejected with an explicit error. Default fee_limit is 100 TRX (TronLink/Ledger Live default); override with `feeLimitTrx` if energy pricing has moved. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY in this release — the Ledger USB HID signing path lands in a later phase. `send_transaction` will refuse TRON handles.",
+      inputSchema: prepareTronTokenSendInput.shape,
+    },
+    handler(buildTronTokenSend)
+  );
+
+  server.registerTool(
+    "prepare_tron_claim_rewards",
+    {
+      description:
+        "Build an unsigned TRON WithdrawBalance transaction that claims accumulated voting rewards to the owner's balance. TRON enforces a 24-hour cooldown between claims — TronGrid will reject (surfaced as an error) if the previous claim was inside the window. Pair with `get_tron_staking` first to read `claimableRewards` and avoid empty-claim tx builds. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY in this release — signing lands with the USB HID phase.",
+      inputSchema: prepareTronClaimRewardsInput.shape,
+    },
+    handler(buildTronClaimRewards)
   );
 
   server.registerTool(

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -1,0 +1,290 @@
+import {
+  TRONGRID_BASE_URL,
+  TRX_DECIMALS,
+  TRON_TOKENS,
+  isTronAddress,
+} from "../../config/tron.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import { issueTronHandle } from "../../signing/tron-tx-store.js";
+import { encodeTrc20TransferParam } from "./address.js";
+import type { UnsignedTronTx } from "../../types/index.js";
+
+/**
+ * Default fee limit (100 TRX) for TRC-20 transfers. TronGrid's
+ * /wallet/triggersmartcontract rejects without a fee_limit. 100 TRX is the
+ * Ledger Live / Tronlink default and far above typical energy burn for a
+ * USDT-TRC20 transfer (~15 TRX at current mainnet energy price).
+ */
+const DEFAULT_FEE_LIMIT_SUN = 100_000_000n;
+
+/** Hardcoded TRC-20 decimals for canonical stablecoins (same as balances.ts). */
+const TOKEN_DECIMALS: Record<keyof typeof TRON_TOKENS, number> = {
+  USDT: 6,
+  USDC: 6,
+  USDD: 18,
+  TUSD: 18,
+};
+const SYMBOL_BY_CONTRACT: Record<string, keyof typeof TRON_TOKENS> = Object.fromEntries(
+  (Object.entries(TRON_TOKENS) as [keyof typeof TRON_TOKENS, string][]).map(
+    ([symbol, addr]) => [addr, symbol]
+  )
+);
+
+/**
+ * Parse a human amount ("1.5") into integer base units given `decimals`.
+ * Mirrors viem's `parseUnits` but doesn't import viem (keeps the TRON
+ * path free of EVM-only helpers).
+ */
+function parseUnits(value: string, decimals: number): bigint {
+  if (!/^\d+(\.\d+)?$/.test(value)) {
+    throw new Error(`Invalid amount "${value}" — expected a positive decimal number.`);
+  }
+  const [whole, frac = ""] = value.split(".");
+  if (frac.length > decimals) {
+    throw new Error(
+      `Amount "${value}" has more decimals than token precision (${decimals}). Truncate or round first.`
+    );
+  }
+  const padded = frac.padEnd(decimals, "0");
+  return BigInt(whole + padded);
+}
+
+async function trongridPost<T>(
+  path: string,
+  body: Record<string, unknown>,
+  apiKey: string | undefined
+): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`TronGrid ${path} returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * TronGrid surfaces errors in two shapes depending on endpoint:
+ *   - /wallet/createtransaction and /wallet/withdrawbalance: `{Error: "..."}`
+ *     at the top level on failure.
+ *   - /wallet/triggersmartcontract: always returns 200; look at
+ *     `result.result === true` and `result.message`.
+ * Normalizing both to exceptions keeps the tx builders uniform.
+ */
+interface TrongridDirectTx {
+  Error?: string;
+  txID?: string;
+  raw_data?: unknown;
+  raw_data_hex?: string;
+  visible?: boolean;
+}
+
+interface TrongridTriggerResponse {
+  result?: { result?: boolean; message?: string; code?: string };
+  transaction?: {
+    txID?: string;
+    raw_data?: unknown;
+    raw_data_hex?: string;
+    visible?: boolean;
+  };
+}
+
+// ----- Native TRX send -----
+
+export interface BuildTronNativeSendArgs {
+  from: string;
+  to: string;
+  amount: string;
+}
+
+export async function buildTronNativeSend(
+  args: BuildTronNativeSendArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  if (!isTronAddress(args.to)) {
+    throw new Error(`"to" is not a valid TRON mainnet address: ${args.to}`);
+  }
+  const amountSun = parseUnits(args.amount, TRX_DECIMALS);
+  if (amountSun <= 0n) {
+    throw new Error(`Amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const body = {
+    owner_address: args.from,
+    to_address: args.to,
+    amount: Number(amountSun),
+    visible: true,
+  };
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/createtransaction",
+    body,
+    apiKey
+  );
+  if (res.Error) {
+    throw new Error(`TronGrid createtransaction failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid createtransaction returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "native_send",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description: `Send ${args.amount} TRX to ${args.to}`,
+    decoded: {
+      functionName: "TransferContract",
+      args: { to: args.to, amount: args.amount, symbol: "TRX" },
+    },
+  };
+  return issueTronHandle(tx);
+}
+
+// ----- TRC-20 send -----
+
+export interface BuildTronTokenSendArgs {
+  from: string;
+  to: string;
+  /** Base58 TRC-20 contract address. */
+  token: string;
+  amount: string;
+  /** Override fee limit in TRX (default: 100 TRX). */
+  feeLimitTrx?: string;
+}
+
+export async function buildTronTokenSend(
+  args: BuildTronTokenSendArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  if (!isTronAddress(args.to)) {
+    throw new Error(`"to" is not a valid TRON mainnet address: ${args.to}`);
+  }
+  if (!isTronAddress(args.token)) {
+    throw new Error(`"token" is not a valid TRC-20 base58 address: ${args.token}`);
+  }
+
+  // Resolve decimals + symbol from the canonical table. Unknown TRC-20s
+  // are rejected here in Phase 2 — a proper `trc20.decimals()` on-chain
+  // read can land later, but for now we only prepare sends for tokens we
+  // can name in the preview (no user-confusing "UNKNOWN token" previews).
+  const symbol = SYMBOL_BY_CONTRACT[args.token];
+  if (!symbol) {
+    throw new Error(
+      `Token ${args.token} is not in the canonical TRC-20 set (USDT/USDC/USDD/TUSD). ` +
+        `Preparing a send for unknown TRC-20s is not supported in Phase 2 — file a capability ` +
+        `request if you need this.`
+    );
+  }
+  const decimals = TOKEN_DECIMALS[symbol];
+  const amountBase = parseUnits(args.amount, decimals);
+  if (amountBase <= 0n) {
+    throw new Error(`Amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const feeLimitSun = args.feeLimitTrx
+    ? parseUnits(args.feeLimitTrx, TRX_DECIMALS)
+    : DEFAULT_FEE_LIMIT_SUN;
+
+  const parameter = encodeTrc20TransferParam(args.to, amountBase);
+  const body = {
+    owner_address: args.from,
+    contract_address: args.token,
+    function_selector: "transfer(address,uint256)",
+    parameter,
+    fee_limit: Number(feeLimitSun),
+    call_value: 0,
+    visible: true,
+  };
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const res = await trongridPost<TrongridTriggerResponse>(
+    "/wallet/triggersmartcontract",
+    body,
+    apiKey
+  );
+  if (!res.result?.result) {
+    throw new Error(
+      `TronGrid triggersmartcontract failed: ${res.result?.message ?? "unknown error"}`
+    );
+  }
+  const ttx = res.transaction;
+  if (!ttx?.txID || !ttx.raw_data_hex) {
+    throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "trc20_send",
+    from: args.from,
+    txID: ttx.txID,
+    rawData: ttx.raw_data,
+    rawDataHex: ttx.raw_data_hex,
+    description: `Send ${args.amount} ${symbol} to ${args.to}`,
+    decoded: {
+      functionName: "transfer(address,uint256)",
+      args: {
+        to: args.to,
+        amount: args.amount,
+        symbol,
+        contract: args.token,
+      },
+    },
+    feeLimitSun: feeLimitSun.toString(),
+  };
+  return issueTronHandle(tx);
+}
+
+// ----- Claim voting rewards (WithdrawBalance) -----
+
+export interface BuildTronClaimRewardsArgs {
+  from: string;
+}
+
+export async function buildTronClaimRewards(
+  args: BuildTronClaimRewardsArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/withdrawbalance",
+    { owner_address: args.from, visible: true },
+    apiKey
+  );
+  if (res.Error) {
+    // Common case: "WithdrawBalance not allowed, need 24 hours since last Withdraw"
+    // — TRON enforces a 24h rate limit on claims. Surface TronGrid's message verbatim.
+    throw new Error(`TronGrid withdrawbalance failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid withdrawbalance returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "claim_rewards",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description: `Claim accumulated TRON voting rewards to ${args.from}`,
+    decoded: {
+      functionName: "WithdrawBalanceContract",
+      args: { owner: args.from },
+    },
+  };
+  return issueTronHandle(tx);
+}

--- a/src/modules/tron/address.ts
+++ b/src/modules/tron/address.ts
@@ -1,0 +1,114 @@
+import { createHash } from "node:crypto";
+import { isTronAddress } from "../../config/tron.js";
+
+/**
+ * Base58 alphabet used by Bitcoin, TRON, and most cryptocurrency address
+ * schemes. Excludes visually-ambiguous characters (0, O, I, l).
+ */
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_INDEX = new Map<string, number>();
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+  BASE58_INDEX.set(BASE58_ALPHABET[i], i);
+}
+
+/**
+ * Decode a base58 string to raw bytes. Throws on invalid characters.
+ * No checksum validation — that's the caller's responsibility (see
+ * `base58ToHex` below which does the full base58check verify).
+ */
+function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) return new Uint8Array();
+
+  let num = 0n;
+  for (const ch of s) {
+    const idx = BASE58_INDEX.get(ch);
+    if (idx === undefined) {
+      throw new Error(`Invalid base58 character "${ch}"`);
+    }
+    num = num * 58n + BigInt(idx);
+  }
+
+  // bigint → bytes (big-endian)
+  const bytes: number[] = [];
+  while (num > 0n) {
+    bytes.unshift(Number(num & 0xffn));
+    num >>= 8n;
+  }
+
+  // Leading "1"s in base58 correspond to leading zero bytes.
+  let leadingOnes = 0;
+  for (const ch of s) {
+    if (ch === "1") leadingOnes++;
+    else break;
+  }
+  const out = new Uint8Array(leadingOnes + bytes.length);
+  out.set(bytes, leadingOnes);
+  return out;
+}
+
+function sha256(data: Uint8Array): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+/**
+ * Decode a TRON base58 mainnet address to the 21-byte hex TRON form (prefix
+ * 0x41 + 20 bytes of EVM-style address). Used as `owner_address`,
+ * `to_address`, and `contract_address` in TronGrid POST bodies when
+ * `visible: false` (hex mode).
+ *
+ * We always call TronGrid with `visible: true` (base58 pass-through), so
+ * this function is primarily used for TRC-20 parameter encoding where the
+ * ABI requires the 20-byte form stripped of the 0x41 prefix.
+ *
+ * Performs the full base58check verification (4-byte double-sha256 checksum
+ * suffix) — throws on any tampering, including case changes and typos that
+ * the charset regex would miss.
+ */
+export function base58ToHex(address: string): string {
+  if (!isTronAddress(address)) {
+    throw new Error(
+      `"${address}" is not a valid TRON mainnet address (expected base58, 34 chars, prefix T).`
+    );
+  }
+  const decoded = base58Decode(address);
+  if (decoded.length !== 25) {
+    throw new Error(
+      `Decoded TRON address must be 25 bytes (1 prefix + 20 addr + 4 checksum), got ${decoded.length}.`
+    );
+  }
+  const payload = decoded.subarray(0, 21);
+  const providedChecksum = decoded.subarray(21, 25);
+  const expectedChecksum = sha256(sha256(payload)).subarray(0, 4);
+  for (let i = 0; i < 4; i++) {
+    if (providedChecksum[i] !== expectedChecksum[i]) {
+      throw new Error(
+        `Checksum mismatch on TRON address "${address}" — possible typo or tampering.`
+      );
+    }
+  }
+  if (payload[0] !== 0x41) {
+    throw new Error(
+      `TRON mainnet addresses must have version byte 0x41 (got 0x${payload[0].toString(16)}).`
+    );
+  }
+  return Buffer.from(payload).toString("hex");
+}
+
+/**
+ * Encode the `transfer(address,uint256)` parameter payload for a TRC-20
+ * call through TronGrid's /wallet/triggersmartcontract.
+ *
+ * Layout: two 32-byte words concatenated as hex (128 chars, no 0x prefix).
+ *   Word 1: the recipient address, 20 bytes left-padded to 32.
+ *           NB: stripped of the 0x41 TRON prefix — TRC-20 ABI uses the
+ *           EVM 20-byte form so the contract can reuse the EIP-20 signature.
+ *   Word 2: the amount as a big-endian uint256.
+ */
+export function encodeTrc20TransferParam(toBase58: string, amountSun: bigint): string {
+  if (amountSun < 0n) throw new Error("TRC-20 transfer amount must be non-negative.");
+  const toHex21 = base58ToHex(toBase58); // 42 hex chars, prefix 41
+  const toHex20 = toHex21.slice(2); // strip the 0x41 version byte → 40 hex chars
+  const addrWord = toHex20.padStart(64, "0");
+  const amountWord = amountSun.toString(16).padStart(64, "0");
+  return addrWord + amountWord;
+}

--- a/src/modules/tron/schemas.ts
+++ b/src/modules/tron/schemas.ts
@@ -4,6 +4,10 @@ const tronAddress = z
   .string()
   .regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/, "expected base58 TRON mainnet address (prefix T, 34 chars)");
 
+const amountString = z
+  .string()
+  .regex(/^\d+(\.\d+)?$/, "expected a positive decimal number (e.g. \"1.5\")");
+
 export const getTronStakingInput = z.object({
   address: tronAddress.describe(
     "Base58 TRON mainnet address (prefix T) — the wallet to read staking state for."
@@ -11,3 +15,35 @@ export const getTronStakingInput = z.object({
 });
 
 export type GetTronStakingArgs = z.infer<typeof getTronStakingInput>;
+
+export const prepareTronNativeSendInput = z.object({
+  from: tronAddress.describe("Base58 TRON sender address (prefix T)."),
+  to: tronAddress.describe("Base58 TRON recipient address (prefix T)."),
+  amount: amountString.describe("TRX amount as a human-readable decimal string (e.g. \"12.5\")."),
+});
+
+export type PrepareTronNativeSendArgs = z.infer<typeof prepareTronNativeSendInput>;
+
+export const prepareTronTokenSendInput = z.object({
+  from: tronAddress.describe("Base58 TRON sender address (prefix T)."),
+  to: tronAddress.describe("Base58 TRON recipient address (prefix T)."),
+  token: tronAddress.describe(
+    "Base58 TRC-20 contract address. Phase 2 only supports the canonical set (USDT, USDC, USDD, TUSD); other TRC-20s are rejected."
+  ),
+  amount: amountString.describe(
+    "Token amount as a human-readable decimal string (decimals are resolved from the canonical table: 6 for USDT/USDC, 18 for USDD/TUSD)."
+  ),
+  feeLimitTrx: amountString
+    .optional()
+    .describe("Optional fee-limit override in TRX. Defaults to 100 TRX — Ledger Live / TronLink standard."),
+});
+
+export type PrepareTronTokenSendArgs = z.infer<typeof prepareTronTokenSendInput>;
+
+export const prepareTronClaimRewardsInput = z.object({
+  from: tronAddress.describe(
+    "Base58 TRON address to claim accumulated voting rewards for. TRON enforces a 24h cooldown between claims."
+  ),
+});
+
+export type PrepareTronClaimRewardsArgs = z.infer<typeof prepareTronClaimRewardsInput>;

--- a/src/signing/tron-tx-store.ts
+++ b/src/signing/tron-tx-store.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import type { UnsignedTronTx } from "../types/index.js";
+
+/**
+ * In-memory registry of prepared TRON transactions. Parallel to
+ * signing/tx-store.ts but stores `UnsignedTronTx` rather than EVM
+ * `UnsignedTx`. Separated deliberately: the EVM send flow runs an
+ * eth_call re-simulation, chain-id check, and spender allowlist that are
+ * all meaningless on TRON. A TRON handle therefore cannot be consumed by
+ * the EVM `send_transaction` — the two stores share no keys and the TRON
+ * send path (Phase 3, USB HID) will have its own security pipeline.
+ *
+ * Lifetime matches the EVM store (15 min from issue).
+ */
+const TX_TTL_MS = 15 * 60_000;
+
+interface StoredTx {
+  tx: UnsignedTronTx;
+  expiresAt: number;
+}
+
+const store = new Map<string, StoredTx>();
+
+function prune(now = Date.now()): void {
+  for (const [handle, entry] of store) {
+    if (entry.expiresAt < now) store.delete(handle);
+  }
+}
+
+export function issueTronHandle(tx: UnsignedTronTx): UnsignedTronTx {
+  prune();
+  const handle = randomUUID();
+  const withHandle: UnsignedTronTx = { ...tx, handle };
+  const { handle: _h, ...stored } = withHandle;
+  store.set(handle, { tx: stored as UnsignedTronTx, expiresAt: Date.now() + TX_TTL_MS });
+  return withHandle;
+}
+
+export function consumeTronHandle(handle: string): UnsignedTronTx {
+  prune();
+  const entry = store.get(handle);
+  if (!entry) {
+    throw new Error(
+      `Unknown or expired TRON tx handle. Prepared transactions expire after 15 minutes ` +
+        `and are single-use after submission. Re-run the prepare_tron_* tool for a fresh handle.`
+    );
+  }
+  return entry.tx;
+}
+
+export function retireTronHandle(handle: string): void {
+  store.delete(handle);
+}
+
+/** Test-only: true if `handle` is still active (not retired, not expired). */
+export function hasTronHandle(handle: string): boolean {
+  prune();
+  return store.has(handle);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -384,6 +384,46 @@ export interface MultiWalletPortfolioSummary {
   coverage: PortfolioCoverage;
 }
 
+/**
+ * Unsigned TRON transaction. Shape is unavoidably different from EVM:
+ * TronGrid builds the tx server-side (raw_data + raw_data_hex) and the
+ * device signs the serialized raw_data_hex. We keep the TRON tx shape
+ * separate from UnsignedTx so send_transaction's EVM-only security pipeline
+ * (eth_call re-simulation, chain-id check, spender allowlist) can't be
+ * silently shortcut by a TRON handle masquerading as an EVM one.
+ *
+ * Phase 2 ships preparation only — there is no send_tron_transaction yet.
+ * Handles are issued so the Phase 3 signer (USB HID via @ledgerhq/hw-app-trx)
+ * can consume them exactly the way send_transaction consumes EVM handles.
+ */
+export interface UnsignedTronTx {
+  chain: "tron";
+  /** Discriminator for the preview + future signer branching. */
+  action: "native_send" | "trc20_send" | "claim_rewards";
+  /** Base58 owner address (prefix T). */
+  from: string;
+  /** TronGrid-returned transaction ID (sha256 of raw_data_hex, hex string). */
+  txID: string;
+  /** TronGrid's raw_data object — opaque to us; serialized in raw_data_hex. */
+  rawData: unknown;
+  /** Hex-encoded raw_data used by the signer. */
+  rawDataHex: string;
+  /** Human-readable description for the preview. */
+  description: string;
+  decoded: {
+    functionName: string;
+    args: Record<string, string>;
+  };
+  /**
+   * Fee limit in SUN, present on contract calls (TRC-20 transfers require it;
+   * TronGrid rejects triggersmartcontract without one). Absent on native TRX
+   * sends and WithdrawBalance — those pay bandwidth only.
+   */
+  feeLimitSun?: string;
+  /** Opaque handle — see tron-tx-store.ts. Phase 3 signer consumes this. */
+  handle?: string;
+}
+
 /** Unsigned transaction, ready to be sent to Ledger Live for signing. */
 export interface UnsignedTx {
   chain: SupportedChain;

--- a/test/tron-phase2-prepare.test.ts
+++ b/test/tron-phase2-prepare.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TRON_TOKENS } from "../src/config/tron.js";
+import { base58ToHex, encodeTrc20TransferParam } from "../src/modules/tron/address.js";
+import {
+  buildTronNativeSend,
+  buildTronTokenSend,
+  buildTronClaimRewards,
+} from "../src/modules/tron/actions.js";
+import { hasTronHandle, consumeTronHandle } from "../src/signing/tron-tx-store.js";
+
+/**
+ * Phase-2 (TRON tx preparation) tests. Network IO against TronGrid is stubbed
+ * via vi.stubGlobal("fetch", ...). We lock down:
+ *   - base58check decode + TRC-20 ABI param encoding (pure crypto, no network)
+ *   - each builder's POST body shape (visible:true, right endpoint, right fields)
+ *   - handle issuance (tx comes back with a handle that consumeTronHandle recognises)
+ *   - error surfacing (TronGrid's two distinct error shapes)
+ *   - validation (non-TRON addresses, non-canonical TRC-20s, zero/negative amounts)
+ */
+
+const ADDR_USDT = TRON_TOKENS.USDT; // "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+const ADDR_FROM = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7"; // well-known large TRX holder
+const ADDR_TO = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9"; // another well-known address
+
+describe("base58ToHex", () => {
+  it("decodes the USDT-TRC20 contract to its canonical 21-byte TRON hex form (prefix 0x41)", () => {
+    // Known constant: USDT-TRC20 → 41a614f803b6fd780986a42c78ec9c7f77e6ded13c
+    const hex = base58ToHex(ADDR_USDT);
+    expect(hex).toBe("41a614f803b6fd780986a42c78ec9c7f77e6ded13c");
+    expect(hex.length).toBe(42);
+    expect(hex.slice(0, 2)).toBe("41"); // TRON mainnet version byte
+  });
+
+  it("rejects a non-TRON string", () => {
+    expect(() => base58ToHex("0xdeadbeef")).toThrow(/TRON mainnet address/);
+  });
+
+  it("rejects a base58 string with a flipped checksum (tampering detection)", () => {
+    // Flip the last character — breaks the base58check suffix.
+    const tampered = ADDR_USDT.slice(0, -1) + (ADDR_USDT.endsWith("t") ? "u" : "t");
+    expect(() => base58ToHex(tampered)).toThrow(/Checksum mismatch|TRON mainnet address/);
+  });
+});
+
+describe("encodeTrc20TransferParam", () => {
+  it("produces 128 hex chars (two 32-byte ABI words) with the 20-byte address form", () => {
+    const param = encodeTrc20TransferParam(ADDR_TO, 1_000_000n); // 1 USDT in base units
+    expect(param.length).toBe(128);
+    // First word: 12 bytes zero-pad + 20-byte address (stripped of the 0x41 prefix).
+    const addrWord = param.slice(0, 64);
+    expect(addrWord.slice(0, 24)).toBe("0".repeat(24));
+    const hex21 = base58ToHex(ADDR_TO); // prefix+20 bytes
+    expect(addrWord.slice(24)).toBe(hex21.slice(2)); // drop the 0x41 prefix
+    // Second word: amount as big-endian uint256.
+    expect(param.slice(64)).toBe((1_000_000n).toString(16).padStart(64, "0"));
+  });
+
+  it("encodes a zero-amount transfer (no revert at encoding layer)", () => {
+    const param = encodeTrc20TransferParam(ADDR_TO, 0n);
+    expect(param.slice(64)).toBe("0".repeat(64));
+  });
+
+  it("rejects a negative amount", () => {
+    expect(() => encodeTrc20TransferParam(ADDR_TO, -1n)).toThrow(/non-negative/);
+  });
+});
+
+describe("buildTronNativeSend (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/createtransaction");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(ADDR_FROM);
+      expect(body.to_address).toBe(ADDR_TO);
+      expect(body.amount).toBe(1_500_000); // 1.5 TRX = 1_500_000 SUN
+      expect(body.visible).toBe(true);
+      return new Response(
+        JSON.stringify({
+          txID: "deadbeef".repeat(8),
+          raw_data: { expiration: 0 },
+          raw_data_hex: "0a02",
+          visible: true,
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns an UnsignedTronTx with a live handle and correct decoded preview", async () => {
+    const tx = await buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1.5" });
+    expect(tx.chain).toBe("tron");
+    expect(tx.action).toBe("native_send");
+    expect(tx.from).toBe(ADDR_FROM);
+    expect(tx.txID).toBe("deadbeef".repeat(8));
+    expect(tx.description).toBe(`Send 1.5 TRX to ${ADDR_TO}`);
+    expect(tx.decoded.functionName).toBe("TransferContract");
+    expect(tx.decoded.args).toEqual({ to: ADDR_TO, amount: "1.5", symbol: "TRX" });
+    expect(tx.handle).toBeDefined();
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+    // Consumed tx must not carry the handle (tx-store strips it on store).
+    const consumed = consumeTronHandle(tx.handle!);
+    expect(consumed.handle).toBeUndefined();
+    expect(consumed.txID).toBe(tx.txID);
+  });
+
+  it("rejects non-TRON from/to", async () => {
+    await expect(
+      buildTronNativeSend({ from: "0xbad", to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/"from" is not a valid TRON/);
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: "notbase58", amount: "1" })
+    ).rejects.toThrow(/"to" is not a valid TRON/);
+  });
+
+  it("rejects zero or invalid amounts", async () => {
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "0" })
+    ).rejects.toThrow(/greater than 0/);
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "-1" })
+    ).rejects.toThrow(/Invalid amount/);
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1.1234567" }) // > 6 dp
+    ).rejects.toThrow(/more decimals than token precision/);
+  });
+
+  it("surfaces TronGrid's top-level `Error` field verbatim", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(JSON.stringify({ Error: "validate transfer contract error, no OwnerAccount" }), {
+          status: 200,
+        })
+    );
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1.5" })
+    ).rejects.toThrow(/no OwnerAccount/);
+  });
+});
+
+describe("buildTronTokenSend (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/triggersmartcontract");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(ADDR_FROM);
+      expect(body.contract_address).toBe(ADDR_USDT);
+      expect(body.function_selector).toBe("transfer(address,uint256)");
+      expect(body.visible).toBe(true);
+      expect(body.call_value).toBe(0);
+      expect(body.fee_limit).toBe(100_000_000); // default 100 TRX
+      // parameter = addrWord + amountWord, 2 USDT = 2_000_000 base units
+      expect(body.parameter.slice(64)).toBe((2_000_000n).toString(16).padStart(64, "0"));
+      return new Response(
+        JSON.stringify({
+          result: { result: true },
+          transaction: {
+            txID: "cafebabe".repeat(8),
+            raw_data: { expiration: 0 },
+            raw_data_hex: "0a03",
+            visible: true,
+          },
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds a USDT transfer with the canonical 6-decimal amount and default fee limit", async () => {
+    const tx = await buildTronTokenSend({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      token: ADDR_USDT,
+      amount: "2",
+    });
+    expect(tx.action).toBe("trc20_send");
+    expect(tx.txID).toBe("cafebabe".repeat(8));
+    expect(tx.description).toBe(`Send 2 USDT to ${ADDR_TO}`);
+    expect(tx.decoded.args.symbol).toBe("USDT");
+    expect(tx.decoded.args.contract).toBe(ADDR_USDT);
+    expect(tx.feeLimitSun).toBe("100000000");
+    expect(tx.handle).toBeDefined();
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("honours an explicit feeLimitTrx override", async () => {
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(init!.body as string);
+      expect(body.fee_limit).toBe(50_000_000); // 50 TRX override
+      return new Response(
+        JSON.stringify({
+          result: { result: true },
+          transaction: { txID: "f".repeat(64), raw_data: {}, raw_data_hex: "00", visible: true },
+        }),
+        { status: 200 }
+      );
+    });
+    const tx = await buildTronTokenSend({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      token: ADDR_USDT,
+      amount: "1",
+      feeLimitTrx: "50",
+    });
+    expect(tx.feeLimitSun).toBe("50000000");
+  });
+
+  it("rejects non-canonical TRC-20 tokens", async () => {
+    // Pick any valid base58 T-address that isn't in TRON_TOKENS.
+    const unknown = ADDR_FROM; // not a contract in the canonical set
+    await expect(
+      buildTronTokenSend({ from: ADDR_FROM, to: ADDR_TO, token: unknown, amount: "1" })
+    ).rejects.toThrow(/not in the canonical TRC-20 set/);
+  });
+
+  it("surfaces TronGrid triggersmartcontract failure from result.message", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(
+          JSON.stringify({
+            result: { result: false, code: "CONTRACT_VALIDATE_ERROR", message: "insufficient balance" },
+          }),
+          { status: 200 }
+        )
+    );
+    await expect(
+      buildTronTokenSend({ from: ADDR_FROM, to: ADDR_TO, token: ADDR_USDT, amount: "2" })
+    ).rejects.toThrow(/insufficient balance/);
+  });
+});
+
+describe("buildTronClaimRewards (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/withdrawbalance");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(ADDR_FROM);
+      expect(body.visible).toBe(true);
+      return new Response(
+        JSON.stringify({
+          txID: "aa".repeat(32),
+          raw_data: { expiration: 0 },
+          raw_data_hex: "0a04",
+          visible: true,
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds a WithdrawBalance tx with the right action tag + handle", async () => {
+    const tx = await buildTronClaimRewards({ from: ADDR_FROM });
+    expect(tx.action).toBe("claim_rewards");
+    expect(tx.decoded.functionName).toBe("WithdrawBalanceContract");
+    expect(tx.description).toContain("Claim accumulated TRON voting rewards");
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("surfaces the 24h cooldown message from TronGrid", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(
+          JSON.stringify({
+            Error: "WithdrawBalance not allowed, need 24 hours since last Withdraw",
+          }),
+          { status: 200 }
+        )
+    );
+    await expect(buildTronClaimRewards({ from: ADDR_FROM })).rejects.toThrow(
+      /need 24 hours since last Withdraw/
+    );
+  });
+
+  it("rejects a non-TRON owner", async () => {
+    await expect(buildTronClaimRewards({ from: "0xbad" })).rejects.toThrow(/TRON mainnet/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds three TRON `prepare_*` tools: `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`. Each calls TronGrid (`createtransaction` / `triggersmartcontract` / `withdrawbalance`) with `visible: true`, validates base58 addresses and amounts, and issues an opaque handle.
- Keeps TRON tx shape (`UnsignedTronTx`) and its handle store separate from EVM so `send_transaction`'s EVM-only security pipeline (eth_call re-simulation, chain-id check, spender allowlist) can't be silently shortcut by type confusion. TRON handles are **preview-only** in this release; `send_transaction` refuses them until Phase 3 lands USB HID signing via `@ledgerhq/hw-app-trx`.
- TRC-20 preparation is restricted to the canonical set (USDT/USDC/USDD/TUSD) whose decimals live in the hardcoded table — unknown TRC-20s are rejected with an explicit error rather than rendered as `UNKNOWN` in the preview.
- Hand-rolled base58check decoder + TRC-20 ABI param encoder (no new deps; base58 alphabet + double-sha256 checksum verify in ~30 LOC).

## Test plan
- [x] `npx vitest run` — 285/285 pass (17 new tests in `test/tron-phase2-prepare.test.ts` covering base58 decode, TRC-20 param layout, POST body shape, handle issuance, and both TronGrid error shapes).
- [x] `npm run build` — clean tsc.
- [ ] Manual: build-and-link the MCP, call each `prepare_tron_*` against a real address and cross-reference `txID` with a direct TronGrid call.
- [ ] Manual: confirm `send_transaction` refuses a TRON handle (EVM-only consume path).
- [ ] Manual: hit the 24h-cooldown branch on `prepare_tron_claim_rewards` and confirm TronGrid's message is surfaced verbatim.

## Follow-ups
- Phase 2b: `freezeBalanceV2`, `unfreezeBalanceV2`, `withdrawExpireUnfreeze` for Stake 2.0 bandwidth/energy management.
- Phase 3: USB HID signing via `@ledgerhq/hw-app-trx` (Ledger Live's WalletConnect relay does not honor `tron:` — verified 2026-04-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)