### PR TITLE
Switch Glama badge URL to vaultpilot-mcp slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/vaultpilot-mcp.svg)](https://www.npmjs.com/package/vaultpilot-mcp)
 [![license](https://img.shields.io/npm/l/vaultpilot-mcp.svg)](./LICENSE)
 [![node](https://img.shields.io/node/v/vaultpilot-mcp.svg)](package.json)
-[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/recon-crypto-mcp)
+[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp)
 
 **Self-custodial crypto portfolio and DeFi, managed by AI agents — signed on your Ledger hardware wallet.**
 


### PR DESCRIPTION
## Summary
- Glama has re-indexed the renamed server; `https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp` now returns 200.
- Revert the temporary old-slug fallback from #28 back to the `vaultpilot-mcp` URL.

## Test plan
- [ ] README renders with a working Glama score badge pointing at the new slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)