### PR TITLE
Incident-awareness bundle: pre-flight pauses, richer reverts, market-info & incident tools

### DIFF
--- a/src/abis/compound-comet.ts
+++ b/src/abis/compound-comet.ts
@@ -80,4 +80,98 @@ export const cometAbi = [
     ],
     outputs: [],
   },
+
+  // Pause flags — per-action, toggled by Comet governance pause guardian. Every
+  // governance pause we've seen in the wild flips one of these before the
+  // corresponding user-facing action starts reverting with Paused().
+  {
+    type: "function",
+    name: "isSupplyPaused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isTransferPaused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isWithdrawPaused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isAbsorbPaused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isBuyPaused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+
+  // Market-level state: utilization + totals. Needed by get_compound_market_info
+  // (tool #2) and by the contagion report (tool #6).
+  {
+    type: "function",
+    name: "getUtilization",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalSupply",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalBorrow",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalsCollateral",
+    stateMutability: "view",
+    inputs: [{ name: "asset", type: "address" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "totalSupplyAsset", type: "uint128" },
+          { name: "_reserved", type: "uint128" },
+        ],
+      },
+    ],
+  },
+  // Interest-rate model reads (per-second rates, multiply by SECONDS_PER_YEAR then divide by 1e18 for APR).
+  {
+    type: "function",
+    name: "getSupplyRate",
+    stateMutability: "view",
+    inputs: [{ name: "utilization", type: "uint256" }],
+    outputs: [{ name: "", type: "uint64" }],
+  },
+  {
+    type: "function",
+    name: "getBorrowRate",
+    stateMutability: "view",
+    inputs: [{ name: "utilization", type: "uint256" }],
+    outputs: [{ name: "", type: "uint64" }],
+  },
 ] as const;

--- a/src/data/apis/fourbyte.ts
+++ b/src/data/apis/fourbyte.ts
@@ -1,0 +1,19 @@
+const FOURBYTE_URL = "https://www.4byte.directory/api/v1/signatures/";
+
+export type FetchLike = (input: string) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+const defaultFetch: FetchLike = (url) => fetch(url);
+
+export async function fetch4byteSignatures(
+  selector: string,
+  fetchFn: FetchLike = defaultFetch
+): Promise<string[]> {
+  const res = await fetchFn(`${FOURBYTE_URL}?hex_signature=${selector}`);
+  if (!res.ok) throw new Error(`4byte.directory returned ${res.status}`);
+  const data = (await res.json()) as { results?: Array<{ text_signature: string }> };
+  return (data.results ?? []).map((r) => r.text_signature);
+}

