### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@lifi/sdk": "^3.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary
Marks the \`recon-crypto-mcp\` → \`vaultpilot-mcp\` rename (#26) as a minor release. Package name, mcpName, and user config dir location all changed (with back-compat fallbacks), which is more than a patch.

Bumps:
- \`package.json\` version: 0.3.1 → 0.4.0
- \`server.json\` top-level version + \`packages[0].version\`: 0.3.1 → 0.4.0
- \`package-lock.json\` regenerated

## Next after merge
- \`npm publish\` under the new name
- \`npm deprecate recon-crypto-mcp@\"<=0.3.1\" \"Renamed to vaultpilot-mcp\"\`
- Re-publish \`server.json\` to the MCP registry under the new \`mcpName\`

## Test plan
- [x] \`tsc\` clean
- [x] Existing tests unaffected (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)