### PR TITLE
Add TRON Phase 3: USB HID Ledger signing + broadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 .env
 .env.*
 !.env.example
+
+# mcp-publisher local auth tokens (created by `mcp-publisher login`)
+.mcpregistry_github_token
+.mcpregistry_registry_token
 .DS_Store
 coverage/
 .vitest-cache/

--- a/README.md
+++ b/README.md
@@ -36,13 +36,12 @@ This is an **agent-driven portfolio management** tool, not a wallet replacement.
 
 EVM: Ethereum, Arbitrum, Polygon, Base.
 
-Non-EVM: TRON (phases 1 + 2 + 2b + 2c — balance + staking reads, SR listing, and tx preparation for native TRX sends, canonical TRC-20 transfers, voting-reward claims, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, and VoteWitness; Ledger signing lands in a follow-up phase).
+Non-EVM: TRON — full reads (balance, staking state, SR listing) and full write coverage (native TRX sends, canonical TRC-20 transfers, voting-reward claims, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, and VoteWitness) signed on a directly-connected Ledger over USB HID. Ledger Live's WalletConnect relay does not currently honor the `tron:` namespace (verified 2026-04-14), so TRON signing goes through `@ledgerhq/hw-app-trx` — the user's Ledger must be plugged into the host running the MCP, unlocked, with the TRON app open. Pair via `pair_ledger_tron` once per session.
 
 Not every protocol is on every chain. Lido and EigenLayer are L1-only (Ethereum). Morpho Blue is currently enabled on Ethereum only — it is deployed on Base at the same address but the discovery scan needs a pinned deployment block, tracked as a follow-up. TRON has no lending/LP coverage in this server (none of Aave/Compound/Morpho/Uniswap are deployed there); balance reads return TRX + canonical TRC-20 stablecoins (USDT, USDC, USDD, TUSD) that together cover the vast majority of TRON token volume, and TRON-native staking (frozen TRX under Stake 2.0, pending unfreezes, claimable voting rewards) is surfaced via `get_tron_staking` and folded into the portfolio summary. Readers short-circuit cleanly on chains where a protocol isn't deployed.
 
 ## Roadmap
 
-- **TRON Ledger signing** — phase 3 of TRON support. All TRON `prepare_*` tools (send, TRC-20, claim rewards, freeze/unfreeze/withdraw-expire-unfreeze) ship as preview-only today; `send_transaction` currently refuses TRON handles. Phase 3 signs them via **direct USB integration with `@ledgerhq/hw-app-trx`** — Ledger Live's WalletConnect relay does *not* currently honor the `tron:` namespace (verified 2026-04-14 via a SunSwap pairing attempt), so TRON signing diverges from the Ledger-Live-at-a-distance flow used for EVM: the user's Ledger must be plugged into the host running the MCP, with the TRON app open on the device.
 - **MetaMask support** (WalletConnect) — alongside the existing Ledger Live integration. Will let users sign through a MetaMask-paired session when a hardware wallet isn't available.
 - **Solana** — coming later. Non-EVM: introduces a separate SDK (`@solana/web3.js`), base58 addresses, and the WalletConnect `solana:` namespace for signing.
 
@@ -71,9 +70,9 @@ Meta:
 
 - `request_capability` — agent-facing escape hatch: files a GitHub issue on this repo when the user asks for something vaultpilot-mcp can't do (new protocol, new chain, missing tool). Default mode returns a pre-filled issue URL (zero spam risk — user must click to submit). Operators can set `VAULTPILOT_FEEDBACK_ENDPOINT` to a proxy that posts directly. Rate-limited: 30s between calls, 3/hour, 10/day, 7-day dedupe on identical summaries.
 
-Execution (Ledger-signed via WalletConnect):
+Execution (Ledger-signed):
 
-- `pair_ledger_live`, `get_ledger_status` — session management and account discovery; `get_ledger_status` returns per-chain exposure (`accountDetails[]` with `address`, `chainIds`, `chains`) so duplicate-looking addresses across chains are disambiguated
+- `pair_ledger_live` (WalletConnect, EVM), `pair_ledger_tron` (USB HID, TRON), `get_ledger_status` — session management and account discovery; `get_ledger_status` returns per-chain EVM exposure (`accountDetails[]` with `address`, `chainIds`, `chains`) so duplicate-looking addresses across chains are disambiguated, and a `tron: { address, path, appVersion }` section when `pair_ledger_tron` has been called
 - `prepare_aave_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_compound_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_morpho_supply` / `_withdraw` / `_borrow` / `_repay` / `_supply_collateral` / `_withdraw_collateral`
@@ -81,14 +80,15 @@ Execution (Ledger-signed via WalletConnect):
 - `prepare_eigenlayer_deposit`
 - `prepare_swap` — LiFi-routed intra- or cross-chain swap/bridge
 - `prepare_native_send`, `prepare_token_send`
-- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`, `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze`, `prepare_tron_vote` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, VoteWitness). Preview-only in this release; `send_transaction` still refuses TRON handles until the USB HID signer lands.
-- `send_transaction` — forwards a prepared EVM tx to Ledger Live for user approval
+- `prepare_tron_native_send`, `prepare_tron_token_send`, `prepare_tron_claim_rewards`, `prepare_tron_freeze`, `prepare_tron_unfreeze`, `prepare_tron_withdraw_expire_unfreeze`, `prepare_tron_vote` — TRON tx builders (native TRX send, canonical TRC-20 transfer, WithdrawBalance claim, Stake 2.0 freeze/unfreeze/withdraw-expire-unfreeze, VoteWitness)
+- `send_transaction` — forwards a prepared tx for user approval. EVM handles go to Ledger Live via WalletConnect; TRON handles go to the USB-connected Ledger via `@ledgerhq/hw-app-trx` and are broadcast via TronGrid
 
 ## Requirements
 
 - Node.js >= 18.17
 - An RPC provider (Infura, Alchemy, or custom) for the EVM chains
-- Optional: Etherscan API key, 1inch Developer Portal API key (enables swap-quote comparison), WalletConnect Cloud project ID (required for Ledger signing), TronGrid API key (enables TRX + TRC-20 balance reads)
+- Optional: Etherscan API key, 1inch Developer Portal API key (enables swap-quote comparison), WalletConnect Cloud project ID (required for EVM Ledger signing), TronGrid API key (enables TRX + TRC-20 balance reads)
+- For TRON signing: USB HID access to a Ledger device with the **Tron** app installed. On Linux, Ledger's [udev rules](https://github.com/LedgerHQ/udev-rules) must be installed or `hidraw` access fails with "permission denied". The `@ledgerhq/hw-transport-node-hid` dependency compiles `node-hid` natively at `npm install` time, which needs `libudev-dev` + a C/C++ toolchain on Debian/Ubuntu (`sudo apt install libudev-dev build-essential`).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Meta:
 
 Execution (Ledger-signed):
 
-- `pair_ledger_live` (WalletConnect, EVM), `pair_ledger_tron` (USB HID, TRON), `get_ledger_status` — session management and account discovery; `get_ledger_status` returns per-chain EVM exposure (`accountDetails[]` with `address`, `chainIds`, `chains`) so duplicate-looking addresses across chains are disambiguated, and a `tron: { address, path, appVersion }` section when `pair_ledger_tron` has been called
+- `pair_ledger_live` (WalletConnect, EVM), `pair_ledger_tron` (USB HID, TRON), `get_ledger_status` — session management and account discovery; `get_ledger_status` returns per-chain EVM exposure (`accountDetails[]` with `address`, `chainIds`, `chains`) so duplicate-looking addresses across chains are disambiguated, and a `tron: [{ address, path, appVersion, accountIndex }, …]` array (one entry per paired TRON account) when `pair_ledger_tron` has been called. Pass `accountIndex: 1` (2, 3, …) to pair additional TRON accounts.
 - `prepare_aave_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_compound_supply` / `_withdraw` / `_borrow` / `_repay`
 - `prepare_morpho_supply` / `_withdraw` / `_borrow` / `_repay` / `_supply_collateral` / `_withdraw_collateral`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@ledgerhq/hw-app-trx": "^6.34.1",
+        "@ledgerhq/hw-transport-node-hid": "^6.32.1",
         "@lifi/sdk": "^3.16.3",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@walletconnect/sign-client": "^2.17.0",
@@ -576,6 +578,80 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.13.0.tgz",
+      "integrity": "sha512-hgGn1kpe/rT0EJ0Qs7rG+1TXA4g6HN2t3dB4DndRTqVqC9aSSbME+ajA0QWLZisxOD3zkwvO4Q0mJ2zARAKyag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.32.0",
+        "@ledgerhq/logs": "^6.16.0",
+        "rxjs": "7.8.2",
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.32.0.tgz",
+      "integrity": "sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/hw-app-trx": {
+      "version": "6.34.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-trx/-/hw-app-trx-6.34.1.tgz",
+      "integrity": "sha512-kWDF+/UEc5LqRx3p8Raqw+yI006bBUMC+Twfutw3NHHb1L1BPJlddbgXkMSGFvbD+mKUhXQIAXC7QUWgco6gYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "6.34.1"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.34.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.34.1.tgz",
+      "integrity": "sha512-Bg9Qk2vtm0m0cZn9prZV2Hbvh3b42KBh4uomO00derh+eiwsdg5AXBBptAJiREkew1RVtETRdWxrKchUJfeWvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.13.0",
+        "@ledgerhq/errors": "^6.32.0",
+        "@ledgerhq/logs": "^6.16.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-node-hid": {
+      "version": "6.32.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.32.1.tgz",
+      "integrity": "sha512-P/X420k+OBbmE1p1fn8LMXL8/SeBA+IyqFxLhdtU2pExb6UBasRrrfpac70kFhoiWbq0LeiwMNJC0FPUvWiuwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.13.0",
+        "@ledgerhq/errors": "^6.32.0",
+        "@ledgerhq/hw-transport": "6.34.1",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^6.34.0",
+        "@ledgerhq/logs": "^6.16.0",
+        "lodash": "^4.17.21",
+        "node-hid": "2.1.2",
+        "usb": "2.9.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.34.0.tgz",
+      "integrity": "sha512-aW8iGvpcxw02aaxRJ2IiAGhEvt82ouL08culAfaIGjO+xqvvN6x1D4K1CZAHG50i8feuaq+YF+asd4l8H1ufYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.13.0",
+        "@ledgerhq/errors": "^6.32.0",
+        "@ledgerhq/hw-transport": "6.34.1",
+        "@ledgerhq/logs": "^6.16.0",
+        "node-hid": "2.1.2"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.16.0.tgz",
+      "integrity": "sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==",
+      "license": "Apache-2.0"
     },
     "node_modules/@lifi/sdk": {
       "version": "3.16.3",
@@ -1445,6 +1521,12 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -2071,6 +2153,15 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
       "license": "MIT"
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bip174": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
@@ -2100,6 +2191,41 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/blakejs": {
@@ -2326,6 +2452,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2438,6 +2570,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2446,6 +2593,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defu": {
@@ -2487,6 +2643,15 @@
       "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2514,6 +2679,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2678,6 +2852,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2785,6 +2968,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2823,6 +3012,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2884,6 +3079,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -3052,6 +3253,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -3186,6 +3393,12 @@
       "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -3267,6 +3480,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3298,6 +3538,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3306,6 +3552,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -3338,11 +3602,28 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
-      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-hid": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.1.2.tgz",
+      "integrity": "sha512-qhCyQqrPpP93F/6Wc/xUR7L8mAJW0Z6R7HMQV8jCHHksAxNDe/4z4Un/H9CpLOT+5K39OPyt9tIQlavxWES3lg==",
+      "hasInstallScript": true,
+      "license": "(MIT OR X11)",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^3.0.2",
+        "prebuild-install": "^7.1.1"
+      },
+      "bin": {
+        "hid-showdevices": "src/show-devices.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-mock-http": {
@@ -3624,6 +3905,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3651,6 +3959,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qrcode-terminal": {
@@ -3710,6 +4028,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -3884,6 +4231,21 @@
         }
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3918,6 +4280,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -4070,6 +4444,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slow-redact": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
@@ -4142,6 +4561,24 @@
         "stream-chain": "^2.2.5"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/superstruct": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
@@ -4149,6 +4586,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/text-encoding-utf-8": {
@@ -4229,6 +4694,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -4398,6 +4875,27 @@
         }
       }
     },
+    "node_modules/usb": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.9.0.tgz",
+      "integrity": "sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^6.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
+    },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
@@ -4412,6 +4910,12 @@
       "engines": {
         "node": ">=6.14.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
   "author": "Viacheslav Zhygulin",
   "license": "MIT",
   "dependencies": {
+    "@ledgerhq/hw-app-trx": "^6.34.1",
+    "@ledgerhq/hw-transport-node-hid": "^6.32.1",
     "@lifi/sdk": "^3.16.3",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@walletconnect/sign-client": "^2.17.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { getSwapQuoteInput, prepareSwapInput } from "./modules/swap/schemas.js";
 
 import {
   pairLedgerLive,
+  pairLedgerTron,
   getLedgerStatus,
   prepareAaveSupply,
   prepareAaveWithdraw,
@@ -60,6 +61,7 @@ import {
 } from "./modules/execution/index.js";
 import {
   pairLedgerLiveInput,
+  pairLedgerTronInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -427,25 +429,36 @@ async function main() {
     "pair_ledger_live",
     {
       description:
-        "Initiate a WalletConnect v2 pairing session with Ledger Live. Returns a URI and ASCII QR code — paste into Ledger Live's WalletConnect screen to complete pairing. The session persists for future transactions.",
+        "Initiate a WalletConnect v2 pairing session with Ledger Live. Returns a URI and ASCII QR code — paste into Ledger Live's WalletConnect screen to complete pairing. The session persists for future transactions. EVM chains only; for TRON use `pair_ledger_tron` instead.",
       inputSchema: pairLedgerLiveInput.shape,
     },
     handler(pairLedgerLive)
   );
 
   server.registerTool(
+    "pair_ledger_tron",
+    {
+      description:
+        "Pair the host's directly-connected Ledger device for TRON signing. REQUIREMENTS: Ledger plugged into the machine running this MCP (USB, not WalletConnect), device unlocked, and the 'Tron' app open on-screen. Ledger Live's WalletConnect relay does not currently honor the `tron:` CAIP namespace, so TRON signing goes over USB HID via @ledgerhq/hw-app-trx. Reads the device address at m/44'/195'/0'/0/0 and caches it so `get_ledger_status` can report it. Call this once per session before calling any `prepare_tron_*` tool or `send_transaction` with a TRON handle. If the TRON app isn't open, or the device is locked, returns an actionable error describing what to fix.",
+      inputSchema: pairLedgerTronInput.shape,
+    },
+    handler(pairLedgerTron)
+  );
+
+  server.registerTool(
     "get_ledger_status",
     {
       description:
-        "Report whether a WalletConnect session with Ledger Live is active, which wallet it's connected to, and which accounts are exposed. " +
-        "Returns `accounts: 0x…[]` — the list of wallet addresses the user has connected. " +
+        "Report whether a WalletConnect session with Ledger Live is active (EVM chains) AND whether a TRON Ledger pairing is cached (USB HID — see `pair_ledger_tron`). " +
+        "Returns `accounts: 0x…[]` — the list of EVM wallet addresses the user has connected — and optionally `tron: { address, path, appVersion }` if `pair_ledger_tron` has run. " +
         "Call this FIRST whenever the user refers to their wallet(s) by position or nickname instead of by address — e.g. " +
-        '\"my wallet\", \"the first address\", \"account 2\", \"second wallet\" — so you can resolve the reference to a concrete 0x… ' +
-        "before invoking any prepare_* / swap / send / portfolio tool that takes a `wallet` argument. Do NOT ask the user to paste an " +
-        "address if it's already in `accounts` here. " +
-        "SECURITY: the returned `wallet`/`peerUrl` are self-reported by the paired app. Before the FIRST send_transaction of a session, " +
+        '\"my wallet\", \"my TRON wallet\", \"the first address\", \"account 2\", \"second wallet\" — so you can resolve the reference to a concrete 0x… / T… ' +
+        "before invoking any prepare_* / swap / send / portfolio tool that takes a `wallet` / `tronAddress` argument. Do NOT ask the user to paste an " +
+        "address if it's already in `accounts` or `tron.address` here. " +
+        "SECURITY: the returned `wallet`/`peerUrl` (EVM) are self-reported by the paired WC app. Before the FIRST send_transaction of a session, " +
         "state the paired wallet name + URL back to the user and ask them to confirm it matches their Ledger Live install — " +
-        "any WalletConnect peer can claim to be 'Ledger Live'. The physical Ledger device's on-screen confirmation is the final check.",
+        "any WalletConnect peer can claim to be 'Ledger Live'. The physical Ledger device's on-screen confirmation is the final check. " +
+        "The `tron` section is read from the cache populated by `pair_ledger_tron`; `send_transaction` re-probes USB on every TRON sign, so the cache cannot be spoofed into approving a tx for the wrong account.",
       inputSchema: getLedgerStatusInput.shape,
     },
     handler(getLedgerStatus)
@@ -525,8 +538,9 @@ async function main() {
     "send_transaction",
     {
       description:
-        "Forward an already-prepared transaction to Ledger Live via WalletConnect for user signing. The user must review and approve the tx in Ledger Live and on their Ledger device; this call blocks until the user signs or rejects. " +
-        "You MUST pass `confirmed: true` — the agent is affirming that the user has seen and acknowledged the decoded preview.",
+        "Forward an already-prepared transaction to the Ledger device for user signing. Routes on the handle's origin: EVM handles (prepare_aave_*, prepare_compound_*, prepare_swap, prepare_native_send, ...) go through Ledger Live via WalletConnect; TRON handles (prepare_tron_*) go through the directly-connected Ledger over USB HID and are broadcast via TronGrid. In both cases the user must review and physically approve the tx on the Ledger screen; this call blocks until the user signs or rejects. " +
+        "You MUST pass `confirmed: true` — the agent is affirming that the user has seen and acknowledged the decoded preview. " +
+        "For TRON handles, `pair_ledger_tron` must have been called at least once per session (so the TRON app has been opened on the device) and the Ledger must still be plugged in with the TRON app open at send time.",
       inputSchema: sendTransactionInput.shape,
     },
     handler(sendTransaction)
@@ -615,7 +629,7 @@ async function main() {
     "prepare_tron_native_send",
     {
       description:
-        "Build an unsigned TRON native TRX send transaction via TronGrid's /wallet/createtransaction. Returns a human-readable preview + opaque handle. NOTE: TRON handles are PREVIEW-ONLY in this release — the physical signing path (USB HID via @ledgerhq/hw-app-trx) lands in a later phase; `send_transaction` only consumes EVM handles. Use this tool today to double-check an intended transfer (recipient, amount) against TronGrid's own tx builder before signing through Ledger Live's native TRON flow, TronLink, or another client.",
+        "Build an unsigned TRON native TRX send transaction via TronGrid's /wallet/createtransaction. Returns a human-readable preview + opaque handle. Forward the handle via `send_transaction` to sign on the directly-connected Ledger (USB HID via @ledgerhq/hw-app-trx) and broadcast to TronGrid. Run `pair_ledger_tron` once per session first so the TRON app is open and the device address is verified.",
       inputSchema: prepareTronNativeSendInput.shape,
     },
     handler(buildTronNativeSend)
@@ -625,7 +639,7 @@ async function main() {
     "prepare_tron_token_send",
     {
       description:
-        "Build an unsigned TRC-20 transfer transaction (canonical set only: USDT, USDC, USDD, TUSD) via TronGrid's /wallet/triggersmartcontract. Decimals are resolved from the canonical table — unknown TRC-20s are rejected with an explicit error. Default fee_limit is 100 TRX (TronLink/Ledger Live default); override with `feeLimitTrx` if energy pricing has moved. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY in this release — the Ledger USB HID signing path lands in a later phase. `send_transaction` will refuse TRON handles.",
+        "Build an unsigned TRC-20 transfer transaction (canonical set only: USDT, USDC, USDD, TUSD) via TronGrid's /wallet/triggersmartcontract. Decimals are resolved from the canonical table — unknown TRC-20s are rejected with an explicit error. Default fee_limit is 100 TRX (TronLink/Ledger Live default); override with `feeLimitTrx` if energy pricing has moved. Returns a preview + opaque handle. Forward via `send_transaction` for USB-HID signing on the paired Ledger. USDT renders natively on the TRON app; other TRC-20s may display raw hex on-device (the contract address and amount are still shown, so the user can verify against the preview).",
       inputSchema: prepareTronTokenSendInput.shape,
     },
     handler(buildTronTokenSend)
@@ -635,7 +649,7 @@ async function main() {
     "prepare_tron_claim_rewards",
     {
       description:
-        "Build an unsigned TRON WithdrawBalance transaction that claims accumulated voting rewards to the owner's balance. TRON enforces a 24-hour cooldown between claims — TronGrid will reject (surfaced as an error) if the previous claim was inside the window. Pair with `get_tron_staking` first to read `claimableRewards` and avoid empty-claim tx builds. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY in this release — signing lands with the USB HID phase.",
+        "Build an unsigned TRON WithdrawBalance transaction that claims accumulated voting rewards to the owner's balance. TRON enforces a 24-hour cooldown between claims — TronGrid will reject (surfaced as an error) if the previous claim was inside the window. Pair with `get_tron_staking` first to read `claimableRewards` and avoid empty-claim tx builds. Returns a preview + opaque handle; forward via `send_transaction` for USB-HID signing on the paired Ledger.",
       inputSchema: prepareTronClaimRewardsInput.shape,
     },
     handler(buildTronClaimRewards)
@@ -645,7 +659,7 @@ async function main() {
     "prepare_tron_freeze",
     {
       description:
-        "Build an unsigned TRON Stake 2.0 FreezeBalanceV2 transaction. Locks TRX to earn `bandwidth` (fuels plain transfers) or `energy` (fuels smart-contract calls) and gains proportional voting power. IMPORTANT: freezing alone does NOT accrue TRX rewards — `claimableRewards` (see `get_tron_staking`) only grows after the user also votes for a Super Representative. Pair this tool with `list_tron_witnesses` + `prepare_tron_vote` for the full reward-earning flow. Unlocking requires a 14-day cooldown via `prepare_tron_unfreeze` + `prepare_tron_withdraw_expire_unfreeze`. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+        "Build an unsigned TRON Stake 2.0 FreezeBalanceV2 transaction. Locks TRX to earn `bandwidth` (fuels plain transfers) or `energy` (fuels smart-contract calls) and gains proportional voting power. IMPORTANT: freezing alone does NOT accrue TRX rewards — `claimableRewards` (see `get_tron_staking`) only grows after the user also votes for a Super Representative. Pair this tool with `list_tron_witnesses` + `prepare_tron_vote` for the full reward-earning flow. Unlocking requires a 14-day cooldown via `prepare_tron_unfreeze` + `prepare_tron_withdraw_expire_unfreeze`. Returns a preview + opaque handle; forward via `send_transaction` for USB-HID signing on the paired Ledger.",
       inputSchema: prepareTronFreezeInput.shape,
     },
     handler(buildTronFreeze)
@@ -655,7 +669,7 @@ async function main() {
     "prepare_tron_unfreeze",
     {
       description:
-        "Build an unsigned TRON Stake 2.0 UnfreezeBalanceV2 transaction — begins the 14-day cooldown on a previously-frozen slice. The `amount` must not exceed what's currently frozen for that resource (query `get_tron_staking` first; TronGrid rejects otherwise with 'less than frozen balance'). After 14 days the slice shows up in `pendingUnfreezes` with an elapsed `unlockAt`; call `prepare_tron_withdraw_expire_unfreeze` to sweep it back to liquid TRX. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+        "Build an unsigned TRON Stake 2.0 UnfreezeBalanceV2 transaction — begins the 14-day cooldown on a previously-frozen slice. The `amount` must not exceed what's currently frozen for that resource (query `get_tron_staking` first; TronGrid rejects otherwise with 'less than frozen balance'). After 14 days the slice shows up in `pendingUnfreezes` with an elapsed `unlockAt`; call `prepare_tron_withdraw_expire_unfreeze` to sweep it back to liquid TRX. Returns a preview + opaque handle; forward via `send_transaction` for USB-HID signing on the paired Ledger.",
       inputSchema: prepareTronUnfreezeInput.shape,
     },
     handler(buildTronUnfreeze)
@@ -665,7 +679,7 @@ async function main() {
     "prepare_tron_withdraw_expire_unfreeze",
     {
       description:
-        "Build an unsigned TRON WithdrawExpireUnfreeze transaction — sweeps every matured unfreeze slice (those whose 14-day cooldown elapsed) back to liquid TRX. No amount needed; the chain drains all eligible slices in one call. Inspect `pendingUnfreezes` from `get_tron_staking` first — if every entry's `unlockAt` is still in the future, TronGrid returns 'no expire unfreeze' and this tool errors. Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+        "Build an unsigned TRON WithdrawExpireUnfreeze transaction — sweeps every matured unfreeze slice (those whose 14-day cooldown elapsed) back to liquid TRX. No amount needed; the chain drains all eligible slices in one call. Inspect `pendingUnfreezes` from `get_tron_staking` first — if every entry's `unlockAt` is still in the future, TronGrid returns 'no expire unfreeze' and this tool errors. Returns a preview + opaque handle; forward via `send_transaction` for USB-HID signing on the paired Ledger.",
       inputSchema: prepareTronWithdrawExpireUnfreezeInput.shape,
     },
     handler(buildTronWithdrawExpireUnfreeze)
@@ -687,7 +701,7 @@ async function main() {
     "prepare_tron_vote",
     {
       description:
-        "Build an unsigned TRON VoteWitnessContract transaction — casts votes for Super Representatives to earn voting rewards on frozen TRX. IMPORTANT: VoteWitness REPLACES the wallet's entire prior vote allocation atomically. Pass every SR you intend to back (not just a delta); an empty `votes` array clears all votes. Sum of `count` values must not exceed the wallet's available TRON Power — check `list_tron_witnesses(address)` → `availableVotes` first. `count` is an integer (1 vote = 1 TRX of TRON Power). Rewards accrue per block and are harvested via `prepare_tron_claim_rewards` (24h cooldown). Returns a preview + opaque handle. NOTE: PREVIEW-ONLY until the USB HID signer lands.",
+        "Build an unsigned TRON VoteWitnessContract transaction — casts votes for Super Representatives to earn voting rewards on frozen TRX. IMPORTANT: VoteWitness REPLACES the wallet's entire prior vote allocation atomically. Pass every SR you intend to back (not just a delta); an empty `votes` array clears all votes. Sum of `count` values must not exceed the wallet's available TRON Power — check `list_tron_witnesses(address)` → `availableVotes` first. `count` is an integer (1 vote = 1 TRX of TRON Power). Rewards accrue per block and are harvested via `prepare_tron_claim_rewards` (24h cooldown). Returns a preview + opaque handle; forward via `send_transaction` for USB-HID signing on the paired Ledger.",
       inputSchema: prepareTronVoteInput.shape,
     },
     handler(buildTronVote)

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,7 +439,7 @@ async function main() {
     "pair_ledger_tron",
     {
       description:
-        "Pair the host's directly-connected Ledger device for TRON signing. REQUIREMENTS: Ledger plugged into the machine running this MCP (USB, not WalletConnect), device unlocked, and the 'Tron' app open on-screen. Ledger Live's WalletConnect relay does not currently honor the `tron:` CAIP namespace, so TRON signing goes over USB HID via @ledgerhq/hw-app-trx. Reads the device address at m/44'/195'/0'/0/0 and caches it so `get_ledger_status` can report it. Call this once per session before calling any `prepare_tron_*` tool or `send_transaction` with a TRON handle. If the TRON app isn't open, or the device is locked, returns an actionable error describing what to fix.",
+        "Pair the host's directly-connected Ledger device for TRON signing. REQUIREMENTS: Ledger plugged into the machine running this MCP (USB, not WalletConnect), device unlocked, and the 'Tron' app open on-screen. Ledger Live's WalletConnect relay does not currently honor the `tron:` CAIP namespace, so TRON signing goes over USB HID via @ledgerhq/hw-app-trx. Reads the device address at m/44'/195'/<accountIndex>'/0/0 (default accountIndex=0) and caches it so `get_ledger_status` can report it. Call multiple times with different `accountIndex` values (0, 1, 2, …) to pair additional TRON accounts — each call adds to the cache; subsequent calls for the same index refresh in place. Call this once per session (per account) before calling any `prepare_tron_*` tool or `send_transaction` with a TRON handle. If the TRON app isn't open, or the device is locked, returns an actionable error describing what to fix.",
       inputSchema: pairLedgerTronInput.shape,
     },
     handler(pairLedgerTron)
@@ -449,16 +449,16 @@ async function main() {
     "get_ledger_status",
     {
       description:
-        "Report whether a WalletConnect session with Ledger Live is active (EVM chains) AND whether a TRON Ledger pairing is cached (USB HID — see `pair_ledger_tron`). " +
-        "Returns `accounts: 0x…[]` — the list of EVM wallet addresses the user has connected — and optionally `tron: { address, path, appVersion }` if `pair_ledger_tron` has run. " +
+        "Report whether a WalletConnect session with Ledger Live is active (EVM chains) AND whether any TRON Ledger pairings are cached (USB HID — see `pair_ledger_tron`). " +
+        "Returns `accounts: 0x…[]` — the list of EVM wallet addresses the user has connected — and optionally `tron: [{ address, path, appVersion, accountIndex }, …]` (one entry per paired TRON account, ordered by accountIndex) if `pair_ledger_tron` has been run at least once. " +
         "Call this FIRST whenever the user refers to their wallet(s) by position or nickname instead of by address — e.g. " +
-        '\"my wallet\", \"my TRON wallet\", \"the first address\", \"account 2\", \"second wallet\" — so you can resolve the reference to a concrete 0x… / T… ' +
+        '\"my wallet\", \"my TRON wallet\", \"the first address\", \"account 2\", \"second wallet\", \"second TRON account\" — so you can resolve the reference to a concrete 0x… / T… ' +
         "before invoking any prepare_* / swap / send / portfolio tool that takes a `wallet` / `tronAddress` argument. Do NOT ask the user to paste an " +
-        "address if it's already in `accounts` or `tron.address` here. " +
+        "address if it's already in `accounts` or a `tron[*].address` here. " +
         "SECURITY: the returned `wallet`/`peerUrl` (EVM) are self-reported by the paired WC app. Before the FIRST send_transaction of a session, " +
         "state the paired wallet name + URL back to the user and ask them to confirm it matches their Ledger Live install — " +
         "any WalletConnect peer can claim to be 'Ledger Live'. The physical Ledger device's on-screen confirmation is the final check. " +
-        "The `tron` section is read from the cache populated by `pair_ledger_tron`; `send_transaction` re-probes USB on every TRON sign, so the cache cannot be spoofed into approving a tx for the wrong account.",
+        "The `tron` array is read from the cache populated by `pair_ledger_tron`; `send_transaction` re-probes USB on every TRON sign, so the cache cannot be spoofed into approving a tx for the wrong account.",
       inputSchema: getLedgerStatusInput.shape,
     },
     handler(getLedgerStatus)

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -7,6 +7,13 @@ import {
 } from "../../signing/walletconnect.js";
 import { getSessionStatus } from "../../signing/session.js";
 import { consumeHandle, retireHandle } from "../../signing/tx-store.js";
+import { consumeTronHandle, retireTronHandle } from "../../signing/tron-tx-store.js";
+import {
+  getTronLedgerAddress,
+  signTronTxOnLedger,
+  setPairedTronAddress,
+} from "../../signing/tron-usb-signer.js";
+import { broadcastTronTx } from "../tron/broadcast.js";
 import { assertTransactionSafe } from "../../signing/pre-sign-check.js";
 import { getClient, verifyChainId } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
@@ -36,7 +43,8 @@ import type {
   SendTransactionArgs,
   GetTransactionStatusArgs,
 } from "./schemas.js";
-import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+import type { SupportedChain, UnsignedTx, UnsignedTronTx } from "../../types/index.js";
+import { hasTronHandle } from "../../signing/tron-tx-store.js";
 import { round } from "../../data/format.js";
 
 /** Render a QR code as an ASCII string (returns promise with the string). */
@@ -65,6 +73,32 @@ export async function pairLedgerLive(): Promise<{
       "Open Ledger Live → Discover → WalletConnect, paste this URI (or scan the QR) to pair. " +
       "Once pairing completes, the session is persisted; you can call `send_transaction` without re-pairing.",
     waitingForApproval: true,
+  };
+}
+
+/**
+ * Pair the host's directly-connected Ledger device for TRON signing. Unlike
+ * `pair_ledger_live` (WalletConnect relay for EVM), TRON signs over USB HID —
+ * the Ledger must be plugged into the host running this MCP, unlocked, with
+ * the TRON app open. Reads + caches the device address at m/44'/195'/0'/0/0
+ * so subsequent `get_ledger_status` calls can report it without re-probing.
+ */
+export async function pairLedgerTron(): Promise<{
+  address: string;
+  path: string;
+  appVersion: string;
+  instructions: string;
+}> {
+  const result = await getTronLedgerAddress();
+  setPairedTronAddress(result);
+  return {
+    address: result.address,
+    path: result.path,
+    appVersion: result.appVersion,
+    instructions:
+      "TRON account paired. You can now call `prepare_tron_*` with this address and " +
+      "forward the handle via `send_transaction`. Keep the Ledger plugged in with the " +
+      "TRON app open — each sign re-opens USB and re-verifies the device address.",
   };
 }
 
@@ -278,11 +312,63 @@ export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<Unsi
 
 // ----- Send + status -----
 
+/**
+ * Sign a prepared TRON tx on the connected Ledger and broadcast via TronGrid.
+ * Called internally from `sendTransaction` when the handle belongs to the
+ * TRON store.
+ *
+ * Security pipeline (intentionally narrower than the EVM one — many EVM
+ * checks don't translate to TRON):
+ *   - consumeTronHandle gives us the exact tx the user previewed.
+ *   - signTronTxOnLedger re-opens USB, re-derives the address, and refuses
+ *     if it doesn't match `tx.from`. This is the TRON equivalent of EVM's
+ *     "tx.from must be a paired account" guard.
+ *   - broadcastTronTx posts the signed envelope; TronGrid validates the
+ *     contract before inclusion.
+ *
+ * We don't re-simulate. TronGrid's createtransaction / triggersmartcontract
+ * already validates at prepare time (insufficient balance, fee_limit too low,
+ * contract revert), and there's no equivalent of eth_call against a specific
+ * block on TRON that we'd gain from re-running. A genuine drift between
+ * prepare and send (someone drained the balance in the interim) surfaces as
+ * a broadcast error, which we propagate verbatim.
+ */
+async function sendTronTransaction(args: SendTransactionArgs): Promise<{
+  txHash: string;
+  chain: "tron";
+}> {
+  const tx: UnsignedTronTx = consumeTronHandle(args.handle);
+  const { signature } = await signTronTxOnLedger({
+    rawDataHex: tx.rawDataHex,
+    expectedFrom: tx.from,
+  });
+  const { txID } = await broadcastTronTx(tx, signature);
+  // Only retire the handle after successful broadcast. If signing fails
+  // (user rejected, device disconnected) or the broadcast fails (transient
+  // TronGrid error), the handle stays valid and the caller can retry
+  // within the 15-min TTL without re-preparing.
+  retireTronHandle(args.handle);
+  return { txHash: txID, chain: "tron" };
+}
+
+/**
+ * Forward a prepared tx to the right signer based on which store owns the
+ * handle. EVM handles take the WalletConnect path (unchanged). TRON handles
+ * take the USB HID path: `consume → sign on Ledger → broadcast via TronGrid`.
+ *
+ * The two stores share no keys (`randomUUID` collision is ~0), and we check
+ * TRON first because its path has strictly fewer side effects on failure
+ * (no WC relay roundtrip, no eth_call, no chain-id check that would
+ * meaninglessly fire before we even know what chain we're on).
+ */
 export async function sendTransaction(args: SendTransactionArgs): Promise<{
-  txHash: `0x${string}`;
-  chain: SupportedChain;
+  txHash: `0x${string}` | string;
+  chain: SupportedChain | "tron";
   nextHandle?: string;
 }> {
+  if (hasTronHandle(args.handle)) {
+    return sendTronTransaction(args);
+  }
   const tx = consumeHandle(args.handle);
   // Last-line check: refuse to sign against an RPC that's pointing at the
   // wrong chain. See verifyChainId() for the threat model.

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -12,6 +12,8 @@ import {
   getTronLedgerAddress,
   signTronTxOnLedger,
   setPairedTronAddress,
+  getPairedTronByAddress,
+  tronPathForAccountIndex,
 } from "../../signing/tron-usb-signer.js";
 import { broadcastTronTx } from "../tron/broadcast.js";
 import { assertTransactionSafe } from "../../signing/pre-sign-check.js";
@@ -31,6 +33,7 @@ import {
 } from "../staking/actions.js";
 import { getTokenPrice } from "../../data/prices.js";
 import type {
+  PairLedgerTronArgs,
   PrepareAaveSupplyArgs,
   PrepareAaveWithdrawArgs,
   PrepareAaveBorrowArgs,
@@ -80,25 +83,32 @@ export async function pairLedgerLive(): Promise<{
  * Pair the host's directly-connected Ledger device for TRON signing. Unlike
  * `pair_ledger_live` (WalletConnect relay for EVM), TRON signs over USB HID —
  * the Ledger must be plugged into the host running this MCP, unlocked, with
- * the TRON app open. Reads + caches the device address at m/44'/195'/0'/0/0
+ * the TRON app open. Reads + caches the device address at the BIP-44 path
+ * derived from `accountIndex` (default 0 = first Ledger Live TRON account)
  * so subsequent `get_ledger_status` calls can report it without re-probing.
+ * Call with different `accountIndex` values to expose multiple TRON accounts.
  */
-export async function pairLedgerTron(): Promise<{
+export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
   address: string;
   path: string;
   appVersion: string;
+  accountIndex: number;
   instructions: string;
 }> {
-  const result = await getTronLedgerAddress();
+  const accountIndex = args.accountIndex ?? 0;
+  const path = tronPathForAccountIndex(accountIndex);
+  const result = await getTronLedgerAddress(path);
   setPairedTronAddress(result);
   return {
     address: result.address,
     path: result.path,
     appVersion: result.appVersion,
+    accountIndex,
     instructions:
       "TRON account paired. You can now call `prepare_tron_*` with this address and " +
       "forward the handle via `send_transaction`. Keep the Ledger plugged in with the " +
-      "TRON app open — each sign re-opens USB and re-verifies the device address.",
+      "TRON app open — each sign re-opens USB and re-verifies the device address. " +
+      "To pair a different slot, call `pair_ledger_tron` again with another `accountIndex`.",
   };
 }
 
@@ -338,9 +348,16 @@ async function sendTronTransaction(args: SendTransactionArgs): Promise<{
   chain: "tron";
 }> {
   const tx: UnsignedTronTx = consumeTronHandle(args.handle);
+  // If the user paired this `from` via `pair_ledger_tron`, use the path they
+  // paired on (covers non-default account slots). If we have no paired entry
+  // for `from`, fall through to the signer's default path — the device
+  // address check inside signTronTxOnLedger will then surface a clear error
+  // telling the user to pair the right slot.
+  const paired = getPairedTronByAddress(tx.from);
   const { signature } = await signTronTxOnLedger({
     rawDataHex: tx.rawDataHex,
     expectedFrom: tx.from,
+    ...(paired ? { path: paired.path } : {}),
   });
   const { txID } = await broadcastTronTx(tx, signature);
   // Only retire the handle after successful broadcast. If signing fails

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -9,7 +9,20 @@ const dataSchema = z.string().regex(/^0x[a-fA-F0-9]*$/);
 
 export const pairLedgerLiveInput = z.object({});
 
-export const pairLedgerTronInput = z.object({});
+export const pairLedgerTronInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "Ledger TRON account slot (hardened BIP-44 account index). 0 = first account, " +
+        "1 = second, etc. — same convention Ledger Live uses. Omit to pair the default " +
+        "account (index 0). Call pair_ledger_tron multiple times with different " +
+        "indices to expose multiple TRON accounts in get_ledger_status."
+    ),
+});
 
 export const getLedgerStatusInput = z.object({});
 
@@ -113,6 +126,7 @@ export const getTransactionStatusInput = z.object({
   txHash: z.string().regex(/^0x[a-fA-F0-9]{64}$/),
 });
 
+export type PairLedgerTronArgs = z.infer<typeof pairLedgerTronInput>;
 export type PrepareAaveSupplyArgs = z.infer<typeof prepareAaveSupplyInput>;
 export type PrepareAaveWithdrawArgs = z.infer<typeof prepareAaveWithdrawInput>;
 export type PrepareAaveBorrowArgs = z.infer<typeof prepareAaveBorrowInput>;

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -9,6 +9,8 @@ const dataSchema = z.string().regex(/^0x[a-fA-F0-9]*$/);
 
 export const pairLedgerLiveInput = z.object({});
 
+export const pairLedgerTronInput = z.object({});
+
 export const getLedgerStatusInput = z.object({});
 
 const baseAaveAction = z.object({

--- a/src/modules/tron/broadcast.ts
+++ b/src/modules/tron/broadcast.ts
@@ -1,0 +1,71 @@
+import { TRONGRID_BASE_URL } from "../../config/tron.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import type { UnsignedTronTx } from "../../types/index.js";
+
+/**
+ * `/wallet/broadcasttransaction` response. TronGrid encodes failures as
+ * `{code: "SIGERROR" | "CONTRACT_VALIDATE_ERROR" | ..., message: hex-utf8}` —
+ * note `message` is hex-encoded UTF-8, not plain text. Success is
+ * `{result: true, txid}`.
+ */
+interface BroadcastResponse {
+  result?: boolean;
+  txid?: string;
+  code?: string;
+  message?: string;
+}
+
+/** Decode TronGrid's hex-encoded UTF-8 error message into plain text. */
+function decodeHexMessage(hex: string): string {
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) return hex;
+  try {
+    return Buffer.from(hex, "hex").toString("utf8");
+  } catch {
+    return hex;
+  }
+}
+
+/**
+ * Broadcast a signed TRON transaction via TronGrid.
+ *
+ * The signature is appended to the raw tx envelope in the `signature[]`
+ * field. TronGrid multi-sig would use multiple entries; for single-sig
+ * (the only flow we support) it's always exactly one.
+ *
+ * Returns the on-chain txID on success. Throws with the decoded error
+ * message on validation / signature failures.
+ */
+export async function broadcastTronTx(
+  tx: UnsignedTronTx,
+  signatureHex: string
+): Promise<{ txID: string }> {
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+
+  const body = {
+    txID: tx.txID,
+    raw_data: tx.rawData,
+    raw_data_hex: tx.rawDataHex,
+    signature: [signatureHex],
+    visible: true,
+  };
+
+  const res = await fetch(`${TRONGRID_BASE_URL}/wallet/broadcasttransaction`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`TronGrid /wallet/broadcasttransaction returned ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as BroadcastResponse;
+  if (data.result === true) {
+    return { txID: data.txid ?? tx.txID };
+  }
+  const decoded = data.message ? decodeHexMessage(data.message) : "unknown error";
+  throw new Error(
+    `TronGrid broadcast rejected the transaction: ${data.code ?? "unknown code"} — ${decoded}`
+  );
+}

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -4,6 +4,7 @@ import {
   getSignClient,
   isPeerUnreachable,
 } from "./walletconnect.js";
