### PR TITLE
Sync server.json version to 0.5.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Fix a release-plumbing miss from #40. `server.json` (MCP Registry metadata) still had `version: "0.4.1"` in both the top-level field and the nested `packages[0].version`. The publish workflow's `mcp-publisher publish` step read this and attempted a duplicate-version publish of 0.4.1 to the MCP Registry, which the server correctly rejected.

Effect of the bug:
- npm: **not affected** — `npm publish` reads `package.json`, which was bumped correctly. v0.5.0 is live on npmjs.com.
- GitHub release: **not affected** — tag + release notes are independent of `server.json`.
- MCP Registry: **stale** — still lists 0.4.1 as the latest. This PR + a re-run of the publish step will bring it to 0.5.0.

Going forward, the 0.5.0 release branch (and future release branches) should bump `server.json` alongside `package.json`. Not wiring that up in this PR — a one-line script or a `npm version` hook is the right fix and deserves its own small PR rather than being smuggled into this hotfix.

## Test plan

- [ ] After merge: run `mcp-publisher publish` locally (or re-trigger the MCP Registry step of the workflow) and verify the Registry lists 0.5.0.
- [ ] `curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=vaultpilot"` shows the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)