### PR TITLE
TRON Phase 2b: Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 EVM: Ethereum, Arbitrum, Polygon, Base.
 
-Non-EVM: TRON (phases 1 + 2 — balance + staking reads and transaction preparation for native TRX sends, canonical TRC-20 transfers, and voting-reward claims; Ledger signing lands in a follow-up phase).
+Non-EVM: TRON (phases 1 + 2 + 2b — balance + staking reads, tx preparation for native TRX sends, canonical TRC-20 transfers, voting-reward claims, and Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze; Ledger signing lands in a follow-up phase).
 
 Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no lending/LP coverage in this server (none of Aave/Compound/Morpho/Uniswap are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume, and TRON-native staking (frozen TRX under Stake 2.0, pending unfreezes, claimable voting rewards) is surfaced via `get_tron_staking` and folded into the portfolio summary. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
 ## Roadmap
 
-- **TRON Ledger signing** — phase 3 of TRON support. TRON preparation tools (`prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`) already ship as preview-only; `send_transaction` currently refuses TRON handles. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
-- **TRON Stake 2.0 writes** — phase 2b follows phase 2: `freezeBalanceV2`, `unfreezeBalanceV2`, and `withdrawExpireUnfreeze` preparation for bandwidth/energy management.
+- **TRON Ledger signing** — phase 3 of TRON support. All TRON `prepare_*` tools (send, TRC-20, claim rewards, freeze/unfreeze/withdraw-expire-unfreeze) ship as preview-only today; `send_transaction` currently refuses TRON handles. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
 - **MetaMask support** (WalletConnect) — alongside the existing Ledger Live integration. Will let users sign through a MetaMask-paired session when a hardware wallet isn't available.
 - **Solana** — coming later. Non-EVM: introduces a separate SDK (`@solana/web3.js`), base58 addresses, and the WalletConnect `solana:` namespace for signing.
 
@@ -81,7 +80,7 @@ Execution (Ledger-signed via WalletConnect):
 - `prepare_eigenlayer_deposit`
 - `prepare_swap` — LiFi-routed intra- or cross-chain swap/bridge
 - `prepare_native_send`, `prepare_token_send`
-- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
+- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`, `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
 - `send_transaction` — forwards a prepared EVM tx to Ledger Live for user approval
 
 ## Requirements

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,12 +86,18 @@ import {
   buildTronNativeSend,
   buildTronTokenSend,
   buildTronClaimRewards,
+  buildTronFreeze,
+  buildTronUnfreeze,
+  buildTronWithdrawExpireUnfreeze,
 } from "./modules/tron/actions.js";
 import {
   getTronStakingInput,
   prepareTronNativeSendInput,
   prepareTronTokenSendInput,
   prepareTronClaimRewardsInput,
+  prepareTronFreezeInput,
+  prepareTronUnfreezeInput,
+  prepareTronWithdrawExpireUnfreezeInput,
 } from "./modules/tron/schemas.js";
 
 import { getCompoundPositions } from "./modules/compound/index.js";
@@ -629,6 +635,36 @@ async function main() {
       inputSchema: prepareTronClaimRewardsInput.shape,
     },
     handler(buildTronClaimRewards)
+  );
+
+  server.registerTool(
+    "prepare_tron_freeze",
+    {
+      description:
+        "Build an unsigned TRON Stake 2.0 FreezeBalanceV2 transaction. Locks TRX to earn `bandwidth` (fuels plain transfers) or `energy` (fuels smart-contract calls) and gains proportional voting power. IMPORTANT: freezing alone does NOT accrue TRX rewards — `claimableRewards` (see `get_tron_staking`) only grows after the user also votes for a Super Representative, and VoteWitness is not yet exposed as a tool in this server. Unlocking requires a 14-day cooldown via `prepare_tron_unfreeze` + `prepare_tron_withdraw_expire_unfreeze`. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+      inputSchema: prepareTronFreezeInput.shape,
+    },
+    handler(buildTronFreeze)
+  );
+
+  server.registerTool(
+    "prepare_tron_unfreeze",
+    {
+      description:
+        "Build an unsigned TRON Stake 2.0 UnfreezeBalanceV2 transaction — begins the 14-day cooldown on a previously-frozen slice. The `amount` must not exceed what's currently frozen for that resource (query `get_tron_staking` first; TronGrid rejects otherwise with 'less than frozen balance'). After 14 days the slice shows up in `pendingUnfreezes` with an elapsed `unlockAt`; call `prepare_tron_withdraw_expire_unfreeze` to sweep it back to liquid TRX. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+      inputSchema: prepareTronUnfreezeInput.shape,
+    },
+    handler(buildTronUnfreeze)
+  );
+
+  server.registerTool(
+    "prepare_tron_withdraw_expire_unfreeze",
+    {
+      description:
+        "Build an unsigned TRON WithdrawExpireUnfreeze transaction — sweeps every matured unfreeze slice (those whose 14-day cooldown elapsed) back to liquid TRX. No amount needed; the chain drains all eligible slices in one call. Inspect `pendingUnfreezes` from `get_tron_staking` first — if every entry's `unlockAt` is still in the future, TronGrid returns 'no expire unfreeze' and this tool errors. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+      inputSchema: prepareTronWithdrawExpireUnfreezeInput.shape,
+    },
+    handler(buildTronWithdrawExpireUnfreeze)
   );
 
   server.registerTool(

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -245,6 +245,164 @@ export async function buildTronTokenSend(
   return issueTronHandle(tx);
 }
 
+// ----- Stake 2.0: Freeze / Unfreeze / WithdrawExpireUnfreeze -----
+
+/**
+ * TRON Stake 2.0 resource types. Lowercase on our API surface for consistency
+ * with the staking reader (`get_tron_staking` returns `type: "bandwidth"|"energy"`).
+ * TronGrid expects uppercase, so we uppercase at the edge.
+ */
+export type TronResource = "bandwidth" | "energy";
+
+export interface BuildTronFreezeArgs {
+  from: string;
+  amount: string;
+  resource: TronResource;
+}
+
+export async function buildTronFreeze(
+  args: BuildTronFreezeArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  const amountSun = parseUnits(args.amount, TRX_DECIMALS);
+  if (amountSun <= 0n) {
+    throw new Error(`Amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const body = {
+    owner_address: args.from,
+    frozen_balance: Number(amountSun),
+    resource: args.resource.toUpperCase(),
+    visible: true,
+  };
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/freezebalancev2",
+    body,
+    apiKey
+  );
+  if (res.Error) {
+    throw new Error(`TronGrid freezebalancev2 failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid freezebalancev2 returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "freeze",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description: `Freeze ${args.amount} TRX for ${args.resource} (Stake 2.0)`,
+    decoded: {
+      functionName: "FreezeBalanceV2Contract",
+      args: { owner: args.from, amount: args.amount, resource: args.resource },
+    },
+  };
+  return issueTronHandle(tx);
+}
+
+export interface BuildTronUnfreezeArgs {
+  from: string;
+  amount: string;
+  resource: TronResource;
+}
+
+export async function buildTronUnfreeze(
+  args: BuildTronUnfreezeArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  const amountSun = parseUnits(args.amount, TRX_DECIMALS);
+  if (amountSun <= 0n) {
+    throw new Error(`Amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const body = {
+    owner_address: args.from,
+    unfreeze_balance: Number(amountSun),
+    resource: args.resource.toUpperCase(),
+    visible: true,
+  };
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/unfreezebalancev2",
+    body,
+    apiKey
+  );
+  if (res.Error) {
+    // Common failure: "less than frozen balance" when the caller asks to
+    // unfreeze more than they've frozen for that resource type. Surface
+    // TronGrid's message verbatim so the agent can relay it.
+    throw new Error(`TronGrid unfreezebalancev2 failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid unfreezebalancev2 returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "unfreeze",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description: `Unfreeze ${args.amount} TRX from ${args.resource} — 14-day unstaking cooldown begins`,
+    decoded: {
+      functionName: "UnfreezeBalanceV2Contract",
+      args: { owner: args.from, amount: args.amount, resource: args.resource },
+    },
+  };
+  return issueTronHandle(tx);
+}
+
+export interface BuildTronWithdrawExpireUnfreezeArgs {
+  from: string;
+}
+
+export async function buildTronWithdrawExpireUnfreeze(
+  args: BuildTronWithdrawExpireUnfreezeArgs
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/withdrawexpireunfreeze",
+    { owner_address: args.from, visible: true },
+    apiKey
+  );
+  if (res.Error) {
+    // Common: "no expire unfreeze" when no unfrozenV2 slices have matured.
+    // Pair with get_tron_staking to check pendingUnfreezes[].unlockAt first.
+    throw new Error(`TronGrid withdrawexpireunfreeze failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid withdrawexpireunfreeze returned no transaction — unexpected shape.");
+  }
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "withdraw_expire_unfreeze",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description: `Withdraw all expired unfreezes back to liquid TRX for ${args.from}`,
+    decoded: {
+      functionName: "WithdrawExpireUnfreezeContract",
+      args: { owner: args.from },
+    },
+  };
+  return issueTronHandle(tx);
+}
+
 // ----- Claim voting rewards (WithdrawBalance) -----
 
 export interface BuildTronClaimRewardsArgs {

--- a/src/modules/tron/schemas.ts
+++ b/src/modules/tron/schemas.ts
@@ -47,3 +47,39 @@ export const prepareTronClaimRewardsInput = z.object({
 });
 
 export type PrepareTronClaimRewardsArgs = z.infer<typeof prepareTronClaimRewardsInput>;
+
+const tronResource = z
+  .enum(["bandwidth", "energy"])
+  .describe(
+    "Which Stake 2.0 resource to freeze/unfreeze TRX for. `bandwidth` fuels plain transactions; `energy` fuels smart-contract calls."
+  );
+
+export const prepareTronFreezeInput = z.object({
+  from: tronAddress.describe("Base58 TRON owner address (prefix T)."),
+  amount: amountString.describe(
+    "TRX amount to freeze as a human-readable decimal string (converted to SUN internally)."
+  ),
+  resource: tronResource,
+});
+
+export type PrepareTronFreezeArgs = z.infer<typeof prepareTronFreezeInput>;
+
+export const prepareTronUnfreezeInput = z.object({
+  from: tronAddress.describe("Base58 TRON owner address (prefix T)."),
+  amount: amountString.describe(
+    "TRX amount to unfreeze. Must not exceed the currently-frozen amount for the given resource — TronGrid rejects otherwise."
+  ),
+  resource: tronResource,
+});
+
+export type PrepareTronUnfreezeArgs = z.infer<typeof prepareTronUnfreezeInput>;
+
+export const prepareTronWithdrawExpireUnfreezeInput = z.object({
+  from: tronAddress.describe(
+    "Base58 TRON owner address. Sweeps all unfreezes whose 14-day cooldown has elapsed (see `pendingUnfreezes[].unlockAt` from `get_tron_staking`) back to liquid TRX."
+  ),
+});
+
+export type PrepareTronWithdrawExpireUnfreezeArgs = z.infer<
+  typeof prepareTronWithdrawExpireUnfreezeInput
+>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -399,7 +399,13 @@ export interface MultiWalletPortfolioSummary {
 export interface UnsignedTronTx {
   chain: "tron";
   /** Discriminator for the preview + future signer branching. */
-  action: "native_send" | "trc20_send" | "claim_rewards";
+  action:
+    | "native_send"
+    | "trc20_send"
+    | "claim_rewards"
+    | "freeze"
+    | "unfreeze"
+    | "withdraw_expire_unfreeze";
   /** Base58 owner address (prefix T). */
   from: string;
   /** TronGrid-returned transaction ID (sha256 of raw_data_hex, hex string). */

--- a/test/tron-phase2b-stake-writes.test.ts
+++ b/test/tron-phase2b-stake-writes.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildTronFreeze,
+  buildTronUnfreeze,
+  buildTronWithdrawExpireUnfreeze,
+} from "../src/modules/tron/actions.js";
+import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+
+/**
+ * Phase-2b (TRON Stake 2.0 writes) tests. Network IO is stubbed via
+ * vi.stubGlobal("fetch", ...). We lock down:
+ *   - POST body shape (endpoint, uppercase resource, SUN-encoded amount, visible:true)
+ *   - handle issuance + preview copy (ensures the user-visible description is right)
+ *   - validation (non-TRON `from`, zero/negative amounts, bad decimals)
+ *   - TronGrid error surfacing (top-level `Error` field)
+ */
+
+const ADDR = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+
+function directTxResponse(txID = "ab".repeat(32)): Response {
+  return new Response(
+    JSON.stringify({
+      txID,
+      raw_data: { expiration: 0 },
+      raw_data_hex: "0a05",
+      visible: true,
+    }),
+    { status: 200 }
+  );
+}
+
+describe("buildTronFreeze (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/freezebalancev2");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(ADDR);
+      expect(body.frozen_balance).toBe(100_000_000); // 100 TRX in SUN
+      expect(body.resource).toBe("BANDWIDTH"); // uppercased at edge
+      expect(body.visible).toBe(true);
+      return directTxResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds a BANDWIDTH freeze with correct body + preview + handle", async () => {
+    const tx = await buildTronFreeze({ from: ADDR, amount: "100", resource: "bandwidth" });
+    expect(tx.action).toBe("freeze");
+    expect(tx.description).toBe("Freeze 100 TRX for bandwidth (Stake 2.0)");
+    expect(tx.decoded.functionName).toBe("FreezeBalanceV2Contract");
+    expect(tx.decoded.args).toEqual({ owner: ADDR, amount: "100", resource: "bandwidth" });
+    expect(tx.handle).toBeDefined();
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("uppercases ENERGY at the TronGrid edge", async () => {
+    fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(init!.body as string);
+      expect(body.resource).toBe("ENERGY");
+      return directTxResponse();
+    });
+    const tx = await buildTronFreeze({ from: ADDR, amount: "50", resource: "energy" });
+    expect(tx.decoded.args.resource).toBe("energy"); // preserved lowercase on preview
+  });
+
+  it("rejects non-TRON `from`", async () => {
+    await expect(
+      buildTronFreeze({ from: "0xdead", amount: "1", resource: "bandwidth" })
+    ).rejects.toThrow(/TRON mainnet/);
+  });
+
+  it("rejects zero or sub-sun amounts", async () => {
+    await expect(
+      buildTronFreeze({ from: ADDR, amount: "0", resource: "bandwidth" })
+    ).rejects.toThrow(/greater than 0/);
+    await expect(
+      buildTronFreeze({ from: ADDR, amount: "1.1234567", resource: "bandwidth" })
+    ).rejects.toThrow(/more decimals than token precision/);
+  });
+
+  it("surfaces TronGrid's top-level Error verbatim", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(JSON.stringify({ Error: "contract validate error : frozen_balance must be greater than 1 TRX" }), {
+          status: 200,
+        })
+    );
+    await expect(
+      buildTronFreeze({ from: ADDR, amount: "0.5", resource: "bandwidth" })
+    ).rejects.toThrow(/greater than 1 TRX/);
+  });
+});
+
+describe("buildTronUnfreeze (network stubbed)", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        expect(url).toBe("https://api.trongrid.io/wallet/unfreezebalancev2");
+        const body = JSON.parse(init!.body as string);
+        expect(body.owner_address).toBe(ADDR);
+        expect(body.unfreeze_balance).toBe(75_000_000); // 75 TRX
+        expect(body.resource).toBe("ENERGY");
+        return directTxResponse();
+      })
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds an ENERGY unfreeze with 14-day-cooldown language in the preview", async () => {
+    const tx = await buildTronUnfreeze({ from: ADDR, amount: "75", resource: "energy" });
+    expect(tx.action).toBe("unfreeze");
+    expect(tx.description).toBe(
+      "Unfreeze 75 TRX from energy — 14-day unstaking cooldown begins"
+    );
+    expect(tx.decoded.functionName).toBe("UnfreezeBalanceV2Contract");
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("surfaces 'less than frozen balance' verbatim (overshoot guard)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ Error: "contract validate error : unfreezeBalance less than frozen balance" }), {
+            status: 200,
+          })
+      )
+    );
+    await expect(
+      buildTronUnfreeze({ from: ADDR, amount: "9999", resource: "bandwidth" })
+    ).rejects.toThrow(/less than frozen balance/);
+  });
+
+  it("rejects zero/negative amounts", async () => {
+    await expect(
+      buildTronUnfreeze({ from: ADDR, amount: "0", resource: "bandwidth" })
+    ).rejects.toThrow(/greater than 0/);
+    await expect(
+      buildTronUnfreeze({ from: ADDR, amount: "-1", resource: "bandwidth" })
+    ).rejects.toThrow(/Invalid amount/);
+  });
+});
+
+describe("buildTronWithdrawExpireUnfreeze (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/withdrawexpireunfreeze");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(ADDR);
+      expect(body.visible).toBe(true);
+      return directTxResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds a sweep tx with handle + preview", async () => {
+    const tx = await buildTronWithdrawExpireUnfreeze({ from: ADDR });
+    expect(tx.action).toBe("withdraw_expire_unfreeze");
+    expect(tx.decoded.functionName).toBe("WithdrawExpireUnfreezeContract");
+    expect(tx.description).toContain("Withdraw all expired unfreezes");
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("surfaces 'no expire unfreeze' when nothing has matured yet", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(
+          JSON.stringify({ Error: "contract validate error : no expire unfreeze" }),
+          { status: 200 }
+        )
+    );
+    await expect(buildTronWithdrawExpireUnfreeze({ from: ADDR })).rejects.toThrow(
+      /no expire unfreeze/
+    );
+  });
+
+  it("rejects a non-TRON owner", async () => {
+    await expect(buildTronWithdrawExpireUnfreeze({ from: "0xbad" })).rejects.toThrow(
+      /TRON mainnet/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds three TRON Stake 2.0 preparation tools: `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze`. Each hits TronGrid's v2 staking endpoints with `visible: true`, uppercases the `bandwidth`/`energy` resource at the edge, and returns an opaque handle.
- `UnsignedTronTx.action` union extended additively — `freeze`, `unfreeze`, `withdraw_expire_unfreeze`.
- Preview-only in this release, consistent with Phase 2: `send_transaction` refuses TRON handles until the USB HID signer lands.
- `prepare_tron_freeze`'s description explicitly calls out that freezing alone does **not** earn rewards — VoteWitness is required and is queued separately as Phase 2c (see follow-up issue).

## Test plan
- [x] `npx vitest run` — 296/296 pass (11 new tests in `test/tron-phase2b-stake-writes.test.ts` covering POST body shape, resource uppercasing, preview copy, handle issuance, and TronGrid error passthrough for overshoot/no-mature cases).
- [x] `npm run build` — clean tsc.
- [ ] Manual: call `prepare_tron_freeze` with `resource: "bandwidth"` against a real address; inspect the returned `txID` and cross-check against a direct `/wallet/freezebalancev2` call.
- [ ] Manual: call `prepare_tron_unfreeze` with an overshoot amount; confirm TronGrid's `less than frozen balance` surfaces verbatim.
- [ ] Manual: call `prepare_tron_withdraw_expire_unfreeze` on an address with no matured slices; confirm `no expire unfreeze` surfaces.

## Follow-ups
- Phase 2c (tracked separately): SR listing + `prepare_tron_vote` — required for freezes to actually accrue rewards.
- Phase 3: USB HID signing via `@ledgerhq/hw-app-trx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)