--- a/src/data/proxy.ts
+++ b/src/data/proxy.ts
@@ -1,0 +1,39 @@
+import { getAddress, zeroAddress } from "viem";
+import { getClient } from "./rpc.js";
+import type { SupportedChain } from "../types/index.js";
+
+export const EIP1967_IMPL_SLOT =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" as const;
+export const EIP1967_ADMIN_SLOT =
+  "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103" as const;
+
+export async function readAddressFromSlot(
+  chain: SupportedChain,
+  address: `0x${string}`,
+  slot: `0x${string}`
+): Promise<`0x${string}` | undefined> {
+  const client = getClient(chain);
+  try {
+    const raw = await client.getStorageAt({ address, slot });
+    if (!raw || raw === "0x" || raw.length < 66) return undefined;
+    const addr = `0x${raw.slice(26)}` as `0x${string}`;
+    if (addr === zeroAddress) return undefined;
+    return getAddress(addr) as `0x${string}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readEip1967Implementation(
+  chain: SupportedChain,
+  address: `0x${string}`
+): Promise<`0x${string}` | undefined> {
+  return readAddressFromSlot(chain, address, EIP1967_IMPL_SLOT);
+}
+
+export async function readEip1967Admin(
+  chain: SupportedChain,
+  address: `0x${string}`
+): Promise<`0x${string}` | undefined> {
+  return readAddressFromSlot(chain, address, EIP1967_ADMIN_SLOT);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ import {
 } from "./modules/tron/schemas.js";
 
 import { getCompoundPositions } from "./modules/compound/index.js";
+import { getCompoundMarketInfo } from "./modules/compound/market-info.js";
 import {
   buildCompoundSupply,
   buildCompoundWithdraw,
@@ -126,6 +127,7 @@ import {
 } from "./modules/compound/actions.js";
 import {
   getCompoundPositionsInput,
+  getCompoundMarketInfoInput,
   prepareCompoundSupplyInput,
   prepareCompoundWithdrawInput,
   prepareCompoundBorrowInput,
@@ -512,7 +514,8 @@ async function main() {
         "reverts and looks like a builder bug — it is not, the allowance just isn't on-chain yet.",
         "",
         "READ-ONLY TOOLS need no pairing and can be called freely: get_lending_positions,",
-        "get_lp_positions, get_compound_positions, get_morpho_positions, get_staking_positions,",
+        "get_lp_positions, get_compound_positions, get_compound_market_info,",
+        "get_morpho_positions, get_staking_positions,",
         "get_staking_rewards, estimate_staking_yield, get_portfolio_summary, get_swap_quote,",
         "get_token_balance, get_token_price, get_token_metadata, resolve_ens_name,",
         "reverse_resolve_ens,",
@@ -1126,6 +1129,16 @@ async function main() {
       inputSchema: getCompoundPositionsInput.shape,
     },
     handler(getCompoundPositions)
+  );
+
+  server.registerTool(
+    "get_compound_market_info",
+    {
+      description:
+        "Fetch structured market info for a single Compound V3 (Comet) market — no wallet required. Returns base-token metadata, totalSupply/totalBorrow, utilization, supply+borrow APR, current pause flags, and the full collateral-asset list with each asset's symbol, decimals, priceFeed, borrow/liquidate/liquidation collateral factors, supply cap, and total amount currently supplied across all users. Use this to explain market state, answer 'what are the listed collaterals for cUSDCv3', or diagnose an incident (pause + utilization + contagion across collaterals) in one call.",
+      inputSchema: getCompoundMarketInfoInput.shape,
+    },
+    handler(getCompoundMarketInfo)
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,7 +655,7 @@ async function main() {
     "simulate_position_change",
     {
       description:
-        "Simulate the effect of adding or removing collateral, or borrowing/repaying debt on an Aave V3 position. Returns the projected health factor and collateral/debt totals. No transaction is sent.",
+        "Simulate the effect of adding or removing collateral, or borrowing/repaying debt on a lending position. Returns the projected health factor and collateral/debt totals. Supports Aave V3 (default), Compound V3 (pass `protocol: \"compound-v3\"` + `market` Comet address), and Morpho Blue (pass `protocol: \"morpho-blue\"` + `marketId` bytes32). No transaction is sent.",
       inputSchema: simulatePositionChangeInput.shape,
     },
     handler(simulatePositionChange)

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,9 +81,15 @@ import {
   getTxVerificationInput,
 } from "./modules/execution/schemas.js";
 
-import { getTokenBalance, resolveName, reverseResolve } from "./modules/balances/index.js";
+import {
+  getTokenBalance,
+  getTokenMetadata,
+  resolveName,
+  reverseResolve,
+} from "./modules/balances/index.js";
 import {
   getTokenBalanceInput,
+  getTokenMetadataInput,
   resolveNameInput,
   reverseResolveInput,
 } from "./modules/balances/schemas.js";
@@ -508,7 +514,8 @@ async function main() {
         "READ-ONLY TOOLS need no pairing and can be called freely: get_lending_positions,",
         "get_lp_positions, get_compound_positions, get_morpho_positions, get_staking_positions,",
         "get_staking_rewards, estimate_staking_yield, get_portfolio_summary, get_swap_quote,",
-        "get_token_balance, get_token_price, resolve_ens_name, reverse_resolve_ens,",
+        "get_token_balance, get_token_price, get_token_metadata, resolve_ens_name,",
+        "reverse_resolve_ens,",
         "get_tron_staking, get_health_alerts, simulate_position_change,",
         "check_contract_security, check_permission_risks, get_protocol_risk_score,",
         "get_transaction_status, get_tx_verification.",
@@ -966,6 +973,16 @@ async function main() {
       inputSchema: getTokenPriceInput.shape,
     },
     handler(getTokenPriceTool)
+  );
+
+  server.registerTool(
+    "get_token_metadata",
+    {
+      description:
+        "Fetch on-chain ERC-20 metadata (symbol, name, decimals) for any token address on an EVM chain — no wallet or balance required. Also detects EIP-1967 transparent proxies and returns the current implementation address when present. Prefer this over running raw simulate_transaction calls against symbol()/name()/decimals() selectors.",
+      inputSchema: getTokenMetadataInput.shape,
+    },
+    handler(getTokenMetadata)
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,8 @@ import {
 
 import { getCompoundPositions } from "./modules/compound/index.js";
 import { getCompoundMarketInfo } from "./modules/compound/market-info.js";
+import { getMarketIncidentStatus } from "./modules/incidents/index.js";
+import { getMarketIncidentStatusInput } from "./modules/incidents/schemas.js";
 import {
   buildCompoundSupply,
   buildCompoundWithdraw,
@@ -515,6 +517,7 @@ async function main() {
         "",
         "READ-ONLY TOOLS need no pairing and can be called freely: get_lending_positions,",
         "get_lp_positions, get_compound_positions, get_compound_market_info,",
+        "get_market_incident_status,",
         "get_morpho_positions, get_staking_positions,",
         "get_staking_rewards, estimate_staking_yield, get_portfolio_summary, get_swap_quote,",
         "get_token_balance, get_token_price, get_token_metadata, resolve_ens_name,",
@@ -1139,6 +1142,16 @@ async function main() {
       inputSchema: getCompoundMarketInfoInput.shape,
     },
     handler(getCompoundMarketInfo)
+  );
+
+  server.registerTool(
+    "get_market_incident_status",
+    {
+      description:
+        "Return an 'is anything on fire' snapshot across every registered market for a protocol + chain. For Compound V3, returns per-market pause flags, utilization, totalSupply, totalBorrow, and a `flagged` bit that's true when any pause is active or utilization ≥ 95% (borrowers trapped). Top-level `incident: true` if any market is flagged. Use this when you suspect a governance pause, a utilization cliff, or a multi-market contagion from a shared collateral exploit — it collapses what would otherwise take one get_compound_market_info call per market.",
+      inputSchema: getMarketIncidentStatusInput.shape,
+    },
+    handler(getMarketIncidentStatus)
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1148,7 +1148,7 @@ async function main() {
     "get_market_incident_status",
     {
       description:
-        "Return an 'is anything on fire' snapshot across every registered market for a protocol + chain. For Compound V3, returns per-market pause flags, utilization, totalSupply, totalBorrow, and a `flagged` bit that's true when any pause is active or utilization ≥ 95% (borrowers trapped). Top-level `incident: true` if any market is flagged. Use this when you suspect a governance pause, a utilization cliff, or a multi-market contagion from a shared collateral exploit — it collapses what would otherwise take one get_compound_market_info call per market.",
+        "Return an 'is anything on fire' snapshot across every registered market for a protocol + chain. For Compound V3, returns per-market pause flags, utilization, totalSupply, totalBorrow. For Aave V3, returns per-reserve isActive/isFrozen/isPaused, utilization, totalSupplied, totalBorrowed. Each entry has a `flagged` bit: Compound flags on any pause or utilization ≥ 95% (borrowers trapped); Aave flags on paused/frozen/inactive or utilization ≥ 95%. Top-level `incident: true` if any market/reserve is flagged. Use when you suspect a governance pause, a utilization cliff, or multi-market contagion from a shared-collateral exploit — collapses what would otherwise take one get_compound_market_info call per market.",
       inputSchema: getMarketIncidentStatusInput.shape,
     },
     handler(getMarketIncidentStatus)

--- a/src/modules/balances/index.ts
+++ b/src/modules/balances/index.ts
@@ -1,11 +1,14 @@
+import { getAddress } from "viem";
 import { getClient } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
 import { makeTokenAmount } from "../../data/format.js";
 import { getTokenPrice } from "../../data/prices.js";
 import { NATIVE_SYMBOL } from "../../config/contracts.js";
+import { readEip1967Implementation } from "../../data/proxy.js";
 import { getTronTokenBalance } from "../tron/balances.js";
 import type {
   GetTokenBalanceArgs,
+  GetTokenMetadataArgs,
   ResolveNameArgs,
   ReverseResolveArgs,
 } from "./schemas.js";
@@ -15,6 +18,16 @@ import type {
   TokenAmount,
   TronBalance,
 } from "../../types/index.js";
+
+export interface TokenMetadata {
+  chain: SupportedChain;
+  address: `0x${string}`;
+  symbol: string;
+  name: string;
+  decimals: number;
+  isProxy: boolean;
+  implementation?: `0x${string}`;
+}
 
 /**
  * Fetch the balance of an arbitrary token (ERC-20 by address, or the chain's native coin).
@@ -72,6 +85,38 @@ export async function getTokenBalance(
     symbol as string,
     price
   );
+}
+
+/**
+ * Fetch on-chain metadata (symbol, name, decimals) for any ERC-20 address, no wallet required.
+ * Also detects EIP-1967 transparent proxies and returns the current implementation slot so
+ * callers know they're looking at a proxy.
+ */
+export async function getTokenMetadata(
+  args: GetTokenMetadataArgs
+): Promise<TokenMetadata> {
+  const chain = args.chain as SupportedChain;
+  const address = getAddress(args.address) as `0x${string}`;
+  const client = getClient(chain);
+
+  const [symbol, nameResult, decimals, implementation] = await Promise.all([
+    client.readContract({ address, abi: erc20Abi, functionName: "symbol" }),
+    client
+      .readContract({ address, abi: erc20Abi, functionName: "name" })
+      .catch(() => undefined),
+    client.readContract({ address, abi: erc20Abi, functionName: "decimals" }),
+    readEip1967Implementation(chain, address),
+  ]);
+
+  return {
+    chain,
+    address,
+    symbol: symbol as string,
+    name: (nameResult as string | undefined) ?? (symbol as string),
+    decimals: Number(decimals),
+    isProxy: implementation !== undefined,
+    implementation,
+  };
 }
 
 /**

--- a/src/modules/balances/schemas.ts
+++ b/src/modules/balances/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ALL_CHAINS } from "../../types/index.js";
+import { ALL_CHAINS, SUPPORTED_CHAINS } from "../../types/index.js";
 
 const chainEnum = z.enum(ALL_CHAINS as unknown as [string, ...string[]]);
 /**
@@ -16,6 +16,13 @@ const tokenSchema = z.union([
   z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
 ]);
+
+const evmChainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
+export const getTokenMetadataInput = z.object({
+  address: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  chain: evmChainEnum.default("ethereum"),
+});
 
 export const getTokenBalanceInput = z.object({
   wallet: walletSchema,
@@ -36,5 +43,6 @@ export const reverseResolveInput = z.object({
 });
 
 export type GetTokenBalanceArgs = z.infer<typeof getTokenBalanceInput>;
+export type GetTokenMetadataArgs = z.infer<typeof getTokenMetadataInput>;
 export type ResolveNameArgs = z.infer<typeof resolveNameInput>;
 export type ReverseResolveArgs = z.infer<typeof reverseResolveInput>;

--- a/src/modules/compound/actions.ts
+++ b/src/modules/compound/actions.ts
@@ -38,11 +38,44 @@ async function resolveBaseToken(
   })) as `0x${string}`;
 }
 
+/**
+ * Refuse to build a tx when the Comet pause-guardian has disabled the relevant
+ * action. The prior behavior was to happily encode the calldata and let the
+ * revert surface downstream during simulation or (worse) signing — that's the
+ * failure mode that bit cUSDCv3 on 2026-04-20. We read one flag per action (not
+ * all five) so this is a single extra eth_call on the prepare path.
+ *
+ * Only the "unambiguous" direction is checked per action: supply/repay need
+ * isSupplyPaused; withdraw/borrow need isWithdrawPaused. Transfer/absorb/buy
+ * aren't reachable through these four prepare_* tools.
+ */
+async function assertCometActionAllowed(
+  chain: SupportedChain,
+  market: `0x${string}`,
+  action: "supply" | "withdraw"
+): Promise<void> {
+  const fn = action === "supply" ? "isSupplyPaused" : "isWithdrawPaused";
+  const client = getClient(chain);
+  const paused = (await client.readContract({
+    address: market,
+    abi: cometAbi,
+    functionName: fn,
+  })) as boolean;
+  if (paused) {
+    throw new Error(
+      `Compound V3 market ${market} on ${chain} has ${action} paused by governance (${fn}=true). ` +
+        `Refusing to prepare the transaction — it would revert with Paused() on send. ` +
+        `Wait for governance to flip the pause flag off before retrying.`
+    );
+  }
+}
+
 export async function buildCompoundSupply(p: PrepareCompoundSupplyArgs): Promise<UnsignedTx> {
   const chain = p.chain as SupportedChain;
   const market = p.market as `0x${string}`;
   const asset = p.asset as `0x${string}`;
   const wallet = p.wallet as `0x${string}`;
+  await assertCometActionAllowed(chain, market, "supply");
   const meta = await resolveMeta(chain, asset);
   const amountWei = parseUnits(p.amount, meta.decimals);
   const { approvalAmount, display } = resolveApprovalCap(
@@ -88,6 +121,7 @@ export async function buildCompoundWithdraw(p: PrepareCompoundWithdrawArgs): Pro
   const market = p.market as `0x${string}`;
   const asset = p.asset as `0x${string}`;
   const wallet = p.wallet as `0x${string}`;
+  await assertCometActionAllowed(chain, market, "withdraw");
   const meta = await resolveMeta(chain, asset);
   const amountWei = p.amount === "max" ? maxUint256 : parseUnits(p.amount, meta.decimals);
   return {
@@ -110,6 +144,7 @@ export async function buildCompoundBorrow(p: PrepareCompoundBorrowArgs): Promise
   const chain = p.chain as SupportedChain;
   const market = p.market as `0x${string}`;
   const wallet = p.wallet as `0x${string}`;
+  await assertCometActionAllowed(chain, market, "withdraw");
   const baseToken = await resolveBaseToken(chain, market);
   const meta = await resolveMeta(chain, baseToken);
   const amountWei = parseUnits(p.amount, meta.decimals);
@@ -133,6 +168,7 @@ export async function buildCompoundRepay(p: PrepareCompoundRepayArgs): Promise<U
   const chain = p.chain as SupportedChain;
   const market = p.market as `0x${string}`;
   const wallet = p.wallet as `0x${string}`;
+  await assertCometActionAllowed(chain, market, "supply");
   const baseToken = await resolveBaseToken(chain, market);
   const meta = await resolveMeta(chain, baseToken);
   const amountWei = p.amount === "max" ? maxUint256 : parseUnits(p.amount, meta.decimals);

--- a/src/modules/compound/index.ts
+++ b/src/modules/compound/index.ts
@@ -13,6 +13,13 @@ import { SUPPORTED_CHAINS } from "../../types/index.js";
  * `baseSupplied` and `baseBorrowed` are mutually exclusive at the Comet level — an
  * account either has a positive base balance or a nonzero borrow balance, never both.
  */
+export type CometPausedAction =
+  | "supply"
+  | "transfer"
+  | "withdraw"
+  | "absorb"
+  | "buy";
+
 export interface CompoundPosition {
   protocol: "compound-v3";
   chain: SupportedChain;
@@ -25,6 +32,52 @@ export interface CompoundPosition {
   totalDebtUsd: number;
   totalSuppliedUsd: number;
   netValueUsd: number;
+  /**
+   * Governance-paused actions on this Comet market. Omitted when nothing is
+   * paused so the JSON shape of healthy positions doesn't change. Catches
+   * situations like Apr-2026 cUSDCv3 where withdraw was frozen in response to
+   * the rsETH exploit — the user's funds were still there but unable to be
+   * withdrawn, and there was no previous way to surface that without a failed
+   * prepare_compound_withdraw.
+   */
+  pausedActions?: CometPausedAction[];
+}
+
+/**
+ * Reads all five Comet pause flags in a single multicall and returns the subset
+ * that are currently `true`. Split out from readMarketPosition so:
+ *   (a) a failed pause-read never masks a position; worst case it returns [].
+ *   (b) the get_compound_market_info tool can reuse it without duplicating ABI.
+ */
+export async function readCometPausedActions(
+  client: ReturnType<typeof getClient>,
+  comet: `0x${string}`
+): Promise<CometPausedAction[]> {
+  const pauseSlots: [string, CometPausedAction][] = [
+    ["isSupplyPaused", "supply"],
+    ["isTransferPaused", "transfer"],
+    ["isWithdrawPaused", "withdraw"],
+    ["isAbsorbPaused", "absorb"],
+    ["isBuyPaused", "buy"],
+  ];
+  const results = await client.multicall({
+    contracts: pauseSlots.map(([fn]) => ({
+      address: comet,
+      abi: cometAbi,
+      functionName: fn as
+        | "isSupplyPaused"
+        | "isTransferPaused"
+        | "isWithdrawPaused"
+        | "isAbsorbPaused"
+        | "isBuyPaused",
+    })),
+    allowFailure: true,
+  });
+  const paused: CometPausedAction[] = [];
+  results.forEach((r, i) => {
+    if (r.status === "success" && r.result === true) paused.push(pauseSlots[i][1]);
+  });
+  return paused;
 }
 
 function listMarkets(chain: SupportedChain): { name: string; address: `0x${string}` }[] {
@@ -76,6 +129,13 @@ async function readMarketPosition(
   const borrowed = results[3].result;
   const baseAddr = baseToken as `0x${string}`;
   const n = results[1].status === "success" ? Number(results[1].result) : 0;
+
+  // Pause-flag reads are best-effort and completely detached from the
+  // position-critical reads above. If this multicall errors on the way in
+  // (older Comet forks without some of these selectors, rate-limit, or a
+  // client mock that doesn't expect the call), we silently omit pausedActions
+  // rather than failing the position read.
+  const pausedActions = await readCometPausedActions(client, comet).catch(() => [] as CometPausedAction[]);
 
   // Fetch base token metadata + enumerate collateral asset addresses. allowFailure:true
   // so one weird collateral (non-standard decimals/symbol, rate-limit) doesn't nuke the
@@ -191,6 +251,7 @@ async function readMarketPosition(
     totalDebtUsd: round(totalDebtUsd, 2),
     totalSuppliedUsd: round(totalSuppliedUsd, 2),
     netValueUsd: round(totalSuppliedUsd + totalCollateralUsd - totalDebtUsd, 2),
+    ...(pausedActions.length > 0 ? { pausedActions } : {}),
   };
 }
 

--- a/src/modules/compound/market-info.ts
+++ b/src/modules/compound/market-info.ts
@@ -1,0 +1,206 @@
+import { formatUnits } from "viem";
+import { getClient } from "../../data/rpc.js";
+import { cometAbi } from "../../abis/compound-comet.js";
+import { erc20Abi } from "../../abis/erc20.js";
+import { round } from "../../data/format.js";
+import { readCometPausedActions, type CometPausedAction } from "./index.js";
+import type { SupportedChain } from "../../types/index.js";
+import type { GetCompoundMarketInfoArgs } from "./schemas.js";
+
+/**
+ * Compound V3 per-collateral listing. Mirrors the public fields of
+ * `Comet.getAssetInfo(i)` plus decoded metadata and the current total amount
+ * of that asset supplied as collateral across all users.
+ */
+export interface CometCollateralAssetInfo {
+  offset: number;
+  asset: `0x${string}`;
+  symbol: string;
+  decimals: number;
+  priceFeed: `0x${string}`;
+  /** borrowCollateralFactor — bps-ish (1e18 == 100%). */
+  borrowCollateralFactor: string;
+  /** liquidateCollateralFactor — bps-ish (1e18 == 100%). */
+  liquidateCollateralFactor: string;
+  /** liquidationFactor — bps-ish (1e18 == 100%). */
+  liquidationFactor: string;
+  /** supplyCap in the asset's native units (formatted using decimals). */
+  supplyCap: string;
+  /** Total amount of this asset currently supplied as collateral (formatted). */
+  totalSupplyCollateral: string;
+}
+
+export interface CompoundMarketInfo {
+  chain: SupportedChain;
+  market: `0x${string}`;
+  baseToken: {
+    address: `0x${string}`;
+    symbol: string;
+    decimals: number;
+  };
+  totalSupply: string;
+  totalBorrow: string;
+  utilization: number;
+  supplyApr: number;
+  borrowApr: number;
+  pausedActions: CometPausedAction[];
+  collateralAssets: CometCollateralAssetInfo[];
+}
+
+const SECONDS_PER_YEAR = 60n * 60n * 24n * 365n;
+
+interface RawAssetInfo {
+  offset: number;
+  asset: `0x${string}`;
+  priceFeed: `0x${string}`;
+  scale: bigint;
+  borrowCollateralFactor: bigint;
+  liquidateCollateralFactor: bigint;
+  liquidationFactor: bigint;
+  supplyCap: bigint;
+}
+
+/**
+ * Fetch structured market info for a single Comet. Designed to replace the
+ * `numAssets` + 13 × `getAssetInfo` + hand-rolled ABI decode loop that the
+ * 2026-04-20 session had to run via raw simulate_transaction. Everything
+ * needed to explain a market's state + all listed collaterals in one call.
+ */
+export async function getCompoundMarketInfo(
+  args: GetCompoundMarketInfoArgs
+): Promise<CompoundMarketInfo> {
+  const chain = args.chain as SupportedChain;
+  const market = args.market as `0x${string}`;
+  const client = getClient(chain);
+
+  const core = await client.multicall({
+    contracts: [
+      { address: market, abi: cometAbi, functionName: "baseToken" },
+      { address: market, abi: cometAbi, functionName: "numAssets" },
+      { address: market, abi: cometAbi, functionName: "totalSupply" },
+      { address: market, abi: cometAbi, functionName: "totalBorrow" },
+      { address: market, abi: cometAbi, functionName: "getUtilization" },
+    ],
+    allowFailure: false,
+  });
+  const baseAddr = core[0] as `0x${string}`;
+  const numAssets = Number(core[1]);
+  const totalSupplyWei = core[2] as bigint;
+  const totalBorrowWei = core[3] as bigint;
+  const utilization = core[4] as bigint;
+
+  // Rate reads depend on utilization, so they run after the core reads. Pause
+  // reads + base metadata + per-slot getAssetInfo all run in parallel. Each
+  // multicall is ABI-homogeneous so the viem tuple inference stays sharp.
+  const baseMetaCalls = [
+    { address: baseAddr, abi: erc20Abi, functionName: "decimals" as const },
+    { address: baseAddr, abi: erc20Abi, functionName: "symbol" as const },
+  ];
+  const assetInfoCalls = Array.from({ length: numAssets }, (_, i) => ({
+    address: market,
+    abi: cometAbi,
+    functionName: "getAssetInfo" as const,
+    args: [i] as const,
+  }));
+
+  const [rates, baseMeta, assetInfoResults, pausedActions] = await Promise.all([
+    client.multicall({
+      contracts: [
+        {
+          address: market,
+          abi: cometAbi,
+          functionName: "getSupplyRate" as const,
+          args: [utilization] as const,
+        },
+        {
+          address: market,
+          abi: cometAbi,
+          functionName: "getBorrowRate" as const,
+          args: [utilization] as const,
+        },
+      ],
+      allowFailure: false,
+    }),
+    client.multicall({ contracts: baseMetaCalls, allowFailure: false }),
+    assetInfoCalls.length === 0
+      ? Promise.resolve([] as unknown[])
+      : client.multicall({ contracts: assetInfoCalls, allowFailure: false }),
+    readCometPausedActions(client, market),
+  ]);
+
+  const supplyRatePerSec = rates[0] as bigint;
+  const borrowRatePerSec = rates[1] as bigint;
+
+  const baseDecimals = Number(baseMeta[0]);
+  const baseSymbol = baseMeta[1] as string;
+  const assetInfos: RawAssetInfo[] = (assetInfoResults as unknown[]).map(
+    (r) => r as RawAssetInfo
+  );
+
+  // Per-collateral enrichment: totalsCollateral(address), ERC-20 decimals,
+  // ERC-20 symbol. Batch all of them into one multicall.
+  const perAssetCalls = assetInfos.flatMap((a) => [
+    {
+      address: market,
+      abi: cometAbi,
+      functionName: "totalsCollateral" as const,
+      args: [a.asset] as const,
+    },
+    { address: a.asset, abi: erc20Abi, functionName: "decimals" as const },
+    { address: a.asset, abi: erc20Abi, functionName: "symbol" as const },
+  ]);
+  const perAssetResults =
+    perAssetCalls.length === 0
+      ? []
+      : await client.multicall({ contracts: perAssetCalls, allowFailure: true });
+
+  const collateralAssets: CometCollateralAssetInfo[] = assetInfos.map((a, i) => {
+    const totalsRes = perAssetResults[i * 3];
+    const decRes = perAssetResults[i * 3 + 1];
+    const symRes = perAssetResults[i * 3 + 2];
+    const decimals = decRes?.status === "success" ? Number(decRes.result) : 18;
+    const symbol =
+      symRes?.status === "success" ? (symRes.result as string) : "?";
+    const totalColl =
+      totalsRes?.status === "success"
+        ? ((totalsRes.result as unknown as { totalSupplyAsset: bigint })
+            .totalSupplyAsset ?? 0n)
+        : 0n;
+    return {
+      offset: a.offset,
+      asset: a.asset,
+      symbol,
+      decimals,
+      priceFeed: a.priceFeed,
+      borrowCollateralFactor: a.borrowCollateralFactor.toString(),
+      liquidateCollateralFactor: a.liquidateCollateralFactor.toString(),
+      liquidationFactor: a.liquidationFactor.toString(),
+      supplyCap: formatUnits(a.supplyCap, decimals),
+      totalSupplyCollateral: formatUnits(totalColl, decimals),
+    };
+  });
+
+  return {
+    chain,
+    market,
+    baseToken: {
+      address: baseAddr,
+      symbol: baseSymbol,
+      decimals: baseDecimals,
+    },
+    totalSupply: formatUnits(totalSupplyWei, baseDecimals),
+    totalBorrow: formatUnits(totalBorrowWei, baseDecimals),
+    // Comet returns utilization as a 1e18-scaled fraction.
+    utilization: round(Number(formatUnits(utilization, 18)), 6),
+    supplyApr: round(
+      Number(formatUnits(supplyRatePerSec * SECONDS_PER_YEAR, 18)),
+      6
+    ),
+    borrowApr: round(
+      Number(formatUnits(borrowRatePerSec * SECONDS_PER_YEAR, 18)),
+      6
+    ),
+    pausedActions,
+    collateralAssets,
+  };
+}

--- a/src/modules/compound/schemas.ts
+++ b/src/modules/compound/schemas.ts
@@ -62,6 +62,17 @@ export const prepareCompoundRepayInput = prepareCompoundBorrowInput.extend({
   approvalCap: approvalCapSchema,
 });
 
+export const getCompoundMarketInfoInput = z.object({
+  chain: chainEnum
+    .default("ethereum")
+    .describe("EVM chain the Comet market lives on. Defaults to ethereum."),
+  market: addressSchema.describe(
+    "Comet market address (e.g. cUSDCv3 at 0xc3d688B66703497DAA19211EEdff47f25384cdc3 on Ethereum)."
+  ),
+});
+
+export type GetCompoundMarketInfoArgs = z.infer<typeof getCompoundMarketInfoInput>;
+
 export type GetCompoundPositionsArgs = z.infer<typeof getCompoundPositionsInput>;
 export type PrepareCompoundSupplyArgs = z.infer<typeof prepareCompoundSupplyInput>;
 export type PrepareCompoundWithdrawArgs = z.infer<typeof prepareCompoundWithdrawInput>;

--- a/src/modules/incidents/index.ts
+++ b/src/modules/incidents/index.ts
@@ -1,0 +1,124 @@
+import { formatUnits } from "viem";
+import { getClient } from "../../data/rpc.js";
+import { CONTRACTS } from "../../config/contracts.js";
+import { cometAbi } from "../../abis/compound-comet.js";
+import { erc20Abi } from "../../abis/erc20.js";
+import { readCometPausedActions, type CometPausedAction } from "../compound/index.js";
+import { round } from "../../data/format.js";
+import type { SupportedChain } from "../../types/index.js";
+import type { GetMarketIncidentStatusArgs } from "./schemas.js";
+
+/**
+ * "Is anything on fire right now in protocol X on chain Y."
+ *
+ * Emerged from the 2026-04-20 session: the agent spent two separate
+ * diagnostic passes to establish that cUSDCv3 had withdraws paused AND the
+ * adjacent cWETHv3 was at 95% utilization AND they shared the rsETH collateral
+ * that was at the root of the incident. This tool folds all three signals into
+ * one call so the "am I in a broader problem" judgment doesn't require hand-
+ * rolled multicalls per market.
+ */
+export interface CompoundMarketIncidentEntry {
+  chain: SupportedChain;
+  market: string;
+  address: `0x${string}`;
+  baseToken: { symbol: string; address: `0x${string}` };
+  pausedActions: CometPausedAction[];
+  utilization: number;
+  totalSupply: string;
+  totalBorrow: string;
+  /** True when any pause flag is set OR utilization ≥ 0.95 (borrowers can't exit). */
+  flagged: boolean;
+}
+
+export interface MarketIncidentStatus {
+  protocol: "compound-v3";
+  chain: SupportedChain;
+  /** Block number at which reads were performed. Useful for incident reports. */
+  blockNumber: string;
+  /** True if any market in the registry is flagged. */
+  incident: boolean;
+  markets: CompoundMarketIncidentEntry[];
+}
+
+const HIGH_UTILIZATION_FLAG = 0.95;
+
+export async function getMarketIncidentStatus(
+  args: GetMarketIncidentStatusArgs
+): Promise<MarketIncidentStatus> {
+  const chain = args.chain as SupportedChain;
+  if (args.protocol !== "compound-v3") {
+    throw new Error(
+      `get_market_incident_status currently supports protocol="compound-v3" only. Requested ${args.protocol}.`
+    );
+  }
+
+  const registry = (CONTRACTS as Record<string, Record<string, Record<string, string>>>)[
+    chain
+  ]?.compound;
+  if (!registry) {
+    throw new Error(`Compound V3 is not registered on ${chain}.`);
+  }
+  const markets = Object.entries(registry).map(([name, address]) => ({
+    name,
+    address: address as `0x${string}`,
+  }));
+
+  const client = getClient(chain);
+  const blockNumber = await client.getBlockNumber();
+
+  const entries: CompoundMarketIncidentEntry[] = await Promise.all(
+    markets.map(async (m) => {
+      const core = await client.multicall({
+        contracts: [
+          { address: m.address, abi: cometAbi, functionName: "baseToken" },
+          { address: m.address, abi: cometAbi, functionName: "getUtilization" },
+          { address: m.address, abi: cometAbi, functionName: "totalSupply" },
+          { address: m.address, abi: cometAbi, functionName: "totalBorrow" },
+        ],
+        allowFailure: false,
+      });
+      const baseAddr = core[0] as `0x${string}`;
+      const utilization = core[1] as bigint;
+      const totalSupplyWei = core[2] as bigint;
+      const totalBorrowWei = core[3] as bigint;
+
+      const [decimals, symbol] = await client.multicall({
+        contracts: [
+          { address: baseAddr, abi: erc20Abi, functionName: "decimals" },
+          { address: baseAddr, abi: erc20Abi, functionName: "symbol" },
+        ],
+        allowFailure: false,
+      });
+      const baseDecimals = Number(decimals);
+      const baseSymbol = symbol as string;
+
+      const pausedActions = await readCometPausedActions(client, m.address).catch(
+        () => [] as CometPausedAction[]
+      );
+
+      const utilFraction = Number(formatUnits(utilization, 18));
+      const flagged = pausedActions.length > 0 || utilFraction >= HIGH_UTILIZATION_FLAG;
+
+      return {
+        chain,
+        market: m.name,
+        address: m.address,
+        baseToken: { symbol: baseSymbol, address: baseAddr },
+        pausedActions,
+        utilization: round(utilFraction, 6),
+        totalSupply: formatUnits(totalSupplyWei, baseDecimals),
+        totalBorrow: formatUnits(totalBorrowWei, baseDecimals),
+        flagged,
+      };
+    })
+  );
+
+  return {
+    protocol: "compound-v3",
+    chain,
+    blockNumber: blockNumber.toString(),
+    incident: entries.some((e) => e.flagged),
+    markets: entries,
+  };
+}

--- a/src/modules/incidents/index.ts
+++ b/src/modules/incidents/index.ts
@@ -3,6 +3,7 @@ import { getClient } from "../../data/rpc.js";
 import { CONTRACTS } from "../../config/contracts.js";
 import { cometAbi } from "../../abis/compound-comet.js";
 import { erc20Abi } from "../../abis/erc20.js";
+import { aaveUiPoolDataProviderAbi } from "../../abis/aave-ui-pool-data-provider.js";
 import { readCometPausedActions, type CometPausedAction } from "../compound/index.js";
 import { round } from "../../data/format.js";
 import type { SupportedChain } from "../../types/index.js";
@@ -31,7 +32,21 @@ export interface CompoundMarketIncidentEntry {
   flagged: boolean;
 }
 
-export interface MarketIncidentStatus {
+export interface AaveReserveIncidentEntry {
+  chain: SupportedChain;
+  symbol: string;
+  underlyingAsset: `0x${string}`;
+  isActive: boolean;
+  isFrozen: boolean;
+  isPaused: boolean;
+  utilization: number;
+  totalSupplied: string;
+  totalBorrowed: string;
+  /** True when any reserve is paused/frozen/inactive OR utilization ≥ 0.95. */
+  flagged: boolean;
+}
+
+export interface CompoundMarketIncidentStatus {
   protocol: "compound-v3";
   chain: SupportedChain;
   /** Block number at which reads were performed. Useful for incident reports. */
@@ -41,18 +56,42 @@ export interface MarketIncidentStatus {
   markets: CompoundMarketIncidentEntry[];
 }
 
+export interface AaveMarketIncidentStatus {
+  protocol: "aave-v3";
+  chain: SupportedChain;
+  blockNumber: string;
+  incident: boolean;
+  markets: AaveReserveIncidentEntry[];
+}
+
+export type MarketIncidentStatus =
+  | CompoundMarketIncidentStatus
+  | AaveMarketIncidentStatus;
+
 const HIGH_UTILIZATION_FLAG = 0.95;
+const RAY = 10n ** 27n;
+function rayMul(a: bigint, b: bigint): bigint {
+  return (a * b + RAY / 2n) / RAY;
+}
 
 export async function getMarketIncidentStatus(
   args: GetMarketIncidentStatusArgs
 ): Promise<MarketIncidentStatus> {
   const chain = args.chain as SupportedChain;
-  if (args.protocol !== "compound-v3") {
-    throw new Error(
-      `get_market_incident_status currently supports protocol="compound-v3" only. Requested ${args.protocol}.`
-    );
+  if (args.protocol === "compound-v3") {
+    return getCompoundIncidentStatus(chain);
   }
+  if (args.protocol === "aave-v3") {
+    return getAaveIncidentStatus(chain);
+  }
+  throw new Error(
+    `get_market_incident_status supports protocol="compound-v3" or "aave-v3". Requested ${args.protocol}.`
+  );
+}
 
+async function getCompoundIncidentStatus(
+  chain: SupportedChain
+): Promise<CompoundMarketIncidentStatus> {
   const registry = (CONTRACTS as Record<string, Record<string, Record<string, string>>>)[
     chain
   ]?.compound;
@@ -116,6 +155,73 @@ export async function getMarketIncidentStatus(
 
   return {
     protocol: "compound-v3",
+    chain,
+    blockNumber: blockNumber.toString(),
+    incident: entries.some((e) => e.flagged),
+    markets: entries,
+  };
+}
+
+interface AaveReserveRaw {
+  underlyingAsset: `0x${string}`;
+  symbol: string;
+  decimals: bigint;
+  isActive: boolean;
+  isFrozen: boolean;
+  isPaused: boolean;
+  variableBorrowIndex: bigint;
+  availableLiquidity: bigint;
+  totalScaledVariableDebt: bigint;
+}
+
+async function getAaveIncidentStatus(
+  chain: SupportedChain
+): Promise<AaveMarketIncidentStatus> {
+  const aave = (CONTRACTS as Record<string, Record<string, Record<string, string>>>)[
+    chain
+  ]?.aave;
+  if (!aave) {
+    throw new Error(`Aave V3 is not registered on ${chain}.`);
+  }
+  const provider = aave.poolAddressProvider as `0x${string}`;
+  const uiProvider = aave.uiPoolDataProvider as `0x${string}`;
+
+  const client = getClient(chain);
+  const blockNumber = await client.getBlockNumber();
+
+  const reservesResult = await client.readContract({
+    address: uiProvider,
+    abi: aaveUiPoolDataProviderAbi,
+    functionName: "getReservesData",
+    args: [provider],
+  });
+  const [reserves] = reservesResult as unknown as [AaveReserveRaw[], unknown];
+
+  const entries: AaveReserveIncidentEntry[] = reserves.map((r) => {
+    const decimals = Number(r.decimals);
+    const variableDebt = rayMul(r.totalScaledVariableDebt, r.variableBorrowIndex);
+    const totalSupplied = r.availableLiquidity + variableDebt;
+    const utilFraction =
+      totalSupplied === 0n ? 0 : Number(variableDebt) / Number(totalSupplied);
+    const flagged =
+      r.isPaused || r.isFrozen || !r.isActive || utilFraction >= HIGH_UTILIZATION_FLAG;
+
+    return {
+      chain,
+      symbol: r.symbol,
+      underlyingAsset: r.underlyingAsset,
+      isActive: r.isActive,
+      isFrozen: r.isFrozen,
+      isPaused: r.isPaused,
+      utilization: round(utilFraction, 6),
+      totalSupplied: formatUnits(totalSupplied, decimals),
+      totalBorrowed: formatUnits(variableDebt, decimals),
+      flagged,
+    };
+  });
+
+  return {
+    protocol: "aave-v3",
     chain,
     blockNumber: blockNumber.toString(),
     incident: entries.some((e) => e.flagged),

--- a/src/modules/incidents/schemas.ts
+++ b/src/modules/incidents/schemas.ts
@@ -5,9 +5,9 @@ const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 
 export const getMarketIncidentStatusInput = z.object({
   protocol: z
-    .enum(["compound-v3"])
+    .enum(["compound-v3", "aave-v3"])
     .describe(
-      "Lending protocol to scan. Currently only compound-v3 is supported. Aave V3 pauses are per-reserve; Morpho Blue has no core-protocol pause."
+      "Lending protocol to scan. compound-v3 flags per-Comet pause + utilization. aave-v3 flags per-reserve isPaused/isFrozen/!isActive + utilization. Morpho Blue has no core-protocol pause and is not supported."
     ),
   chain: chainEnum
     .default("ethereum")

--- a/src/modules/incidents/schemas.ts
+++ b/src/modules/incidents/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+
+const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
+export const getMarketIncidentStatusInput = z.object({
+  protocol: z
+    .enum(["compound-v3"])
+    .describe(
+      "Lending protocol to scan. Currently only compound-v3 is supported. Aave V3 pauses are per-reserve; Morpho Blue has no core-protocol pause."
+    ),
+  chain: chainEnum
+    .default("ethereum")
+    .describe("EVM chain to scan. Defaults to ethereum."),
+});
+
+export type GetMarketIncidentStatusArgs = z.infer<typeof getMarketIncidentStatusInput>;

--- a/src/modules/morpho/actions.ts
+++ b/src/modules/morpho/actions.ts
@@ -21,6 +21,13 @@ function morphoAddress(chain: SupportedChain): `0x${string}` {
   return addr as `0x${string}`;
 }
 
+// Intentionally no pre-flight pause/frozen check here. Morpho Blue core markets
+// are immutable — once created, MarketParams (lltv, oracle, irm, tokens) cannot
+// change and there is no governance pause at the core-protocol level. The only
+// "pause-shaped" surface is MetaMorpho vaults built on top of Blue, which these
+// prepare_morpho_* tools do not drive. resolveMarketParams already refuses
+// unknown market ids (loanToken=0x0).
+
 async function resolveMarketParams(
   chain: SupportedChain,
   marketId: `0x${string}`

--- a/src/modules/positions/aave.ts
+++ b/src/modules/positions/aave.ts
@@ -35,6 +35,9 @@ interface ReserveData {
   priceInMarketReferenceCurrency: bigint;
   liquidityIndex: bigint;
   variableBorrowIndex: bigint;
+  isActive: boolean;
+  isFrozen: boolean;
+  isPaused: boolean;
 }
 
 interface BaseCurrencyInfo {
@@ -140,11 +143,12 @@ async function readAaveLendingPosition(
 
   const collateral: TokenAmount[] = [];
   const debt: TokenAmount[] = [];
+  const warnings: string[] = [];
 
   // Skip per-reserve breakdown if the UiPoolDataProvider call failed — aggregate totals above
   // are still returned.
   if (!baseCurrencyRaw) {
-    return buildPosition(chain, agg, collateral, debt);
+    return buildPosition(chain, agg, collateral, debt, warnings);
   }
 
   // Unit-of-account price = USD price with `networkBaseTokenPriceDecimals` decimals
@@ -190,16 +194,31 @@ async function readAaveLendingPosition(
         valueUsd: round(amount * tokenPriceUsd, 2),
       });
     }
+
+    // Only emit a warning if the user actually has exposure (collateral OR debt) on this
+    // reserve. A frozen reserve the user isn't in isn't a surprise for their position.
+    if (aTokenBalance > 0n || totalDebt > 0n) {
+      if (reserve.isPaused) {
+        warnings.push(
+          `${reserve.symbol}: paused — all supply/borrow/withdraw/repay disabled on this reserve until Aave governance unpauses`
+        );
+      } else if (reserve.isFrozen) {
+        warnings.push(
+          `${reserve.symbol}: frozen — no new supplies or borrows; existing withdraws/repays still allowed`
+        );
+      }
+    }
   }
 
-  return buildPosition(chain, agg, collateral, debt);
+  return buildPosition(chain, agg, collateral, debt, warnings);
 }
 
 function buildPosition(
   chain: SupportedChain,
   agg: AggregateData,
   collateral: TokenAmount[],
-  debt: TokenAmount[]
+  debt: TokenAmount[],
+  warnings: string[]
 ): LendingPosition {
   const totalCollateralUsd = Number(formatUnits(agg.totalCollateralBase, BASE_DECIMALS));
   const totalDebtUsd = Number(formatUnits(agg.totalDebtBase, BASE_DECIMALS));
@@ -219,6 +238,7 @@ function buildPosition(
     healthFactor: hf === Number.POSITIVE_INFINITY ? 1e18 : round(hf, 4),
     liquidationThreshold: Number(agg.currentLiquidationThreshold),
     ltv: Number(agg.ltv),
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
 

--- a/src/modules/positions/actions.ts
+++ b/src/modules/positions/actions.ts
@@ -27,6 +27,63 @@ function assertNotNativePseudoaddr(asset: `0x${string}`, op: string): void {
   }
 }
 
+/**
+ * Aave V3 ReserveConfiguration bitmap — the bits we read on the prepare path.
+ * Docs: https://docs.aave.com/developers/core-contracts/pool#getconfiguration
+ *   bit 56: ACTIVE — false means the reserve is disabled entirely.
+ *   bit 57: FROZEN — existing withdraws/repays allowed, new supply/borrow blocked.
+ *   bit 60: PAUSED — all supply/withdraw/borrow/repay disabled.
+ */
+const BIT_ACTIVE = 56n;
+const BIT_FROZEN = 57n;
+const BIT_PAUSED = 60n;
+
+function readBit(data: bigint, bit: bigint): boolean {
+  return ((data >> bit) & 1n) === 1n;
+}
+
+/**
+ * Refuse to build a tx when the reserve's pause/frozen/inactive state would
+ * cause the action to revert on send. One `getReserveData` read per prepare.
+ *
+ * Paused → every action blocked. Frozen → only supply/borrow blocked (users
+ * can still wind down existing positions via withdraw/repay). Inactive is a
+ * hard stop for everything.
+ */
+async function assertAaveActionAllowed(
+  chain: SupportedChain,
+  asset: `0x${string}`,
+  action: "supply" | "withdraw" | "borrow" | "repay"
+): Promise<void> {
+  const pool = await getAavePoolAddress(chain);
+  const client = getClient(chain);
+  const reserve = (await client.readContract({
+    address: pool,
+    abi: aavePoolAbi,
+    functionName: "getReserveData",
+    args: [asset],
+  })) as { configuration: { data: bigint } };
+  const data = reserve.configuration.data;
+  const active = readBit(data, BIT_ACTIVE);
+  const frozen = readBit(data, BIT_FROZEN);
+  const paused = readBit(data, BIT_PAUSED);
+  if (!active) {
+    throw new Error(
+      `Aave V3 reserve ${asset} on ${chain} is not active. Refusing to prepare ${action}; it would revert on send.`
+    );
+  }
+  if (paused) {
+    throw new Error(
+      `Aave V3 reserve ${asset} on ${chain} is paused by governance. All supply/withdraw/borrow/repay are blocked until Aave governance unpauses. Refusing to prepare ${action}.`
+    );
+  }
+  if (frozen && (action === "supply" || action === "borrow")) {
+    throw new Error(
+      `Aave V3 reserve ${asset} on ${chain} is frozen. New supplies and borrows are blocked (withdraws and repays still work). Refusing to prepare ${action}.`
+    );
+  }
+}
+
 interface AaveActionParams {
   wallet: `0x${string}`;
   chain: SupportedChain;
@@ -44,6 +101,7 @@ function parseAmountFriendly(amount: string, decimals: number): bigint {
 
 export async function buildAaveSupply(p: AaveActionParams): Promise<UnsignedTx> {
   assertNotNativePseudoaddr(p.asset, "supply");
+  await assertAaveActionAllowed(p.chain, p.asset, "supply");
   const pool = await getAavePoolAddress(p.chain);
   const amountWei = parseAmountFriendly(p.amount, p.decimals);
   const { approvalAmount, display } = resolveApprovalCap(
@@ -91,6 +149,7 @@ export async function buildAaveSupply(p: AaveActionParams): Promise<UnsignedTx> 
 }
 
 export async function buildAaveWithdraw(p: AaveActionParams): Promise<UnsignedTx> {
+  await assertAaveActionAllowed(p.chain, p.asset, "withdraw");
   const pool = await getAavePoolAddress(p.chain);
   // Special case: passing max uint means "withdraw all" in Aave V3.
   const amountWei =
@@ -117,6 +176,7 @@ export async function buildAaveWithdraw(p: AaveActionParams): Promise<UnsignedTx
 const VARIABLE_RATE_MODE = 2n;
 
 export async function buildAaveBorrow(p: AaveActionParams): Promise<UnsignedTx> {
+  await assertAaveActionAllowed(p.chain, p.asset, "borrow");
   const pool = await getAavePoolAddress(p.chain);
   const amountWei = parseAmountFriendly(p.amount, p.decimals);
   return {
@@ -173,6 +233,7 @@ async function getCurrentVariableDebt(
 
 export async function buildAaveRepay(p: AaveActionParams): Promise<UnsignedTx> {
   assertNotNativePseudoaddr(p.asset, "repay");
+  await assertAaveActionAllowed(p.chain, p.asset, "repay");
   const pool = await getAavePoolAddress(p.chain);
   let amountWei: bigint;
   let neededForApproval: bigint;

--- a/src/modules/positions/index.ts
+++ b/src/modules/positions/index.ts
@@ -1,5 +1,8 @@
 import { getAaveLendingPosition, simulateHealthFactorChange } from "./aave.js";
 import { getUniswapPositions } from "./uniswap.js";
+import { getCompoundPositions } from "../compound/index.js";
+import { getCompoundMarketInfo } from "../compound/market-info.js";
+import { getMorphoPositions } from "../morpho/index.js";
 import type {
   GetLendingPositionsArgs,
   GetLpPositionsArgs,
@@ -62,31 +65,194 @@ export async function getHealthAlerts(args: GetHealthAlertsArgs): Promise<{
 export async function simulatePositionChange(args: SimulatePositionChangeArgs): Promise<{
   wallet: string;
   chain: SupportedChain;
+  protocol: "aave-v3" | "compound-v3" | "morpho-blue";
   action: string;
   before: { healthFactor: number; collateralUsd: number; debtUsd: number };
   after: { healthFactor: number; collateralUsd: number; debtUsd: number; safe: boolean };
 }> {
   const wallet = args.wallet as `0x${string}`;
   const chain = (args.chain ?? "ethereum") as SupportedChain;
-  const base = await getAaveLendingPosition(wallet, chain);
-  if (!base) {
-    throw new Error(`Wallet ${wallet} has no Aave V3 position on ${chain}.`);
+  const protocol = args.protocol ?? "aave-v3";
+
+  if (protocol === "aave-v3") {
+    const base = await getAaveLendingPosition(wallet, chain);
+    if (!base) {
+      throw new Error(`Wallet ${wallet} has no Aave V3 position on ${chain}.`);
+    }
+    const sim = simulateHealthFactorChange(base, args.action, args.amountUsd);
+    return {
+      wallet,
+      chain,
+      protocol,
+      action: args.action,
+      before: {
+        healthFactor: base.healthFactor,
+        collateralUsd: base.totalCollateralUsd,
+        debtUsd: base.totalDebtUsd,
+      },
+      after: {
+        healthFactor: sim.newHealthFactor,
+        collateralUsd: sim.newCollateralUsd,
+        debtUsd: sim.newDebtUsd,
+        safe: sim.safe,
+      },
+    };
   }
-  const sim = simulateHealthFactorChange(base, args.action, args.amountUsd);
+
+  if (protocol === "compound-v3") {
+    if (!args.market) {
+      throw new Error(
+        `simulate_position_change for compound-v3 requires \`market\` (the Comet market address).`
+      );
+    }
+    const market = args.market as `0x${string}`;
+    const [{ positions }, info] = await Promise.all([
+      getCompoundPositions({ wallet: args.wallet, chains: [chain] }),
+      getCompoundMarketInfo({ chain, market }),
+    ]);
+    const pos = positions.find(
+      (p) => p.chain === chain && p.marketAddress.toLowerCase() === market.toLowerCase()
+    );
+    if (!pos) {
+      throw new Error(
+        `Wallet ${wallet} has no Compound V3 position in market ${market} on ${chain}.`
+      );
+    }
+    // Comet's liquidation rule: sum(collateral_i × liquidateCF_i) ≥ baseBorrowed.
+    // Reproduce that as a 1-to-1 health factor.
+    const cfByAsset = new Map<string, number>();
+    for (const c of info.collateralAssets) {
+      cfByAsset.set(
+        c.asset.toLowerCase(),
+        Number(c.liquidateCollateralFactor) / 1e18
+      );
+    }
+    const liquidationCollateralUsd = pos.collateral.reduce((sum, t) => {
+      const cf = cfByAsset.get(t.token.toLowerCase()) ?? 0;
+      return sum + (t.valueUsd ?? 0) * cf;
+    }, 0);
+    const beforeDebt = pos.totalDebtUsd;
+    const beforeHF =
+      beforeDebt === 0 ? Number.POSITIVE_INFINITY : liquidationCollateralUsd / beforeDebt;
+
+    // Apply delta. For add/remove_collateral, use the asset-specific CF when
+    // `asset` was passed and resolves to a known collateral; otherwise weighted
+    // average across existing collaterals.
+    const weightedAvgCF =
+      pos.totalCollateralUsd > 0
+        ? liquidationCollateralUsd / pos.totalCollateralUsd
+        : 0;
+    const argAssetCF =
+      args.asset && cfByAsset.has(args.asset.toLowerCase())
+        ? cfByAsset.get(args.asset.toLowerCase())!
+        : weightedAvgCF;
+
+    let newCollateralUsd = pos.totalCollateralUsd;
+    let newLiquidationCollateralUsd = liquidationCollateralUsd;
+    let newDebt = beforeDebt;
+    switch (args.action) {
+      case "add_collateral":
+        newCollateralUsd += args.amountUsd;
+        newLiquidationCollateralUsd += args.amountUsd * argAssetCF;
+        break;
+      case "remove_collateral":
+        newCollateralUsd = Math.max(0, newCollateralUsd - args.amountUsd);
+        newLiquidationCollateralUsd = Math.max(
+          0,
+          newLiquidationCollateralUsd - args.amountUsd * argAssetCF
+        );
+        break;
+      case "borrow":
+        newDebt += args.amountUsd;
+        break;
+      case "repay":
+        newDebt = Math.max(0, newDebt - args.amountUsd);
+        break;
+    }
+    const afterHF =
+      newDebt === 0 ? Number.POSITIVE_INFINITY : newLiquidationCollateralUsd / newDebt;
+
+    return {
+      wallet,
+      chain,
+      protocol,
+      action: args.action,
+      before: {
+        healthFactor: beforeHF === Number.POSITIVE_INFINITY ? 1e18 : Math.round(beforeHF * 10000) / 10000,
+        collateralUsd: pos.totalCollateralUsd,
+        debtUsd: beforeDebt,
+      },
+      after: {
+        healthFactor: afterHF === Number.POSITIVE_INFINITY ? 1e18 : Math.round(afterHF * 10000) / 10000,
+        collateralUsd: Math.round(newCollateralUsd * 100) / 100,
+        debtUsd: Math.round(newDebt * 100) / 100,
+        safe: afterHF > 1.0,
+      },
+    };
+  }
+
+  // morpho-blue
+  if (!args.marketId) {
+    throw new Error(
+      `simulate_position_change for morpho-blue requires \`marketId\` (bytes32).`
+    );
+  }
+  const marketId = args.marketId as `0x${string}`;
+  const { positions } = await getMorphoPositions({
+    wallet: args.wallet,
+    chain,
+    marketIds: [marketId],
+  });
+  const pos = positions.find((p) => p.marketId.toLowerCase() === marketId.toLowerCase());
+  if (!pos) {
+    throw new Error(
+      `Wallet ${wallet} has no Morpho Blue position in market ${marketId} on ${chain}.`
+    );
+  }
+  // Morpho: liquidation when collateralUsd × lltv < borrowedUsd. lltv is a
+  // 1e18-scaled fraction. Health = (collat × lltv) / debt.
+  const lltvFraction = Number(pos.lltv) / 1e18;
+  const beforeHF =
+    pos.totalDebtUsd === 0
+      ? Number.POSITIVE_INFINITY
+      : (pos.totalCollateralUsd * lltvFraction) / pos.totalDebtUsd;
+
+  let newCollateralUsd = pos.totalCollateralUsd;
+  let newDebt = pos.totalDebtUsd;
+  switch (args.action) {
+    case "add_collateral":
+      newCollateralUsd += args.amountUsd;
+      break;
+    case "remove_collateral":
+      newCollateralUsd = Math.max(0, newCollateralUsd - args.amountUsd);
+      break;
+    case "borrow":
+      newDebt += args.amountUsd;
+      break;
+    case "repay":
+      newDebt = Math.max(0, newDebt - args.amountUsd);
+      break;
+  }
+  const afterHF =
+    newDebt === 0
+      ? Number.POSITIVE_INFINITY
+      : (newCollateralUsd * lltvFraction) / newDebt;
+
   return {
     wallet,
     chain,
+    protocol,
     action: args.action,
     before: {
-      healthFactor: base.healthFactor,
-      collateralUsd: base.totalCollateralUsd,
-      debtUsd: base.totalDebtUsd,
+      healthFactor: beforeHF === Number.POSITIVE_INFINITY ? 1e18 : Math.round(beforeHF * 10000) / 10000,
+      collateralUsd: pos.totalCollateralUsd,
+      debtUsd: pos.totalDebtUsd,
     },
     after: {
-      healthFactor: sim.newHealthFactor,
-      collateralUsd: sim.newCollateralUsd,
-      debtUsd: sim.newDebtUsd,
-      safe: sim.safe,
+      healthFactor: afterHF === Number.POSITIVE_INFINITY ? 1e18 : Math.round(afterHF * 10000) / 10000,
+      collateralUsd: Math.round(newCollateralUsd * 100) / 100,
+      debtUsd: Math.round(newDebt * 100) / 100,
+      safe: afterHF > 1.0,
     },
   };
 }

--- a/src/modules/positions/schemas.ts
+++ b/src/modules/positions/schemas.ts
@@ -26,6 +26,25 @@ export const simulatePositionChangeInput = z.object({
   asset: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   /** Amount in USD (base currency) — we approximate since asset price lookups are cheap. */
   amountUsd: z.number().positive(),
+  /**
+   * Which lending protocol this simulation targets. Defaults to "aave-v3".
+   * When "compound-v3", pass `market` (Comet address). When "morpho-blue",
+   * pass `marketId` (bytes32).
+   */
+  protocol: z
+    .enum(["aave-v3", "compound-v3", "morpho-blue"])
+    .optional()
+    .default("aave-v3"),
+  /** Compound V3 Comet market address (required when protocol="compound-v3"). */
+  market: z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{40}$/)
+    .optional(),
+  /** Morpho Blue market id (required when protocol="morpho-blue"). */
+  marketId: z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{64}$/)
+    .optional(),
 });
 
 export type GetLendingPositionsArgs = z.infer<typeof getLendingPositionsInput>;

--- a/src/modules/security/verification.ts
+++ b/src/modules/security/verification.ts
@@ -1,29 +1,7 @@
-import { getAddress, zeroAddress } from "viem";
-import { getClient } from "../../data/rpc.js";
+import { getAddress } from "viem";
 import { getContractInfo } from "../../data/apis/etherscan.js";
+import { readEip1967Admin, readEip1967Implementation } from "../../data/proxy.js";
 import type { SecurityReport, SupportedChain } from "../../types/index.js";
-
-// EIP-1967 storage slots.
-const EIP1967_IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-const EIP1967_ADMIN_SLOT = "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
-
-/** Read a 32-byte storage slot and return it as a 20-byte address (last 20 bytes). */
-async function readAddressFromSlot(
-  chain: SupportedChain,
-  address: `0x${string}`,
-  slot: `0x${string}`
-): Promise<`0x${string}` | undefined> {
-  const client = getClient(chain);
-  try {
-    const raw = await client.getStorageAt({ address, slot });
-    if (!raw || raw === "0x" || raw.length < 66) return undefined;
-    const addr = `0x${raw.slice(26)}` as `0x${string}`;
-    if (addr === zeroAddress) return undefined;
-    return getAddress(addr) as `0x${string}`;
-  } catch {
-    return undefined;
-  }
-}
 
 const DANGEROUS_FUNCTION_NAMES = new Set([
   "mint",
@@ -58,8 +36,8 @@ export async function checkContractSecurity(
 ): Promise<SecurityReport> {
   const [info, eipImpl, eipAdmin] = await Promise.all([
     getContractInfo(address, chain),
-    readAddressFromSlot(chain, address, EIP1967_IMPL_SLOT),
-    readAddressFromSlot(chain, address, EIP1967_ADMIN_SLOT),
+    readEip1967Implementation(chain, address),
+    readEip1967Admin(chain, address),
   ]);
 
   const isProxy = info.isProxy || eipImpl !== undefined;

--- a/src/modules/simulation/index.ts
+++ b/src/modules/simulation/index.ts
@@ -1,29 +1,20 @@
-import { BaseError } from "viem";
 import { getClient } from "../../data/rpc.js";
 import type { SupportedChain } from "../../types/index.js";
 import type { SimulateTransactionArgs } from "./schemas.js";
+import { enrichRevertReason, type DecodedRevert } from "./revert-decode.js";
 
 export interface SimulationResult {
   chain: SupportedChain;
   ok: boolean;
   returnData?: `0x${string}`;
+  /** Human-readable revert summary; populated when ok === false. */
   revertReason?: string;
-}
-
-/**
- * Best-effort decoding of a revert. viem wraps the RPC error in a BaseError
- * chain; `shortMessage` usually contains the decoded "Execution reverted with
- * reason: ..." line. We fall back to the first line of `.message` for non-viem
- * errors (e.g. raw RPC HTTP failures).
- */
-function decodeRevertError(err: unknown): string {
-  if (err instanceof BaseError) {
-    return err.shortMessage || err.message.split("\n")[0] || "execution reverted";
-  }
-  if (err instanceof Error) {
-    return err.message.split("\n")[0] || "execution reverted";
-  }
-  return "execution reverted";
+  /**
+   * Structured revert details (errorName, args, data, source). Populated when
+   * ok === false and we managed to decode anything beyond a bare "execution reverted".
+   * Callers that need more than the human string should prefer this.
+   */
+  revert?: DecodedRevert;
 }
 
 /**
@@ -58,10 +49,12 @@ export async function simulateTx(args: {
       returnData: (result.data ?? "0x") as `0x${string}`,
     };
   } catch (err) {
+    const revert = await enrichRevertReason(err);
     return {
       chain: args.chain,
       ok: false,
-      revertReason: decodeRevertError(err),
+      revertReason: revert.message,
+      revert,
     };
   }
 }

--- a/src/modules/simulation/revert-decode.ts
+++ b/src/modules/simulation/revert-decode.ts
@@ -1,0 +1,228 @@
+import { BaseError, decodeErrorResult, parseAbiItem, type AbiItem } from "viem";
+import { fetch4byteSignatures, type FetchLike } from "../../data/apis/fourbyte.js";
+
+export interface DecodedRevert {
+  /** Error name (e.g. "Paused", "InsufficientCollateral"), or undefined if we couldn't decode. */
+  errorName?: string;
+  /** Positional args as stringified values, or undefined if the error has no args. */
+  args?: string[];
+  /** Extra human hint for specific well-known errors (e.g. which pause flag to check for Comet Paused()). */
+  hint?: string;
+  /** Raw revert data, if we managed to extract it from the error chain. */
+  data?: `0x${string}`;
+  /** Where the decode came from — local ABI, 4byte.directory fallback, or just the selector. */
+  source: "local-abi" | "4byte" | "selector-only" | "string-reason" | "unknown";
+  /** Final human-readable message suitable for surfacing directly to the agent/user. */
+  message: string;
+}
+
+/**
+ * Curated registry of custom errors we care enough about to decode inline.
+ * Kept deliberately small — every entry here is an error a DeFi user is
+ * plausibly going to hit on a preview, and whose name alone is actionable.
+ * Falls back to 4byte.directory for anything else.
+ */
+const KNOWN_ERROR_ABIS = [
+  // Compound V3 Comet — named errors from comet-rs
+  "error Paused()",
+  "error NotCollateralized()",
+  "error SupplyCapExceeded()",
+  "error Absurd()",
+  "error BorrowTooSmall()",
+  "error BadAsset()",
+  "error BadDecimals()",
+  "error BadMinimum()",
+  "error BadPrice()",
+  "error BorrowCFTooLarge()",
+  "error InsufficientReserves()",
+  "error LiquidateCFTooLarge()",
+  "error NoSelfTransfer()",
+  "error NotForSale()",
+  "error NotLiquidatable()",
+  "error StoreFrontPriceFactorTooLarge()",
+  "error Unauthorized()",
+  "error InvalidUInt64(uint256)",
+  "error InvalidUInt128(uint256)",
+  "error InvalidInt104(uint256)",
+  "error InvalidInt256(uint256)",
+  "error TransferInFailed()",
+  "error TransferOutFailed()",
+  "error TooManyAssets()",
+  "error TooMuchSlippage()",
+  "error NegativeNumber()",
+  "error BadDiscount()",
+  "error AlreadyInitialized()",
+
+  // Morpho Blue
+  "error InsufficientCollateral()",
+  "error InsufficientLiquidity()",
+  "error MarketNotCreated()",
+  "error InconsistentInput()",
+  "error AlreadyCreated()",
+  "error NotCreated()",
+  "error ZeroAddress()",
+  "error ZeroAssets()",
+  "error MaxUint128Exceeded()",
+
+  // OpenZeppelin ERC-20 v5 custom errors
+  "error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)",
+  "error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)",
+  "error ERC20InvalidSender(address sender)",
+  "error ERC20InvalidReceiver(address receiver)",
+  "error ERC20InvalidApprover(address approver)",
+  "error ERC20InvalidSpender(address spender)",
+].map((s) => parseAbiItem(s) as AbiItem);
+
+/**
+ * Walks the viem error cause-chain looking for anything that carries the raw
+ * revert-data hex string. Different viem versions attach it to different error
+ * classes (`RawContractError`, `ExecutionRevertedError`, `ContractFunctionRevertedError`),
+ * so we defensively check every cause for a `data` field that looks like hex.
+ */
+export function extractRevertData(err: unknown): `0x${string}` | undefined {
+  if (!(err instanceof BaseError)) return undefined;
+  const candidate = err.walk((e: unknown) => {
+    if (!e || typeof e !== "object") return false;
+    const d = (e as { data?: unknown }).data;
+    if (typeof d === "string" && d.startsWith("0x") && d.length >= 10) return true;
+    // Some viem versions wrap it as { data: { data: "0x..." } }
+    if (d && typeof d === "object" && typeof (d as { data?: unknown }).data === "string") return true;
+    return false;
+  }) as { data?: unknown } | null;
+  if (!candidate) return undefined;
+  const d = candidate.data;
+  if (typeof d === "string" && d.startsWith("0x")) return d as `0x${string}`;
+  if (d && typeof d === "object") {
+    const inner = (d as { data?: unknown }).data;
+    if (typeof inner === "string" && inner.startsWith("0x")) return inner as `0x${string}`;
+  }
+  return undefined;
+}
+
+function stringifyArg(v: unknown): string {
+  if (typeof v === "bigint") return v.toString();
+  if (typeof v === "string") return v;
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (v === null || v === undefined) return String(v);
+  try {
+    return JSON.stringify(v, (_k, x) => (typeof x === "bigint" ? x.toString() : x));
+  } catch {
+    return String(v);
+  }
+}
+
+function hintFor(errorName: string): string | undefined {
+  switch (errorName) {
+    case "Paused":
+      return (
+        "Market is paused. On a Comet market, call isWithdrawPaused / isSupplyPaused / " +
+        "isTransferPaused / isBuyPaused / isAbsorbPaused to see which action is disabled."
+      );
+    case "NotCollateralized":
+      return "Position would be under-collateralized after this action. Reduce borrow or add collateral.";
+    case "InsufficientLiquidity":
+      return "Market doesn't have enough available base asset to satisfy this borrow/withdraw right now.";
+    case "InsufficientCollateral":
+      return "Not enough collateral in the position to back this borrow / remain solvent after withdraw.";
+    case "SupplyCapExceeded":
+      return "This supply would exceed the market's configured supply cap.";
+    case "TooMuchSlippage":
+      return "Price moved past the configured slippage tolerance. Retry with a refreshed quote.";
+    default:
+      return undefined;
+  }
+}
+
+function tryDecodeKnown(data: `0x${string}`): DecodedRevert | undefined {
+  try {
+    const decoded = decodeErrorResult({ abi: KNOWN_ERROR_ABIS, data });
+    const args = decoded.args ? (decoded.args as readonly unknown[]).map(stringifyArg) : undefined;
+    return {
+      errorName: decoded.errorName,
+      args,
+      hint: hintFor(decoded.errorName),
+      data,
+      source: "local-abi",
+      message: formatMessage(decoded.errorName, args, hintFor(decoded.errorName)),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function formatMessage(errorName: string, args?: string[], hint?: string): string {
+  const base = args && args.length > 0
+    ? `reverted with ${errorName}(${args.join(", ")})`
+    : `reverted with ${errorName}()`;
+  return hint ? `${base} — ${hint}` : base;
+}
+
+function extractStringReason(err: unknown): string | undefined {
+  if (!(err instanceof BaseError)) return undefined;
+  const msg = err.shortMessage || err.message.split("\n")[0];
+  if (!msg) return undefined;
+  const m = msg.match(/reverted with reason(?: string)?:\s*['"]?([^'"]+?)['"]?\s*$/i);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Enriched revert decoder. Tries, in order:
+ *   1. Extract raw revert data from the error chain + decode against the known-error ABI registry.
+ *   2. Fall back to 4byte.directory lookup by 4-byte selector, for unknown selectors.
+ *   3. If the error carries a plain string reason (Aave V3 style numeric require-codes,
+ *      "SafeERC20" OZ reasons), surface that directly.
+ *   4. Give up and return a sanitized version of viem's shortMessage.
+ */
+export async function enrichRevertReason(
+  err: unknown,
+  fetchFn?: FetchLike
+): Promise<DecodedRevert> {
+  const data = extractRevertData(err);
+
+  if (data && data.length >= 10) {
+    const local = tryDecodeKnown(data);
+    if (local) return local;
+
+    const selector = data.slice(0, 10).toLowerCase();
+    try {
+      const sigs = await fetch4byteSignatures(selector, fetchFn);
+      if (sigs.length > 0) {
+        const nameMatch = sigs[0].match(/^([^(]+)\(/);
+        const errorName = nameMatch ? nameMatch[1] : sigs[0];
+        return {
+          errorName,
+          data,
+          source: "4byte",
+          message: `reverted with ${sigs[0]} (selector ${selector}, via 4byte.directory — first of ${sigs.length} candidates)`,
+        };
+      }
+    } catch {
+      // fall through to selector-only
+    }
+
+    return {
+      data,
+      source: "selector-only",
+      message: `reverted with unknown custom error (selector ${selector}; not in local registry or 4byte.directory)`,
+    };
+  }
+
+  const stringReason = extractStringReason(err);
+  if (stringReason) {
+    return {
+      source: "string-reason",
+      message: `reverted with reason: ${stringReason}`,
+    };
+  }
+
+  if (err instanceof BaseError) {
+    return {
+      source: "unknown",
+      message: err.shortMessage || err.message.split("\n")[0] || "execution reverted",
+    };
+  }
+  return {
+    source: "unknown",
+    message: err instanceof Error ? err.message.split("\n")[0] : "execution reverted",
+  };
+}

--- a/src/signing/verify-decode.ts
+++ b/src/signing/verify-decode.ts
@@ -5,7 +5,10 @@ import {
   toFunctionSelector,
   type AbiFunction,
 } from "viem";
+import { fetch4byteSignatures, type FetchLike } from "../data/apis/fourbyte.js";
 import type { UnsignedTx } from "../types/index.js";
+
+export type { FetchLike };
 
 /**
  * Independent arg+selector cross-check.
@@ -60,22 +63,6 @@ export interface VerifyDecodeResult {
   summary: string;
 }
 
-const FOURBYTE_URL = "https://www.4byte.directory/api/v1/signatures/";
-
-export type FetchLike = (input: string) => Promise<{
-  ok: boolean;
-  status: number;
-  json(): Promise<unknown>;
-}>;
-
-const defaultFetch: FetchLike = (url) => fetch(url);
-
-async function fetch4byteSignatures(selector: string, fetchFn: FetchLike): Promise<string[]> {
-  const res = await fetchFn(`${FOURBYTE_URL}?hex_signature=${selector}`);
-  if (!res.ok) throw new Error(`4byte.directory returned ${res.status}`);
-  const data = (await res.json()) as { results?: Array<{ text_signature: string }> };
-  return (data.results ?? []).map((r) => r.text_signature);
-}
 
 function funcName(sig: string): string {
   const idx = sig.indexOf("(");
@@ -133,7 +120,7 @@ const ERC20_APPROVE_SELECTOR = "0x095ea7b3";
 
 export async function verifyEvmCalldata(
   tx: Pick<UnsignedTx, "data" | "verification">,
-  fetchFn: FetchLike = defaultFetch,
+  fetchFn?: FetchLike,
 ): Promise<VerifyDecodeResult> {
   const data = tx.data;
   if (!data || data === "0x" || data.length < 10) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,6 +130,14 @@ export interface LendingPosition {
   liquidationThreshold: number;
   /** Weighted average loan-to-value (bps). */
   ltv: number;
+  /**
+   * Per-asset warnings derived from reserve.isPaused / reserve.isFrozen. Scoped
+   * to assets the user actually holds or borrows — a pause on a market they
+   * aren't in isn't a surprise for their position. Paused = all ops blocked
+   * until governance unpauses; Frozen = no new supplies/borrows but existing
+   * positions can still withdraw/repay.
+   */
+  warnings?: string[];
 }
 
 /**
@@ -149,6 +157,12 @@ export interface CompoundLendingPosition {
   totalDebtUsd: number;
   totalSuppliedUsd: number;
   netValueUsd: number;
+  /**
+   * Governance-paused actions on this Comet market. Subset of
+   * {supply, transfer, withdraw, absorb, buy}. Omitted when nothing is paused
+   * so the JSON shape of healthy positions doesn't change.
+   */
+  pausedActions?: ("supply" | "transfer" | "withdraw" | "absorb" | "buy")[];
 }
 
 /**

--- a/test/aave-preflight-pause.test.ts
+++ b/test/aave-preflight-pause.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pre-flight reserve-state checks for prepare_aave_* tools.
+ *
+ * The pool's reserve configuration bitmap has bit 56 (active), bit 57 (frozen),
+ * and bit 60 (paused). Before this change, a prepare_aave_withdraw against a
+ * paused reserve would return a valid-looking UnsignedTx that reverts on send.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const WALLET = "0x1111111111111111111111111111111111111111" as const;
+
+function cfgBitmap({
+  active = true,
+  frozen = false,
+  paused = false,
+}: {
+  active?: boolean;
+  frozen?: boolean;
+  paused?: boolean;
+}): bigint {
+  let data = 0n;
+  if (active) data |= 1n << 56n;
+  if (frozen) data |= 1n << 57n;
+  if (paused) data |= 1n << 60n;
+  return data;
+}
+
+function mockAaveClient(state: { paused?: boolean; frozen?: boolean; active?: boolean }) {
+  return {
+    readContract: vi.fn(async (params: { functionName: string }) => {
+      if (params.functionName === "getPool") {
+        return "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2";
+      }
+      if (params.functionName === "getReserveData") {
+        return { configuration: { data: cfgBitmap(state) } };
+      }
+      throw new Error(`unmocked: ${params.functionName}`);
+    }),
+  };
+}
+
+describe("Aave V3 prepare_* reserve-state pre-flight", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("refuses buildAaveWithdraw when reserve.isPaused=true", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockAaveClient({ paused: true }),
+      resetClients: () => {},
+    }));
+    const { buildAaveWithdraw } = await import(
+      "../src/modules/positions/actions.js"
+    );
+    await expect(
+      buildAaveWithdraw({
+        chain: "ethereum",
+        wallet: WALLET,
+        asset: USDC,
+        amount: "100",
+        decimals: 6,
+        symbol: "USDC",
+      })
+    ).rejects.toThrow(/paused by governance/);
+  });
+
+  it("refuses buildAaveSupply when reserve.isFrozen=true", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockAaveClient({ frozen: true }),
+      resetClients: () => {},
+    }));
+    const { buildAaveSupply } = await import(
+      "../src/modules/positions/actions.js"
+    );
+    await expect(
+      buildAaveSupply({
+        chain: "ethereum",
+        wallet: WALLET,
+        asset: USDC,
+        amount: "100",
+        decimals: 6,
+        symbol: "USDC",
+      })
+    ).rejects.toThrow(/frozen/);
+  });
+
+  it("refuses buildAaveBorrow when reserve.isFrozen=true", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockAaveClient({ frozen: true }),
+      resetClients: () => {},
+    }));
+    const { buildAaveBorrow } = await import(
+      "../src/modules/positions/actions.js"
+    );
+    await expect(
+      buildAaveBorrow({
+        chain: "ethereum",
+        wallet: WALLET,
+        asset: USDC,
+        amount: "100",
+        decimals: 6,
+        symbol: "USDC",
+      })
+    ).rejects.toThrow(/frozen/);
+  });
+
+  it("allows buildAaveRepay when reserve.isFrozen=true (winding down is allowed)", async () => {
+    // Frozen reserves must still allow repay + withdraw so users can exit their
+    // positions. This test locks that in so a future tightening doesn't
+    // accidentally trap users.
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => ({
+        ...mockAaveClient({ frozen: true }),
+        multicall: vi.fn(async () => [false]),
+      }),
+      resetClients: () => {},
+    }));
+    // We only test that the pre-flight doesn't reject; we don't need the full
+    // repay path to succeed (it needs ERC-20 metadata etc). The assert-allowed
+    // call is the first await in the function, so we drive it via getReserveData
+    // and expect no synchronous rejection from the pre-flight itself.
+    const { buildAaveRepay } = await import(
+      "../src/modules/positions/actions.js"
+    );
+    await expect(
+      buildAaveRepay({
+        chain: "ethereum",
+        wallet: WALLET,
+        asset: USDC,
+        amount: "100",
+        decimals: 6,
+        symbol: "USDC",
+      })
+    ).rejects.not.toThrow(/frozen|paused/);
+  });
+
+  it("refuses all actions when reserve is inactive", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockAaveClient({ active: false }),
+      resetClients: () => {},
+    }));
+    const { buildAaveWithdraw } = await import(
+      "../src/modules/positions/actions.js"
+    );
+    await expect(
+      buildAaveWithdraw({
+        chain: "ethereum",
+        wallet: WALLET,
+        asset: USDC,
+        amount: "100",
+        decimals: 6,
+        symbol: "USDC",
+      })
+    ).rejects.toThrow(/not active/);
+  });
+});

--- a/test/compound-market-info.test.ts
+++ b/test/compound-market-info.test.ts
@@ -1,0 +1,134 @@
+/**
+ * get_compound_market_info tool.
+ *
+ * Collapses what the 2026-04-20 session had to do manually: numAssets() +
+ * 13 × getAssetInfo(uint8) + hand-rolled ABI decode loop, plus
+ * totalsCollateral() per asset, plus pause flag reads. This test locks in the
+ * structured response shape so future ABI drift in Comet doesn't silently
+ * degrade the tool.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("get_compound_market_info", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns base token, utilization, rates, pause flags, and collateral list", async () => {
+    const baseAddr = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const; // USDC
+
+    const mockClient = {
+      multicall: vi.fn(async ({ contracts }: { contracts: unknown[] }) => {
+        const first = contracts[0] as { functionName: string };
+        // Core reads: baseToken, numAssets, totalSupply, totalBorrow, getUtilization.
+        if (first.functionName === "baseToken" && contracts.length === 5) {
+          return [
+            baseAddr,
+            2,
+            5_000_000_000_000n, // totalSupply
+            3_500_000_000_000n, // totalBorrow (69% utilization-ish)
+            690_000_000_000_000_000n, // utilization = 0.69 * 1e18
+          ];
+        }
+        // Rate reads.
+        if (first.functionName === "getSupplyRate") {
+          return [
+            634_000_000n, // per-second supply rate
+            951_000_000n, // per-second borrow rate
+          ];
+        }
+        // Base metadata: decimals + symbol.
+        if (first.functionName === "decimals" && contracts.length === 2) {
+          return [6, "USDC"];
+        }
+        // getAssetInfo per slot.
+        if (first.functionName === "getAssetInfo") {
+          return [
+            {
+              offset: 0,
+              asset: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", // WBTC
+              priceFeed: "0x0000000000000000000000000000000000000001",
+              scale: 100_000_000n,
+              borrowCollateralFactor: 700_000_000_000_000_000n, // 70%
+              liquidateCollateralFactor: 770_000_000_000_000_000n,
+              liquidationFactor: 930_000_000_000_000_000n,
+              supplyCap: 3_500_00000000n, // 3500 WBTC
+            },
+            {
+              offset: 1,
+              asset: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+              priceFeed: "0x0000000000000000000000000000000000000002",
+              scale: 1_000_000_000_000_000_000n,
+              borrowCollateralFactor: 825_000_000_000_000_000n,
+              liquidateCollateralFactor: 895_000_000_000_000_000n,
+              liquidationFactor: 950_000_000_000_000_000n,
+              supplyCap: 350_000_000_000_000_000_000_000n,
+            },
+          ];
+        }
+        // Per-asset enrichment: totalsCollateral + decimals + symbol, per asset.
+        // Mixed-ABI; the function identifies it by checking functionName on each.
+        return contracts.map((c) => {
+          const fn = (c as { functionName: string }).functionName;
+          if (fn === "totalsCollateral") {
+            return {
+              status: "success",
+              result: { totalSupplyAsset: 1n, _reserved: 0n },
+            };
+          }
+          if (fn === "decimals") return { status: "success", result: 18 };
+          if (fn === "symbol") return { status: "success", result: "X" };
+          return { status: "success", result: 0n };
+        });
+      }),
+      readContract: vi.fn(async (p: { functionName: string }) => {
+        // Pause-flag reads (from readCometPausedActions).
+        if (p.functionName === "isWithdrawPaused") return true; // Simulates cUSDCv3 on 2026-04-20.
+        return false;
+      }),
+    };
+
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient,
+      resetClients: () => {},
+    }));
+
+    // readCometPausedActions uses multicall; redirect it too. We patched a
+    // pause branch into multicall above if contracts are pause flags.
+    const origMulticall = mockClient.multicall;
+    mockClient.multicall = vi.fn(async ({ contracts }: { contracts: unknown[] }) => {
+      const first = contracts[0] as { functionName: string };
+      if (first.functionName === "isSupplyPaused") {
+        return [
+          { status: "success", result: false },
+          { status: "success", result: false },
+          { status: "success", result: true }, // isWithdrawPaused
+          { status: "success", result: false },
+          { status: "success", result: false },
+        ];
+      }
+      return origMulticall({ contracts });
+    });
+
+    const { getCompoundMarketInfo } = await import(
+      "../src/modules/compound/market-info.js"
+    );
+    const info = await getCompoundMarketInfo({
+      chain: "ethereum",
+      market: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+    });
+
+    expect(info.baseToken.symbol).toBe("USDC");
+    expect(info.baseToken.decimals).toBe(6);
+    expect(info.totalSupply).toBe("5000000");
+    expect(info.totalBorrow).toBe("3500000");
+    expect(info.utilization).toBeCloseTo(0.69, 2);
+    expect(info.pausedActions).toContain("withdraw");
+    expect(info.collateralAssets).toHaveLength(2);
+    expect(info.collateralAssets[0].asset.toLowerCase()).toBe(
+      "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+    );
+    expect(info.collateralAssets[1].asset.toLowerCase()).toBe(
+      "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    );
+  });
+});

--- a/test/compound-preflight-pause.test.ts
+++ b/test/compound-preflight-pause.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pre-flight pause checks for prepare_compound_* tools.
+ *
+ * The prior behavior was to build an UnsignedTx unconditionally; the Paused()
+ * revert would only surface during simulate_transaction or signing. That's the
+ * bug that bit cUSDCv3 on 2026-04-20 after the rsETH exploit — governance
+ * paused withdraws but prepare_compound_withdraw still produced a handle and a
+ * decoded preview that both looked fine. These tests lock in the refusal.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("Compound V3 prepare_* pause pre-flight", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  function mockClient(paused: Record<string, boolean>) {
+    return {
+      readContract: vi.fn(async (params: { functionName: string }) => {
+        if (params.functionName in paused) return paused[params.functionName];
+        if (params.functionName === "baseToken") {
+          return "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+        }
+        throw new Error(`unmocked readContract: ${params.functionName}`);
+      }),
+      multicall: vi.fn(async () => [6, "USDC"]),
+    };
+  }
+
+  it("buildCompoundWithdraw refuses when isWithdrawPaused=true", async () => {
+    const client = mockClient({ isWithdrawPaused: true });
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => client,
+      resetClients: () => {},
+    }));
+    const { buildCompoundWithdraw } = await import(
+      "../src/modules/compound/actions.js"
+    );
+    await expect(
+      buildCompoundWithdraw({
+        chain: "ethereum",
+        market: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        wallet: "0x1111111111111111111111111111111111111111",
+        amount: "100",
+      })
+    ).rejects.toThrow(/withdraw paused/);
+  });
+
+  it("buildCompoundSupply refuses when isSupplyPaused=true", async () => {
+    const client = mockClient({ isSupplyPaused: true });
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => client,
+      resetClients: () => {},
+    }));
+    const { buildCompoundSupply } = await import(
+      "../src/modules/compound/actions.js"
+    );
+    await expect(
+      buildCompoundSupply({
+        chain: "ethereum",
+        market: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        wallet: "0x1111111111111111111111111111111111111111",
+        amount: "100",
+      })
+    ).rejects.toThrow(/supply paused/);
+  });
+
+  it("buildCompoundBorrow refuses when isWithdrawPaused=true (borrow == withdraw of base)", async () => {
+    const client = mockClient({ isWithdrawPaused: true });
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => client,
+      resetClients: () => {},
+    }));
+    const { buildCompoundBorrow } = await import(
+      "../src/modules/compound/actions.js"
+    );
+    await expect(
+      buildCompoundBorrow({
+        chain: "ethereum",
+        market: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        wallet: "0x1111111111111111111111111111111111111111",
+        amount: "100",
+      })
+    ).rejects.toThrow(/withdraw paused/);
+  });
+
+  it("buildCompoundRepay refuses when isSupplyPaused=true (repay == supply of base)", async () => {
+    const client = mockClient({ isSupplyPaused: true });
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => client,
+      resetClients: () => {},
+    }));
+    const { buildCompoundRepay } = await import(
+      "../src/modules/compound/actions.js"
+    );
+    await expect(
+      buildCompoundRepay({
+        chain: "ethereum",
+        market: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        wallet: "0x1111111111111111111111111111111111111111",
+        amount: "100",
+      })
+    ).rejects.toThrow(/supply paused/);
+  });
+});

--- a/test/market-incident-status.test.ts
+++ b/test/market-incident-status.test.ts
@@ -123,7 +123,99 @@ describe("get_market_incident_status (compound-v3)", () => {
     expect(cusdt.flagged).toBe(false);
   });
 
-  it("refuses protocols other than compound-v3", async () => {
+  it("flags a paused Aave reserve and a high-utilization reserve", async () => {
+    // Three reserves: WETH (paused, low utilization), USDC (clean, 99% utilization),
+    // DAI (clean, normal utilization). Expect incident=true with two flagged entries.
+    const reserves = [
+      {
+        underlyingAsset: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        name: "Wrapped Ether",
+        symbol: "WETH",
+        decimals: 18n,
+        isActive: true,
+        isFrozen: false,
+        isPaused: true, // flagged: paused
+        variableBorrowIndex: 10n ** 27n,
+        availableLiquidity: 1000n * 10n ** 18n,
+        totalScaledVariableDebt: 100n * 10n ** 18n,
+      },
+      {
+        underlyingAsset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        name: "USD Coin",
+        symbol: "USDC",
+        decimals: 6n,
+        isActive: true,
+        isFrozen: false,
+        isPaused: false,
+        variableBorrowIndex: 10n ** 27n,
+        // 1 unit liquid, 99 units borrowed → 99% util → flagged.
+        availableLiquidity: 1_000_000n,
+        totalScaledVariableDebt: 99_000_000n,
+      },
+      {
+        underlyingAsset: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        name: "Dai Stablecoin",
+        symbol: "DAI",
+        decimals: 18n,
+        isActive: true,
+        isFrozen: false,
+        isPaused: false,
+        variableBorrowIndex: 10n ** 27n,
+        availableLiquidity: 500n * 10n ** 18n,
+        totalScaledVariableDebt: 500n * 10n ** 18n, // 50% util, not flagged
+      },
+    ];
+
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => 19_800_000n),
+      readContract: vi.fn(
+        async ({ functionName }: { functionName: string }) => {
+          if (functionName === "getReservesData") {
+            return [
+              reserves,
+              {
+                marketReferenceCurrencyUnit: 10n ** 8n,
+                marketReferenceCurrencyPriceInUsd: 10n ** 8n,
+                networkBaseTokenPriceInUsd: 0n,
+                networkBaseTokenPriceDecimals: 8,
+              },
+            ];
+          }
+          throw new Error(`unexpected readContract ${functionName}`);
+        }
+      ),
+    };
+
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient,
+      resetClients: () => {},
+    }));
+
+    const { getMarketIncidentStatus } = await import(
+      "../src/modules/incidents/index.js"
+    );
+    const result = await getMarketIncidentStatus({
+      protocol: "aave-v3",
+      chain: "ethereum",
+    });
+
+    expect(result.protocol).toBe("aave-v3");
+    expect(result.incident).toBe(true);
+    expect(result.markets).toHaveLength(3);
+
+    const weth = result.markets.find((m) => m.symbol === "WETH")!;
+    expect(weth.isPaused).toBe(true);
+    expect(weth.flagged).toBe(true);
+
+    const usdc = result.markets.find((m) => m.symbol === "USDC")!;
+    expect(usdc.utilization).toBeGreaterThanOrEqual(0.95);
+    expect(usdc.flagged).toBe(true);
+
+    const dai = result.markets.find((m) => m.symbol === "DAI")!;
+    expect(dai.flagged).toBe(false);
+  });
+
+  it("refuses unsupported protocols", async () => {
     vi.doMock("../src/data/rpc.js", () => ({
       getClient: () => ({ getBlockNumber: async () => 0n, multicall: async () => [] }),
       resetClients: () => {},
@@ -133,9 +225,9 @@ describe("get_market_incident_status (compound-v3)", () => {
     );
     await expect(
       getMarketIncidentStatus({
-        protocol: "aave-v3" as unknown as "compound-v3",
+        protocol: "morpho-blue" as unknown as "compound-v3",
         chain: "ethereum",
       })
-    ).rejects.toThrow(/compound-v3/);
+    ).rejects.toThrow(/compound-v3|aave-v3/);
   });
 });

--- a/test/market-incident-status.test.ts
+++ b/test/market-incident-status.test.ts
@@ -1,0 +1,141 @@
+/**
+ * get_market_incident_status — "is anything on fire right now".
+ *
+ * Scenario mirrored from 2026-04-20: cUSDCv3 has isWithdrawPaused=true AND
+ * cWETHv3 is at 95%+ utilization. The tool should flag both and return
+ * incident=true at the top level.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("get_market_incident_status (compound-v3)", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("flags a paused market and a high-utilization market", async () => {
+    // cUSDCv3 and cUSDTv3 addresses are taken from the actual registry so the
+    // module's listMarkets returns them. The cWETHv3 and cwstETHv3 addresses
+    // are also real; we only care about the shape of the reads here.
+    const cUSDCv3 = "0xc3d688B66703497DAA19211EEdff47f25384cdc3".toLowerCase();
+    const cUSDTv3 = "0x3Afdc9BCA9213A35503b077a6072F3D0d5AB0840".toLowerCase();
+    const cWETHv3 = "0xA17581A9E3356d9A858b789D68B4d866e593aE94".toLowerCase();
+
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => 19_800_000n),
+      multicall: vi.fn(
+        async ({ contracts }: { contracts: { address: string; functionName: string }[] }) => {
+          const first = contracts[0];
+          const target = first.address.toLowerCase();
+          // Pause-flag multicall (5 calls, all to the same comet).
+          if (first.functionName === "isSupplyPaused") {
+            // cUSDCv3 → withdraw paused. others clean.
+            if (target === cUSDCv3) {
+              return [
+                { status: "success", result: false },
+                { status: "success", result: false },
+                { status: "success", result: true }, // isWithdrawPaused
+                { status: "success", result: false },
+                { status: "success", result: false },
+              ];
+            }
+            return Array.from({ length: 5 }, () => ({
+              status: "success",
+              result: false,
+            }));
+          }
+          // Core reads: baseToken, getUtilization, totalSupply, totalBorrow.
+          if (first.functionName === "baseToken") {
+            if (target === cUSDCv3) {
+              return [
+                "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+                600_000_000_000_000_000n, // 0.6 utilization
+                1_000_000_000_000n,
+                600_000_000_000n,
+              ];
+            }
+            if (target === cUSDTv3) {
+              return [
+                "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
+                700_000_000_000_000_000n,
+                500_000_000_000n,
+                350_000_000_000n,
+              ];
+            }
+            if (target === cWETHv3) {
+              return [
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+                960_000_000_000_000_000n, // 96% utilization → flagged
+                100_000_000_000_000_000_000_000n,
+                96_000_000_000_000_000_000_000n,
+              ];
+            }
+            // cwstETHv3 default
+            return [
+              "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+              500_000_000_000_000_000n,
+              1_000_000_000_000_000_000_000n,
+              500_000_000_000_000_000_000n,
+            ];
+          }
+          // Base-token metadata multicall: decimals + symbol.
+          if (first.functionName === "decimals") {
+            const addr = first.address.toLowerCase();
+            if (addr === "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48") return [6, "USDC"];
+            if (addr === "0xdac17f958d2ee523a2206206994597c13d831ec7") return [6, "USDT"];
+            if (addr === "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2") return [18, "WETH"];
+            return [18, "wstETH"];
+          }
+          return [];
+        }
+      ),
+    };
+
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient,
+      resetClients: () => {},
+    }));
+
+    const { getMarketIncidentStatus } = await import(
+      "../src/modules/incidents/index.js"
+    );
+    const result = await getMarketIncidentStatus({
+      protocol: "compound-v3",
+      chain: "ethereum",
+    });
+
+    expect(result.incident).toBe(true);
+    expect(result.markets.length).toBeGreaterThanOrEqual(3);
+
+    const cusdc = result.markets.find(
+      (m) => m.address.toLowerCase() === cUSDCv3
+    )!;
+    expect(cusdc.pausedActions).toContain("withdraw");
+    expect(cusdc.flagged).toBe(true);
+
+    const cweth = result.markets.find(
+      (m) => m.address.toLowerCase() === cWETHv3
+    )!;
+    expect(cweth.utilization).toBeGreaterThanOrEqual(0.95);
+    expect(cweth.flagged).toBe(true);
+
+    const cusdt = result.markets.find(
+      (m) => m.address.toLowerCase() === cUSDTv3
+    )!;
+    expect(cusdt.flagged).toBe(false);
+  });
+
+  it("refuses protocols other than compound-v3", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => ({ getBlockNumber: async () => 0n, multicall: async () => [] }),
+      resetClients: () => {},
+    }));
+    const { getMarketIncidentStatus } = await import(
+      "../src/modules/incidents/index.js"
+    );
+    await expect(
+      getMarketIncidentStatus({
+        protocol: "aave-v3" as unknown as "compound-v3",
+        chain: "ethereum",
+      })
+    ).rejects.toThrow(/compound-v3/);
+  });
+});

--- a/test/revert-decode.test.ts
+++ b/test/revert-decode.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the enriched revert decoder used by simulate_transaction.
+ * The decoder must:
+ *   - Decode well-known custom errors (Comet Paused(), OZ ERC-20, Morpho) from raw revert bytes.
+ *   - Surface a specific hint for Paused() so the agent knows which pause flag to inspect.
+ *   - Fall back to 4byte.directory for unknown selectors.
+ *   - Extract plain-string reasons ("reverted with reason: …") from Aave-style numeric codes.
+ *   - Degrade gracefully to viem's shortMessage when nothing decodes.
+ */
+import { describe, it, expect } from "vitest";
+import { BaseError, encodeErrorResult, parseAbiItem, type AbiItem } from "viem";
+import { enrichRevertReason } from "../src/modules/simulation/revert-decode.js";
+
+function errWithData(data: `0x${string}`): BaseError {
+  const err = new BaseError("Execution reverted");
+  // Viem's own error classes attach the revert data on the cause; mimic that
+  // shape so the extractor's walk(...) finds it.
+  (err as unknown as { data?: string }).data = data;
+  return err;
+}
+
+describe("enrichRevertReason", () => {
+  it("decodes Comet Paused() from raw revert bytes and attaches the pause-flag hint", async () => {
+    const data = encodeErrorResult({
+      abi: [parseAbiItem("error Paused()")] as AbiItem[],
+    });
+    const result = await enrichRevertReason(errWithData(data));
+    expect(result.source).toBe("local-abi");
+    expect(result.errorName).toBe("Paused");
+    expect(result.hint).toMatch(/isWithdrawPaused/);
+    expect(result.message).toMatch(/Paused\(\)/);
+    expect(result.message).toMatch(/isWithdrawPaused/);
+  });
+
+  it("decodes OZ ERC-20 InsufficientBalance with positional args", async () => {
+    const data = encodeErrorResult({
+      abi: [
+        parseAbiItem(
+          "error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)"
+        ),
+      ] as AbiItem[],
+      args: ["0x000000000000000000000000000000000000dEaD", 5n, 100n],
+    });
+    const result = await enrichRevertReason(errWithData(data));
+    expect(result.source).toBe("local-abi");
+    expect(result.errorName).toBe("ERC20InsufficientBalance");
+    expect(result.args).toEqual([
+      "0x000000000000000000000000000000000000dEaD",
+      "5",
+      "100",
+    ]);
+  });
+
+  it("falls back to 4byte.directory when the selector is unknown locally", async () => {
+    // A fabricated selector that the local registry does not cover.
+    const unknownSelector = "0xdeadbeef";
+    const data = (unknownSelector + "00".repeat(32)) as `0x${string}`;
+    const result = await enrichRevertReason(errWithData(data), async (url) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        results: [{ text_signature: "SomeObscureError(uint256)" }],
+      }),
+    }));
+    expect(result.source).toBe("4byte");
+    expect(result.errorName).toBe("SomeObscureError");
+    expect(result.message).toMatch(/SomeObscureError/);
+    expect(result.message).toMatch(/0xdeadbeef/);
+  });
+
+  it("surfaces a plain-string revert reason when no raw data is available", async () => {
+    const err = new BaseError("Execution reverted");
+    err.shortMessage = "Execution reverted with reason: 23";
+    const result = await enrichRevertReason(err);
+    expect(result.source).toBe("string-reason");
+    expect(result.message).toBe("reverted with reason: 23");
+  });
+
+  it("degrades to viem shortMessage when nothing else is decodable", async () => {
+    const err = new BaseError("Execution reverted");
+    err.shortMessage = "rpc node choked";
+    const result = await enrichRevertReason(err);
+    expect(result.source).toBe("unknown");
+    expect(result.message).toBe("rpc node choked");
+  });
+});

--- a/test/security-audit.test.ts
+++ b/test/security-audit.test.ts
@@ -179,9 +179,14 @@ describe("H1: USDT-style approve(0) reset in Aave action builder", () => {
     readContractMock.mockReset();
     // getAavePoolAddress issues `readContract({ functionName: "getPool" })`
     // then ensureApproval issues `readContract({ functionName: "allowance" })`.
+    // buildAaveSupply also pre-flights via getReserveData — return an
+    // active, non-paused, non-frozen reserve.
     readContractMock.mockImplementation(
       async ({ functionName }: { functionName: string }) => {
         if (functionName === "getPool") return POOL;
+        if (functionName === "getReserveData") {
+          return { configuration: { data: 1n << 56n } };
+        }
         if (functionName === "allowance") return 500n; // nonzero → triggers reset
         throw new Error(`unexpected readContract: ${functionName}`);
       }
@@ -241,6 +246,9 @@ describe("H1: USDT-style approve(0) reset in Aave action builder", () => {
     readContractMock.mockImplementation(
       async ({ functionName }: { functionName: string }) => {
         if (functionName === "getPool") return POOL;
+        if (functionName === "getReserveData") {
+          return { configuration: { data: 1n << 56n } };
+        }
         if (functionName === "allowance") return 0n;
         throw new Error(`unexpected readContract: ${functionName}`);
       }
@@ -281,7 +289,12 @@ describe("H2: Aave repay-max sizes approval against live debt", () => {
       async ({ functionName }: { functionName: string }) => {
         if (functionName === "getPool") return POOL;
         if (functionName === "getReserveData") {
-          return { variableDebtTokenAddress: V_DEBT };
+          // Reserve is active + non-paused + non-frozen AND exposes the
+          // variableDebtToken (the repay path still reads it).
+          return {
+            configuration: { data: 1n << 56n },
+            variableDebtTokenAddress: V_DEBT,
+          };
         }
         if (functionName === "balanceOf") return debt;
         if (functionName === "allowance") return 0n; // force an approve step
@@ -325,7 +338,10 @@ describe("H2: Aave repay-max sizes approval against live debt", () => {
       async ({ functionName }: { functionName: string }) => {
         if (functionName === "getPool") return POOL;
         if (functionName === "getReserveData") {
-          return { variableDebtTokenAddress: V_DEBT };
+          return {
+            configuration: { data: 1n << 56n },
+            variableDebtTokenAddress: V_DEBT,
+          };
         }
         if (functionName === "balanceOf") return 0n;
         throw new Error(`unexpected readContract: ${functionName}`);


### PR DESCRIPTION
## Summary
This bundle stitches together every MCP-server gap exposed by the 2026-04-20 cUSDCv3 withdraw session, where Compound governance had paused withdraws (downstream of the rsETH exploit) and the agent had to fall back to raw `cast sig`, hand-crafted `simulate_transaction` calls, and Python ABI decoding to work out why a valid-looking unsigned tx was reverting.

Eight features, all in one PR per the brainstorm plan:

- **#4** `get_token_metadata` — symbol/name/decimals for any ERC-20 plus EIP-1967 proxy detection, no wallet required.
- **#3** Richer `simulate_transaction` revert decoding — curated ABI registry (Comet, Morpho Blue, OZ ERC-20) + 4byte.directory fallback + specific hints (e.g. Comet `Paused()` names the flag to inspect).
- **#5** Surface `isPaused`/`isFrozen` in position readers — Aave V3 `warnings[]` scoped to user-held reserves; Compound V3 `pausedActions[]` per market.
- **#1 (Compound)** Pre-flight `isSupplyPaused`/`isWithdrawPaused` in every `prepare_compound_*` tool.
- **#2** New `get_compound_market_info` — base-token metadata, totals, utilization, supply/borrow APR, pause flags, and full collateral-asset listing (symbol, decimals, priceFeed, CFs, supplyCap, totalsCollateral) in one call.
- **#1 (Aave)** Pre-flight reserve-state check (active/paused/frozen bitmap) in every `prepare_aave_*` tool. Frozen reserves still allow withdraw/repay so users can wind down. Morpho Blue intentionally not touched: core markets are immutable and have no protocol pause.
- **#7** `simulate_position_change` extended to Compound V3 (uses per-asset `liquidateCollateralFactor`) and Morpho Blue (uses `lltv`).
- **#6** New `get_market_incident_status` — 'is anything on fire right now' across every registered Compound V3 market on a chain. Top-level `incident: true` when any market is paused or at ≥95% utilization.

Net effect: the 2026-04-20 session's ~10 raw-calldata detours would collapse to 2-3 MCP calls.

## Test plan
- [x] `npm run build` passes (no type errors)
- [x] `npm test` — 426 tests across 27 files pass
- [x] H1/H2 security-audit tests updated to return a valid reserve configuration bitmap (new pre-flight reads it)
- [x] New tests: `compound-preflight-pause.test.ts`, `aave-preflight-pause.test.ts`, `compound-market-info.test.ts`, `market-incident-status.test.ts`, `revert-decode.test.ts`
- [ ] Manual smoke: run `get_market_incident_status` against mainnet and confirm flagged markets match external sources
- [ ] Manual smoke: run `prepare_compound_withdraw` against a paused market and confirm the structured refusal message

🤖 Generated with [Claude Code](https://claude.com/claude-code)