+import { getPairedTronAddress } from "./tron-usb-signer.js";
 import type { SupportedChain } from "../types/index.js";
 
 export interface SessionAccount {
@@ -45,6 +46,18 @@ export interface SessionStatus {
    * peer comes back online or the user re-pairs.
    */
   peerUnreachable?: boolean;
+  /**
+   * Present when the user has run `pair_ledger_tron`. TRON doesn't share
+   * WalletConnect with EVM — signing goes over USB HID — so this section is
+   * independent of the `paired`/`accounts` fields above (which describe the
+   * WC session for EVM chains only). Unset means the agent should ask the
+   * user to run `pair_ledger_tron` before preparing a TRON tx.
+   */
+  tron?: {
+    address: string;
+    path: string;
+    appVersion: string;
+  };
 }
 
 export const PEER_TRUST_WARNING =
@@ -56,12 +69,23 @@ export const PEER_TRUST_WARNING =
 export async function getSessionStatus(): Promise<SessionStatus> {
   await getSignClient(); // triggers restore + liveness check
   const session = getCurrentSession();
+  const tronPaired = getPairedTronAddress();
+  const tronSection = tronPaired
+    ? {
+        tron: {
+          address: tronPaired.address,
+          path: tronPaired.path,
+          appVersion: tronPaired.appVersion,
+        },
+      }
+    : {};
   if (!session)
     return {
       paired: false,
       accounts: [],
       accountDetails: [],
       peerTrustWarning: PEER_TRUST_WARNING,
+      ...tronSection,
     };
   const accountDetails = await getConnectedAccountsDetailed();
   const accounts = accountDetails.map((a) => a.address);
@@ -78,5 +102,6 @@ export async function getSessionStatus(): Promise<SessionStatus> {
     ...(meta?.description ? { peerDescription: meta.description } : {}),
     peerTrustWarning: PEER_TRUST_WARNING,
     ...(unreachable ? { peerUnreachable: true } : {}),
+    ...tronSection,
   };
 }

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -4,7 +4,7 @@ import {
   getSignClient,
   isPeerUnreachable,
 } from "./walletconnect.js";
-import { getPairedTronAddress } from "./tron-usb-signer.js";
+import { getPairedTronAddresses } from "./tron-usb-signer.js";
 import type { SupportedChain } from "../types/index.js";
 
 export interface SessionAccount {
@@ -47,17 +47,22 @@ export interface SessionStatus {
    */
   peerUnreachable?: boolean;
   /**
-   * Present when the user has run `pair_ledger_tron`. TRON doesn't share
-   * WalletConnect with EVM — signing goes over USB HID — so this section is
-   * independent of the `paired`/`accounts` fields above (which describe the
-   * WC session for EVM chains only). Unset means the agent should ask the
-   * user to run `pair_ledger_tron` before preparing a TRON tx.
+   * Present when the user has run `pair_ledger_tron` at least once. TRON
+   * doesn't share WalletConnect with EVM — signing goes over USB HID — so
+   * this section is independent of the `paired`/`accounts` fields above
+   * (which describe the WC session for EVM chains only). An array because
+   * users can pair multiple account slots (index 0, 1, …) in the same
+   * session; entries are ordered by `accountIndex`. Absent/empty means the
+   * agent should ask the user to run `pair_ledger_tron` before preparing a
+   * TRON tx.
    */
-  tron?: {
+  tron?: Array<{
     address: string;
     path: string;
     appVersion: string;
-  };
+    /** Null when the path is not in the standard `44'/195'/<n>'/0/0` layout. */
+    accountIndex: number | null;
+  }>;
 }
 
 export const PEER_TRUST_WARNING =
@@ -69,16 +74,18 @@ export const PEER_TRUST_WARNING =
 export async function getSessionStatus(): Promise<SessionStatus> {
   await getSignClient(); // triggers restore + liveness check
   const session = getCurrentSession();
-  const tronPaired = getPairedTronAddress();
-  const tronSection = tronPaired
-    ? {
-        tron: {
-          address: tronPaired.address,
-          path: tronPaired.path,
-          appVersion: tronPaired.appVersion,
-        },
-      }
-    : {};
+  const tronPaired = getPairedTronAddresses();
+  const tronSection =
+    tronPaired.length > 0
+      ? {
+          tron: tronPaired.map((e) => ({
+            address: e.address,
+            path: e.path,
+            appVersion: e.appVersion,
+            accountIndex: e.accountIndex,
+          })),
+        }
+      : {};
   if (!session)
     return {
       paired: false,

--- a/src/signing/tron-tx-store.ts
+++ b/src/signing/tron-tx-store.ts
@@ -6,9 +6,9 @@ import type { UnsignedTronTx } from "../types/index.js";
  * signing/tx-store.ts but stores `UnsignedTronTx` rather than EVM
  * `UnsignedTx`. Separated deliberately: the EVM send flow runs an
  * eth_call re-simulation, chain-id check, and spender allowlist that are
- * all meaningless on TRON. A TRON handle therefore cannot be consumed by
- * the EVM `send_transaction` — the two stores share no keys and the TRON
- * send path (Phase 3, USB HID) will have its own security pipeline.
+ * all meaningless on TRON. `send_transaction` routes by which store owns
+ * the handle — TRON handles go to the USB HID signer in
+ * tron-usb-signer.ts, EVM handles stay on the WalletConnect path.
  *
  * Lifetime matches the EVM store (15 min from issue).
  */

--- a/src/signing/tron-usb-loader.ts
+++ b/src/signing/tron-usb-loader.ts
@@ -1,0 +1,46 @@
+import { createRequire } from "node:module";
+
+/**
+ * Thin loader that brings the two Ledger packages in via CommonJS.
+ *
+ * Why this indirection: `@ledgerhq/hw-transport-node-hid` ships an `exports`
+ * map whose ESM build (`lib-es/`) is compiled with `--moduleResolution bundler`
+ * and omits `.js` extensions on relative imports. Node's ESM loader rejects
+ * those imports (it requires explicit extensions), so a plain
+ * `import TransportNodeHid from "@ledgerhq/hw-transport-node-hid"` crashes at
+ * runtime with `ERR_MODULE_NOT_FOUND`. The package's CJS build (`lib/`)
+ * resolves cleanly, so we load it via `createRequire`.
+ *
+ * Isolating the require() in this module makes it easy to vi.mock the loader
+ * in tests without touching the ESM module registry. The signer talks to
+ * `openLedger()`, not to the Ledger SDK directly.
+ */
+export interface TronLedgerTransport {
+  close(): Promise<void>;
+}
+
+export interface TronLedgerApp {
+  getAddress(
+    path: string,
+    display?: boolean
+  ): Promise<{ publicKey: string; address: string }>;
+  signTransaction(
+    path: string,
+    rawTxHex: string,
+    tokenSignatures: string[]
+  ): Promise<string>;
+  getAppConfiguration(): Promise<{ version: string }>;
+}
+
+const requireCjs = createRequire(import.meta.url);
+
+export async function openLedger(): Promise<{
+  app: TronLedgerApp;
+  transport: TronLedgerTransport;
+}> {
+  const TransportNodeHid = requireCjs("@ledgerhq/hw-transport-node-hid").default;
+  const Trx = requireCjs("@ledgerhq/hw-app-trx").default;
+  const transport: TronLedgerTransport = await TransportNodeHid.open("");
+  const app: TronLedgerApp = new Trx(transport);
+  return { app, transport };
+}

--- a/src/signing/tron-usb-signer.ts
+++ b/src/signing/tron-usb-signer.ts
@@ -2,29 +2,87 @@ import { isTronAddress } from "../config/tron.js";
 import { openLedger } from "./tron-usb-loader.js";
 
 /**
- * TRON signing path. BIP-44 coin type 195 (SLIP-44). Single path only in this
- * release — multi-account TRON discovery can come later if users ask.
+ * TRON signing path. BIP-44 coin type 195 (SLIP-44). The hardened account
+ * segment is the Ledger Live account index — 0 is the first TRON account,
+ * 1 the second, etc. Matches the layout Ledger Live uses internally.
  */
 export const DEFAULT_TRON_PATH = "44'/195'/0'/0/0";
 
-/**
- * Last-known Ledger TRON pairing. Populated by `pair_ledger_tron` and read
- * back by `get_ledger_status` so the agent can resolve "my TRON wallet"
- * without re-probing USB on every read. `send_transaction` does NOT trust
- * this cache — it always re-opens the device and verifies the address
- * matches `from` before signing.
- */
-let pairedTronAddress: { address: string; publicKey: string; path: string; appVersion: string } | null =
-  null;
+/** Arbitrary cap to keep pathological inputs from producing absurd paths. */
+const MAX_TRON_ACCOUNT_INDEX = 100;
 
-export function getPairedTronAddress() {
-  return pairedTronAddress;
+/**
+ * Build the standard Ledger Live TRON BIP-44 path for `accountIndex`.
+ * Hardened account segment (matches Ledger Live's own derivation).
+ */
+export function tronPathForAccountIndex(accountIndex: number): string {
+  if (!Number.isInteger(accountIndex) || accountIndex < 0 || accountIndex > MAX_TRON_ACCOUNT_INDEX) {
+    throw new Error(
+      `Invalid TRON accountIndex ${accountIndex} — must be an integer in [0, ${MAX_TRON_ACCOUNT_INDEX}].`
+    );
+  }
+  return `44'/195'/${accountIndex}'/0/0`;
 }
 
-export function setPairedTronAddress(
-  entry: { address: string; publicKey: string; path: string; appVersion: string } | null
-): void {
-  pairedTronAddress = entry;
+/**
+ * Extract the Ledger Live account index from a standard TRON path. Returns
+ * `null` if the path doesn't match the `44'/195'/<n>'/0/0` shape — callers
+ * treat missing indices as "custom path, no account-slot mapping".
+ */
+export function parseTronAccountIndex(path: string): number | null {
+  const m = /^44'\/195'\/(\d+)'\/0\/0$/.exec(path);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isInteger(n) ? n : null;
+}
+
+export interface PairedTronEntry {
+  address: string;
+  publicKey: string;
+  path: string;
+  appVersion: string;
+  /** Null when the path is not in the standard `44'/195'/<n>'/0/0` layout. */
+  accountIndex: number | null;
+}
+
+/**
+ * Ledger TRON pairings. Populated by `pair_ledger_tron` and read back by
+ * `get_ledger_status` so the agent can resolve "my TRON wallet" / "my second
+ * TRON account" without re-probing USB on every read. Keyed by BIP-44 path
+ * so users can pair multiple account slots in parallel (e.g. index 0 and
+ * index 1). `send_transaction` does NOT trust this cache — it always
+ * re-opens the device and verifies the derived address matches `from`
+ * before signing.
+ */
+const pairedTronByPath = new Map<string, PairedTronEntry>();
+
+/** All paired TRON accounts, sorted by `accountIndex` (standard paths first). */
+export function getPairedTronAddresses(): PairedTronEntry[] {
+  return Array.from(pairedTronByPath.values()).sort((a, b) => {
+    if (a.accountIndex === null && b.accountIndex === null) return 0;
+    if (a.accountIndex === null) return 1;
+    if (b.accountIndex === null) return -1;
+    return a.accountIndex - b.accountIndex;
+  });
+}
+
+/** Look up a paired entry by its derived base58 address. */
+export function getPairedTronByAddress(address: string): PairedTronEntry | null {
+  for (const entry of pairedTronByPath.values()) {
+    if (entry.address === address) return entry;
+  }
+  return null;
+}
+
+export function setPairedTronAddress(entry: Omit<PairedTronEntry, "accountIndex">): PairedTronEntry {
+  const full: PairedTronEntry = { ...entry, accountIndex: parseTronAccountIndex(entry.path) };
+  pairedTronByPath.set(entry.path, full);
+  return full;
+}
+
+/** Test-only hook — lets us reset state between suites without juggling module caches. */
+export function clearPairedTronAddresses(): void {
+  pairedTronByPath.clear();
 }
 
 /**

--- a/src/signing/tron-usb-signer.ts
+++ b/src/signing/tron-usb-signer.ts
@@ -1,0 +1,178 @@
+import { isTronAddress } from "../config/tron.js";
+import { openLedger } from "./tron-usb-loader.js";
+
+/**
+ * TRON signing path. BIP-44 coin type 195 (SLIP-44). Single path only in this
+ * release — multi-account TRON discovery can come later if users ask.
+ */
+export const DEFAULT_TRON_PATH = "44'/195'/0'/0/0";
+
+/**
+ * Last-known Ledger TRON pairing. Populated by `pair_ledger_tron` and read
+ * back by `get_ledger_status` so the agent can resolve "my TRON wallet"
+ * without re-probing USB on every read. `send_transaction` does NOT trust
+ * this cache — it always re-opens the device and verifies the address
+ * matches `from` before signing.
+ */
+let pairedTronAddress: { address: string; publicKey: string; path: string; appVersion: string } | null =
+  null;
+
+export function getPairedTronAddress() {
+  return pairedTronAddress;
+}
+
+export function setPairedTronAddress(
+  entry: { address: string; publicKey: string; path: string; appVersion: string } | null
+): void {
+  pairedTronAddress = entry;
+}
+
+/**
+ * USB HID signing for TRON. Unlike EVM (WalletConnect → Ledger Live → device),
+ * TRON signs via direct USB because Ledger Live's WalletConnect relay does
+ * not honor the `tron:` CAIP namespace (verified 2026-04-14). The user's
+ * Ledger must be plugged into the host running the MCP, unlocked, with the
+ * TRON app open.
+ *
+ * Every sign/address call opens a fresh transport and closes it in finally —
+ * HID handles are exclusive, so leaving one open blocks `ledger-live` and
+ * other Ledger tooling from connecting in parallel.
+ */
+
+/**
+ * Map the common Ledger status-word failures to user-actionable English.
+ * Status words come back as `statusCode` on TransportStatusError and occasionally
+ * as part of the message; we normalize by inspecting both.
+ */
+function mapLedgerError(e: unknown, ctx: string): Error {
+  const err = e as { statusCode?: number; message?: string; name?: string };
+  const sw = err?.statusCode;
+  const msg = err?.message ?? String(e);
+  // 0x6511 / 0x6E00 / 0x6D00: CLA not supported — wrong app (or dashboard).
+  if (sw === 0x6511 || sw === 0x6e00 || sw === 0x6d00) {
+    return new Error(
+      `Ledger is connected but the TRON app isn't open. On the device, open the "Tron" app and retry (${ctx}).`
+    );
+  }
+  // 0x5515 / 0x6B0C: device locked.
+  if (sw === 0x5515 || sw === 0x6b0c) {
+    return new Error(`Ledger device is locked. Enter your PIN on the device and retry (${ctx}).`);
+  }
+  // 0x6985: user rejected.
+  if (sw === 0x6985 || /conditions.*not.*satisfied/i.test(msg) || /denied by the user/i.test(msg)) {
+    return new Error(`User rejected the transaction on the Ledger device (${ctx}).`);
+  }
+  // No device / cannot open HID — surfaces differently by OS.
+  if (/cannot open device/i.test(msg) || /no device/i.test(msg) || /NoDevice/i.test(msg)) {
+    return new Error(
+      `No Ledger device detected over USB. Plug the device in, unlock it, open the TRON app, and retry. ` +
+        `On Linux, ensure Ledger's udev rules are installed (see https://github.com/LedgerHQ/udev-rules) ` +
+        `otherwise hidraw access fails with "permission denied" (${ctx}).`
+    );
+  }
+  return new Error(`Ledger TRON ${ctx} failed: ${msg}`);
+}
+
+async function openTronApp() {
+  let ledger;
+  try {
+    ledger = await openLedger();
+  } catch (e) {
+    throw mapLedgerError(e, "open");
+  }
+  const { app, transport } = ledger;
+  let appVersion: string;
+  try {
+    // Probe app config — confirms the TRON app is actually open. If the
+    // dashboard is on screen this returns 0x6511 (CLA not supported) and
+    // we surface the correct "open TRON app" message.
+    const cfg = await app.getAppConfiguration();
+    appVersion = cfg.version;
+  } catch (e) {
+    await transport.close().catch(() => {});
+    throw mapLedgerError(e, "app-open check");
+  }
+  return { app, transport, appVersion };
+}
+
+/**
+ * Query the device for its TRON address at `path`. Used by `pair_ledger_tron`
+ * to cache the address for subsequent sign calls, and as the identity check
+ * before signing.
+ */
+export async function getTronLedgerAddress(
+  path: string = DEFAULT_TRON_PATH
+): Promise<{ address: string; publicKey: string; path: string; appVersion: string }> {
+  const { app, transport, appVersion } = await openTronApp();
+  try {
+    const { address, publicKey } = await app.getAddress(path, false);
+    if (!isTronAddress(address)) {
+      throw new Error(
+        `Ledger returned an address that doesn't look like a TRON mainnet address: "${address}". ` +
+          `Is the TRON (not Tron-classic / testnet) app open on the device?`
+      );
+    }
+    return { address, publicKey, path, appVersion };
+  } catch (e) {
+    throw mapLedgerError(e, "getAddress");
+  } finally {
+    await transport.close().catch(() => {});
+  }
+}
+
+export interface TronSignRequest {
+  /** Hex-encoded raw_data to sign — exactly what TronGrid returned at prepare time. */
+  rawDataHex: string;
+  /** Base58 `from` from the prepared tx. The device address must match, or we refuse. */
+  expectedFrom: string;
+  /**
+   * Ledger-signed token descriptors used to render TRC-20 transfer amounts
+   * on-device. Pass `[]` for canonical tokens — the TRON app has hardcoded
+   * support for USDT. Non-USDT TRC-20 amounts may display as raw hex without
+   * a descriptor; Phase 3 accepts that tradeoff.
+   */
+  tokenSignatures?: string[];
+  /** BIP-44 path override. Defaults to m/44'/195'/0'/0/0. */
+  path?: string;
+}
+
+/**
+ * Open USB, assert the device address matches `expectedFrom`, sign
+ * `rawDataHex`, and return the hex signature ready to be attached to the
+ * TronGrid transaction envelope for broadcast.
+ *
+ * Fresh transport open per call — avoids holding the HID handle across
+ * multiple async operations where a disconnect could leave it dangling.
+ */
+export async function signTronTxOnLedger(
+  req: TronSignRequest
+): Promise<{ signature: string; signerAddress: string }> {
+  const path = req.path ?? DEFAULT_TRON_PATH;
+  const { app, transport } = await openTronApp();
+  try {
+    const { address } = await app.getAddress(path, false);
+    if (address !== req.expectedFrom) {
+      throw new Error(
+        `Ledger device address (${address}) does not match the prepared tx's \`from\` ` +
+          `(${req.expectedFrom}). Either connect the Ledger that holds keys for \`from\`, ` +
+          `or re-prepare the tx for the Ledger-derived address (\`pair_ledger_tron\`).`
+      );
+    }
+    const signature = await app.signTransaction(
+      path,
+      req.rawDataHex,
+      req.tokenSignatures ?? []
+    );
+    // Ledger returns the signature as a hex string (65 bytes: r || s || v).
+    if (!/^[0-9a-fA-F]{130}$/.test(signature)) {
+      throw new Error(
+        `Ledger returned an unexpected signature shape (length ${signature.length}). Expected 130 hex chars.`
+      );
+    }
+    return { signature, signerAddress: address };
+  } catch (e) {
+    throw mapLedgerError(e, "signTransaction");
+  } finally {
+    await transport.close().catch(() => {});
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -448,9 +448,9 @@ export interface MultiWalletPortfolioSummary {
  * (eth_call re-simulation, chain-id check, spender allowlist) can't be
  * silently shortcut by a TRON handle masquerading as an EVM one.
  *
- * Phase 2 ships preparation only — there is no send_tron_transaction yet.
- * Handles are issued so the Phase 3 signer (USB HID via @ledgerhq/hw-app-trx)
- * can consume them exactly the way send_transaction consumes EVM handles.
+ * Phase 3 (this release) routes TRON handles through `send_transaction`:
+ * the USB HID signer (@ledgerhq/hw-app-trx) verifies the device address
+ * matches `from`, signs `rawDataHex`, and broadcasts via TronGrid.
  */
 export interface UnsignedTronTx {
   chain: "tron";

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -274,9 +274,15 @@ describe("sendTransaction — TRON handle routing", () => {
 });
 
 describe("pair_ledger_tron + get_ledger_status", () => {
-  beforeEach(() => installStubs());
+  beforeEach(async () => {
+    installStubs();
+    // Clear pairings between tests — the module-level cache otherwise leaks
+    // across cases in the describe block.
+    const { clearPairedTronAddresses } = await import("../src/signing/tron-usb-signer.js");
+    clearPairedTronAddresses();
+  });
 
-  it("populates the tron section of getSessionStatus after pairing", async () => {
+  it("populates the tron section of getSessionStatus after pairing (default accountIndex)", async () => {
     // Reset the module cache so `session.ts`'s transitive import of
     // `walletconnect.js` (already resolved by earlier tests via execution/index)
     // is re-evaluated and picks up the doMock below.
@@ -293,12 +299,117 @@ describe("pair_ledger_tron + get_ledger_status", () => {
     const pair = await pairLedgerTron();
     expect(pair.address).toBe(DEVICE_ADDRESS);
     expect(pair.path).toBe("44'/195'/0'/0/0");
+    expect(pair.accountIndex).toBe(0);
 
     const status = await getSessionStatus();
-    expect(status.tron).toEqual({
-      address: DEVICE_ADDRESS,
-      path: "44'/195'/0'/0/0",
-      appVersion: "0.5.0",
+    expect(status.tron).toEqual([
+      {
+        address: DEVICE_ADDRESS,
+        path: "44'/195'/0'/0/0",
+        appVersion: "0.5.0",
+        accountIndex: 0,
+      },
+    ]);
+  });
+
+  it("pairs a second TRON account via accountIndex=1 and lists both in getSessionStatus", async () => {
+    vi.resetModules();
+    vi.doMock("../src/signing/walletconnect.js", () => ({
+      getSignClient: async () => ({}),
+      getCurrentSession: () => null,
+      getConnectedAccountsDetailed: async () => [],
+      isPeerUnreachable: () => false,
+    }));
+    // First pair returns DEVICE_ADDRESS (account 0); second returns OTHER_ADDRESS (account 1).
+    installStubs();
+    const addressByPath: Record<string, string> = {
+      "44'/195'/0'/0/0": DEVICE_ADDRESS,
+      "44'/195'/1'/0/0": OTHER_ADDRESS,
+    };
+    trxInstance.getAddress = vi.fn(async (path: string) => {
+      const addr = addressByPath[path];
+      if (!addr) throw new Error(`unexpected path ${path}`);
+      return { publicKey: "04abcd", address: addr };
     });
+
+    const { pairLedgerTron } = await import("../src/modules/execution/index.js");
+    const { getSessionStatus } = await import("../src/signing/session.js");
+
+    const first = await pairLedgerTron({ accountIndex: 0 });
+    expect(first.address).toBe(DEVICE_ADDRESS);
+    expect(first.path).toBe("44'/195'/0'/0/0");
+    const second = await pairLedgerTron({ accountIndex: 1 });
+    expect(second.address).toBe(OTHER_ADDRESS);
+    expect(second.path).toBe("44'/195'/1'/0/0");
+    expect(second.accountIndex).toBe(1);
+
+    const status = await getSessionStatus();
+    expect(status.tron).toHaveLength(2);
+    expect(status.tron?.[0].accountIndex).toBe(0);
+    expect(status.tron?.[1].accountIndex).toBe(1);
+    expect(status.tron?.[0].address).toBe(DEVICE_ADDRESS);
+    expect(status.tron?.[1].address).toBe(OTHER_ADDRESS);
+  });
+
+  it("rejects an out-of-range accountIndex", async () => {
+    const { pairLedgerTron } = await import("../src/modules/execution/index.js");
+    await expect(pairLedgerTron({ accountIndex: 999 })).rejects.toThrow(
+      /Invalid TRON accountIndex/
+    );
+  });
+
+  it("signing for a paired non-default account routes through the paired BIP-44 path", async () => {
+    // End-to-end: pair accountIndex=1 (→ OTHER_ADDRESS), prepare+send a tx
+    // from OTHER_ADDRESS, and assert `app.signTransaction` was called with
+    // the corresponding `44'/195'/1'/0/0` path — not the default path.
+    installStubs();
+    const addressByPath: Record<string, string> = {
+      "44'/195'/0'/0/0": DEVICE_ADDRESS,
+      "44'/195'/1'/0/0": OTHER_ADDRESS,
+    };
+    trxInstance.getAddress = vi.fn(async (path: string) => {
+      const addr = addressByPath[path];
+      if (!addr) throw new Error(`unexpected path ${path}`);
+      return { publicKey: "04abcd", address: addr };
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "https://api.trongrid.io/wallet/createtransaction") {
+        return new Response(
+          JSON.stringify({
+            txID: "ef".repeat(32),
+            raw_data: { expiration: 1 },
+            raw_data_hex: RAW_HEX,
+            visible: true,
+          }),
+          { status: 200 }
+        );
+      }
+      if (url === "https://api.trongrid.io/wallet/broadcasttransaction") {
+        return new Response(JSON.stringify({ result: true, txid: "ef".repeat(32) }), {
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { pairLedgerTron, sendTransaction } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const { buildTronNativeSend } = await import("../src/modules/tron/actions.js");
+
+    await pairLedgerTron({ accountIndex: 1 });
+    const tx = await buildTronNativeSend({
+      from: OTHER_ADDRESS,
+      to: DEVICE_ADDRESS,
+      amount: "1",
+    });
+    const result = await sendTransaction({ handle: tx.handle!, confirmed: true });
+    expect(result.txHash).toBe("ef".repeat(32));
+    expect(trxInstance.signTransaction).toHaveBeenCalledWith(
+      "44'/195'/1'/0/0",
+      RAW_HEX,
+      []
+    );
   });
 });

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Phase-3 (TRON USB HID signing) tests.
+ *
+ * We mock `src/signing/tron-usb-loader.ts` — a thin wrapper that loads the
+ * two Ledger CJS packages — rather than trying to mock the packages
+ * themselves. The Ledger SDK's ESM build has broken relative imports
+ * (missing `.js` extensions), so we route through a loader module; mocking
+ * the loader is also simpler and keeps the test free of SDK coupling.
+ */
+
+type TrxStub = {
+  getAddress: ReturnType<typeof vi.fn>;
+  signTransaction: ReturnType<typeof vi.fn>;
+  getAppConfiguration: ReturnType<typeof vi.fn>;
+};
+
+let openLedgerMock: ReturnType<typeof vi.fn>;
+let trxInstance: TrxStub;
+let transportCloseMock: ReturnType<typeof vi.fn>;
+
+vi.mock("../src/signing/tron-usb-loader.js", () => ({
+  openLedger: () => openLedgerMock(),
+}));
+
+const DEVICE_ADDRESS = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const OTHER_ADDRESS = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9";
+const RAW_HEX = "0a02487b2208b6f0a4c9dd5b6c";
+const GOOD_SIG = "a".repeat(130);
+
+function makeTrxStub(overrides: Partial<TrxStub> = {}): TrxStub {
+  return {
+    getAppConfiguration: vi.fn(async () => ({ version: "0.5.0" })),
+    getAddress: vi.fn(async () => ({ publicKey: "04abcd", address: DEVICE_ADDRESS })),
+    signTransaction: vi.fn(async () => GOOD_SIG),
+    ...overrides,
+  };
+}
+
+function installStubs(overrides: Partial<TrxStub> = {}) {
+  trxInstance = makeTrxStub(overrides);
+  transportCloseMock = vi.fn(async () => {});
+  openLedgerMock = vi.fn(async () => ({
+    app: trxInstance,
+    transport: { close: transportCloseMock },
+  }));
+}
+
+function statusCodeError(code: number, message = "") {
+  const e = new Error(message || `TransportStatusError 0x${code.toString(16)}`);
+  (e as Error & { statusCode?: number }).statusCode = code;
+  return e;
+}
+
+beforeEach(() => installStubs());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("tron-usb-signer", () => {
+  it("getTronLedgerAddress returns {address, publicKey, path, appVersion} and closes the transport", async () => {
+    const { getTronLedgerAddress } = await import("../src/signing/tron-usb-signer.js");
+    const result = await getTronLedgerAddress();
+    expect(result).toEqual({
+      address: DEVICE_ADDRESS,
+      publicKey: "04abcd",
+      path: "44'/195'/0'/0/0",
+      appVersion: "0.5.0",
+    });
+    expect(openLedgerMock).toHaveBeenCalledOnce();
+    expect(transportCloseMock).toHaveBeenCalledOnce();
+    expect(trxInstance.getAddress).toHaveBeenCalledWith("44'/195'/0'/0/0", false);
+  });
+
+  it("signTronTxOnLedger signs when the device address matches `expectedFrom`", async () => {
+    const { signTronTxOnLedger } = await import("../src/signing/tron-usb-signer.js");
+    const res = await signTronTxOnLedger({ rawDataHex: RAW_HEX, expectedFrom: DEVICE_ADDRESS });
+    expect(res).toEqual({ signature: GOOD_SIG, signerAddress: DEVICE_ADDRESS });
+    expect(trxInstance.signTransaction).toHaveBeenCalledWith("44'/195'/0'/0/0", RAW_HEX, []);
+    expect(transportCloseMock).toHaveBeenCalledOnce();
+  });
+
+  it("signTronTxOnLedger refuses when device address does NOT match `expectedFrom`", async () => {
+    const { signTronTxOnLedger } = await import("../src/signing/tron-usb-signer.js");
+    await expect(
+      signTronTxOnLedger({ rawDataHex: RAW_HEX, expectedFrom: OTHER_ADDRESS })
+    ).rejects.toThrow(/does not match the prepared tx's `from`/);
+    expect(trxInstance.signTransaction).not.toHaveBeenCalled();
+    expect(transportCloseMock).toHaveBeenCalledOnce();
+  });
+
+  it("maps 0x6985 (user rejected) to a human-readable error", async () => {
+    installStubs({
+      signTransaction: vi.fn(async () => {
+        throw statusCodeError(0x6985, "Conditions of use not satisfied");
+      }),
+    });
+    const { signTronTxOnLedger } = await import("../src/signing/tron-usb-signer.js");
+    await expect(
+      signTronTxOnLedger({ rawDataHex: RAW_HEX, expectedFrom: DEVICE_ADDRESS })
+    ).rejects.toThrow(/User rejected the transaction/);
+  });
+
+  it("maps 0x6511 (wrong app) to 'open the TRON app'", async () => {
+    installStubs({
+      getAppConfiguration: vi.fn(async () => {
+        throw statusCodeError(0x6511, "CLA not supported");
+      }),
+    });
+    const { getTronLedgerAddress } = await import("../src/signing/tron-usb-signer.js");
+    await expect(getTronLedgerAddress()).rejects.toThrow(/TRON app isn't open/);
+    expect(transportCloseMock).toHaveBeenCalledOnce();
+  });
+
+  it("maps a loader failure to a 'no Ledger device' error", async () => {
+    installStubs();
+    openLedgerMock = vi.fn(async () => {
+      throw new Error("cannot open device /dev/hidraw0: No such file or directory");
+    });
+    const { getTronLedgerAddress } = await import("../src/signing/tron-usb-signer.js");
+    await expect(getTronLedgerAddress()).rejects.toThrow(/No Ledger device detected/);
+  });
+
+  it("rejects a signature that isn't 130 hex chars", async () => {
+    installStubs({ signTransaction: vi.fn(async () => "deadbeef") });
+    const { signTronTxOnLedger } = await import("../src/signing/tron-usb-signer.js");
+    await expect(
+      signTronTxOnLedger({ rawDataHex: RAW_HEX, expectedFrom: DEVICE_ADDRESS })
+    ).rejects.toThrow(/unexpected signature shape/);
+  });
+});
+
+describe("broadcastTronTx", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const baseTx = {
+    chain: "tron" as const,
+    action: "native_send" as const,
+    from: DEVICE_ADDRESS,
+    txID: "cc".repeat(32),
+    rawData: { expiration: 0 },
+    rawDataHex: RAW_HEX,
+    description: "Send 1 TRX",
+    decoded: { functionName: "TransferContract", args: {} },
+  };
+
+  it("posts the signed envelope and returns the on-chain txID on success", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.trongrid.io/wallet/broadcasttransaction");
+      const body = JSON.parse(init!.body as string);
+      expect(body).toEqual({
+        txID: baseTx.txID,
+        raw_data: baseTx.rawData,
+        raw_data_hex: baseTx.rawDataHex,
+        signature: [GOOD_SIG],
+        visible: true,
+      });
+      return new Response(JSON.stringify({ result: true, txid: baseTx.txID }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { broadcastTronTx } = await import("../src/modules/tron/broadcast.js");
+    const res = await broadcastTronTx(baseTx, GOOD_SIG);
+    expect(res.txID).toBe(baseTx.txID);
+  });
+
+  it("decodes TronGrid's hex-encoded error messages into UTF-8", async () => {
+    const hexMsg = Buffer.from("Validate signature error", "utf8").toString("hex");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ code: "SIGERROR", message: hexMsg }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { broadcastTronTx } = await import("../src/modules/tron/broadcast.js");
+    await expect(broadcastTronTx(baseTx, GOOD_SIG)).rejects.toThrow(
+      /SIGERROR — Validate signature error/
+    );
+  });
+
+  it("surfaces plain-text messages verbatim when not hex-encoded", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ code: "CONTRACT_VALIDATE_ERROR", message: "not-hex message!" }),
+          { status: 200 }
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { broadcastTronTx } = await import("../src/modules/tron/broadcast.js");
+    await expect(broadcastTronTx(baseTx, GOOD_SIG)).rejects.toThrow(
+      /CONTRACT_VALIDATE_ERROR — not-hex message!/
+    );
+  });
+});
+
+describe("sendTransaction — TRON handle routing", () => {
+  beforeEach(() => installStubs());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("signs on USB, broadcasts to TronGrid, and retires the handle on success", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "https://api.trongrid.io/wallet/createtransaction") {
+        return new Response(
+          JSON.stringify({
+            txID: "ab".repeat(32),
+            raw_data: { expiration: 1 },
+            raw_data_hex: RAW_HEX,
+            visible: true,
+          }),
+          { status: 200 }
+        );
+      }
+      if (url === "https://api.trongrid.io/wallet/broadcasttransaction") {
+        return new Response(JSON.stringify({ result: true, txid: "ab".repeat(32) }), {
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { buildTronNativeSend } = await import("../src/modules/tron/actions.js");
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const { hasTronHandle } = await import("../src/signing/tron-tx-store.js");
+
+    const tx = await buildTronNativeSend({
+      from: DEVICE_ADDRESS,
+      to: OTHER_ADDRESS,
+      amount: "1",
+    });
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+
+    const result = await sendTransaction({ handle: tx.handle!, confirmed: true });
+    expect(result).toEqual({ txHash: "ab".repeat(32), chain: "tron" });
+    expect(hasTronHandle(tx.handle!)).toBe(false);
+    expect(trxInstance.signTransaction).toHaveBeenCalledWith("44'/195'/0'/0/0", RAW_HEX, []);
+  });
+
+  it("keeps the handle alive when signing fails so the caller can retry", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "https://api.trongrid.io/wallet/createtransaction") {
+        return new Response(
+          JSON.stringify({
+            txID: "cd".repeat(32),
+            raw_data: { expiration: 1 },
+            raw_data_hex: RAW_HEX,
+            visible: true,
+          }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    installStubs({
+      signTransaction: vi.fn(async () => {
+        throw statusCodeError(0x6985, "Conditions of use not satisfied");
+      }),
+    });
+
+    const { buildTronNativeSend } = await import("../src/modules/tron/actions.js");
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const { hasTronHandle } = await import("../src/signing/tron-tx-store.js");
+
+    const tx = await buildTronNativeSend({
+      from: DEVICE_ADDRESS,
+      to: OTHER_ADDRESS,
+      amount: "1",
+    });
+    await expect(
+      sendTransaction({ handle: tx.handle!, confirmed: true })
+    ).rejects.toThrow(/User rejected/);
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+});
+
+describe("pair_ledger_tron + get_ledger_status", () => {
+  beforeEach(() => installStubs());
+
+  it("populates the tron section of getSessionStatus after pairing", async () => {
+    vi.doMock("../src/signing/walletconnect.js", () => ({
+      getSignClient: async () => ({}),
+      getCurrentSession: () => null,
+      getConnectedAccountsDetailed: async () => [],
+      isPeerUnreachable: () => false,
+    }));
+    const { pairLedgerTron } = await import("../src/modules/execution/index.js");
+    const { getSessionStatus } = await import("../src/signing/session.js");
+
+    const pair = await pairLedgerTron();
+    expect(pair.address).toBe(DEVICE_ADDRESS);
+    expect(pair.path).toBe("44'/195'/0'/0/0");
+
+    const status = await getSessionStatus();
+    expect(status.tron).toEqual({
+      address: DEVICE_ADDRESS,
+      path: "44'/195'/0'/0/0",
+      appVersion: "0.5.0",
+    });
+  });
+});

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -277,6 +277,10 @@ describe("pair_ledger_tron + get_ledger_status", () => {
   beforeEach(() => installStubs());
 
   it("populates the tron section of getSessionStatus after pairing", async () => {
+    // Reset the module cache so `session.ts`'s transitive import of
+    // `walletconnect.js` (already resolved by earlier tests via execution/index)
+    // is re-evaluated and picks up the doMock below.
+    vi.resetModules();
     vi.doMock("../src/signing/walletconnect.js", () => ({
       getSignClient: async () => ({}),
       getCurrentSession: () => null,


### PR DESCRIPTION
## Summary
- Adds end-to-end TRON signing via `@ledgerhq/hw-app-trx` over USB HID. All seven `prepare_tron_*` tools are no longer preview-only — their handles are now accepted by `send_transaction`.
- New `pair_ledger_tron` tool probes the USB-connected Ledger, caches the address for `get_ledger_status`, and verifies the TRON app is open. Pair once per session.
- `send_transaction` routes by handle store: TRON handles sign on USB and broadcast via TronGrid; EVM handles continue through WalletConnect unchanged. Handles stay alive on sign/broadcast failure so users can retry within the 15-min TTL.

## Why USB instead of WalletConnect
Ledger Live's WalletConnect relay does not honor the `tron:` CAIP namespace (verified 2026-04-14). USB HID is the only path today — the user's Ledger must be plugged into the host running the MCP, unlocked, with the Tron app open. On Linux this needs Ledger's udev rules and `libudev-dev` + a C toolchain for the `node-hid` native compile; README calls both out.

## Implementation notes
- Ledger SDK's ESM build has broken relative imports (missing `.js` extensions under `--moduleResolution bundler`). Worked around with a thin `tron-usb-loader.ts` using `createRequire` to pull the CJS entries. Isolating the `require()` also makes the signer trivially mockable in tests.
- Fresh transport open per operation, closed in `finally` — HID handles are exclusive, so holding one would block `ledger-live` and other tooling.
- Device address is re-verified against the prepared tx's `from` on every sign call; cached pairing is never trusted for authorization.
- Empty `tokenSignatures []` passed to `signTransaction` — USDT has hardcoded TRON-app support; other TRC-20 amounts may display as raw hex. Contract address + amount remain verifiable on-device.
- TronGrid error messages come back hex-encoded; `broadcastTronTx` decodes to UTF-8 before surfacing.

## Test plan
- [x] 13 new tests in `test/tron-phase3-signing.test.ts` covering: happy-path sign, address-mismatch refusal, user-reject (0x6985), wrong-app (0x6511), no-device, malformed signature, broadcast happy path, hex-decoded error, plain-text error, `send_transaction` TRON routing with handle retirement, handle survives sign failure, `pair_ledger_tron` populates session status.
- [x] Full suite: 321/321 pass.
- [x] `tsc` clean.
- [ ] End-to-end smoke on a physical Ledger (reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)