### PR TITLE
Rename project to vaultpilot-mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # RPC provider — one of: infura, alchemy, custom
-# If unset, the MCP server falls back to ~/.recon-crypto-mcp/config.json (written by `recon-crypto-mcp-setup`).
+# If unset, the MCP server falls back to ~/.vaultpilot-mcp/config.json (written by `vaultpilot-mcp-setup`).
 RPC_PROVIDER=infura
 
 # API key for the chosen provider (unused when RPC_PROVIDER=custom)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Recon Crypto MCP
+# VaultPilot MCP
 
-[![npm version](https://img.shields.io/npm/v/recon-crypto-mcp.svg)](https://www.npmjs.com/package/recon-crypto-mcp)
-[![license](https://img.shields.io/npm/l/recon-crypto-mcp.svg)](./LICENSE)
-[![node](https://img.shields.io/node/v/recon-crypto-mcp.svg)](package.json)
-[![recon-crypto-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp)
+[![npm version](https://img.shields.io/npm/v/vaultpilot-mcp.svg)](https://www.npmjs.com/package/vaultpilot-mcp)
+[![license](https://img.shields.io/npm/l/vaultpilot-mcp.svg)](./LICENSE)
+[![node](https://img.shields.io/node/v/vaultpilot-mcp.svg)](package.json)
+[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp)
 
 **Self-custodial crypto portfolio and DeFi, managed by AI agents — signed on your Ledger hardware wallet.**
 
-Recon Crypto MCP is a Model Context Protocol server that lets AI agents — **Claude Code, Claude Desktop, Cursor**, and any MCP-compatible client — read your on-chain positions across **Ethereum, Arbitrum, Polygon, Base**, and **TRON** and prepare EVM transactions that you sign on your **Ledger device via WalletConnect**. Your private keys never leave the hardware wallet, and every transaction is previewed in human-readable form before you approve it on the device.
+VaultPilot MCP is a Model Context Protocol server that lets AI agents — **Claude Code, Claude Desktop, Cursor**, and any MCP-compatible client — read your on-chain positions across **Ethereum, Arbitrum, Polygon, Base**, and **TRON** and prepare EVM transactions that you sign on your **Ledger device via WalletConnect**. Your private keys never leave the hardware wallet, and every transaction is previewed in human-readable form before you approve it on the device.
 
 Supported protocols: **Aave V3, Compound V3 (Comet), Morpho Blue, Uniswap V3 LP, Lido (stETH/wstETH), EigenLayer**, plus **LiFi** for swap/bridge aggregation and **1inch** for optional intra-chain quote comparison.
 
@@ -69,7 +69,7 @@ Read-only (no Ledger pairing required):
 
 Meta:
 
-- `request_capability` — agent-facing escape hatch: files a GitHub issue on this repo when the user asks for something recon-crypto-mcp can't do (new protocol, new chain, missing tool). Default mode returns a pre-filled issue URL (zero spam risk — user must click to submit). Operators can set `RECON_FEEDBACK_ENDPOINT` to a proxy that posts directly. Rate-limited: 30s between calls, 3/hour, 10/day, 7-day dedupe on identical summaries.
+- `request_capability` — agent-facing escape hatch: files a GitHub issue on this repo when the user asks for something vaultpilot-mcp can't do (new protocol, new chain, missing tool). Default mode returns a pre-filled issue URL (zero spam risk — user must click to submit). Operators can set `VAULTPILOT_FEEDBACK_ENDPOINT` to a proxy that posts directly. Rate-limited: 30s between calls, 3/hour, 10/day, 7-day dedupe on identical summaries.
 
 Execution (Ledger-signed via WalletConnect):
 
@@ -95,22 +95,22 @@ Execution (Ledger-signed via WalletConnect):
 ### From npm (recommended)
 
 ```bash
-npm install -g recon-crypto-mcp
-recon-crypto-mcp-setup
+npm install -g vaultpilot-mcp
+vaultpilot-mcp-setup
 ```
 
 ### From source
 
 ```bash
-git clone https://github.com/szhygulin/recon-crypto-mcp.git
-cd recon-crypto-mcp
+git clone https://github.com/szhygulin/vaultpilot-mcp.git
+cd vaultpilot-mcp
 npm install
 npm run build
 ```
 
 ## Setup
 
-Run the interactive setup to pick an RPC provider, validate the key, optionally pair Ledger Live, and write `~/.recon-crypto-mcp/config.json`:
+Run the interactive setup to pick an RPC provider, validate the key, optionally pair Ledger Live, and write `~/.vaultpilot-mcp/config.json`:
 
 ```bash
 npm run setup
@@ -125,20 +125,20 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "recon-crypto-mcp": {
-      "command": "recon-crypto-mcp"
+    "vaultpilot-mcp": {
+      "command": "vaultpilot-mcp"
     }
   }
 }
 ```
 
-(If you installed from source rather than via `npm i -g`, swap `"command": "recon-crypto-mcp"` for `"command": "node"` and `"args": ["/absolute/path/to/recon-crypto-mcp/dist/index.js"]`.)
+(If you installed from source rather than via `npm i -g`, swap `"command": "vaultpilot-mcp"` for `"command": "node"` and `"args": ["/absolute/path/to/vaultpilot-mcp/dist/index.js"]`.)
 
 The setup script prints a ready-to-paste snippet.
 
 ## Environment variables
 
-All are optional if the matching field is in `~/.recon-crypto-mcp/config.json`; env vars take precedence when both are set.
+All are optional if the matching field is in `~/.vaultpilot-mcp/config.json`; env vars take precedence when both are set.
 
 - `ETHEREUM_RPC_URL`, `ARBITRUM_RPC_URL`, `POLYGON_RPC_URL`, `BASE_RPC_URL` — custom RPC endpoints
 - `RPC_PROVIDER` (`infura` | `alchemy`) + `RPC_API_KEY` — alternative to custom URLs
@@ -147,8 +147,8 @@ All are optional if the matching field is in `~/.recon-crypto-mcp/config.json`; 
 - `TRON_API_KEY` — TronGrid API key (sent as `TRON-PRO-API-KEY`). Required in practice to read TRON balances — anonymous TronGrid calls are capped at ~15 req/min, which the portfolio fan-out exceeds. Free to create at [trongrid.io](https://www.trongrid.io).
 - `WALLETCONNECT_PROJECT_ID` — required for Ledger Live signing
 - `RPC_BATCH=1` — opt into JSON-RPC batching (off by default; many public endpoints mishandle batched POSTs)
-- `RECON_ALLOW_INSECURE_RPC=1` — opt out of the https/private-IP check on RPC URLs. Only set this when pointing at a local anvil/hardhat fork; never in production.
-- `RECON_FEEDBACK_ENDPOINT` — optional https URL for `request_capability` to POST directly (e.g. a maintainer-operated proxy that creates GitHub issues with a bot token). When unset (the default), `request_capability` returns a pre-filled GitHub issue URL for the user to click through; nothing is transmitted automatically. **Operator responsibility:** the recon-crypto-mcp client does not sign or authenticate POST requests. If you set this endpoint, the proxy MUST enforce its own auth (IP allowlist, Cloudflare Access, HMAC header validation, etc.) — otherwise any caller who learns the URL can submit to it. The on-process rate limiter (3/hour, 10/day) is a courtesy, not a security control.
+- `VAULTPILOT_ALLOW_INSECURE_RPC=1` — opt out of the https/private-IP check on RPC URLs. Only set this when pointing at a local anvil/hardhat fork; never in production. (Old name `RECON_ALLOW_INSECURE_RPC` is still honored for one release.)
+- `VAULTPILOT_FEEDBACK_ENDPOINT` — optional https URL for `request_capability` to POST directly (e.g. a maintainer-operated proxy that creates GitHub issues with a bot token). When unset (the default), `request_capability` returns a pre-filled GitHub issue URL for the user to click through; nothing is transmitted automatically. **Operator responsibility:** the vaultpilot-mcp client does not sign or authenticate POST requests. If you set this endpoint, the proxy MUST enforce its own auth (IP allowlist, Cloudflare Access, HMAC header validation, etc.) — otherwise any caller who learns the URL can submit to it. The on-process rate limiter (3/hour, 10/day) is a courtesy, not a security control. (Old name `RECON_FEEDBACK_ENDPOINT` is still honored for one release.)
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "recon-crypto-mcp",
+  "name": "vaultpilot-mcp",
   "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "recon-crypto-mcp",
+      "name": "vaultpilot-mcp",
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
@@ -19,8 +19,8 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "recon-crypto-mcp": "dist/index.js",
-        "recon-crypto-mcp-setup": "dist/setup.js"
+        "vaultpilot-mcp": "dist/index.js",
+        "vaultpilot-mcp-setup": "dist/setup.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "recon-crypto-mcp",
+  "name": "vaultpilot-mcp",
   "version": "0.3.1",
-  "mcpName": "io.github.szhygulin/recon-crypto-mcp",
+  "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "recon-crypto-mcp": "dist/index.js",
-    "recon-crypto-mcp-setup": "dist/setup.js"
+    "vaultpilot-mcp": "dist/index.js",
+    "vaultpilot-mcp-setup": "dist/setup.js"
   },
   "files": [
     "dist",
@@ -105,13 +105,13 @@
     "multisig",
     "timelock"
   ],
-  "homepage": "https://github.com/szhygulin/recon-crypto-mcp#readme",
+  "homepage": "https://github.com/szhygulin/vaultpilot-mcp#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/szhygulin/recon-crypto-mcp.git"
+    "url": "git+https://github.com/szhygulin/vaultpilot-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/szhygulin/recon-crypto-mcp/issues"
+    "url": "https://github.com/szhygulin/vaultpilot-mcp/issues"
   },
   "author": "Viacheslav Zhygulin",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.szhygulin/recon-crypto-mcp",
-  "title": "Recon Crypto MCP",
+  "name": "io.github.szhygulin/vaultpilot-mcp",
+  "title": "VaultPilot MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
   "version": "0.3.1",
-  "websiteUrl": "https://github.com/szhygulin/recon-crypto-mcp",
+  "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
-    "url": "https://github.com/szhygulin/recon-crypto-mcp",
+    "url": "https://github.com/szhygulin/vaultpilot-mcp",
     "source": "github"
   },
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "recon-crypto-mcp",
+      "identifier": "vaultpilot-mcp",
       "version": "0.3.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -48,23 +48,29 @@ export class RpcConfigError extends Error {
  *    got mis-pasted (e.g. a neighbour's dev box) and we'd rather fail loud
  *    than exfiltrate wallet addresses to an unexpected host.
  * Callers who intentionally want to hit a local forked node (anvil, hardhat,
- * etc.) can opt out with RECON_ALLOW_INSECURE_RPC=1.
+ * etc.) can opt out with VAULTPILOT_ALLOW_INSECURE_RPC=1 (legacy alias
+ * RECON_ALLOW_INSECURE_RPC is still honored for one release).
  */
 export function validateRpcUrl(chain: SupportedChain, url: string): void {
-  if (process.env.RECON_ALLOW_INSECURE_RPC === "1") return;
+  if (
+    process.env.VAULTPILOT_ALLOW_INSECURE_RPC === "1" ||
+    process.env.RECON_ALLOW_INSECURE_RPC === "1"
+  ) {
+    return;
+  }
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     throw new RpcConfigError(
-      `RPC URL for ${chain} is not a valid URL: ${url}. Fix it via \`recon-crypto-mcp-setup\` or the relevant env var.`
+      `RPC URL for ${chain} is not a valid URL: ${url}. Fix it via \`vaultpilot-mcp-setup\` or the relevant env var.`
     );
   }
   if (parsed.protocol !== "https:") {
     throw new RpcConfigError(
       `RPC URL for ${chain} must use https (got ${parsed.protocol}//). ` +
         `Plaintext RPCs leak wallet addresses to anyone on the network path. ` +
-        `Set RECON_ALLOW_INSECURE_RPC=1 only if you're pointing at a local anvil/hardhat fork.`
+        `Set VAULTPILOT_ALLOW_INSECURE_RPC=1 only if you're pointing at a local anvil/hardhat fork.`
     );
   }
   const host = parsed.hostname.toLowerCase();
@@ -72,7 +78,7 @@ export function validateRpcUrl(chain: SupportedChain, url: string): void {
     throw new RpcConfigError(
       `RPC URL for ${chain} points at a private/loopback host (${host}). ` +
         `This is almost always a mis-pasted config. ` +
-        `Set RECON_ALLOW_INSECURE_RPC=1 if you intend to hit a local fork.`
+        `Set VAULTPILOT_ALLOW_INSECURE_RPC=1 if you intend to hit a local fork.`
     );
   }
 }
@@ -129,7 +135,7 @@ function isPrivateOrLoopbackIPv4(a: number, b: number): boolean {
 
 /**
  * Resolve the RPC URL for a given chain based on env vars (highest priority)
- * then the user's ~/.recon-crypto-mcp/config.json.
+ * then the user's ~/.vaultpilot-mcp/config.json.
  */
 export function resolveRpcUrl(chain: SupportedChain, userConfig: UserConfig | null): string {
   const url = resolveRpcUrlRaw(chain, userConfig);
@@ -159,13 +165,13 @@ function resolveRpcUrlRaw(chain: SupportedChain, userConfig: UserConfig | null):
       const url = customUrls?.[chain];
       if (url) return url;
       throw new RpcConfigError(
-        `No custom RPC URL configured for chain "${chain}". Re-run \`recon-crypto-mcp-setup\`.`
+        `No custom RPC URL configured for chain "${chain}". Re-run \`vaultpilot-mcp-setup\`.`
       );
     }
     if (provider === "infura" || provider === "alchemy") {
       if (!apiKey) {
         throw new RpcConfigError(
-          `Missing API key for RPC provider "${provider}". Re-run \`recon-crypto-mcp-setup\`.`
+          `Missing API key for RPC provider "${provider}". Re-run \`vaultpilot-mcp-setup\`.`
         );
       }
       return PROVIDER_URL_TEMPLATES[provider][chain](apiKey);
@@ -174,6 +180,6 @@ function resolveRpcUrlRaw(chain: SupportedChain, userConfig: UserConfig | null):
 
   throw new RpcConfigError(
     `No RPC provider configured for chain "${chain}". ` +
-      `Run \`recon-crypto-mcp-setup\` to configure Infura, Alchemy, or a custom endpoint.`
+      `Run \`vaultpilot-mcp-setup\` to configure Infura, Alchemy, or a custom endpoint.`
   );
 }

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -1,30 +1,47 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, lstatSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, lstatSync, cpSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import type { UserConfig } from "../types/index.js";
 
-const CONFIG_DIR = join(homedir(), ".recon-crypto-mcp");
+const CONFIG_DIR = join(homedir(), ".vaultpilot-mcp");
 const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+// Pre-rename path. We still read from here if the new dir doesn't exist, and
+// copy the legacy dir on first write so existing users keep their WC pairing
+// state (walletconnect.db) across the rename.
+const LEGACY_CONFIG_DIR = join(homedir(), ".recon-crypto-mcp");
+const LEGACY_CONFIG_PATH = join(LEGACY_CONFIG_DIR, "config.json");
 
 /** Read the user config file; returns null if it doesn't exist. Throws on malformed JSON. */
 export function readUserConfig(): UserConfig | null {
-  if (!existsSync(CONFIG_PATH)) return null;
-  const raw = readFileSync(CONFIG_PATH, "utf8");
+  const path = existsSync(CONFIG_PATH)
+    ? CONFIG_PATH
+    : existsSync(LEGACY_CONFIG_PATH)
+      ? LEGACY_CONFIG_PATH
+      : null;
+  if (!path) return null;
+  const raw = readFileSync(path, "utf8");
   try {
     return JSON.parse(raw) as UserConfig;
   } catch (err) {
     throw new Error(
-      `~/.recon-crypto-mcp/config.json is malformed: ${(err as Error).message}. Delete it or re-run \`recon-crypto-mcp-setup\`.`
+      `~/.vaultpilot-mcp/config.json is malformed: ${(err as Error).message}. Delete it or re-run \`vaultpilot-mcp-setup\`.`
     );
   }
 }
 
 export function writeUserConfig(config: UserConfig): void {
+  // Migrate the legacy `.recon-crypto-mcp` dir to the new `.vaultpilot-mcp`
+  // location on first write after upgrade. We `cp -r` rather than rename so the
+  // user can roll back if something goes sideways. The legacy dir stays put;
+  // a future release can drop it.
+  if (!existsSync(CONFIG_DIR) && existsSync(LEGACY_CONFIG_DIR)) {
+    cpSync(LEGACY_CONFIG_DIR, CONFIG_DIR, { recursive: true, preserveTimestamps: true });
+  }
   if (!existsSync(CONFIG_DIR)) {
     mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   }
   // Refuse to follow symlinks or hardlinks when writing the config. A local
-  // attacker with write access to ~/.recon-crypto-mcp (or with a race-window before
+  // attacker with write access to ~/.vaultpilot-mcp (or with a race-window before
   // first-run setup creates the dir) could pre-place config.json as a symlink
   // to another file (~/.ssh/authorized_keys, ~/.bashrc, etc.) so the next
   // writeFileSync clobbers it. lstatSync on the path (not following the link)

--- a/src/data/rpc.ts
+++ b/src/data/rpc.ts
@@ -60,7 +60,7 @@ export async function verifyChainId(chain: SupportedChain): Promise<void> {
     throw new Error(
       `RPC for ${chain} returned chainId ${actual}, expected ${expected}. ` +
         `The configured endpoint does NOT point at ${chain} — refusing to proceed. ` +
-        `Fix via \`recon-crypto-mcp-setup\` or the relevant env var.`
+        `Fix via \`vaultpilot-mcp-setup\` or the relevant env var.`
     );
   }
   verifiedChains.add(chain);

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,20 +201,20 @@ async function main() {
   const hasEnvProvider = process.env.RPC_PROVIDER && process.env.RPC_API_KEY;
   if (!cfg && !hasEnvChain && !hasEnvProvider) {
     console.error(
-      "[recon-crypto-mcp] warning: no RPC provider configured. Run `recon-crypto-mcp-setup` or set RPC_PROVIDER + RPC_API_KEY."
+      "[vaultpilot-mcp] warning: no RPC provider configured. Run `vaultpilot-mcp-setup` or set RPC_PROVIDER + RPC_API_KEY."
     );
   }
 
   const server = new McpServer(
     {
-      name: "recon-crypto-mcp",
-      title: "Recon — Ledger-Signed Crypto Portfolio & DeFi",
+      name: "vaultpilot-mcp",
+      title: "VaultPilot — Ledger-Signed Crypto Portfolio & DeFi",
       version: "0.1.0",
-      websiteUrl: "https://github.com/szhygulin/recon-crypto-mcp",
+      websiteUrl: "https://github.com/szhygulin/vaultpilot-mcp",
     },
     {
       instructions: [
-        "Recon is a self-custodial crypto-portfolio and DeFi tooling server for AI agents.",
+        "VaultPilot is a self-custodial crypto-portfolio and DeFi tooling server for AI agents.",
         "The user's private keys live on a Ledger hardware wallet; this server never holds or",
         "broadcasts keys. Every state-changing transaction is prepared here (read-only) and",
         "then forwarded to Ledger Live via WalletConnect so the user can review and approve it",
@@ -272,7 +272,7 @@ async function main() {
         "",
         "CAPABILITY GAPS: if the user asks for something this server cannot do (unsupported",
         "protocol, chain, token, or a workflow none of the existing tools cover), call",
-        "`request_capability` to file a GitHub issue on the recon-crypto-mcp repo. By default it",
+        "`request_capability` to file a GitHub issue on the vaultpilot-mcp repo. By default it",
         "returns a prefilled URL for the user to click — nothing is sent automatically. Use",
         "this only after confirming no existing tool fits; it is rate-limited (3/hour,",
         "10/day, dedup'd for 7 days). Never substitute this for completing the task.",
@@ -840,11 +840,11 @@ async function main() {
     "request_capability",
     {
       description:
-        "File a capability request against the recon-crypto-mcp GitHub repository when the user asks for something this server cannot do " +
+        "File a capability request against the vaultpilot-mcp GitHub repository when the user asks for something this server cannot do " +
         "(e.g. an unsupported protocol, chain, token, or missing tool). " +
         "USE ONLY AFTER confirming no existing tool can accomplish the task. " +
         "By default this returns a pre-filled GitHub issue URL — NO data is transmitted; the user must click through to submit. " +
-        "If the operator has configured RECON_FEEDBACK_ENDPOINT, it posts directly to that proxy instead. " +
+        "If the operator has configured VAULTPILOT_FEEDBACK_ENDPOINT, it posts directly to that proxy instead. " +
         "Rate-limited per install (30s between calls, 3/hour, 10/day, 7-day dedupe on identical summaries). " +
         "Write clear, actionable summaries — this lands in a real issue tracker read by humans.",
       inputSchema: requestCapabilityInput.shape,
@@ -857,6 +857,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("[recon-crypto-mcp] fatal:", err);
+  console.error("[vaultpilot-mcp] fatal:", err);
   process.exit(1);
 });

--- a/src/modules/feedback/index.ts
+++ b/src/modules/feedback/index.ts
@@ -2,9 +2,9 @@ import { requestCapabilityInput, type RequestCapabilityArgs } from "./schemas.js
 import { checkAndRecord, hashPayload, RATE_LIMITS } from "./rate-limit.js";
 
 const REPO_OWNER = "szhygulin";
-const REPO_NAME = "recon-crypto-mcp";
+const REPO_NAME = "vaultpilot-mcp";
 const ISSUE_LABEL = "agent-request";
-const USER_AGENT = "recon-crypto-mcp/0.1.0 capability-request";
+const USER_AGENT = "vaultpilot-mcp/0.1.0 capability-request";
 const POST_TIMEOUT_MS = 8_000;
 const MAX_POST_BODY_BYTES = 16_384;
 const MAX_PREFILLED_URL_BYTES = 7168;
@@ -50,11 +50,13 @@ export async function requestCapability(args: RequestCapabilityArgs) {
   const labels = [ISSUE_LABEL, category].filter((v): v is string => Boolean(v));
   const payload: IssuePayload = { title, body, labels };
 
-  const endpoint = process.env.RECON_FEEDBACK_ENDPOINT?.trim();
+  const endpoint = (
+    process.env.VAULTPILOT_FEEDBACK_ENDPOINT ?? process.env.RECON_FEEDBACK_ENDPOINT
+  )?.trim();
   if (endpoint) {
     if (!/^https:\/\//i.test(endpoint)) {
       throw new Error(
-        "RECON_FEEDBACK_ENDPOINT must be an https:// URL. Refusing to submit over plaintext."
+        "VAULTPILOT_FEEDBACK_ENDPOINT must be an https:// URL. Refusing to submit over plaintext."
       );
     }
     return await postToEndpoint(endpoint, payload);
@@ -64,7 +66,7 @@ export async function requestCapability(args: RequestCapabilityArgs) {
   return {
     status: "prefilled_url" as const,
     message:
-      "No data has been transmitted. Show this URL to the user — opening it prefills a GitHub issue on the recon-crypto-mcp repo; " +
+      "No data has been transmitted. Show this URL to the user — opening it prefills a GitHub issue on the vaultpilot-mcp repo; " +
       "submission requires the user to click 'Submit new issue'." +
       (truncated
         ? " The issue body was truncated to fit GitHub's prefilled-URL length limit; tell the user to paste the full context into the issue before submitting."
@@ -113,7 +115,7 @@ function buildIssueBody(opts: {
 
   const agent = opts.agentName ? neutralizeMentions(opts.agentName) : undefined;
   const footer =
-    "_Submitted via the `request_capability` tool in recon-crypto-mcp by an AI agent" +
+    "_Submitted via the `request_capability` tool in vaultpilot-mcp by an AI agent" +
     (agent ? ` (${agent})` : "") +
     "._";
   lines.push("---", footer);

--- a/src/modules/feedback/rate-limit.ts
+++ b/src/modules/feedback/rate-limit.ts
@@ -13,13 +13,18 @@ type FeedbackEvent = { ts: number; hash: string };
 
 /**
  * The state-file path is computed lazily from an env-var override so tests can
- * redirect writes into a temp dir. Default: `~/.recon-crypto-mcp/feedback-log.json`.
+ * redirect writes into a temp dir. Default: `~/.vaultpilot-mcp/feedback-log.json`,
+ * with back-compat fallback to `~/.recon-crypto-mcp/feedback-log.json` if that's
+ * the only one that exists (pre-rename users).
  */
 function getStateFilePath(): string {
-  return (
-    process.env.RECON_FEEDBACK_STATE_FILE ??
-    join(homedir(), ".recon-crypto-mcp", "feedback-log.json")
-  );
+  const envOverride =
+    process.env.VAULTPILOT_FEEDBACK_STATE_FILE ?? process.env.RECON_FEEDBACK_STATE_FILE;
+  if (envOverride) return envOverride;
+  const newPath = join(homedir(), ".vaultpilot-mcp", "feedback-log.json");
+  const legacyPath = join(homedir(), ".recon-crypto-mcp", "feedback-log.json");
+  if (!existsSync(newPath) && existsSync(legacyPath)) return legacyPath;
+  return newPath;
 }
 
 const MIN_INTERVAL_MS = 30_000;

--- a/src/modules/feedback/schemas.ts
+++ b/src/modules/feedback/schemas.ts
@@ -27,7 +27,7 @@ export const requestCapabilityInput = z.object({
         .string()
         .max(100)
         .optional()
-        .describe("Name of the recon-crypto-mcp tool the agent tried first, if any."),
+        .describe("Name of the vaultpilot-mcp tool the agent tried first, if any."),
       chain: z.string().max(50).optional().describe("Chain involved, if relevant."),
       errorObserved: z
         .string()

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -7,7 +7,7 @@ let initialized = false;
 export function initLifi(): void {
   if (initialized) return;
   createConfig({
-    integrator: "recon-crypto-mcp",
+    integrator: "vaultpilot-mcp",
     // We don't execute routes through LiFi — we just fetch tx data and hand it to WalletConnect.
   });
   initialized = true;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * Interactive setup for Recon Crypto MCP.
+ * Interactive setup for VaultPilot MCP.
  *
  *   - Picks an RPC provider (Infura / Alchemy / custom) and validates the API key
  *     against a live eth_chainId call.
  *   - Optionally captures an Etherscan API key (improves contract-verification tools).
  *   - Optionally captures a WalletConnect Cloud project ID.
  *   - Optionally pairs Ledger Live over WalletConnect right now.
- *   - Persists everything to ~/.recon-crypto-mcp/config.json (0600) and prints a
+ *   - Persists everything to ~/.vaultpilot-mcp/config.json (0600) and prints a
  *     Claude Desktop config snippet the user can copy.
  *
  * Env vars always override the config file at runtime — the setup flow is for
@@ -252,10 +252,10 @@ async function pairLedgerLiveFlow(p: Prompt): Promise<void> {
 }
 
 function printClaudeDesktopSnippet(): void {
-  const binPath = "recon-crypto-mcp"; // installed via `npm i -g recon-crypto-mcp`
+  const binPath = "vaultpilot-mcp"; // installed via `npm i -g vaultpilot-mcp`
   const snippet = {
     mcpServers: {
-      "recon-crypto-mcp": {
+      "vaultpilot-mcp": {
         command: binPath,
       },
     },
@@ -268,7 +268,7 @@ function printClaudeDesktopSnippet(): void {
       JSON.stringify(
         {
           mcpServers: {
-            "recon-crypto-mcp": {
+            "vaultpilot-mcp": {
               command: "node",
               args: [`${process.cwd()}/dist/index.js`],
             },
@@ -281,7 +281,7 @@ function printClaudeDesktopSnippet(): void {
 }
 
 async function main() {
-  console.log("Recon Crypto MCP — interactive setup\n");
+  console.log("VaultPilot MCP — interactive setup\n");
   console.log(`Config path: ${getConfigPath()}`);
 
   const p = new Prompt();

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -12,7 +12,7 @@ import {
 
 /**
  * Default WalletConnect Cloud project ID. Users should provide their own via
- * WALLETCONNECT_PROJECT_ID or `recon-crypto-mcp-setup` — the default is a placeholder
+ * WALLETCONNECT_PROJECT_ID or `vaultpilot-mcp-setup` — the default is a placeholder
  * that will 401 against production relay. We keep a constant here so the code
  * compiles; `getProjectId()` will throw if a real ID is not set.
  */
@@ -58,7 +58,7 @@ function getProjectId(): string {
   const id = resolveWalletConnectProjectId(readUserConfig()) || DEFAULT_PROJECT_ID;
   if (!id) {
     throw new Error(
-      "No WalletConnect project ID configured. Set WALLETCONNECT_PROJECT_ID in your env or re-run `recon-crypto-mcp-setup`. " +
+      "No WalletConnect project ID configured. Set WALLETCONNECT_PROJECT_ID in your env or re-run `vaultpilot-mcp-setup`. " +
         "Create a free project at https://cloud.walletconnect.com."
     );
   }
@@ -67,16 +67,16 @@ function getProjectId(): string {
 
 export async function getSignClient(): Promise<InstanceType<typeof SignClient>> {
   if (client) return client;
-  // Persist WC symkey/pairing/session state under ~/.recon-crypto-mcp so it survives process exit.
+  // Persist WC symkey/pairing/session state under ~/.vaultpilot-mcp so it survives process exit.
   // Without this, the SignClient defaults to an unstorage path in cwd — which Claude Code
   // kills on exit, leaving the saved session topic useless (no keys to decrypt the relay).
   const storageDbPath = join(getConfigDir(), "walletconnect.db");
   client = await SignClient.init({
     projectId: getProjectId(),
     metadata: {
-      name: "Recon Crypto MCP",
+      name: "VaultPilot MCP",
       description: "MCP server that prepares DeFi transactions for Ledger Live signing.",
-      url: "https://github.com/szhygulin/recon-crypto-mcp",
+      url: "https://github.com/szhygulin/vaultpilot-mcp",
       icons: [],
     },
     storageOptions: { database: storageDbPath },
@@ -244,7 +244,7 @@ export async function requestSendTransaction(tx: UnsignedTx): Promise<`0x${strin
   const c = await getSignClient();
   if (!currentSession) {
     throw new Error(
-      "No active WalletConnect session. Pair Ledger Live first via `pair_ledger_live` or `recon-crypto-mcp-setup`."
+      "No active WalletConnect session. Pair Ledger Live first via `pair_ledger_live` or `vaultpilot-mcp-setup`."
     );
   }
   const chainId = CHAIN_IDS[tx.chain];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -527,7 +527,7 @@ export interface UnsignedTx {
   handle?: string;
 }
 
-/** Shape of ~/.recon-crypto-mcp/config.json. */
+/** Shape of ~/.vaultpilot-mcp/config.json. */
 export interface UserConfig {
   rpc: {
     provider: RpcProvider;

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -12,12 +12,12 @@ let stateFile: string;
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "recon-feedback-"));
   stateFile = join(tmpDir, "feedback-log.json");
-  process.env.RECON_FEEDBACK_STATE_FILE = stateFile;
-  delete process.env.RECON_FEEDBACK_ENDPOINT;
+  process.env.VAULTPILOT_FEEDBACK_STATE_FILE = stateFile;
+  delete process.env.VAULTPILOT_FEEDBACK_ENDPOINT;
 });
 
 afterEach(() => {
-  delete process.env.RECON_FEEDBACK_STATE_FILE;
+  delete process.env.VAULTPILOT_FEEDBACK_STATE_FILE;
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -135,8 +135,8 @@ describe("requestCapability (prefilled URL mode)", () => {
       description: "User asked for Pendle positions; no existing tool reads them.",
     })) as { status: string; issueUrl: string; repo: string; rateLimit: unknown };
     expect(res.status).toBe("prefilled_url");
-    expect(res.issueUrl).toMatch(/^https:\/\/github\.com\/szhygulin\/recon-crypto-mcp\/issues\/new\?/);
-    expect(res.repo).toBe("szhygulin/recon-crypto-mcp");
+    expect(res.issueUrl).toMatch(/^https:\/\/github\.com\/szhygulin\/vaultpilot-mcp\/issues\/new\?/);
+    expect(res.repo).toBe("szhygulin/vaultpilot-mcp");
     expect(res.rateLimit).toEqual(RATE_LIMITS);
   });
 
@@ -203,8 +203,8 @@ describe("requestCapability (prefilled URL mode)", () => {
     ).rejects.toThrow(/between calls/i);
   });
 
-  it("rejects a non-https RECON_FEEDBACK_ENDPOINT", async () => {
-    process.env.RECON_FEEDBACK_ENDPOINT = "http://insecure.example/hook";
+  it("rejects a non-https VAULTPILOT_FEEDBACK_ENDPOINT", async () => {
+    process.env.VAULTPILOT_FEEDBACK_ENDPOINT = "http://insecure.example/hook";
     try {
       await expect(
         requestCapability({
@@ -213,7 +213,7 @@ describe("requestCapability (prefilled URL mode)", () => {
         })
       ).rejects.toThrow(/https:\/\//i);
     } finally {
-      delete process.env.RECON_FEEDBACK_ENDPOINT;
+      delete process.env.VAULTPILOT_FEEDBACK_ENDPOINT;
     }
   });
 });

--- a/test/security-audit.test.ts
+++ b/test/security-audit.test.ts
@@ -456,13 +456,17 @@ describe("H9: Etherscan field sanitization", () => {
 // H10 — RPC URLs validated (https, no RFC1918/loopback) + chainId check.
 // ====================================================================
 describe("H10: RPC URL validation", () => {
-  const savedAllow = process.env.RECON_ALLOW_INSECURE_RPC;
+  const savedAllow = process.env.VAULTPILOT_ALLOW_INSECURE_RPC;
+  const savedLegacy = process.env.RECON_ALLOW_INSECURE_RPC;
   beforeEach(() => {
+    delete process.env.VAULTPILOT_ALLOW_INSECURE_RPC;
     delete process.env.RECON_ALLOW_INSECURE_RPC;
   });
   afterAll(() => {
-    if (savedAllow === undefined) delete process.env.RECON_ALLOW_INSECURE_RPC;
-    else process.env.RECON_ALLOW_INSECURE_RPC = savedAllow;
+    if (savedAllow === undefined) delete process.env.VAULTPILOT_ALLOW_INSECURE_RPC;
+    else process.env.VAULTPILOT_ALLOW_INSECURE_RPC = savedAllow;
+    if (savedLegacy === undefined) delete process.env.RECON_ALLOW_INSECURE_RPC;
+    else process.env.RECON_ALLOW_INSECURE_RPC = savedLegacy;
   });
 
   it("rejects plaintext http:// URLs", async () => {
@@ -507,7 +511,13 @@ describe("H10: RPC URL validation", () => {
     ).not.toThrow();
   });
 
-  it("RECON_ALLOW_INSECURE_RPC=1 opts out (for anvil/hardhat forks)", async () => {
+  it("VAULTPILOT_ALLOW_INSECURE_RPC=1 opts out (for anvil/hardhat forks)", async () => {
+    const { validateRpcUrl } = await import("../src/config/chains.js");
+    process.env.VAULTPILOT_ALLOW_INSECURE_RPC = "1";
+    expect(() => validateRpcUrl("ethereum", "http://127.0.0.1:8545")).not.toThrow();
+  });
+
+  it("legacy RECON_ALLOW_INSECURE_RPC=1 still works (back-compat)", async () => {
     const { validateRpcUrl } = await import("../src/config/chains.js");
     process.env.RECON_ALLOW_INSECURE_RPC = "1";
     expect(() => validateRpcUrl("ethereum", "http://127.0.0.1:8545")).not.toThrow();

--- a/test/security-hardening.test.ts
+++ b/test/security-hardening.test.ts
@@ -353,7 +353,7 @@ describe("L1: writeUserConfig refuses symlinks at the target path", () => {
   let originalHome: string | undefined;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "recon-crypto-mcp-test-"));
+    tmpDir = mkdtempSync(join(tmpdir(), "vaultpilot-mcp-test-"));
     originalHome = process.env.HOME;
     process.env.HOME = tmpDir;
     vi.resetModules();
@@ -368,7 +368,7 @@ describe("L1: writeUserConfig refuses symlinks at the target path", () => {
   it("throws when config.json is a symlink to another file", async () => {
     // Pre-place config.json as a symlink pointing at a sensitive file path.
     // writeUserConfig must refuse rather than clobber the symlink target.
-    const configDir = join(tmpDir, ".recon-crypto-mcp");
+    const configDir = join(tmpDir, ".vaultpilot-mcp");
     const { mkdirSync } = await import("node:fs");
     mkdirSync(configDir, { recursive: true });
     const target = join(tmpDir, "victim.txt");
@@ -400,7 +400,7 @@ describe("L2: patchUserConfig rpc-change hook", () => {
   let originalHome: string | undefined;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "recon-crypto-mcp-test-"));
+    tmpDir = mkdtempSync(join(tmpdir(), "vaultpilot-mcp-test-"));
     originalHome = process.env.HOME;
     process.env.HOME = tmpDir;
     vi.resetModules();


### PR DESCRIPTION
## Summary
- Renames the npm package, mcpName identifier, CLI binaries, and all user-facing copy from \`recon-crypto-mcp\` to \`vaultpilot-mcp\`.
- Migrates user config dir \`~/.recon-crypto-mcp\` → \`~/.vaultpilot-mcp\` with a back-compat fallback: reads the old path if the new one doesn't exist, and copies the legacy dir to the new location on first write. Existing installs keep their WalletConnect pairing state (walletconnect.db) across the rename.
- Env vars \`RECON_*\` renamed to \`VAULTPILOT_*\` with the old names still honored for one release.

## Scope of the diff
- \`package.json\`, \`server.json\`, \`glama.json\`: name / bin / mcpName / URLs
- \`README.md\`: title, badges, install commands, env var docs
- \`src/**\`, \`test/**\`: brand name in tool descriptions, error messages, log prefixes, WalletConnect session metadata, LiFi \`integrator\` tag, test fixtures

## Follow-ups (intentionally not in this PR)
After merge:
1. \`gh repo rename vaultpilot-mcp\` (GitHub auto-preserves old clone URLs and transfers open PRs)
2. \`npm publish\` new name + \`npm deprecate recon-crypto-mcp \"Renamed to vaultpilot-mcp\"\`
3. Re-publish \`server.json\` to the MCP registry under the new \`mcpName\`
4. glama.ai re-indexes automatically once the repo URL redirects

## Test plan
- [x] All 309 existing tests pass
- [x] \`tsc\` clean
- [x] New back-compat test: legacy \`RECON_ALLOW_INSECURE_RPC=1\` still opts out of RPC validation
- [ ] Manual smoke on a box with \`~/.recon-crypto-mcp/config.json\` already populated — confirm first run finds the legacy dir and the second run migrates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)