### PR TITLE
Release 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@ledgerhq/hw-app-trx": "^6.34.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump for 0.5.0. Post-merge, tag and publish to npm.

### Since 0.4.1

- **Two-step sign protocol** — `prepare_* → preview_send → send_transaction`. `preview_send` pins nonce + EIP-1559 fees server-side and emits a `LEDGER BLIND-SIGN HASH` block BEFORE the device prompt fires, so the hash is on-screen when the user needs to match it (#37).
- **Fee-pin formula** — `baseFee * 2 + max(estimateMaxPriorityFeePerGas, 1.5 gwei)`, replacing viem's default 1.2× baseFee which left live-test txs stuck in the mempool (#37).
- **`TRANSACTION BROADCAST` block** — post-send verbatim-relay block carrying `Chain`, `Tx hash`, markdown explorer link. Closes a live-test regression where the agent sometimes dropped the hash from chat (#37).
- **`PREPARE RECEIPT` block** — every `prepare_*` response now carries a verbatim-relay block listing the raw args the agent supplied. Raises the tampering bar against narrow agent compromise (prompt injection from other tool output, malicious skills, compromised subagents) (#39).
- **Agent-side independent pre-sign hash recomputation** — `preview_send` emits an optional agent-task block instructing the agent to offer the user a fourth trust-boundary check: `keccak256(serializeTransaction(tuple))` in a local `node -e` against MCP's reported hash. Catches a compromised MCP that lies about the hash (#39).
- **Security-model documentation** — new README section with a threat→defense table, honest limits, the agent/MCP asymmetry, and preserved `payloadFingerprint` verification snippet (#39).
- **Tests** — `test/send-hash-pin.test.ts` (7) and `test/integration-security.test.ts` (5) pin the new behaviors end-to-end.

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npx vitest run` green
- [ ] After merge: `git tag v0.5.0`, GitHub release, `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)