### PR TITLE
Security audit fixes (2026-04): TRON rawData verify, feedback @-mentions, RPC URL redaction, vitest 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^22.0.0",
         "@types/qrcode-terminal": "^0.12.2",
         "typescript": "^5.6.0",
-        "vitest": "^2.1.0"
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -121,396 +121,63 @@
         "@noble/curves": "^1.7.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@gql.tada/cli-utils": {
       "version": "1.7.3",
@@ -845,6 +512,25 @@
         "@wallet-standard/core": "1.1.1"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -884,6 +570,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@protobuf-ts/grpcweb-transport": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz",
@@ -909,24 +605,10 @@
         "@protobuf-ts/runtime": "^2.11.1"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -935,12 +617,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -949,12 +634,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -963,26 +651,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -991,12 +668,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -1005,26 +685,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
@@ -1033,12 +702,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1047,40 +719,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1089,54 +736,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
@@ -1145,12 +753,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
@@ -1159,12 +770,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
@@ -1173,26 +787,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1201,12 +804,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -1215,26 +840,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -1243,21 +857,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
@@ -1468,6 +1078,13 @@
         "base-x": "^3.0.2"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
@@ -1483,6 +1100,36 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1491,6 +1138,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1537,38 +1191,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1580,70 +1236,68 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2359,16 +2013,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2399,18 +2043,11 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -2425,16 +2062,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2488,6 +2115,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -2583,16 +2217,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -2709,9 +2333,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2750,45 +2374,6 @@
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escape-html": {
@@ -3393,17 +2978,271 @@
       "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -3662,6 +3501,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -3789,21 +3639,11 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4090,49 +3930,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/router": {
@@ -4540,9 +4369,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4638,36 +4467,67 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinypool": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5076,21 +4936,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -5099,23 +4961,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -5132,85 +5004,102 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://opencollective.com/vitest"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -5221,7 +5110,23 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@types/node": "^22.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5.6.0",
-    "vitest": "^2.1.0"
+    "vitest": "^4.1.4"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -62,8 +62,11 @@ export function validateRpcUrl(chain: SupportedChain, url: string): void {
   try {
     parsed = new URL(url);
   } catch {
+    // Do NOT echo the URL back — configured RPC URLs often contain a provider
+    // API key in the path (e.g. .../v3/<key>). A malformed URL may still carry
+    // one, and error messages end up in logs / stderr where keys leak.
     throw new RpcConfigError(
-      `RPC URL for ${chain} is not a valid URL: ${url}. Fix it via \`vaultpilot-mcp-setup\` or the relevant env var.`
+      `RPC URL for ${chain} is not a valid URL. Fix it via \`vaultpilot-mcp-setup\` or the relevant env var.`
     );
   }
   if (parsed.protocol !== "https:") {

--- a/src/modules/feedback/index.ts
+++ b/src/modules/feedback/index.ts
@@ -45,7 +45,9 @@ export async function requestCapability(args: RequestCapabilityArgs) {
     throw err;
   }
 
-  const title = `[agent-request] ${summary}`;
+  // Titles parse @-mentions too — a prompt-injected summary containing
+  // `@someuser` would ping arbitrary GitHub users when the issue is opened.
+  const title = `[agent-request] ${neutralizeMentions(summary)}`;
   const body = buildIssueBody({ description, category, context, agentName });
   const labels = [ISSUE_LABEL, category].filter((v): v is string => Boolean(v));
   const payload: IssuePayload = { title, body, labels };

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -7,6 +7,7 @@ import {
 import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
 import { issueTronHandle } from "../../signing/tron-tx-store.js";
 import { encodeTrc20TransferParam } from "./address.js";
+import { assertTronRawDataMatches } from "./verify-raw-data.js";
 import type { UnsignedTronTx } from "../../types/index.js";
 
 /**
@@ -134,6 +135,13 @@ export async function buildTronNativeSend(
     throw new Error("TronGrid createtransaction returned no transaction — unexpected shape.");
   }
 
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "native_send",
+    from: args.from,
+    to: args.to,
+    amountSun,
+  });
+
   const tx: UnsignedTronTx = {
     chain: "tron",
     action: "native_send",
@@ -222,6 +230,15 @@ export async function buildTronTokenSend(
   if (!ttx?.txID || !ttx.raw_data_hex) {
     throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
   }
+
+  assertTronRawDataMatches(ttx.raw_data_hex, {
+    kind: "trc20_send",
+    from: args.from,
+    contract: args.token,
+    parameterHex: parameter,
+    feeLimitSun,
+    callValue: 0n,
+  });
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -319,6 +336,12 @@ export async function buildTronVote(args: BuildTronVoteArgs): Promise<UnsignedTr
           args.votes.length === 1 ? "" : "s"
         } (replaces any prior votes)`;
 
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "vote",
+    from: args.from,
+    votes: args.votes.map((v) => ({ address: v.address, count: v.count })),
+  });
+
   const tx: UnsignedTronTx = {
     chain: "tron",
     action: "vote",
@@ -384,6 +407,13 @@ export async function buildTronFreeze(
     throw new Error("TronGrid freezebalancev2 returned no transaction — unexpected shape.");
   }
 
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "freeze",
+    from: args.from,
+    frozenBalanceSun: amountSun,
+    resource: args.resource,
+  });
+
   const tx: UnsignedTronTx = {
     chain: "tron",
     action: "freeze",
@@ -439,6 +469,13 @@ export async function buildTronUnfreeze(
     throw new Error("TronGrid unfreezebalancev2 returned no transaction — unexpected shape.");
   }
 
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "unfreeze",
+    from: args.from,
+    unfreezeBalanceSun: amountSun,
+    resource: args.resource,
+  });
+
   const tx: UnsignedTronTx = {
     chain: "tron",
     action: "unfreeze",
@@ -480,6 +517,11 @@ export async function buildTronWithdrawExpireUnfreeze(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid withdrawexpireunfreeze returned no transaction — unexpected shape.");
   }
+
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "withdraw_expire_unfreeze",
+    from: args.from,
+  });
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -524,6 +566,11 @@ export async function buildTronClaimRewards(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid withdrawbalance returned no transaction — unexpected shape.");
   }
+
+  assertTronRawDataMatches(res.raw_data_hex, {
+    kind: "claim_rewards",
+    from: args.from,
+  });
 
   const tx: UnsignedTronTx = {
     chain: "tron",

--- a/src/modules/tron/verify-raw-data.ts
+++ b/src/modules/tron/verify-raw-data.ts
@@ -1,0 +1,421 @@
+import { base58ToHex } from "./address.js";
+
+/**
+ * Local verification of the `raw_data_hex` that TronGrid returns and that the
+ * Ledger will ultimately sign. TronGrid is a trusted service in practice, but
+ * we don't want to rely on that trust alone: a compromised or MITM'd TronGrid
+ * could return a `raw_data_hex` that doesn't match the request we made (e.g.
+ * swap `to_address` for an attacker's wallet) while returning a benign
+ * `raw_data` JSON structure alongside. The Ledger screen would catch it, but
+ * the agent-visible preview would lie.
+ *
+ * This module decodes the protobuf wire form ourselves and asserts every
+ * field the builder specified is present verbatim. Scope: exactly the
+ * contract types we build in actions.ts / staking.ts / witnesses.ts.
+ */
+
+// --- Wire-format primitives (just what we need for Transaction.raw) --------
+
+interface DecodedField {
+  // wire type 0 | 1 | 5 carry a numeric payload; we keep it as bigint for
+  // int64 safety.
+  varint?: bigint;
+  // wire type 2 carries length-delimited bytes.
+  bytes?: Uint8Array;
+}
+
+type FieldMap = Map<number, DecodedField[]>;
+
+function readVarint(buf: Uint8Array, offset: number): { value: bigint; next: number } {
+  let result = 0n;
+  let shift = 0n;
+  let next = offset;
+  for (;;) {
+    if (next >= buf.length) throw new Error("TRON rawData verify: truncated varint");
+    const b = buf[next++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 70n) throw new Error("TRON rawData verify: varint overflow");
+  }
+  return { value: result, next };
+}
+
+function parseProtobuf(buf: Uint8Array): FieldMap {
+  const map: FieldMap = new Map();
+  let offset = 0;
+  while (offset < buf.length) {
+    const { value: tag, next } = readVarint(buf, offset);
+    offset = next;
+    const fieldNum = Number(tag >> 3n);
+    const wireType = Number(tag & 0x7n);
+    let decoded: DecodedField;
+    if (wireType === 0) {
+      const v = readVarint(buf, offset);
+      offset = v.next;
+      decoded = { varint: v.value };
+    } else if (wireType === 2) {
+      const l = readVarint(buf, offset);
+      offset = l.next;
+      const len = Number(l.value);
+      if (offset + len > buf.length) {
+        throw new Error("TRON rawData verify: length-delimited field overruns buffer");
+      }
+      decoded = { bytes: buf.subarray(offset, offset + len) };
+      offset += len;
+    } else if (wireType === 1) {
+      if (offset + 8 > buf.length) throw new Error("TRON rawData verify: truncated fixed64");
+      let v = 0n;
+      for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(buf[offset + i]);
+      offset += 8;
+      decoded = { varint: v };
+    } else if (wireType === 5) {
+      if (offset + 4 > buf.length) throw new Error("TRON rawData verify: truncated fixed32");
+      let v = 0n;
+      for (let i = 3; i >= 0; i--) v = (v << 8n) | BigInt(buf[offset + i]);
+      offset += 4;
+      decoded = { varint: v };
+    } else {
+      throw new Error(`TRON rawData verify: unsupported wire type ${wireType}`);
+    }
+    const arr = map.get(fieldNum) ?? [];
+    arr.push(decoded);
+    map.set(fieldNum, arr);
+  }
+  return map;
+}
+
+function requireBytes(fields: FieldMap, tag: number, label: string): Uint8Array {
+  const arr = fields.get(tag);
+  if (!arr || arr.length === 0 || !arr[0].bytes) {
+    throw new Error(`TRON rawData verify: missing ${label} (tag ${tag})`);
+  }
+  return arr[0].bytes;
+}
+
+function optionalBytes(fields: FieldMap, tag: number): Uint8Array | undefined {
+  const arr = fields.get(tag);
+  if (!arr || arr.length === 0) return undefined;
+  return arr[0].bytes;
+}
+
+function optionalVarint(fields: FieldMap, tag: number): bigint {
+  const arr = fields.get(tag);
+  if (!arr || arr.length === 0 || arr[0].varint === undefined) return 0n;
+  return arr[0].varint;
+}
+
+function toHex(u: Uint8Array): string {
+  return Buffer.from(u).toString("hex");
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length % 2 !== 0) {
+    throw new Error("TRON rawData verify: raw_data_hex is not valid hex");
+  }
+  return Uint8Array.from(Buffer.from(clean, "hex"));
+}
+
+// --- Contract-type constants (Transaction.Contract.ContractType enum) ------
+
+const CONTRACT_TYPE = {
+  TransferContract: 1,
+  VoteWitnessContract: 4,
+  WithdrawBalanceContract: 13,
+  TriggerSmartContract: 31,
+  FreezeBalanceV2Contract: 54,
+  UnfreezeBalanceV2Contract: 55,
+  WithdrawExpireUnfreezeContract: 56,
+} as const;
+
+// TRON's ResourceCode enum: 0 = BANDWIDTH, 1 = ENERGY, 2 = TRON_POWER.
+// We only expose bandwidth/energy at the builder surface.
+const RESOURCE_ENUM: Record<"bandwidth" | "energy", bigint> = {
+  bandwidth: 0n,
+  energy: 1n,
+};
+
+// --- Public expectation shapes ---------------------------------------------
+
+export type TronRawDataExpectation =
+  | { kind: "native_send"; from: string; to: string; amountSun: bigint }
+  | {
+      kind: "trc20_send";
+      from: string;
+      contract: string;
+      parameterHex: string;
+      feeLimitSun?: bigint;
+      callValue?: bigint;
+    }
+  | {
+      kind: "vote";
+      from: string;
+      votes: ReadonlyArray<{ address: string; count: number }>;
+    }
+  | {
+      kind: "freeze";
+      from: string;
+      frozenBalanceSun: bigint;
+      resource: "bandwidth" | "energy";
+    }
+  | {
+      kind: "unfreeze";
+      from: string;
+      unfreezeBalanceSun: bigint;
+      resource: "bandwidth" | "energy";
+    }
+  | { kind: "withdraw_expire_unfreeze"; from: string }
+  | { kind: "claim_rewards"; from: string };
+
+// --- Main entry point ------------------------------------------------------
+
+/**
+ * Throws if `rawDataHex` doesn't encode exactly the transaction the builder
+ * asked TronGrid to create. Call once per builder immediately before
+ * `issueTronHandle`.
+ */
+export function assertTronRawDataMatches(
+  rawDataHex: string,
+  expected: TronRawDataExpectation
+): void {
+  const buf = hexToBytes(rawDataHex);
+  const raw = parseProtobuf(buf);
+
+  // Transaction.raw.contract (repeated, tag 11). We only ever build single-
+  // contract transactions; multi-contract raw_data is suspicious.
+  const contracts = raw.get(11) ?? [];
+  if (contracts.length !== 1) {
+    throw new Error(
+      `TRON rawData verify: expected exactly 1 contract, got ${contracts.length}. ` +
+        `Refusing to sign a multi-contract transaction built by prepare_tron_*.`
+    );
+  }
+  const contractBytes = contracts[0].bytes;
+  if (!contractBytes) throw new Error("TRON rawData verify: contract[0] not length-delimited");
+
+  // Transaction.Contract { type (1, enum), parameter (2, Any) }
+  const contract = parseProtobuf(contractBytes);
+  const typeField = contract.get(1)?.[0];
+  if (!typeField || typeField.varint === undefined) {
+    throw new Error("TRON rawData verify: contract.type missing");
+  }
+  const type = Number(typeField.varint);
+  const parameterBytes = requireBytes(contract, 2, "contract.parameter");
+
+  // google.protobuf.Any { type_url (1, string), value (2, bytes) }
+  const anyFields = parseProtobuf(parameterBytes);
+  const innerBytes = requireBytes(anyFields, 2, "Any.value");
+  const inner = parseProtobuf(innerBytes);
+
+  // Fee limit (tag 18 on Transaction.raw) — only meaningful for
+  // TriggerSmartContract; other builders don't set it.
+  const feeLimit = optionalVarint(raw, 18);
+
+  switch (expected.kind) {
+    case "native_send":
+      return verifyTransfer(type, inner, expected);
+    case "trc20_send":
+      return verifyTriggerSmartContract(type, inner, expected, feeLimit);
+    case "vote":
+      return verifyVote(type, inner, expected);
+    case "freeze":
+      return verifyFreezeV2(type, inner, expected);
+    case "unfreeze":
+      return verifyUnfreezeV2(type, inner, expected);
+    case "withdraw_expire_unfreeze":
+      return verifyOwnerOnly(
+        type,
+        CONTRACT_TYPE.WithdrawExpireUnfreezeContract,
+        inner,
+        expected.from,
+        "WithdrawExpireUnfreezeContract"
+      );
+    case "claim_rewards":
+      return verifyOwnerOnly(
+        type,
+        CONTRACT_TYPE.WithdrawBalanceContract,
+        inner,
+        expected.from,
+        "WithdrawBalanceContract"
+      );
+  }
+}
+
+// --- Per-contract verifiers ------------------------------------------------
+
+function expectAddress(actual: Uint8Array, expectedBase58: string, label: string): void {
+  const expectedHex = base58ToHex(expectedBase58);
+  const actualHex = toHex(actual);
+  if (actualHex.toLowerCase() !== expectedHex.toLowerCase()) {
+    throw new Error(
+      `TRON rawData verify: ${label} mismatch — TronGrid returned 0x${actualHex} ` +
+        `but we asked for ${expectedBase58} (0x${expectedHex}). Refusing to sign.`
+    );
+  }
+}
+
+function expectType(actual: number, want: number, label: string): void {
+  if (actual !== want) {
+    throw new Error(
+      `TRON rawData verify: contract type mismatch — expected ${label} (${want}), got ${actual}. ` +
+        `TronGrid returned a different contract type than requested.`
+    );
+  }
+}
+
+function verifyTransfer(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "native_send" }>
+): void {
+  expectType(type, CONTRACT_TYPE.TransferContract, "TransferContract");
+  expectAddress(requireBytes(inner, 1, "TransferContract.owner_address"), e.from, "owner_address");
+  expectAddress(requireBytes(inner, 2, "TransferContract.to_address"), e.to, "to_address");
+  const amount = optionalVarint(inner, 3);
+  if (amount !== e.amountSun) {
+    throw new Error(
+      `TRON rawData verify: amount mismatch — raw_data_hex has ${amount} sun, ` +
+        `we asked for ${e.amountSun} sun. Refusing to sign.`
+    );
+  }
+}
+
+function verifyTriggerSmartContract(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "trc20_send" }>,
+  actualFeeLimit: bigint
+): void {
+  expectType(type, CONTRACT_TYPE.TriggerSmartContract, "TriggerSmartContract");
+  expectAddress(
+    requireBytes(inner, 1, "TriggerSmartContract.owner_address"),
+    e.from,
+    "owner_address"
+  );
+  expectAddress(
+    requireBytes(inner, 2, "TriggerSmartContract.contract_address"),
+    e.contract,
+    "contract_address"
+  );
+  // call_value — default 0 if absent.
+  const callValue = optionalVarint(inner, 3);
+  if (callValue !== (e.callValue ?? 0n)) {
+    throw new Error(
+      `TRON rawData verify: call_value mismatch — raw_data_hex has ${callValue}, ` +
+        `we asked for ${e.callValue ?? 0n}.`
+    );
+  }
+  // data — function selector + ABI-encoded params.
+  const dataBytes = optionalBytes(inner, 4) ?? new Uint8Array();
+  const dataHex = toHex(dataBytes).toLowerCase();
+  // Builder's `parameterHex` is the ABI param payload WITHOUT the 4-byte
+  // selector. TronGrid prepends `a9059cbb` (transfer(address,uint256)) to
+  // produce the full calldata. Compare on the suffix.
+  const expectedParam = e.parameterHex.toLowerCase();
+  const transferSelector = "a9059cbb";
+  const expectedFullData = transferSelector + expectedParam;
+  if (dataHex !== expectedFullData) {
+    throw new Error(
+      `TRON rawData verify: TriggerSmartContract.data mismatch — got 0x${dataHex}, ` +
+        `expected 0x${expectedFullData}. Refusing to sign.`
+    );
+  }
+  if (e.feeLimitSun !== undefined && actualFeeLimit !== e.feeLimitSun) {
+    throw new Error(
+      `TRON rawData verify: fee_limit mismatch — raw_data_hex has ${actualFeeLimit} sun, ` +
+        `we asked for ${e.feeLimitSun} sun.`
+    );
+  }
+}
+
+function verifyVote(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "vote" }>
+): void {
+  expectType(type, CONTRACT_TYPE.VoteWitnessContract, "VoteWitnessContract");
+  expectAddress(requireBytes(inner, 1, "VoteWitnessContract.owner_address"), e.from, "owner_address");
+  const voteFields = inner.get(2) ?? [];
+  if (voteFields.length !== e.votes.length) {
+    throw new Error(
+      `TRON rawData verify: vote count mismatch — raw_data_hex has ${voteFields.length} ` +
+        `entries, we asked for ${e.votes.length}.`
+    );
+  }
+  // Vote order must match what we sent — TronGrid preserves it.
+  for (let i = 0; i < e.votes.length; i++) {
+    const voteBytes = voteFields[i].bytes;
+    if (!voteBytes) throw new Error(`TRON rawData verify: vote[${i}] not length-delimited`);
+    const v = parseProtobuf(voteBytes);
+    expectAddress(requireBytes(v, 1, `vote[${i}].vote_address`), e.votes[i].address, `vote[${i}].address`);
+    const count = optionalVarint(v, 2);
+    if (count !== BigInt(e.votes[i].count)) {
+      throw new Error(
+        `TRON rawData verify: vote[${i}].vote_count mismatch — raw_data_hex has ${count}, ` +
+          `we asked for ${e.votes[i].count}.`
+      );
+    }
+  }
+}
+
+function verifyFreezeV2(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "freeze" }>
+): void {
+  expectType(type, CONTRACT_TYPE.FreezeBalanceV2Contract, "FreezeBalanceV2Contract");
+  expectAddress(requireBytes(inner, 1, "FreezeBalanceV2Contract.owner_address"), e.from, "owner_address");
+  const frozen = optionalVarint(inner, 2);
+  if (frozen !== e.frozenBalanceSun) {
+    throw new Error(
+      `TRON rawData verify: frozen_balance mismatch — raw_data_hex has ${frozen} sun, ` +
+        `we asked for ${e.frozenBalanceSun} sun.`
+    );
+  }
+  const resource = optionalVarint(inner, 3);
+  if (resource !== RESOURCE_ENUM[e.resource]) {
+    throw new Error(
+      `TRON rawData verify: resource mismatch — raw_data_hex has enum ${resource}, ` +
+        `we asked for "${e.resource}" (${RESOURCE_ENUM[e.resource]}).`
+    );
+  }
+}
+
+function verifyUnfreezeV2(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "unfreeze" }>
+): void {
+  expectType(type, CONTRACT_TYPE.UnfreezeBalanceV2Contract, "UnfreezeBalanceV2Contract");
+  expectAddress(
+    requireBytes(inner, 1, "UnfreezeBalanceV2Contract.owner_address"),
+    e.from,
+    "owner_address"
+  );
+  const unfreeze = optionalVarint(inner, 2);
+  if (unfreeze !== e.unfreezeBalanceSun) {
+    throw new Error(
+      `TRON rawData verify: unfreeze_balance mismatch — raw_data_hex has ${unfreeze} sun, ` +
+        `we asked for ${e.unfreezeBalanceSun} sun.`
+    );
+  }
+  const resource = optionalVarint(inner, 3);
+  if (resource !== RESOURCE_ENUM[e.resource]) {
+    throw new Error(
+      `TRON rawData verify: resource mismatch — raw_data_hex has enum ${resource}, ` +
+        `we asked for "${e.resource}" (${RESOURCE_ENUM[e.resource]}).`
+    );
+  }
+}
+
+function verifyOwnerOnly(
+  type: number,
+  expectedType: number,
+  inner: FieldMap,
+  from: string,
+  label: string
+): void {
+  expectType(type, expectedType, label);
+  expectAddress(requireBytes(inner, 1, `${label}.owner_address`), from, "owner_address");
+}

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -151,6 +151,20 @@ describe("requestCapability (prefilled URL mode)", () => {
     expect(body).toContain("@\u200Bfake-admin");
   });
 
