### PR TITLE
Revert Glama badge URL to old slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/vaultpilot-mcp.svg)](https://www.npmjs.com/package/vaultpilot-mcp)
 [![license](https://img.shields.io/npm/l/vaultpilot-mcp.svg)](./LICENSE)
 [![node](https://img.shields.io/node/v/vaultpilot-mcp.svg)](package.json)
-[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp)
+[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp)
 
 **Self-custodial crypto portfolio and DeFi, managed by AI agents — signed on your Ledger hardware wallet.**
 


### PR DESCRIPTION
## Summary
- Glama still indexes this server under the pre-rename slug `recon-crypto-mcp`; the `vaultpilot-mcp` URL in the badge 404s.
- Revert just the badge URL to the working old slug, keep the display label as `vaultpilot-mcp`.
- Swap back once Glama re-crawls the renamed GitHub repo.

## Test plan
- [ ] README renders with a working Glama score badge on GitHub
- [ ] Other shields.io badges (`npm`, `license`, `node`) still resolve to `vaultpilot-mcp@0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)