### PR TITLE
Release 0.4.1 — security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@ledgerhq/hw-app-trx": "^6.34.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Security patch release. No API changes, no breaking behaviour.

Bundles the fixes merged in #30:

- **TRON rawDataHex verification before signing** — every TronGrid builder now decodes the returned `Transaction.raw` protobuf and asserts it matches caller intent byte-for-byte before issuing a signing handle. Closes the MITM window between the JSON preview and the hex the Ledger signs.
- **Feedback issue titles neutralize @-mentions** — GitHub parses @-mentions in titles too; prompt-injected summaries could have pinged arbitrary users.
- **RPC config errors redact URLs** — provider API keys often live in RPC URL paths; errors no longer echo them into logs.
- **vitest 2.x → 4.x** — resolves GHSA-67mh-4wv8-2f99 (dev-only). 341/341 tests pass on the new major.

## Release checklist

- [x] Version bumped in `package.json`, `package-lock.json`, `server.json`
- [x] Tests pass (`npx vitest run`)
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] `npm audit` — 0 vulnerabilities
- [ ] Merge → create GitHub release `v0.4.1` → workflow publishes to npm + MCP Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)