### PR TITLE
Surface Compound decimals-guard failure via errored flag (#36)

### DIFF
--- a/src/modules/compound/index.ts
+++ b/src/modules/compound/index.ts
@@ -93,16 +93,24 @@ async function readMarketPosition(
   const metaResults = await client.multicall({ contracts: metaCalls, allowFailure: true });
   const baseSuppliedWei = supplied as bigint;
   const baseBorrowedWei = borrowed as bigint;
-  // If either base balance is nonzero we MUST know the base token's decimals to
-  // format correctly. Previously this silently fell back to 18, which rendered a
-  // 184k USDC (6-decimal) supply as ~0.0000002 USDC — showed up as dust in the
-  // portfolio summary while the direct get_compound_positions call succeeded.
-  // Skip the market rather than emit a wrong-scale amount.
+  // If either base balance is nonzero we MUST know the base token's decimals
+  // to format correctly — a silent fallback to 18 once rendered a 184k USDC
+  // (6-decimal) supply as ~0.0000002 USDC. Previously this path `return null`'d,
+  // which aggregator-side looked like "no position" and did NOT set the
+  // `errored` flag (issue #36: a 184k cUSDCv3 supply vanished from results
+  // with clean coverage). Throw instead, so the Promise.allSettled wrapper in
+  // getCompoundPositions classifies the market as errored and `positions: []`
+  // is never reported as clean coverage when a curated-registry market's
+  // base-token decimals read failed.
   if (
     metaResults[0].status !== "success" &&
     (baseSuppliedWei > 0n || baseBorrowedWei > 0n)
   ) {
-    return null;
+    throw new Error(
+      `Compound V3 ${chain}:${market.name} — base-token decimals read failed ` +
+        `on a curated-registry market with a nonzero base balance; refusing to ` +
+        `emit a wrong-scale amount.`,
+    );
   }
   const baseDecimals =
     metaResults[0].status === "success" ? Number(metaResults[0].result) : 18;

--- a/test/session-regression.test.ts
+++ b/test/session-regression.test.ts
@@ -489,13 +489,15 @@ describe("Bug 8: Compound V3 reader surfaces base balance even when a getAssetIn
     expect(ethMarket!.baseSupplied?.formatted).toBe("184874.39434");
   });
 
-  it("skips a market with a nonzero base balance when the base token's decimals read fails", async () => {
+  it("surfaces a nonzero-base-balance decimals-read failure via the errored flag (issue #36)", async () => {
     // Live-session bug: wallet C0f5...4075 held 184377 USDC in cUSDCv3, but
     // get_portfolio_summary rendered it as ~0.0000002 USDC because the base
     // token's decimals() multicall entry transiently failed and the code fell
     // back to decimals=18. A 6-decimal USDC supply formatted as 18 decimals
-    // looks like dust. Fix: skip the market rather than emit wrong-scale
-    // numbers; the direct get_compound_positions retry will typically succeed.
+    // looks like dust. PR #35 blocked the wrong-scale number but still
+    // `return null`'d — the aggregator then reported clean coverage with the
+    // six-figure supply silently missing. Issue #36: throw instead so the
+    // Promise.allSettled wrapper classifies the market as errored.
     let callIdx = 0;
     const mockClient = {
       multicall: vi.fn(async ({ contracts }: { contracts: unknown[] }) => {
@@ -539,12 +541,18 @@ describe("Bug 8: Compound V3 reader surfaces base balance even when a getAssetIn
     });
 
     const { getCompoundPositions } = await import("../src/modules/compound/index.js");
-    const { positions } = await getCompoundPositions({
+    const result = await getCompoundPositions({
       wallet: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
       chains: ["ethereum"],
     });
-    const ethMarket = positions.find((p) => p.chain === "ethereum");
+    const ethMarket = result.positions.find((p) => p.chain === "ethereum");
     expect(ethMarket).toBeUndefined();
+    expect(result.errored).toBe(true);
+    expect(result.erroredMarkets).toBeDefined();
+    const ethFailure = result.erroredMarkets!.find(
+      (m) => m.chain === "ethereum" && /decimals read failed/i.test(m.error),
+    );
+    expect(ethFailure).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Closes #36. PR #35 tightened three of the four position-critical multicalls in Compound V3, but left the base-token `decimals()` guard at `return null`. A transient failure on that read (with a nonzero base balance) silently dropped the market while `coverage.compound.errored` stayed false — the aggregator reported clean coverage with a curated-registry market silently missing.
- Throw instead so the `Promise.allSettled` wrapper in `getCompoundPositions` classifies the market as errored and surfaces it via `erroredMarkets`.
- Regression test in `test/session-regression.test.ts` now asserts `result.errored === true` and that `erroredMarkets` names the failing market, rather than just checking the old silent-skip behavior.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 395/395 pass
- [x] Updated regression test exercises the decimals-read-fails-with-nonzero-base-balance path and asserts the new errored surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)