+  it("neutralizes @-mentions in the issue title (S1b)", async () => {
+    // GitHub parses @-mentions in titles too — a prompt-injected summary
+    // containing "@someone" would ping arbitrary users at open-issue time.
+    const res = (await requestCapability({
+      summary: "Ping @octocat and @fake-admin about this",
+      description: "Body content long enough to satisfy the zod min-length check.",
+    })) as { issueUrl: string; title: string };
+    const title = new URL(res.issueUrl).searchParams.get("title") ?? "";
+    expect(title).not.toMatch(/@[a-zA-Z0-9_-]/);
+    expect(title).toContain("@\u200Boctocat");
+    expect(title).toContain("@\u200Bfake-admin");
+    expect(res.title).toContain("@\u200Boctocat");
+  });
+
   it("escapes embedded triple-backticks in errorObserved (B4)", async () => {
     const res = (await requestCapability({
       summary: "Error report with fenced block",

--- a/test/helpers/tron-raw-data-encode.ts
+++ b/test/helpers/tron-raw-data-encode.ts
@@ -1,0 +1,222 @@
+import { base58ToHex } from "../../src/modules/tron/address.js";
+
+/**
+ * Test-only encoder for TRON Transaction.raw protobuf bytes. Used to give
+ * fetch-stubs a realistic `raw_data_hex` so the production verifier runs
+ * against well-formed input instead of toy placeholders.
+ *
+ * NOTE: This mirrors the wire-format assumptions the verifier makes. Keep in
+ * sync with src/modules/tron/verify-raw-data.ts — if the verifier adds a new
+ * contract type, this helper needs the matching encoder.
+ */
+
+const CONTRACT_TYPE = {
+  TransferContract: 1,
+  VoteWitnessContract: 4,
+  WithdrawBalanceContract: 13,
+  TriggerSmartContract: 31,
+  FreezeBalanceV2Contract: 54,
+  UnfreezeBalanceV2Contract: 55,
+  WithdrawExpireUnfreezeContract: 56,
+} as const;
+
+const RESOURCE_ENUM: Record<"bandwidth" | "energy", number> = {
+  bandwidth: 0,
+  energy: 1,
+};
+
+function writeVarint(n: bigint): number[] {
+  const out: number[] = [];
+  let v = n;
+  if (v < 0n) throw new Error("encoder: negative varint");
+  do {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) byte |= 0x80;
+    out.push(byte);
+  } while (v > 0n);
+  return out;
+}
+
+function writeTag(fieldNum: number, wireType: number): number[] {
+  return writeVarint(BigInt((fieldNum << 3) | wireType));
+}
+
+function writeVarintField(fieldNum: number, value: bigint | number): number[] {
+  return [...writeTag(fieldNum, 0), ...writeVarint(BigInt(value))];
+}
+
+function writeBytesField(fieldNum: number, value: Uint8Array): number[] {
+  return [
+    ...writeTag(fieldNum, 2),
+    ...writeVarint(BigInt(value.length)),
+    ...value,
+  ];
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(hex, "hex"));
+}
+
+function addrBytes(base58: string): Uint8Array {
+  return hexToBytes(base58ToHex(base58));
+}
+
+function wrapContract(type: number, innerBytes: Uint8Array, typeUrl: string): Uint8Array {
+  // google.protobuf.Any { type_url (1, string), value (2, bytes) }
+  const anyBytes = Uint8Array.from([
+    ...writeBytesField(1, Buffer.from(typeUrl, "utf8")),
+    ...writeBytesField(2, innerBytes),
+  ]);
+  // Transaction.Contract { type (1, varint), parameter (2, bytes) }
+  const contractBytes = Uint8Array.from([
+    ...writeVarintField(1, type),
+    ...writeBytesField(2, anyBytes),
+  ]);
+  return contractBytes;
+}
+
+function wrapRaw(contractBytes: Uint8Array, feeLimit?: bigint): Uint8Array {
+  // Transaction.raw { contract (11, repeated bytes), fee_limit (18, int64) }
+  const parts: number[] = [];
+  parts.push(...writeBytesField(11, contractBytes));
+  if (feeLimit !== undefined) parts.push(...writeVarintField(18, feeLimit));
+  return Uint8Array.from(parts);
+}
+
+function toHex(u: Uint8Array): string {
+  return Buffer.from(u).toString("hex");
+}
+
+export function encodeTransferRawData(args: {
+  from: string;
+  to: string;
+  amountSun: bigint;
+}): string {
+  const inner = Uint8Array.from([
+    ...writeBytesField(1, addrBytes(args.from)),
+    ...writeBytesField(2, addrBytes(args.to)),
+    ...writeVarintField(3, args.amountSun),
+  ]);
+  return toHex(
+    wrapRaw(
+      wrapContract(
+        CONTRACT_TYPE.TransferContract,
+        inner,
+        "type.googleapis.com/protocol.TransferContract"
+      )
+    )
+  );
+}
+
+export function encodeTriggerSmartContractRawData(args: {
+  from: string;
+  contract: string;
+  dataHex: string;
+  callValue?: bigint;
+  feeLimitSun?: bigint;
+}): string {
+  const inner = Uint8Array.from([
+    ...writeBytesField(1, addrBytes(args.from)),
+    ...writeBytesField(2, addrBytes(args.contract)),
+    ...(args.callValue && args.callValue !== 0n
+      ? writeVarintField(3, args.callValue)
+      : []),
+    ...writeBytesField(4, hexToBytes(args.dataHex)),
+  ]);
+  return toHex(
+    wrapRaw(
+      wrapContract(
+        CONTRACT_TYPE.TriggerSmartContract,
+        inner,
+        "type.googleapis.com/protocol.TriggerSmartContract"
+      ),
+      args.feeLimitSun
+    )
+  );
+}
+
+export function encodeVoteWitnessRawData(args: {
+  from: string;
+  votes: ReadonlyArray<{ address: string; count: number }>;
+}): string {
+  const voteFields: number[] = [];
+  for (const v of args.votes) {
+    const voteInner = Uint8Array.from([
+      ...writeBytesField(1, addrBytes(v.address)),
+      ...writeVarintField(2, v.count),
+    ]);
+    voteFields.push(...writeBytesField(2, voteInner));
+  }
+  const inner = Uint8Array.from([
+    ...writeBytesField(1, addrBytes(args.from)),
+    ...voteFields,
+  ]);
+  return toHex(
+    wrapRaw(
+      wrapContract(
+        CONTRACT_TYPE.VoteWitnessContract,
+        inner,
+        "type.googleapis.com/protocol.VoteWitnessContract"
+      )
+    )
+  );
+}
+
+export function encodeFreezeV2RawData(args: {
+  from: string;
+  frozenBalanceSun: bigint;
+  resource: "bandwidth" | "energy";
+}): string {
+  const inner = Uint8Array.from([
+    ...writeBytesField(1, addrBytes(args.from)),
+    ...writeVarintField(2, args.frozenBalanceSun),
+    ...writeVarintField(3, RESOURCE_ENUM[args.resource]),
+  ]);
+  return toHex(
+    wrapRaw(
+      wrapContract(
+        CONTRACT_TYPE.FreezeBalanceV2Contract,
+        inner,
+        "type.googleapis.com/protocol.FreezeBalanceV2Contract"
+      )
+    )
+  );
+}
+
+export function encodeUnfreezeV2RawData(args: {
+  from: string;
+  unfreezeBalanceSun: bigint;
+  resource: "bandwidth" | "energy";
+}): string {
+  const inner = Uint8Array.from([
+    ...writeBytesField(1, addrBytes(args.from)),
+    ...writeVarintField(2, args.unfreezeBalanceSun),
+    ...writeVarintField(3, RESOURCE_ENUM[args.resource]),
+  ]);
+  return toHex(
+    wrapRaw(
+      wrapContract(
+        CONTRACT_TYPE.UnfreezeBalanceV2Contract,
+        inner,
+        "type.googleapis.com/protocol.UnfreezeBalanceV2Contract"
+      )
+    )
+  );
+}
+
+export function encodeOwnerOnlyRawData(args: {
+  kind: "withdraw_expire_unfreeze" | "claim_rewards";
+  from: string;
+}): string {
+  const type =
+    args.kind === "withdraw_expire_unfreeze"
+      ? CONTRACT_TYPE.WithdrawExpireUnfreezeContract
+      : CONTRACT_TYPE.WithdrawBalanceContract;
+  const typeUrl =
+    args.kind === "withdraw_expire_unfreeze"
+      ? "type.googleapis.com/protocol.WithdrawExpireUnfreezeContract"
+      : "type.googleapis.com/protocol.WithdrawBalanceContract";
+  const inner = Uint8Array.from([...writeBytesField(1, addrBytes(args.from))]);
+  return toHex(wrapRaw(wrapContract(type, inner, typeUrl)));
+}

--- a/test/tron-phase2-prepare.test.ts
+++ b/test/tron-phase2-prepare.test.ts
@@ -7,6 +7,11 @@ import {
   buildTronClaimRewards,
 } from "../src/modules/tron/actions.js";
 import { hasTronHandle, consumeTronHandle } from "../src/signing/tron-tx-store.js";
+import {
+  encodeTransferRawData,
+  encodeTriggerSmartContractRawData,
+  encodeOwnerOnlyRawData,
+} from "./helpers/tron-raw-data-encode.js";
 
 /**
  * Phase-2 (TRON tx preparation) tests. Network IO against TronGrid is stubbed
@@ -81,7 +86,11 @@ describe("buildTronNativeSend (network stubbed)", () => {
         JSON.stringify({
           txID: "deadbeef".repeat(8),
           raw_data: { expiration: 0 },
-          raw_data_hex: "0a02",
+          raw_data_hex: encodeTransferRawData({
+            from: ADDR_FROM,
+            to: ADDR_TO,
+            amountSun: 1_500_000n,
+          }),
           visible: true,
         }),
         { status: 200 }
@@ -163,7 +172,12 @@ describe("buildTronTokenSend (network stubbed)", () => {
           transaction: {
             txID: "cafebabe".repeat(8),
             raw_data: { expiration: 0 },
-            raw_data_hex: "0a03",
+            raw_data_hex: encodeTriggerSmartContractRawData({
+              from: ADDR_FROM,
+              contract: ADDR_USDT,
+              dataHex: "a9059cbb" + body.parameter,
+              feeLimitSun: BigInt(body.fee_limit),
+            }),
             visible: true,
           },
         }),
@@ -198,7 +212,17 @@ describe("buildTronTokenSend (network stubbed)", () => {
       return new Response(
         JSON.stringify({
           result: { result: true },
-          transaction: { txID: "f".repeat(64), raw_data: {}, raw_data_hex: "00", visible: true },
+          transaction: {
+            txID: "f".repeat(64),
+            raw_data: {},
+            raw_data_hex: encodeTriggerSmartContractRawData({
+              from: ADDR_FROM,
+              contract: ADDR_USDT,
+              dataHex: "a9059cbb" + body.parameter,
+              feeLimitSun: BigInt(body.fee_limit),
+            }),
+            visible: true,
+          },
         }),
         { status: 200 }
       );
@@ -250,7 +274,10 @@ describe("buildTronClaimRewards (network stubbed)", () => {
         JSON.stringify({
           txID: "aa".repeat(32),
           raw_data: { expiration: 0 },
-          raw_data_hex: "0a04",
+          raw_data_hex: encodeOwnerOnlyRawData({
+            kind: "claim_rewards",
+            from: ADDR_FROM,
+          }),
           visible: true,
         }),
         { status: 200 }

--- a/test/tron-phase2b-stake-writes.test.ts
+++ b/test/tron-phase2b-stake-writes.test.ts
@@ -5,6 +5,11 @@ import {
   buildTronWithdrawExpireUnfreeze,
 } from "../src/modules/tron/actions.js";
 import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+import {
+  encodeFreezeV2RawData,
+  encodeUnfreezeV2RawData,
+  encodeOwnerOnlyRawData,
+} from "./helpers/tron-raw-data-encode.js";
 
 /**
  * Phase-2b (TRON Stake 2.0 writes) tests. Network IO is stubbed via
@@ -17,12 +22,12 @@ import { hasTronHandle } from "../src/signing/tron-tx-store.js";
 
 const ADDR = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
 
-function directTxResponse(txID = "ab".repeat(32)): Response {
+function directTxResponse(rawDataHex: string, txID = "ab".repeat(32)): Response {
   return new Response(
     JSON.stringify({
       txID,
       raw_data: { expiration: 0 },
-      raw_data_hex: "0a05",
+      raw_data_hex: rawDataHex,
       visible: true,
     }),
     { status: 200 }
@@ -40,7 +45,13 @@ describe("buildTronFreeze (network stubbed)", () => {
       expect(body.frozen_balance).toBe(100_000_000); // 100 TRX in SUN
       expect(body.resource).toBe("BANDWIDTH"); // uppercased at edge
       expect(body.visible).toBe(true);
-      return directTxResponse();
+      return directTxResponse(
+        encodeFreezeV2RawData({
+          from: ADDR,
+          frozenBalanceSun: BigInt(body.frozen_balance),
+          resource: "bandwidth",
+        })
+      );
     });
     vi.stubGlobal("fetch", fetchMock);
   });
@@ -60,7 +71,13 @@ describe("buildTronFreeze (network stubbed)", () => {
     fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(init!.body as string);
       expect(body.resource).toBe("ENERGY");
-      return directTxResponse();
+      return directTxResponse(
+        encodeFreezeV2RawData({
+          from: ADDR,
+          frozenBalanceSun: BigInt(body.frozen_balance),
+          resource: "energy",
+        })
+      );
     });
     const tx = await buildTronFreeze({ from: ADDR, amount: "50", resource: "energy" });
     expect(tx.decoded.args.resource).toBe("energy"); // preserved lowercase on preview
@@ -104,7 +121,13 @@ describe("buildTronUnfreeze (network stubbed)", () => {
         expect(body.owner_address).toBe(ADDR);
         expect(body.unfreeze_balance).toBe(75_000_000); // 75 TRX
         expect(body.resource).toBe("ENERGY");
-        return directTxResponse();
+        return directTxResponse(
+          encodeUnfreezeV2RawData({
+            from: ADDR,
+            unfreezeBalanceSun: BigInt(body.unfreeze_balance),
+            resource: "energy",
+          })
+        );
       })
     );
   });
@@ -154,7 +177,9 @@ describe("buildTronWithdrawExpireUnfreeze (network stubbed)", () => {
       const body = JSON.parse(init!.body as string);
       expect(body.owner_address).toBe(ADDR);
       expect(body.visible).toBe(true);
-      return directTxResponse();
+      return directTxResponse(
+        encodeOwnerOnlyRawData({ kind: "withdraw_expire_unfreeze", from: ADDR })
+      );
     });
     vi.stubGlobal("fetch", fetchMock);
   });

--- a/test/tron-phase2c-voting.test.ts
+++ b/test/tron-phase2c-voting.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { listTronWitnesses } from "../src/modules/tron/witnesses.js";
 import { buildTronVote } from "../src/modules/tron/actions.js";
 import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+import { encodeVoteWitnessRawData } from "./helpers/tron-raw-data-encode.js";
 
 /**
  * Phase-2c (TRON voting) tests. Covers:
@@ -170,7 +171,12 @@ describe("buildTronVote (network stubbed)", () => {
         JSON.stringify({
           txID: "cc".repeat(32),
           raw_data: { expiration: 0 },
-          raw_data_hex: "0a06",
+          raw_data_hex: encodeVoteWitnessRawData({
+            from: OWNER,
+            votes: (body.votes as Array<{ vote_address: string; vote_count: number }>).map(
+              (v) => ({ address: v.vote_address, count: v.vote_count })
+            ),
+          }),
           visible: true,
         }),
         { status: 200 }

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { encodeTransferRawData } from "./helpers/tron-raw-data-encode.js";
 
 /**
  * Phase-3 (TRON USB HID signing) tests.
@@ -27,6 +28,18 @@ vi.mock("../src/signing/tron-usb-loader.js", () => ({
 const DEVICE_ADDRESS = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
 const OTHER_ADDRESS = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9";
 const RAW_HEX = "0a02487b2208b6f0a4c9dd5b6c";
+// Realistic Transfer protobuf for flows that exercise buildTronNativeSend +
+// the verifier. Tests not going through the builder can keep using RAW_HEX.
+const TRANSFER_1TRX_DEVICE_TO_OTHER = encodeTransferRawData({
+  from: DEVICE_ADDRESS,
+  to: OTHER_ADDRESS,
+  amountSun: 1_000_000n,
+});
+const TRANSFER_1TRX_OTHER_TO_DEVICE = encodeTransferRawData({
+  from: OTHER_ADDRESS,
+  to: DEVICE_ADDRESS,
+  amountSun: 1_000_000n,
+});
 const GOOD_SIG = "a".repeat(130);
 
 function makeTrxStub(overrides: Partial<TrxStub> = {}): TrxStub {
@@ -202,7 +215,7 @@ describe("sendTransaction — TRON handle routing", () => {
           JSON.stringify({
             txID: "ab".repeat(32),
             raw_data: { expiration: 1 },
-            raw_data_hex: RAW_HEX,
+            raw_data_hex: TRANSFER_1TRX_DEVICE_TO_OTHER,
             visible: true,
           }),
           { status: 200 }
@@ -231,7 +244,11 @@ describe("sendTransaction — TRON handle routing", () => {
     const result = await sendTransaction({ handle: tx.handle!, confirmed: true });
     expect(result).toEqual({ txHash: "ab".repeat(32), chain: "tron" });
     expect(hasTronHandle(tx.handle!)).toBe(false);
-    expect(trxInstance.signTransaction).toHaveBeenCalledWith("44'/195'/0'/0/0", RAW_HEX, []);
+    expect(trxInstance.signTransaction).toHaveBeenCalledWith(
+      "44'/195'/0'/0/0",
+      TRANSFER_1TRX_DEVICE_TO_OTHER,
+      []
+    );
   });
 
   it("keeps the handle alive when signing fails so the caller can retry", async () => {
@@ -241,7 +258,7 @@ describe("sendTransaction — TRON handle routing", () => {
           JSON.stringify({
             txID: "cd".repeat(32),
             raw_data: { expiration: 1 },
-            raw_data_hex: RAW_HEX,
+            raw_data_hex: TRANSFER_1TRX_DEVICE_TO_OTHER,
             visible: true,
           }),
           { status: 200 }
@@ -378,7 +395,7 @@ describe("pair_ledger_tron + get_ledger_status", () => {
           JSON.stringify({
             txID: "ef".repeat(32),
             raw_data: { expiration: 1 },
-            raw_data_hex: RAW_HEX,
+            raw_data_hex: TRANSFER_1TRX_OTHER_TO_DEVICE,
             visible: true,
           }),
           { status: 200 }
@@ -408,7 +425,7 @@ describe("pair_ledger_tron + get_ledger_status", () => {
     expect(result.txHash).toBe("ef".repeat(32));
     expect(trxInstance.signTransaction).toHaveBeenCalledWith(
       "44'/195'/1'/0/0",
-      RAW_HEX,
+      TRANSFER_1TRX_OTHER_TO_DEVICE,
       []
     );
   });

--- a/test/tron-raw-data-verify.test.ts
+++ b/test/tron-raw-data-verify.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import { assertTronRawDataMatches } from "../src/modules/tron/verify-raw-data.js";
+import {
+  encodeTransferRawData,
+  encodeTriggerSmartContractRawData,
+  encodeVoteWitnessRawData,
+  encodeFreezeV2RawData,
+  encodeUnfreezeV2RawData,
+  encodeOwnerOnlyRawData,
+} from "./helpers/tron-raw-data-encode.js";
+
+/**
+ * Tamper-detection tests for the TRON rawData verifier. Each case encodes a
+ * protobuf that does NOT match the expectation and asserts the verifier
+ * throws — this is the defence against a MITM'd/malicious TronGrid swapping
+ * destination/amount/contract between the JSON preview and the signed hex.
+ */
+
+const A = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const B = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9";
+const C = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const USDT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+describe("assertTronRawDataMatches — happy path", () => {
+  it("accepts a matching TransferContract", () => {
+    const hex = encodeTransferRawData({ from: A, to: B, amountSun: 1_500_000n });
+    expect(() =>
+      assertTronRawDataMatches(hex, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a matching TriggerSmartContract (TRC-20 transfer)", () => {
+    // transfer(recipient, amount) calldata: selector a9059cbb + param
+    const param = "0".repeat(24) +
+      // recipient 20-byte form (strip 0x41 prefix). For this test just reuse
+      // a fixed hex; verifier only compares full data byte-for-byte.
+      "ffffffffffffffffffffffffffffffffffffffff" +
+      (1_000_000n).toString(16).padStart(64, "0");
+    const hex = encodeTriggerSmartContractRawData({
+      from: A,
+      contract: USDT,
+      dataHex: "a9059cbb" + param,
+      feeLimitSun: 100_000_000n,
+    });
+    expect(() =>
+      assertTronRawDataMatches(hex, {
+        kind: "trc20_send",
+        from: A,
+        contract: USDT,
+        parameterHex: param,
+        feeLimitSun: 100_000_000n,
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a matching VoteWitnessContract", () => {
+    const votes = [
+      { address: B, count: 10 },
+      { address: C, count: 5 },
+    ];
+    const hex = encodeVoteWitnessRawData({ from: A, votes });
+    expect(() =>
+      assertTronRawDataMatches(hex, { kind: "vote", from: A, votes })
+    ).not.toThrow();
+  });
+
+  it("accepts matching Freeze/Unfreeze V2", () => {
+    const freezeHex = encodeFreezeV2RawData({
+      from: A,
+      frozenBalanceSun: 100_000_000n,
+      resource: "energy",
+    });
+    expect(() =>
+      assertTronRawDataMatches(freezeHex, {
+        kind: "freeze",
+        from: A,
+        frozenBalanceSun: 100_000_000n,
+        resource: "energy",
+      })
+    ).not.toThrow();
+
+    const unfreezeHex = encodeUnfreezeV2RawData({
+      from: A,
+      unfreezeBalanceSun: 50_000_000n,
+      resource: "bandwidth",
+    });
+    expect(() =>
+      assertTronRawDataMatches(unfreezeHex, {
+        kind: "unfreeze",
+        from: A,
+        unfreezeBalanceSun: 50_000_000n,
+        resource: "bandwidth",
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts matching WithdrawExpireUnfreeze / WithdrawBalance", () => {
+    expect(() =>
+      assertTronRawDataMatches(
+        encodeOwnerOnlyRawData({ kind: "withdraw_expire_unfreeze", from: A }),
+        { kind: "withdraw_expire_unfreeze", from: A }
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertTronRawDataMatches(
+        encodeOwnerOnlyRawData({ kind: "claim_rewards", from: A }),
+        { kind: "claim_rewards", from: A }
+      )
+    ).not.toThrow();
+  });
+});
+
+describe("assertTronRawDataMatches — tamper detection", () => {
+  it("rejects a swapped to_address (canonical MITM pattern)", () => {
+    const tampered = encodeTransferRawData({ from: A, to: C, amountSun: 1_500_000n });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).toThrow(/to_address mismatch/);
+  });
+
+  it("rejects a swapped amount", () => {
+    const tampered = encodeTransferRawData({ from: A, to: B, amountSun: 9_000_000n });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).toThrow(/amount mismatch/);
+  });
+
+  it("rejects a swapped owner_address", () => {
+    const tampered = encodeTransferRawData({ from: C, to: B, amountSun: 1_500_000n });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).toThrow(/owner_address mismatch/);
+  });
+
+  it("rejects a contract-type swap (TriggerSmartContract where TransferContract expected)", () => {
+    const tampered = encodeTriggerSmartContractRawData({
+      from: A,
+      contract: USDT,
+      dataHex: "a9059cbb" + "0".repeat(128),
+    });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).toThrow(/contract type mismatch/);
+  });
+
+  it("rejects a swapped TRC-20 contract_address", () => {
+    const param = "0".repeat(24) + "ff".repeat(20) + (1n).toString(16).padStart(64, "0");
+    // TronGrid claims we're transferring to USDT, but the hex encodes a
+    // different TRC-20 contract.
+    const tampered = encodeTriggerSmartContractRawData({
+      from: A,
+      contract: B, // NOT USDT
+      dataHex: "a9059cbb" + param,
+    });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "trc20_send",
+        from: A,
+        contract: USDT,
+        parameterHex: param,
+      })
+    ).toThrow(/contract_address mismatch/);
+  });
+
+  it("rejects a tampered TRC-20 parameter (amount or recipient inside calldata)", () => {
+    const goodParam = "0".repeat(24) + "ff".repeat(20) + (1n).toString(16).padStart(64, "0");
+    const tamperedParam = "0".repeat(24) + "aa".repeat(20) + (999n).toString(16).padStart(64, "0");
+    const tampered = encodeTriggerSmartContractRawData({
+      from: A,
+      contract: USDT,
+      dataHex: "a9059cbb" + tamperedParam,
+    });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "trc20_send",
+        from: A,
+        contract: USDT,
+        parameterHex: goodParam,
+      })
+    ).toThrow(/TriggerSmartContract\.data mismatch/);
+  });
+
+  it("rejects a vote-count tamper", () => {
+    const tampered = encodeVoteWitnessRawData({
+      from: A,
+      votes: [{ address: B, count: 999 }],
+    });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "vote",
+        from: A,
+        votes: [{ address: B, count: 10 }],
+      })
+    ).toThrow(/vote_count mismatch/);
+  });
+
+  it("rejects a resource-type swap (bandwidth vs energy)", () => {
+    const tampered = encodeFreezeV2RawData({
+      from: A,
+      frozenBalanceSun: 100_000_000n,
+      resource: "bandwidth",
+    });
+    expect(() =>
+      assertTronRawDataMatches(tampered, {
+        kind: "freeze",
+        from: A,
+        frozenBalanceSun: 100_000_000n,
+        resource: "energy",
+      })
+    ).toThrow(/resource mismatch/);
+  });
+
+  it("rejects hex that isn't valid hex at all", () => {
+    expect(() =>
+      assertTronRawDataMatches("zzzz", {
+        kind: "withdraw_expire_unfreeze",
+        from: A,
+      })
+    ).toThrow(/valid hex/);
+  });
+
+  it("rejects a truncated protobuf", () => {
+    const good = encodeTransferRawData({ from: A, to: B, amountSun: 1_500_000n });
+    const truncated = good.slice(0, good.length - 20);
+    expect(() =>
+      assertTronRawDataMatches(truncated, {
+        kind: "native_send",
+        from: A,
+        to: B,
+        amountSun: 1_500_000n,
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **M1 — TRON rawDataHex verification before signing.** Every TronGrid builder now decodes the returned `Transaction.raw` protobuf and asserts the inner contract matches caller intent byte-for-byte *before* the signing handle is issued. Closes the MITM window where a compromised TronGrid response could swap destination/amount/contract between the JSON preview shown to the user and the hex the Ledger actually signs.
- **M2 — Neutralize @-mentions in feedback issue titles.** GitHub parses @-mentions in titles, not just bodies; prompt-injected summaries could have pinged arbitrary users.
- **L1 — Redact RPC URLs from `RpcConfigError`.** Provider API keys commonly live in the URL path; no longer interpolated into error messages that end up in logs.
- **I1 — vitest `^2.1.0` → `^4.1.4`.** Pulls a vite/esbuild chain that resolves GHSA-67mh-4wv8-2f99 (dev-only). All 341 tests pass unchanged. `npm audit` → 0 vulns.

## TRON verifier details

New `src/modules/tron/verify-raw-data.ts` (~250 LOC) decodes `Transaction.raw` → `Contract` → `google.protobuf.Any` → the inner contract using a minimal wire-format parser (no new deps), then matches against a discriminated-union `TronRawDataExpectation` for all seven contract kinds:

- `TransferContract` (native TRX send)
- `TriggerSmartContract` (TRC-20)
- `VoteWitnessContract`
- `FreezeBalanceV2Contract` / `UnfreezeBalanceV2Contract`
- `WithdrawExpireUnfreezeContract`
- `WithdrawBalanceContract`

Covered by `test/tron-raw-data-verify.test.ts`: 5 happy-path + 10 tamper-detection cases (swapped `to_address` / `amount` / `owner_address` / contract-type / TRC-20 contract / TRC-20 calldata / vote_count / resource, invalid hex, truncated protobuf).

## Socket.dev triage (no code change)

| Alert | Package | Assessment |
|---|---|---|
| Potential vuln (ReDoS) | `picomatch@2.3.2` | **Not reachable.** Pulled via `@walletconnect/keyvaluestorage → unstorage → anymatch@3`. Patterns are WC-internal storage keys, never user-controlled. `picomatch@4` is ESM-only and breaks `anymatch@3`'s CJS usage. |
| Network access | `@0no-co/graphqlsp@1.15.3` | Dev-only GraphQL LSP via `@lifi/sdk → @mysten/sui → gql.tada`. Not invoked at runtime. |
| Shell access | `@gql.tada/cli-utils@1.7.3` | Same path. CLI tool, never invoked by our code. |
| Typosquat | `node-mock-http` / `parseurl` | False positives — legitimate UnJS / jshttp packages. |
| Unstable ownership | `content-disposition@1.1.0` | Legitimate maintainer on transitive express dep. |

## Test plan

- [x] `npx vitest run` — 341/341 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual smoke: prepare a TRON native send via the MCP and confirm the verifier passes on a real TronGrid response
- [ ] Manual smoke: tampered TronGrid response (patch `raw_data_hex` locally) → verifier should throw before handle is issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)