### PR TITLE
Add TRON Phase 2c: SR listing + VoteWitness preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 EVM: Ethereum, Arbitrum, Polygon, Base.
 
-Non-EVM: TRON (phases 1 + 2 + 2b — balance + staking reads, tx preparation for native TRX sends, canonical TRC-20 transfers, voting-reward claims, and Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze; Ledger signing lands in a follow-up phase).
+Non-EVM: TRON (phases 1 + 2 + 2b + 2c — balance + staking reads, SR listing, and tx preparation for native TRX sends, canonical TRC-20 transfers, voting-reward claims, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, and VoteWitness; Ledger signing lands in a follow-up phase).
 
 Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no lending/LP coverage in this server (none of Aave/Compound/Morpho/Uniswap are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume, and TRON-native staking (frozen TRX under Stake 2.0, pending unfreezes, claimable voting rewards) is surfaced via `get_tron_staking` and folded into the portfolio summary. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
@@ -61,6 +61,7 @@ Read-only (no Ledger pairing required):
 - `simulate_transaction` — run `eth_call` against a prepared or arbitrary tx to preview success/revert before signing; prepared txs are re-simulated automatically at send time
 - `get_token_balance`, `get_token_price` — balances and DefiLlama prices; `get_token_balance` accepts `chain: "tron"` with a base58 wallet and a base58 TRC-20 address (or `token: "native"` for TRX), returning a `TronBalance` shape
 - `get_tron_staking` — TRON-native staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with ISO unlock timestamps. Pair with `prepare_tron_claim_rewards` to actually withdraw accumulated rewards.
+- `list_tron_witnesses` — TRON Super Representatives + SR candidates, ranked by vote weight, with a rough voter-APR estimate per SR. Optionally augments with the caller's current vote allocation, total TRON Power, and available (unused) votes — pair with `prepare_tron_vote`.
 - `resolve_ens_name`, `reverse_resolve_ens` — ENS forward/reverse
 - `get_swap_quote` — LiFi quote (optionally cross-checked against 1inch)
 - `check_contract_security`, `check_permission_risks`, `get_protocol_risk_score` — risk tooling
@@ -80,7 +81,7 @@ Execution (Ledger-signed via WalletConnect):
 - `prepare_eigenlayer_deposit`
 - `prepare_swap` — LiFi-routed intra- or cross-chain swap/bridge
 - `prepare_native_send`, `prepare_token_send`
-- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`, `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
+- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`, `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze`, `prepare_tron_vote` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, VoteWitness). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
 - `send_transaction` — forwards a prepared EVM tx to Ledger Live for user approval
 
 ## Requirements

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import {
 } from "./modules/balances/schemas.js";
 
 import { getTronStaking } from "./modules/tron/staking.js";
+import { listTronWitnesses } from "./modules/tron/witnesses.js";
 import {
   buildTronNativeSend,
   buildTronTokenSend,
@@ -89,6 +90,7 @@ import {
   buildTronFreeze,
   buildTronUnfreeze,
   buildTronWithdrawExpireUnfreeze,
+  buildTronVote,
 } from "./modules/tron/actions.js";
 import {
   getTronStakingInput,
@@ -98,6 +100,8 @@ import {
   prepareTronFreezeInput,
   prepareTronUnfreezeInput,
   prepareTronWithdrawExpireUnfreezeInput,
+  listTronWitnessesInput,
+  prepareTronVoteInput,
 } from "./modules/tron/schemas.js";
 
 import { getCompoundPositions } from "./modules/compound/index.js";
@@ -641,7 +645,7 @@ async function main() {
     "prepare_tron_freeze",
     {
       description:
-        "Build an unsigned TRON Stake 2.0 FreezeBalanceV2 transaction. Locks TRX to earn `bandwidth` (fuels plain transfers) or `energy` (fuels smart-contract calls) and gains proportional voting power. IMPORTANT: freezing alone does NOT accrue TRX rewards — `claimableRewards` (see `get_tron_staking`) only grows after the user also votes for a Super Representative, and VoteWitness is not yet exposed as a tool in this server. Unlocking requires a 14-day cooldown via `prepare_tron_unfreeze` + `prepare_tron_withdraw_expire_unfreeze`. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+        "Build an unsigned TRON Stake 2.0 FreezeBalanceV2 transaction. Locks TRX to earn `bandwidth` (fuels plain transfers) or `energy` (fuels smart-contract calls) and gains proportional voting power. IMPORTANT: freezing alone does NOT accrue TRX rewards — `claimableRewards` (see `get_tron_staking`) only grows after the user also votes for a Super Representative. Pair this tool with `list_tron_witnesses` + `prepare_tron_vote` for the full reward-earning flow. Unlocking requires a 14-day cooldown via `prepare_tron_unfreeze` + `prepare_tron_withdraw_expire_unfreeze`. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
       inputSchema: prepareTronFreezeInput.shape,
     },
     handler(buildTronFreeze)
@@ -665,6 +669,28 @@ async function main() {
       inputSchema: prepareTronWithdrawExpireUnfreezeInput.shape,
     },
     handler(buildTronWithdrawExpireUnfreeze)
+  );
+
+  server.registerTool(
+    "list_tron_witnesses",
+    {
+      description:
+        "List TRON Super Representatives (SRs) + SR candidates, ranked by total vote count. Active SRs (rank ≤ 27, `isActive: true`) produce blocks and distribute the 160 TRX/block voter-reward pool pro-rata to their voters; every witness in the top 127 shares the same APR estimate (pro-rata split of the pool); witnesses ranked > 127 get `estVoterApr: 0`. APR estimates assume current mainnet constants (3-second blocks, 27 active SRs, 365 days/year) and are best-effort — actual rewards depend on missed blocks and competing voters shifting between your vote tx and reward claim. When `address` is passed, also returns `userVotes`, `totalTronPower`, `totalVotesCast`, and `availableVotes` so you can diff against a target allocation before calling `prepare_tron_vote`. Defaults to top-27 only; pass `includeCandidates: true` for the long tail.",
+      inputSchema: listTronWitnessesInput.shape,
+    },
+    handler((args: { address?: string; includeCandidates?: boolean }) =>
+      listTronWitnesses(args.address, args.includeCandidates ?? false)
+    )
+  );
+
+  server.registerTool(
+    "prepare_tron_vote",
+    {
+      description:
+        "Build an unsigned TRON VoteWitnessContract transaction — casts votes for Super Representatives to earn voting rewards on frozen TRX. IMPORTANT: VoteWitness REPLACES the wallet's entire prior vote allocation atomically. Pass every SR you intend to back (not just a delta); an empty `votes` array clears all votes. Sum of `count` values must not exceed the wallet's available TRON Power — check `list_tron_witnesses(address)` → `availableVotes` first. `count` is an integer (1 vote = 1 TRX of TRON Power). Rewards accrue per block and are harvested via `prepare_tron_claim_rewards` (24h cooldown). Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+      inputSchema: prepareTronVoteInput.shape,
+    },
+    handler(buildTronVote)
   );
 
   server.registerTool(

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -245,6 +245,100 @@ export async function buildTronTokenSend(
   return issueTronHandle(tx);
 }
 
+// ----- VoteWitness (cast/replace all votes atomically) -----
+
+export interface TronVoteEntry {
+  /** Base58 SR address to vote for. */
+  address: string;
+  /** Integer vote count — 1 vote requires 1 TRX of frozen TRON Power. */
+  count: number;
+}
+
+export interface BuildTronVoteArgs {
+  from: string;
+  votes: TronVoteEntry[];
+}
+
+/**
+ * Build a VoteWitnessContract tx. This REPLACES the wallet's entire vote
+ * allocation atomically — TRON has no delta/patch endpoint. The caller must
+ * pass the full intended allocation; passing `votes: []` clears all votes.
+ *
+ * We enforce unique `vote_address` entries (TronGrid accepts duplicates but
+ * silently collapses them, which confuses downstream previews) and positive
+ * integer counts. The sum of counts must not exceed the wallet's TRON Power
+ * (frozen TRX) — we don't pre-check that here because it requires a second
+ * TronGrid round-trip; TronGrid rejects with a clear message in that case and
+ * `list_tron_witnesses(address)` exposes `availableVotes` for the caller.
+ */
+export async function buildTronVote(args: BuildTronVoteArgs): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  const seen = new Set<string>();
+  for (const v of args.votes) {
+    if (!isTronAddress(v.address)) {
+      throw new Error(`Vote target "${v.address}" is not a valid TRON base58 address.`);
+    }
+    if (!Number.isInteger(v.count) || v.count <= 0) {
+      throw new Error(
+        `Vote count must be a positive integer (got ${v.count} for ${v.address}).`
+      );
+    }
+    if (seen.has(v.address)) {
+      throw new Error(`Duplicate vote target in allocation: ${v.address}`);
+    }
+    seen.add(v.address);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const body = {
+    owner_address: args.from,
+    votes: args.votes.map((v) => ({ vote_address: v.address, vote_count: v.count })),
+    visible: true,
+  };
+  const res = await trongridPost<TrongridDirectTx>(
+    "/wallet/votewitnessaccount",
+    body,
+    apiKey
+  );
+  if (res.Error) {
+    // Common: "Not enough tron power" when sum > availableVotes; "witness not
+    // exists" if the address isn't an active SR or candidate. Surface verbatim.
+    throw new Error(`TronGrid votewitnessaccount failed: ${res.Error}`);
+  }
+  if (!res.txID || !res.raw_data_hex) {
+    throw new Error("TronGrid votewitnessaccount returned no transaction — unexpected shape.");
+  }
+
+  const totalVotes = args.votes.reduce((s, v) => s + v.count, 0);
+  const description =
+    args.votes.length === 0
+      ? `Clear all SR votes for ${args.from}`
+      : `Cast ${totalVotes} TRON Power across ${args.votes.length} SR${
+          args.votes.length === 1 ? "" : "s"
+        } (replaces any prior votes)`;
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "vote",
+    from: args.from,
+    txID: res.txID,
+    rawData: res.raw_data,
+    rawDataHex: res.raw_data_hex,
+    description,
+    decoded: {
+      functionName: "VoteWitnessContract",
+      args: {
+        owner: args.from,
+        totalVotes: totalVotes.toString(),
+        allocation: JSON.stringify(args.votes),
+      },
+    },
+  };
+  return issueTronHandle(tx);
+}
+
 // ----- Stake 2.0: Freeze / Unfreeze / WithdrawExpireUnfreeze -----
 
 /**

--- a/src/modules/tron/schemas.ts
+++ b/src/modules/tron/schemas.ts
@@ -83,3 +83,39 @@ export const prepareTronWithdrawExpireUnfreezeInput = z.object({
 export type PrepareTronWithdrawExpireUnfreezeArgs = z.infer<
   typeof prepareTronWithdrawExpireUnfreezeInput
 >;
+
+export const listTronWitnessesInput = z.object({
+  address: tronAddress
+    .optional()
+    .describe(
+      "Optional base58 TRON address. When provided, the response also includes the wallet's current vote allocation, total TRON Power (frozenV2 sum in whole TRX), and remaining available votes — diff these against your target allocation before building `prepare_tron_vote`."
+    ),
+  includeCandidates: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include SR candidates (rank > 27) alongside the active top 27. Candidates don't produce blocks so their voter APR is 0. Defaults to false."
+    ),
+});
+
+export type ListTronWitnessesArgs = z.infer<typeof listTronWitnessesInput>;
+
+export const prepareTronVoteInput = z.object({
+  from: tronAddress.describe("Base58 TRON owner address (prefix T)."),
+  votes: z
+    .array(
+      z.object({
+        address: tronAddress.describe("Base58 SR or candidate address to vote for."),
+        count: z
+          .number()
+          .int()
+          .positive()
+          .describe("Integer vote count — 1 vote consumes 1 TRX of TRON Power."),
+      })
+    )
+    .describe(
+      "Full vote allocation. VoteWitness REPLACES all prior votes atomically — pass every SR you intend to back, not just the delta. An empty array clears all votes. Sum of counts must not exceed the wallet's available TRON Power (see `list_tron_witnesses` → `availableVotes`); TronGrid rejects otherwise."
+    ),
+});
+
+export type PrepareTronVoteArgs = z.infer<typeof prepareTronVoteInput>;

--- a/src/modules/tron/witnesses.ts
+++ b/src/modules/tron/witnesses.ts
@@ -1,0 +1,189 @@
+import { TRONGRID_BASE_URL, TRX_DECIMALS, isTronAddress } from "../../config/tron.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import type { TronWitnessInfo, TronWitnessList, TronVoteAllocation } from "../../types/index.js";
+
+/**
+ * TRON mainnet reward constants used for the voter-APR estimate. These are the
+ * chain-parameter defaults and have been stable for years; a live
+ * `/wallet/getchainparameters` fetch would be more accurate but adds a round-trip
+ * for marginal precision. If TRON governance ever shifts these, the estimates
+ * drift until this file is updated.
+ */
+const VOTER_REWARD_POOL_TRX_PER_BLOCK = 160;
+const BLOCK_TIME_SECONDS = 3;
+const BLOCKS_PER_DAY = (24 * 60 * 60) / BLOCK_TIME_SECONDS; // 28800
+const DAYS_PER_YEAR = 365;
+const ACTIVE_SR_COUNT = 27;
+/**
+ * The 160 TRX voter-reward pool is distributed pro-rata to voters for the
+ * top 127 witnesses (active SRs + standby candidates), not per-SR. Every
+ * voter's per-TRX APR is therefore roughly uniform within the top-127 band
+ * and driven by the total vote weight cast across it.
+ */
+const REWARD_ELIGIBLE_SR_COUNT = 127;
+
+interface TrongridWitness {
+  /** Base58 when called with visible=true. */
+  address?: string;
+  voteCount?: number;
+  url?: string;
+  totalProduced?: number;
+  totalMissed?: number;
+  latestBlockNum?: number;
+  latestSlotNum?: number;
+  isJobs?: boolean;
+}
+
+interface TrongridListWitnessesResponse {
+  witnesses?: TrongridWitness[];
+}
+
+interface TrongridAccountVotesEntry {
+  vote_address?: string;
+  vote_count?: number;
+}
+
+interface TrongridV1Account {
+  address?: string;
+  votes?: TrongridAccountVotesEntry[];
+  frozenV2?: Array<{ amount?: number; type?: "BANDWIDTH" | "ENERGY" }>;
+}
+
+interface TrongridV1AccountResponse {
+  data?: TrongridV1Account[];
+}
+
+async function trongridGet<T>(path: string, apiKey: string | undefined): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, { headers });
+  if (!res.ok) {
+    throw new Error(`TronGrid ${path} returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Rough annualised voter APR.
+ *
+ *   apr = (VOTER_REWARD_POOL × BLOCKS_PER_DAY × 365) / totalTop127Votes
+ *
+ * The 160 TRX voter-reward pool is split each block pro-rata by vote share
+ * across the top 127 witnesses. A hypothetical 1-TRX vote anywhere in the
+ * top 127 therefore claims 160/totalTop127Votes per block, independent of
+ * which specific SR it's cast for. APRs are roughly uniform within the top
+ * 127; real differences come from per-SR commission rates (not exposed by
+ * this endpoint) and reliability (totalMissed). Out-of-top-127 ⇒ 0.
+ *
+ * This ignores block-reward APR (16 TRX/block to producers, ~1/27 of blocks
+ * per active SR, divided by voteCount) which contributes <10 % of typical
+ * voter returns and varies per-SR — leaving it out keeps the estimate simple
+ * and roughly flat across the top 127, matching how most TRON staking UIs
+ * present the number.
+ */
+function estimateVoterApr(rank: number, totalTop127Votes: number): number {
+  if (rank > REWARD_ELIGIBLE_SR_COUNT) return 0;
+  if (totalTop127Votes <= 0) return 0;
+  return (
+    (VOTER_REWARD_POOL_TRX_PER_BLOCK * BLOCKS_PER_DAY * DAYS_PER_YEAR) /
+    totalTop127Votes
+  );
+}
+
+/** SUN → integer TRX floor (1 vote = 1 whole TRX of frozen TRON Power). */
+function sunToVotes(sun: bigint): number {
+  return Number(sun / BigInt(10 ** TRX_DECIMALS));
+}
+
+/**
+ * List TRON Super Representatives and SR candidates, ranked by total votes.
+ * Every witness in the top 127 (active SRs + standby candidates) shares the
+ * same voter APR estimate — the 160 TRX/block pool is split pro-rata across
+ * all of them. Witnesses ranked > 127 get APR 0.
+ *
+ * When `address` is provided, also returns the wallet's current vote
+ * allocation, total TRON Power (frozenV2 sum), and available (unused) votes
+ * so the caller can diff before building a `prepare_tron_vote` tx.
+ *
+ * `includeCandidates` defaults to false — most agents only care about the
+ * top 27. Pass true to include the long tail.
+ *
+ * Filters out any witness whose address doesn't pass `isTronAddress` so that
+ * if TronGrid returns hex-form addresses (e.g. if `visible=true` is ignored
+ * on a proxy deployment) we fail closed with an empty list instead of
+ * emitting addresses that can't round-trip into `prepare_tron_vote`.
+ */
+export async function listTronWitnesses(
+  address?: string,
+  includeCandidates = false
+): Promise<TronWitnessList> {
+  if (address !== undefined && !isTronAddress(address)) {
+    throw new Error(
+      `"${address}" is not a valid TRON mainnet address (expected base58, 34 chars, prefix T).`
+    );
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+
+  const [witnessRes, accountRes] = await Promise.all([
+    trongridGet<TrongridListWitnessesResponse>("/wallet/listwitnesses?visible=true", apiKey),
+    address !== undefined
+      ? trongridGet<TrongridV1AccountResponse>(`/v1/accounts/${address}`, apiKey)
+      : Promise.resolve(undefined),
+  ]);
+
+  const raw = witnessRes.witnesses ?? [];
+  const sorted = [...raw].sort((a, b) => (b.voteCount ?? 0) - (a.voteCount ?? 0));
+
+  // Total votes across the top 127 — the denominator for voter APR.
+  let totalTop127Votes = 0;
+  for (let i = 0; i < Math.min(sorted.length, REWARD_ELIGIBLE_SR_COUNT); i++) {
+    totalTop127Votes += sorted[i].voteCount ?? 0;
+  }
+
+  const witnesses: TronWitnessInfo[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    const w = sorted[i];
+    if (!w.address || !isTronAddress(w.address)) continue;
+    const rank = i + 1;
+    const isActive = rank <= ACTIVE_SR_COUNT;
+    if (!isActive && !includeCandidates) continue;
+    const voteCount = w.voteCount ?? 0;
+    witnesses.push({
+      address: w.address,
+      ...(w.url !== undefined ? { url: w.url } : {}),
+      voteCount: voteCount.toString(),
+      isActive,
+      rank,
+      ...(w.totalProduced !== undefined ? { totalProduced: w.totalProduced } : {}),
+      ...(w.totalMissed !== undefined ? { totalMissed: w.totalMissed } : {}),
+      estVoterApr: estimateVoterApr(rank, totalTop127Votes),
+    });
+  }
+
+  const result: TronWitnessList = { witnesses };
+
+  if (address !== undefined) {
+    const acc = accountRes?.data?.[0];
+    const userVotes: TronVoteAllocation[] = [];
+    for (const v of acc?.votes ?? []) {
+      if (!v.vote_address) continue;
+      const count = v.vote_count ?? 0;
+      if (count <= 0) continue;
+      userVotes.push({ address: v.vote_address, count });
+    }
+    let frozenSun = 0n;
+    for (const f of acc?.frozenV2 ?? []) {
+      frozenSun += BigInt(f.amount ?? 0);
+    }
+    const totalTronPower = sunToVotes(frozenSun);
+    const totalVotesCast = userVotes.reduce((s, v) => s + v.count, 0);
+    const availableVotes = Math.max(0, totalTronPower - totalVotesCast);
+    result.userVotes = userVotes;
+    result.totalTronPower = totalTronPower;
+    result.totalVotesCast = totalVotesCast;
+    result.availableVotes = availableVotes;
+  }
+
+  return result;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -336,6 +336,62 @@ export interface TronStakingSlice {
   totalStakedUsd: number;
 }
 
+/**
+ * A single Super Representative / SR candidate entry from TronGrid's
+ * `/wallet/listwitnesses`. Ranks are 1-based by voteCount DESC; active SRs
+ * are rank ≤ 27 (those that actually produce blocks and distribute voter
+ * rewards). Candidates have rank > 27 and receive no voter rewards.
+ */
+export interface TronWitnessInfo {
+  /** Base58 TRON address (prefix T). */
+  address: string;
+  /** SR operator URL (self-declared; not validated). */
+  url?: string;
+  /** Total vote weight for this SR, as a decimal string (1 frozen TRX = 1 vote). */
+  voteCount: string;
+  /** True iff rank ≤ 27 — this SR produces blocks. */
+  isActive: boolean;
+  /** 1-based rank by voteCount DESC. */
+  rank: number;
+  totalProduced?: number;
+  totalMissed?: number;
+  /**
+   * Rough annualised voter APR estimate as a decimal fraction (0.04 = 4 %).
+   * Computed from mainnet reward constants (160 TRX/block voter pool, ~28 800
+   * blocks/day, 365 days/year) divided by the total vote weight across the
+   * top 127 witnesses — the APR is therefore roughly uniform for every
+   * witness in the top 127. Witnesses ranked > 127 get 0. This is an
+   * ESTIMATE — actual rewards depend on per-SR commission, missed blocks,
+   * chain-param changes, and competing voters joining/leaving between your
+   * vote tx and reward claim.
+   */
+  estVoterApr?: number;
+}
+
+/** The wallet's current vote allocation from `account.votes`. */
+export interface TronVoteAllocation {
+  /** Base58 SR address the vote is cast for. */
+  address: string;
+  /** Integer vote count (1 vote = 1 frozen TRX of TRON Power). */
+  count: number;
+}
+
+export interface TronWitnessList {
+  witnesses: TronWitnessInfo[];
+  /** Present only when the caller passed `address`. */
+  userVotes?: TronVoteAllocation[];
+  /**
+   * Total TRON Power available to the caller's wallet (= integer TRX frozen
+   * under Stake 2.0, summed across bandwidth + energy). Set when `address`
+   * is passed.
+   */
+  totalTronPower?: number;
+  /** Sum of userVotes[].count. Set when `address` is passed. */
+  totalVotesCast?: number;
+  /** totalTronPower − totalVotesCast, floored at 0. Set when `address` is passed. */
+  availableVotes?: number;
+}
+
 /** Per-wallet slice of a multi-wallet portfolio, or a stand-alone single-wallet summary. */
 export interface PortfolioSummary {
   wallet: `0x${string}`;
@@ -405,7 +461,8 @@ export interface UnsignedTronTx {
     | "claim_rewards"
     | "freeze"
     | "unfreeze"
-    | "withdraw_expire_unfreeze";
+    | "withdraw_expire_unfreeze"
+    | "vote";
   /** Base58 owner address (prefix T). */
   from: string;
   /** TronGrid-returned transaction ID (sha256 of raw_data_hex, hex string). */

--- a/test/tron-phase2c-voting.test.ts
+++ b/test/tron-phase2c-voting.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { listTronWitnesses } from "../src/modules/tron/witnesses.js";
+import { buildTronVote } from "../src/modules/tron/actions.js";
+import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+
+/**
+ * Phase-2c (TRON voting) tests. Covers:
+ *   - SR ranking + active/candidate split + APR math against a fixed synthetic set
+ *   - Per-wallet augmentation (userVotes, totalTronPower, availableVotes)
+ *   - VoteWitness builder body shape, dedupe, positive-integer-count guards,
+ *     TronGrid error surfacing, and clear-all-votes (empty array) semantics
+ */
+
+const OWNER = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const SR1 = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9";
+const SR2 = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const SR3 = "TWGEPPwSxGNwQBefExdbVybgrsNuF47yYJ";
+
+/**
+ * Build a synthetic /wallet/listwitnesses response with 30 SRs of decreasing
+ * vote weight, so the 27-active threshold actually gets tested. Addresses
+ * don't need to be unique to the point of chain reality — base58 regex is
+ * all the reader validates.
+ */
+function fakeWitnessList(): { witnesses: Array<{ address: string; voteCount: number; url?: string; totalProduced?: number; totalMissed?: number }> } {
+  // Use our three known-valid base58 addresses as the top 3, then fill the
+  // remaining 27 with deterministic variants. All 30 still need to be valid
+  // TRON addresses (base58check) — easiest is to just reuse SR1 for the tail
+  // since listTronWitnesses only checks each is a string and doesn't enforce
+  // uniqueness (TronGrid wouldn't serve dupes on real mainnet).
+  const top = [
+    { address: SR1, voteCount: 5_000_000_000, url: "https://sr1.example", totalProduced: 1000, totalMissed: 1 },
+    { address: SR2, voteCount: 3_000_000_000, url: "https://sr2.example", totalProduced: 800 },
+    { address: SR3, voteCount: 1_000_000_000 },
+  ];
+  const tail = Array.from({ length: 27 }, (_, i) => ({
+    address: SR1,
+    voteCount: 1_000_000 - i, // strictly decreasing, well below the top 3
+  }));
+  return { witnesses: [...top, ...tail] };
+}
+
+describe("listTronWitnesses (network stubbed)", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "https://api.trongrid.io/wallet/listwitnesses?visible=true") {
+          return new Response(JSON.stringify(fakeWitnessList()), { status: 200 });
+        }
+        if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  address: OWNER,
+                  votes: [
+                    { vote_address: SR1, vote_count: 100 },
+                    { vote_address: SR2, vote_count: 50 },
+                  ],
+                  frozenV2: [
+                    { amount: 200_000_000, type: "BANDWIDTH" }, // 200 TRX
+                    { amount: 50_000_000, type: "ENERGY" }, // 50 TRX
+                  ],
+                },
+              ],
+            }),
+            { status: 200 }
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      })
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns only the top 27 active SRs by default, ranked by voteCount DESC", async () => {
+    const list = await listTronWitnesses();
+    expect(list.witnesses).toHaveLength(27);
+    // All active.
+    expect(list.witnesses.every((w) => w.isActive)).toBe(true);
+    // Top-ranked entry is SR1 (highest voteCount).
+    expect(list.witnesses[0].address).toBe(SR1);
+    expect(list.witnesses[0].rank).toBe(1);
+    // userVotes-related fields absent when no address passed.
+    expect(list.userVotes).toBeUndefined();
+    expect(list.totalTronPower).toBeUndefined();
+  });
+
+  it("includes candidates when includeCandidates=true, and top-127 candidates share the same APR as active SRs", async () => {
+    const list = await listTronWitnesses(undefined, true);
+    expect(list.witnesses.length).toBeGreaterThan(27);
+    const candidate = list.witnesses.find((w) => !w.isActive);
+    expect(candidate).toBeDefined();
+    expect(candidate!.rank).toBeGreaterThan(27);
+    // All 30 witnesses in the fake list fall inside top-127 so they all get
+    // the same (non-zero) APR — the split is "top 127 earn pool, rest get 0",
+    // not "active earn, candidates don't".
+    expect(candidate!.estVoterApr).toBeGreaterThan(0);
+    expect(candidate!.estVoterApr).toBe(list.witnesses[0].estVoterApr);
+  });
+
+  it("computes voter APR as 160 TRX/block pool ÷ total top-127 vote weight", async () => {
+    const list = await listTronWitnesses();
+    const top = list.witnesses[0];
+    // Fake set total top-127 votes = top3 (9e9) + 27 tail entries summing
+    // to Σ_{i=0..26}(1_000_000 - i) = 27 * 1_000_000 - (0+1+...+26)
+    // = 27_000_000 - 351 = 26_999_649.
+    const totalTop127 = 5_000_000_000 + 3_000_000_000 + 1_000_000_000 + 26_999_649;
+    const expected = (160 * 28800 * 365) / totalTop127;
+    expect(top.estVoterApr).toBeCloseTo(expected, 10);
+    // The APR is uniform across all active SRs under this model.
+    for (const w of list.witnesses) {
+      expect(w.estVoterApr).toBeCloseTo(expected, 10);
+    }
+  });
+
+  it("augments the response with userVotes / totalTronPower / availableVotes when address is passed", async () => {
+    const list = await listTronWitnesses(OWNER);
+    expect(list.userVotes).toEqual([
+      { address: SR1, count: 100 },
+      { address: SR2, count: 50 },
+    ]);
+    // 200 + 50 = 250 TRX frozen → 250 vote units.
+    expect(list.totalTronPower).toBe(250);
+    expect(list.totalVotesCast).toBe(150);
+    expect(list.availableVotes).toBe(100);
+  });
+
+  it("clamps availableVotes to 0 when cast > power (edge case; shouldn't happen on-chain but be defensive)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/wallet/listwitnesses")) {
+          return new Response(JSON.stringify(fakeWitnessList()), { status: 200 });
+        }
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                votes: [{ vote_address: SR1, vote_count: 999 }],
+                frozenV2: [{ amount: 100_000_000, type: "BANDWIDTH" }], // 100 TRX
+              },
+            ],
+          }),
+          { status: 200 }
+        );
+      })
+    );
+    const list = await listTronWitnesses(OWNER);
+    expect(list.availableVotes).toBe(0);
+  });
+
+  it("rejects a malformed address", async () => {
+    await expect(listTronWitnesses("0xdeadbeef")).rejects.toThrow(/TRON mainnet/);
+  });
+});
+
+describe("buildTronVote (network stubbed)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/votewitnessaccount");
+      const body = JSON.parse(init!.body as string);
+      expect(body.owner_address).toBe(OWNER);
+      expect(body.visible).toBe(true);
+      expect(Array.isArray(body.votes)).toBe(true);
+      return new Response(
+        JSON.stringify({
+          txID: "cc".repeat(32),
+          raw_data: { expiration: 0 },
+          raw_data_hex: "0a06",
+          visible: true,
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds a multi-SR vote tx with the right body shape + handle", async () => {
+    const tx = await buildTronVote({
+      from: OWNER,
+      votes: [
+        { address: SR1, count: 100 },
+        { address: SR2, count: 50 },
+      ],
+    });
+    expect(tx.action).toBe("vote");
+    expect(tx.decoded.functionName).toBe("VoteWitnessContract");
+    expect(tx.description).toBe(
+      "Cast 150 TRON Power across 2 SRs (replaces any prior votes)"
+    );
+    expect(tx.decoded.args.totalVotes).toBe("150");
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+
+    // TronGrid body uses vote_address / vote_count, not our external shape.
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.votes).toEqual([
+      { vote_address: SR1, vote_count: 100 },
+      { vote_address: SR2, vote_count: 50 },
+    ]);
+  });
+
+  it("emits a clear-votes description when votes=[]", async () => {
+    const tx = await buildTronVote({ from: OWNER, votes: [] });
+    expect(tx.description).toBe(`Clear all SR votes for ${OWNER}`);
+    expect(tx.decoded.args.totalVotes).toBe("0");
+  });
+
+  it("rejects duplicate SR addresses in the allocation", async () => {
+    await expect(
+      buildTronVote({
+        from: OWNER,
+        votes: [
+          { address: SR1, count: 100 },
+          { address: SR1, count: 50 },
+        ],
+      })
+    ).rejects.toThrow(/Duplicate vote target/);
+  });
+
+  it("rejects non-integer or non-positive counts", async () => {
+    await expect(
+      buildTronVote({ from: OWNER, votes: [{ address: SR1, count: 0 }] })
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      buildTronVote({ from: OWNER, votes: [{ address: SR1, count: 1.5 }] })
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  it("rejects non-TRON vote targets", async () => {
+    await expect(
+      buildTronVote({ from: OWNER, votes: [{ address: "0xbad", count: 1 }] })
+    ).rejects.toThrow(/not a valid TRON/);
+  });
+
+  it("surfaces TronGrid 'Not enough tron power' verbatim", async () => {
+    fetchMock.mockImplementationOnce(
+      async () =>
+        new Response(
+          JSON.stringify({ Error: "contract validate error : Not enough tron power" }),
+          { status: 200 }
+        )
+    );
+    await expect(
+      buildTronVote({ from: OWNER, votes: [{ address: SR1, count: 999_999 }] })
+    ).rejects.toThrow(/Not enough tron power/);
+  });
+});


### PR DESCRIPTION
Closes #23.

## Summary
- `list_tron_witnesses` — ranks all SRs + candidates by vote weight; optionally augments with the caller's vote allocation, total TRON Power, and available votes. Voter APR estimated as 160 TRX/block ÷ total top-127 vote weight (uniform across top 127; 0 for ranks > 127).
- `prepare_tron_vote` — builds a VoteWitnessContract tx via `/wallet/votewitnessaccount`. Atomic full-replacement semantics; empty array clears all votes. Guards duplicates, non-integer/non-positive counts, and non-TRON targets.
- Defensive: witnesses whose addresses don't pass `isTronAddress` are filtered, so a hypothetical TronGrid quirk that ignores `visible=true` fails closed rather than leaking hex addresses into `prepare_tron_vote`.

Preview-only until Phase 3 lands the `@ledgerhq/hw-app-trx` USB signer; `send_transaction` still refuses TRON handles.

## Test plan
- [x] `npx vitest run` — 308/308 pass (12 new tests for Phase 2c)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: `list_tron_witnesses` with a real base58 address, verify `userVotes` / `totalTronPower` / `availableVotes` match TronScan
- [ ] Manual: `prepare_tron_vote` with a 2-SR allocation; verify decoded preview shows correct total + SR addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)