### PR TITLE
Live TRON resource awareness: meter + tx pre-flight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1015,7 +1015,7 @@ async function main() {
     "get_tron_staking",
     {
       description:
-        "Read TRON staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), and pending unfreezes with their unlock timestamps. Returns raw SUN + formatted TRX + USD values, plus a `totalStakedUsd` rollup. Read-only; pair with `prepare_tron_claim_rewards` to actually withdraw the accumulated reward.",
+        "Read TRON staking state for a base58 address: claimable voting rewards (WithdrawBalance-ready), frozen TRX under Stake 2.0 (bandwidth + energy), pending unfreezes with unlock timestamps, AND the live account-resource meter (`resources`) showing immediately-consumable bandwidth units (free + staked pools), energy units, and voting-power units. The resource meter is what tx execution actually charges against — frozen TRX only determines the daily limit. Read-only; pair with `prepare_tron_claim_rewards` to withdraw rewards or `prepare_tron_vote` to allocate voting power.",
       inputSchema: getTronStakingInput.shape,
     },
     handler((args: { address: string }) => getTronStaking(args.address))

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -69,6 +69,124 @@ async function trongridPost<T>(
 }
 
 /**
+ * TRON bandwidth-burn rate: 1000 sun (0.001 TRX) per byte of signed tx that
+ * can't be covered by the account's free+staked bandwidth pool. Constant
+ * on mainnet, documented in TRON's resource-model spec.
+ */
+const BANDWIDTH_BURN_SUN_PER_BYTE = 1000n;
+
+/**
+ * Signed tx envelope overhead on top of `raw_data_hex`: the ECDSA signature
+ * (65 bytes) plus a small protobuf wrapper. Empirically 67 bytes for
+ * singleton-signature txs on mainnet — we round up slightly (to 68) so the
+ * pre-flight errs on the cautious side. A false-negative here is a clear
+ * error message the user can act on; a false-positive is the exact
+ * broadcast-time rejection we're trying to prevent.
+ */
+const SIGNATURE_OVERHEAD_BYTES = 68;
+
+interface TrongridAccountBalanceResponse {
+  balance?: number;
+}
+
+interface TrongridBandwidthResourceResponse {
+  freeNetUsed?: number;
+  freeNetLimit?: number;
+  NetUsed?: number;
+  NetLimit?: number;
+}
+
+/**
+ * Pre-flight: does `from` have enough bandwidth (or liquid TRX for the
+ * burn) to broadcast a tx of this size? The on-chain rule is per-pool,
+ * not combined (from java-tron `BandwidthProcessor.consume`):
+ *
+ *   1. Try staked pool: if `bytes > NetLimit - NetUsed`, skip.
+ *   2. Try free pool: if `bytes > freeNetLimit - freeNetUsed`, skip.
+ *   3. Fall back to TRX burn: FULL `bytes * 1000 sun` deducted from
+ *      liquid balance — not the shortfall. If balance can't cover the
+ *      full burn, broadcast rejects with `BANDWITH_ERROR` (sic).
+ *
+ * Earlier versions of this check summed the two pools and used a
+ * shortfall burn; that was wrong on both axes — a user with, say, 120
+ * units free + 100 staked + 0.1 TRX liquid was incorrectly marked OK for
+ * a 250-byte tx (sum 220 looked close, shortfall-burn 30 bytes = 0.03
+ * TRX looked covered) when in reality neither pool covers the tx and the
+ * real burn is 250 × 1000 sun = 0.25 TRX. That miscalculation is exactly
+ * how a real vote-cast flow slipped through to a failed broadcast.
+ *
+ * Called after the tx is built (we need `rawDataHex` for size) but before
+ * the handle is issued, so the error surfaces at prepare time.
+ */
+async function assertBandwidthSufficient(
+  from: string,
+  rawDataHex: string,
+  apiKey: string | undefined
+): Promise<void> {
+  const [resources, account] = await Promise.all([
+    trongridPost<TrongridBandwidthResourceResponse>(
+      "/wallet/getaccountresource",
+      { address: from, visible: true },
+      apiKey
+    ),
+    trongridPost<TrongridAccountBalanceResponse>(
+      "/wallet/getaccount",
+      { address: from, visible: true },
+      apiKey
+    ),
+  ]);
+
+  const signedTxBytes = rawDataHex.length / 2 + SIGNATURE_OVERHEAD_BYTES;
+  const freeBw = Math.max(0, (resources.freeNetLimit ?? 0) - (resources.freeNetUsed ?? 0));
+  const stakedBw = Math.max(0, (resources.NetLimit ?? 0) - (resources.NetUsed ?? 0));
+
+  // Per-pool coverage: staked pool OR free pool must fully cover on its
+  // own. Pools don't combine (java-tron checks each sequentially and
+  // falls through on partial coverage).
+  if (stakedBw >= signedTxBytes) return;
+  if (freeBw >= signedTxBytes) return;
+
+  // Both pools skipped → full-tx TRX burn.
+  const burnNeededSun = BigInt(signedTxBytes) * BANDWIDTH_BURN_SUN_PER_BYTE;
+  const balanceSun = BigInt(account.balance ?? 0);
+  if (balanceSun >= burnNeededSun) return;
+
+  const burnNeededTrx = (Number(burnNeededSun) / 1_000_000).toFixed(3);
+  const balanceTrx = (Number(balanceSun) / 1_000_000).toFixed(3);
+  throw new Error(
+    `Insufficient bandwidth to broadcast this ${signedTxBytes}-byte tx. Neither pool ` +
+      `covers it on its own (${freeBw} free, ${stakedBw} staked; tx needs ${signedTxBytes} ` +
+      `from a single pool), and liquid TRX can't cover the fallback burn ` +
+      `(${balanceTrx} TRX available, ${burnNeededTrx} TRX required at 1000 sun/byte × full tx). ` +
+      `Either (a) top up liquid TRX by at least ~${burnNeededTrx} TRX, (b) wait ${formatFreeRegenHint(resources.freeNetUsed ?? 0, resources.freeNetLimit ?? 0, signedTxBytes)} for ` +
+      `the free bandwidth pool to regenerate past ${signedTxBytes} units, or (c) freeze ` +
+      `additional TRX for bandwidth via prepare_tron_freeze(resource: "bandwidth"). This ` +
+      `would have failed at broadcast with TronGrid's BANDWITH_ERROR.`
+  );
+}
+
+/**
+ * Estimate how long until the free bandwidth pool has enough headroom to
+ * cover a tx of `signedTxBytes`. TRON's free-pool usage decays linearly
+ * over a 24h window (`netUsage(t) = currentUsage * max(0, 1 - t/86400)`).
+ * For the pool to cover the tx, usage must drop to `freeLimit -
+ * signedTxBytes`. If the tx exceeds the per-day free cap entirely,
+ * no amount of waiting helps — say so. Otherwise we linear-interpolate.
+ *
+ * A concrete estimate beats "~24h" from the old error message, which was
+ * the worst case (full pool needed from an empty start) but wrong for
+ * the common case (user needs back a small fraction of the daily cap).
+ */
+function formatFreeRegenHint(freeUsed: number, freeLimit: number, signedTxBytes: number): string {
+  const targetUsage = freeLimit - signedTxBytes;
+  if (targetUsage < 0) return "(unreachable — tx exceeds the per-day free cap)";
+  if (freeUsed <= targetUsage) return "(already enough — retry)";
+  const regenSec = 86400 * (freeUsed - targetUsage) / freeUsed;
+  if (regenSec < 3600) return `~${Math.ceil(regenSec / 60)} minutes`;
+  return `~${(regenSec / 3600).toFixed(1)} hours`;
+}
+
+/**
  * TronGrid surfaces errors in two shapes depending on endpoint:
  *   - /wallet/createtransaction and /wallet/withdrawbalance: `{Error: "..."}`
  *     at the top level on failure.
@@ -247,6 +365,7 @@ export async function buildTronNativeSend(
     to: args.to,
     amountSun,
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -351,6 +470,7 @@ export async function buildTronTokenSend(
     feeLimitSun,
     callValue: 0n,
   });
+  await assertBandwidthSufficient(args.from, ttx.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -455,6 +575,7 @@ export async function buildTronVote(args: BuildTronVoteArgs): Promise<UnsignedTr
     from: args.from,
     votes: args.votes.map((v) => ({ address: v.address, count: v.count })),
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -527,6 +648,7 @@ export async function buildTronFreeze(
     frozenBalanceSun: amountSun,
     resource: args.resource,
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -589,6 +711,7 @@ export async function buildTronUnfreeze(
     unfreezeBalanceSun: amountSun,
     resource: args.resource,
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -636,6 +759,7 @@ export async function buildTronWithdrawExpireUnfreeze(
     kind: "withdraw_expire_unfreeze",
     from: args.from,
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",
@@ -699,6 +823,7 @@ export async function buildTronClaimRewards(
     kind: "claim_rewards",
     from: args.from,
   });
+  await assertBandwidthSufficient(args.from, res.raw_data_hex, apiKey);
 
   const tx: UnsignedTronTx = {
     chain: "tron",

--- a/src/modules/tron/staking.ts
+++ b/src/modules/tron/staking.ts
@@ -3,6 +3,7 @@ import { CACHE_TTL } from "../../config/cache.js";
 import { TRONGRID_BASE_URL, TRX_DECIMALS, isTronAddress } from "../../config/tron.js";
 import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
 import type {
+  TronAccountResources,
   TronClaimableReward,
   TronFrozenEntry,
   TronPendingUnfreeze,
@@ -42,6 +43,30 @@ interface TrongridV1AccountResponse {
 
 interface TrongridRewardResponse {
   reward?: number;
+}
+
+/**
+ * Real fields returned by `/wallet/getaccountresource`. Note the casing:
+ * bandwidth fields are camelCase (`freeNetUsed`, `NetUsed`) while energy and
+ * aggregate fields use PascalCase (`EnergyUsed`, `TotalNetLimit`) — that's
+ * not a typo, it's how TronGrid ships the payload. Missing fields mean
+ * zero (fresh accounts with no stake omit `NetUsed` / `EnergyUsed`).
+ */
+interface TrongridAccountResourceResponse {
+  freeNetUsed?: number;
+  freeNetLimit?: number;
+  NetUsed?: number;
+  NetLimit?: number;
+  EnergyUsed?: number;
+  EnergyLimit?: number;
+  tronPowerUsed?: number;
+  tronPowerLimit?: number;
+}
+
+function meter(used: number | undefined, limit: number | undefined) {
+  const u = used ?? 0;
+  const l = limit ?? 0;
+  return { usedUnits: u, limitUnits: l, availableUnits: Math.max(0, l - u) };
 }
 
 interface LlamaResponse {
@@ -119,13 +144,22 @@ export async function getTronStaking(address: string): Promise<TronStakingSlice>
 
   const apiKey = resolveTronApiKey(readUserConfig());
 
-  const [accountRes, rewardRes, trxPrice] = await Promise.all([
+  // Resources can tolerate a TronGrid failure without killing the rest of
+  // the staking read — return undefined from the helper and the caller
+  // sets `resources` to undefined in the response. The other three calls
+  // let their errors propagate (the portfolio aggregator wraps them).
+  const [accountRes, rewardRes, resourcesRes, trxPrice] = await Promise.all([
     trongridGet<TrongridV1AccountResponse>(`/v1/accounts/${address}`, apiKey),
     trongridPost<TrongridRewardResponse>(
       "/wallet/getReward",
       { address, visible: true },
       apiKey
     ),
+    trongridPost<TrongridAccountResourceResponse>(
+      "/wallet/getaccountresource",
+      { address, visible: true },
+      apiKey
+    ).catch(() => undefined),
     fetchTrxPrice(),
   ]);
 
@@ -185,11 +219,23 @@ export async function getTronStaking(address: string): Promise<TronStakingSlice>
       ? Math.round(Number(totalStakedTrx) * trxPrice * 100) / 100
       : 0;
 
+  const resources: TronAccountResources | undefined = resourcesRes
+    ? {
+        bandwidth: {
+          free: meter(resourcesRes.freeNetUsed, resourcesRes.freeNetLimit),
+          staked: meter(resourcesRes.NetUsed, resourcesRes.NetLimit),
+        },
+        energy: meter(resourcesRes.EnergyUsed, resourcesRes.EnergyLimit),
+        votingPower: meter(resourcesRes.tronPowerUsed, resourcesRes.tronPowerLimit),
+      }
+    : undefined;
+
   return {
     address,
     claimableRewards,
     frozen,
     pendingUnfreezes,
+    ...(resources ? { resources } : {}),
     totalStakedTrx,
     totalStakedUsd,
   };

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -507,6 +507,14 @@ export function renderPostSendPollBlock(args: {
 
 export function renderTronVerificationBlock(tx: UnsignedTronTx & { verification: TxVerification }): string {
   const v = tx.verification;
+  // No on-device hash line for TRON. The Ledger TRON app clear-signs all
+  // native actions (TransferContract, VoteWitness, FreezeBalanceV2, etc.)
+  // and well-known TRC-20 transfers (USDT/USDC) — there is no blind-sign
+  // hash for the user to match. The txID below is the cross-check anchor:
+  // it appears on-device during clear-sign approval AND on tronscan after
+  // broadcast. Adding a server-side "payload hash" here would train the
+  // user to compare against something the device never shows, reinforcing
+  // rubber-stamp habits rather than preventing them.
   return [
     "VERIFY BEFORE SIGNING (TRON) — no browser decoder URL; confirm the",
     "action + args below match what you intended, else REJECT on Ledger.",
@@ -514,7 +522,6 @@ export function renderTronVerificationBlock(tx: UnsignedTronTx & { verification:
     `  Call:    ${v.humanDecode.functionName}`,
     ...formatArgs(v),
     `  from=${tx.from}  txID=${tx.txID}  rawData=${truncateHex(tx.rawDataHex, true)}`,
-    `  Hash: ${v.payloadHash}  (short ${v.payloadHashShort}, echoed at send time)`,
     "  After signing, paste txID into https://tronscan.org to cross-check.",
   ].join("\n");
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -336,6 +336,47 @@ export interface TronClaimableReward {
 }
 
 /**
+ * Live resource meter for a TRON account, in consumable UNITS (not TRX).
+ * Units are what each contract call charges against; frozen TRX only
+ * determines how many units you receive per day. `used` rolls off linearly
+ * over the 24h regen window, so `available = limit - used` is the
+ * instantaneous remaining headroom.
+ */
+export interface TronResourceMeter {
+  /** Units consumed in the current 24h window. */
+  usedUnits: number;
+  /** Total units available per 24h window at current freeze level. */
+  limitUnits: number;
+  /** `limitUnits - usedUnits` — immediately consumable. */
+  availableUnits: number;
+}
+
+/**
+ * Live account-resource snapshot from TronGrid's `/wallet/getaccountresource`.
+ * Distinct from `TronFrozenEntry`: that's the frozen TRX backing the
+ * resource, this is the units-available-right-now meter.
+ *
+ * Bandwidth has two sub-pools: `free` (600 units/day granted to every
+ * account, independent of stake) and `staked` (proportional to frozen TRX).
+ * TronGrid returns them as separate fields; we expose both because a fresh
+ * account with no stake still has the free pool and agents need to reason
+ * about it.
+ */
+export interface TronAccountResources {
+  bandwidth: {
+    free: TronResourceMeter;
+    staked: TronResourceMeter;
+  };
+  energy: TronResourceMeter;
+  /**
+   * Voting power derived from frozen TRX (1 TRX = 1 vote). `used` is how
+   * many votes are currently cast across all SRs; `available` is the
+   * unallocated headroom a new `prepare_tron_vote` can spend.
+   */
+  votingPower: TronResourceMeter;
+}
+
+/**
  * TRON staking view: frozen resources, pending unfreezes, claimable rewards.
  * Totals roll up into the portfolio's `tronUsd` via `totalStakedUsd`.
  */
@@ -344,6 +385,12 @@ export interface TronStakingSlice {
   claimableRewards: TronClaimableReward;
   frozen: TronFrozenEntry[];
   pendingUnfreezes: TronPendingUnfreeze[];
+  /**
+   * Live consumable-units meter (independent of frozen TRX). Absent only
+   * when TronGrid's `/wallet/getaccountresource` fails — the rest of the
+   * staking slice still returns.
+   */
+  resources?: TronAccountResources;
   /** Frozen + pending-unfreeze + claimable, in TRX (formatted). */
   totalStakedTrx: string;
   /** USD value of everything above at current TRX price. */

--- a/test/helpers/tron-bandwidth-mock.ts
+++ b/test/helpers/tron-bandwidth-mock.ts
@@ -1,0 +1,35 @@
+/**
+ * Helper: match a TronGrid URL against the two endpoints the bandwidth
+ * pre-flight hits and return a success fixture. Callers fall through to
+ * their own URL handling on a `null` return.
+ *
+ * The pre-flight needs two things:
+ *   - `/wallet/getaccountresource` for the bandwidth meter (free + staked pools)
+ *   - `/wallet/getaccount` for the liquid TRX balance
+ *
+ * The default fixture returns plenty of bandwidth AND plenty of TRX so the
+ * pre-flight passes trivially — tests that want to exercise the
+ * insufficient-bandwidth branch should short-circuit with their own mock
+ * before falling through to this helper.
+ */
+export function maybeTronBandwidthResponse(url: string): Response | null {
+  if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+    return new Response(
+      JSON.stringify({
+        freeNetUsed: 0,
+        freeNetLimit: 5000,
+        NetUsed: 0,
+        NetLimit: 5000,
+        EnergyUsed: 0,
+        EnergyLimit: 1_000_000,
+        tronPowerUsed: 0,
+        tronPowerLimit: 0,
+      }),
+      { status: 200 }
+    );
+  }
+  if (url === "https://api.trongrid.io/wallet/getaccount") {
+    return new Response(JSON.stringify({ balance: 1_000_000_000 }), { status: 200 }); // 1000 TRX
+  }
+  return null;
+}

--- a/test/tron-bandwidth-preflight.test.ts
+++ b/test/tron-bandwidth-preflight.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { buildTronNativeSend } from "../src/modules/tron/actions.js";
+import { encodeTransferRawData } from "./helpers/tron-raw-data-encode.js";
+
+/**
+ * Pre-flight bandwidth check. On-chain rule (java-tron
+ * BandwidthProcessor.consume): tx must fit entirely in STAKED pool OR
+ * entirely in FREE pool — pools do not combine. If neither pool covers,
+ * TronGrid burns the FULL tx byte length at 1000 sun/byte from liquid
+ * TRX. If that too is insufficient, broadcast rejects post-signature
+ * with `BANDWITH_ERROR` (sic). This pre-flight catches that failure
+ * mode at prepare time.
+ *
+ * Regression context: an earlier implementation summed free + staked and
+ * used a shortfall-based burn estimate. That let a real vote-cast flow
+ * slip through — an account with 121 free + 102 staked + ~0.1 TRX
+ * passed the (buggy) preflight but then failed the actual broadcast
+ * because neither pool individually covers a ~230-byte tx and the real
+ * burn is full-tx × 1000 sun (~0.23 TRX), not shortfall × 1000.
+ */
+
+const ADDR_FROM = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const ADDR_TO = "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9";
+
+type ResourceFixture = {
+  freeNetUsed?: number;
+  freeNetLimit?: number;
+  NetUsed?: number;
+  NetLimit?: number;
+};
+
+function stubFetch(opts: { resources: ResourceFixture; balanceSun: number }) {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+      return new Response(JSON.stringify(opts.resources), { status: 200 });
+    }
+    if (url === "https://api.trongrid.io/wallet/getaccount") {
+      return new Response(JSON.stringify({ balance: opts.balanceSun }), { status: 200 });
+    }
+    if (url === "https://api.trongrid.io/wallet/createtransaction") {
+      return new Response(
+        JSON.stringify({
+          txID: "aa".repeat(32),
+          raw_data: { expiration: 0 },
+          raw_data_hex: encodeTransferRawData({
+            from: ADDR_FROM,
+            to: ADDR_TO,
+            amountSun: 1_000_000n,
+          }),
+          visible: true,
+        }),
+        { status: 200 }
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("TRON bandwidth pre-flight", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("throws with an actionable message when no pool covers and TRX is insufficient", async () => {
+    stubFetch({
+      resources: { freeNetLimit: 0, freeNetUsed: 0, NetLimit: 0, NetUsed: 0 },
+      balanceSun: 0,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/Insufficient bandwidth.*BANDWITH_ERROR/s);
+  });
+
+  it("passes when the FREE pool alone covers the tx (even with zero staked and zero TRX)", async () => {
+    stubFetch({
+      resources: { freeNetLimit: 5000, freeNetUsed: 0, NetLimit: 0, NetUsed: 0 },
+      balanceSun: 0,
+    });
+    const tx = await buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" });
+    expect(tx.action).toBe("native_send");
+  });
+
+  it("passes when the STAKED pool alone covers the tx", async () => {
+    stubFetch({
+      resources: { freeNetLimit: 0, freeNetUsed: 0, NetLimit: 5000, NetUsed: 0 },
+      balanceSun: 0,
+    });
+    const tx = await buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" });
+    expect(tx.action).toBe("native_send");
+  });
+
+  it("passes when no pool covers but liquid TRX covers the full-tx burn", async () => {
+    // No pool coverage at all; 1 TRX (1_000_000 sun) covers the
+    // full ~250-byte burn (~250_000 sun).
+    stubFetch({
+      resources: { freeNetLimit: 0, freeNetUsed: 0, NetLimit: 0, NetUsed: 0 },
+      balanceSun: 1_000_000,
+    });
+    const tx = await buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" });
+    expect(tx.action).toBe("native_send");
+  });
+
+  it("REJECTS when neither pool individually covers even though the SUM would (regression for the real-vote failure)", async () => {
+    // 120 free + 120 staked = 240 units; tx is ~200 bytes. Under the
+    // old buggy check the sum passed. Under the correct per-pool check
+    // neither pool alone covers → falls through to burn. With 0 TRX,
+    // the preflight must reject.
+    stubFetch({
+      resources: { freeNetLimit: 120, freeNetUsed: 0, NetLimit: 120, NetUsed: 0 },
+      balanceSun: 0,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/Insufficient bandwidth/);
+  });
+
+  it("REJECTS when neither pool covers AND TRX only covers a shortfall burn (not full-tx)", async () => {
+    // Tx is ~170 bytes. 50/50 pool split: neither pool individually
+    // covers and the sum (100) doesn't either, so burn kicks in.
+    // Balance covers a shortfall burn (70 bytes × 1000 = 70_000 sun)
+    // but not a full-tx burn (~170_000 sun). The earlier buggy
+    // shortfall-based check let this pass; the correct full-tx check
+    // rejects.
+    stubFetch({
+      resources: { freeNetLimit: 50, freeNetUsed: 0, NetLimit: 50, NetUsed: 0 },
+      balanceSun: 80_000,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/Insufficient bandwidth/);
+  });
+
+  it("error message quotes a realistic free-pool regen ETA, not a blanket ~24h", async () => {
+    // Mirror the real vote-flow failure: 600/471 free, 595/493 staked,
+    // 0.06 TRX liquid, ~230-byte tx. The old error message hard-coded
+    // "~24h"; the pool actually decays linearly so only a few hours'
+    // wait is needed when the current usage is close to the target.
+    stubFetch({
+      resources: { freeNetLimit: 600, freeNetUsed: 471, NetLimit: 595, NetUsed: 493 },
+      balanceSun: 60_000,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/wait ~\d/);
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.not.toThrow(/wait ~24h/);
+  });
+
+  it("error message flags an unreachable wait when tx exceeds the per-day free cap", async () => {
+    // Tx is ~170 bytes but free cap is lower — even an empty pool
+    // can't cover it, so waiting is pointless and the message must
+    // say so instead of quoting a misleading "~N hours".
+    stubFetch({
+      resources: { freeNetLimit: 100, freeNetUsed: 0, NetLimit: 0, NetUsed: 0 },
+      balanceSun: 0,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/unreachable — tx exceeds the per-day free cap/);
+  });
+
+  it("clamps to zero when usage has somehow exceeded the limit", async () => {
+    stubFetch({
+      resources: { freeNetLimit: 100, freeNetUsed: 500, NetLimit: 100, NetUsed: 500 },
+      balanceSun: 0,
+    });
+    await expect(
+      buildTronNativeSend({ from: ADDR_FROM, to: ADDR_TO, amount: "1" })
+    ).rejects.toThrow(/Insufficient bandwidth/);
+  });
+});

--- a/test/tron-phase2-prepare.test.ts
+++ b/test/tron-phase2-prepare.test.ts
@@ -12,6 +12,7 @@ import {
   encodeTriggerSmartContractRawData,
   encodeOwnerOnlyRawData,
 } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
 
 /**
  * Phase-2 (TRON tx preparation) tests. Network IO against TronGrid is stubbed
@@ -75,6 +76,8 @@ describe("buildTronNativeSend (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       expect(url).toBe("https://api.trongrid.io/wallet/createtransaction");
       expect(init?.method).toBe("POST");
       const body = JSON.parse(init!.body as string);
@@ -156,7 +159,9 @@ describe("buildTronTokenSend (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      // Pre-flight dry-run hits triggerconstantcontract first.
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
+      // Energy pre-flight dry-run hits triggerconstantcontract first.
       if (url === "https://api.trongrid.io/wallet/triggerconstantcontract") {
         return new Response(
           JSON.stringify({
@@ -218,6 +223,8 @@ describe("buildTronTokenSend (network stubbed)", () => {
 
   it("honours an explicit feeLimitTrx override", async () => {
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       if (url === "https://api.trongrid.io/wallet/triggerconstantcontract") {
         return new Response(
           JSON.stringify({ result: { result: true }, energy_used: 14650, constant_result: [""] }),
@@ -328,6 +335,8 @@ describe("buildTronClaimRewards (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       expect(url).toBe("https://api.trongrid.io/wallet/withdrawbalance");
       const body = JSON.parse(init!.body as string);
       expect(body.owner_address).toBe(ADDR_FROM);

--- a/test/tron-phase2b-stake-writes.test.ts
+++ b/test/tron-phase2b-stake-writes.test.ts
@@ -10,6 +10,7 @@ import {
   encodeUnfreezeV2RawData,
   encodeOwnerOnlyRawData,
 } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
 
 /**
  * Phase-2b (TRON Stake 2.0 writes) tests. Network IO is stubbed via
@@ -39,6 +40,8 @@ describe("buildTronFreeze (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       expect(url).toBe("https://api.trongrid.io/wallet/freezebalancev2");
       const body = JSON.parse(init!.body as string);
       expect(body.owner_address).toBe(ADDR);
@@ -68,7 +71,9 @@ describe("buildTronFreeze (network stubbed)", () => {
   });
 
   it("uppercases ENERGY at the TronGrid edge", async () => {
-    fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       const body = JSON.parse(init!.body as string);
       expect(body.resource).toBe("ENERGY");
       return directTxResponse(
@@ -99,12 +104,13 @@ describe("buildTronFreeze (network stubbed)", () => {
   });
 
   it("surfaces TronGrid's top-level Error verbatim", async () => {
-    fetchMock.mockImplementationOnce(
-      async () =>
-        new Response(JSON.stringify({ Error: "contract validate error : frozen_balance must be greater than 1 TRX" }), {
-          status: 200,
-        })
-    );
+    fetchMock.mockImplementation(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
+      return new Response(JSON.stringify({ Error: "contract validate error : frozen_balance must be greater than 1 TRX" }), {
+        status: 200,
+      });
+    });
     await expect(
       buildTronFreeze({ from: ADDR, amount: "0.5", resource: "bandwidth" })
     ).rejects.toThrow(/greater than 1 TRX/);
@@ -116,6 +122,8 @@ describe("buildTronUnfreeze (network stubbed)", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string, init?: RequestInit) => {
+        const preflight = maybeTronBandwidthResponse(url);
+        if (preflight) return preflight;
         expect(url).toBe("https://api.trongrid.io/wallet/unfreezebalancev2");
         const body = JSON.parse(init!.body as string);
         expect(body.owner_address).toBe(ADDR);
@@ -146,12 +154,13 @@ describe("buildTronUnfreeze (network stubbed)", () => {
   it("surfaces 'less than frozen balance' verbatim (overshoot guard)", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify({ Error: "contract validate error : unfreezeBalance less than frozen balance" }), {
-            status: 200,
-          })
-      )
+      vi.fn(async (url: string) => {
+        const preflight = maybeTronBandwidthResponse(url);
+        if (preflight) return preflight;
+        return new Response(JSON.stringify({ Error: "contract validate error : unfreezeBalance less than frozen balance" }), {
+          status: 200,
+        });
+      })
     );
     await expect(
       buildTronUnfreeze({ from: ADDR, amount: "9999", resource: "bandwidth" })
@@ -173,6 +182,8 @@ describe("buildTronWithdrawExpireUnfreeze (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       expect(url).toBe("https://api.trongrid.io/wallet/withdrawexpireunfreeze");
       const body = JSON.parse(init!.body as string);
       expect(body.owner_address).toBe(ADDR);
@@ -194,13 +205,14 @@ describe("buildTronWithdrawExpireUnfreeze (network stubbed)", () => {
   });
 
   it("surfaces 'no expire unfreeze' when nothing has matured yet", async () => {
-    fetchMock.mockImplementationOnce(
-      async () =>
-        new Response(
-          JSON.stringify({ Error: "contract validate error : no expire unfreeze" }),
-          { status: 200 }
-        )
-    );
+    fetchMock.mockImplementation(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
+      return new Response(
+        JSON.stringify({ Error: "contract validate error : no expire unfreeze" }),
+        { status: 200 }
+      );
+    });
     await expect(buildTronWithdrawExpireUnfreeze({ from: ADDR })).rejects.toThrow(
       /no expire unfreeze/
     );

--- a/test/tron-phase2c-voting.test.ts
+++ b/test/tron-phase2c-voting.test.ts
@@ -3,6 +3,7 @@ import { listTronWitnesses } from "../src/modules/tron/witnesses.js";
 import { buildTronVote } from "../src/modules/tron/actions.js";
 import { hasTronHandle } from "../src/signing/tron-tx-store.js";
 import { encodeVoteWitnessRawData } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
 
 /**
  * Phase-2c (TRON voting) tests. Covers:
@@ -162,6 +163,8 @@ describe("buildTronVote (network stubbed)", () => {
 
   beforeEach(() => {
     fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       expect(url).toBe("https://api.trongrid.io/wallet/votewitnessaccount");
       const body = JSON.parse(init!.body as string);
       expect(body.owner_address).toBe(OWNER);
@@ -244,13 +247,14 @@ describe("buildTronVote (network stubbed)", () => {
   });
 
   it("surfaces TronGrid 'Not enough tron power' verbatim", async () => {
-    fetchMock.mockImplementationOnce(
-      async () =>
-        new Response(
-          JSON.stringify({ Error: "contract validate error : Not enough tron power" }),
-          { status: 200 }
-        )
-    );
+    fetchMock.mockImplementation(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
+      return new Response(
+        JSON.stringify({ Error: "contract validate error : Not enough tron power" }),
+        { status: 200 }
+      );
+    });
     await expect(
       buildTronVote({ from: OWNER, votes: [{ address: SR1, count: 999_999 }] })
     ).rejects.toThrow(/Not enough tron power/);

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { encodeTransferRawData } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
 
 /**
  * Phase-3 (TRON USB HID signing) tests.
@@ -210,6 +211,8 @@ describe("sendTransaction — TRON handle routing", () => {
 
   it("signs on USB, broadcasts to TronGrid, and retires the handle on success", async () => {
     const fetchMock = vi.fn(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       if (url === "https://api.trongrid.io/wallet/createtransaction") {
         return new Response(
           JSON.stringify({
@@ -253,6 +256,8 @@ describe("sendTransaction — TRON handle routing", () => {
 
   it("keeps the handle alive when signing fails so the caller can retry", async () => {
     const fetchMock = vi.fn(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       if (url === "https://api.trongrid.io/wallet/createtransaction") {
         return new Response(
           JSON.stringify({
@@ -390,6 +395,8 @@ describe("pair_ledger_tron + get_ledger_status", () => {
       return { publicKey: "04abcd", address: addr };
     });
     const fetchMock = vi.fn(async (url: string) => {
+      const preflight = maybeTronBandwidthResponse(url);
+      if (preflight) return preflight;
       if (url === "https://api.trongrid.io/wallet/createtransaction") {
         return new Response(
           JSON.stringify({

--- a/test/tron-support.test.ts
+++ b/test/tron-support.test.ts
@@ -402,6 +402,21 @@ describe("getTronStaking (network stubbed)", () => {
           expect(init?.method).toBe("POST");
           return new Response(JSON.stringify({ reward: 1_500_000 }), { status: 200 }); // 1.5 TRX claimable
         }
+        if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+          return new Response(
+            JSON.stringify({
+              freeNetUsed: 100,
+              freeNetLimit: 600,
+              NetUsed: 500,
+              NetLimit: 1200,
+              EnergyUsed: 10_000,
+              EnergyLimit: 50_000,
+              tronPowerUsed: 120,
+              tronPowerLimit: 150,
+            }),
+            { status: 200 }
+          );
+        }
         if (url.startsWith("https://coins.llama.fi/prices/current/")) {
           return new Response(
             JSON.stringify({ coins: { "coingecko:tron": { price: 0.1 } } }),
@@ -450,6 +465,13 @@ describe("getTronStaking (network stubbed)", () => {
         if (url === "https://api.trongrid.io/wallet/getReward") {
           return new Response(JSON.stringify({ reward: 0 }), { status: 200 });
         }
+        if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+          // Fresh account — free bandwidth pool only, no stake.
+          return new Response(
+            JSON.stringify({ freeNetUsed: 0, freeNetLimit: 600 }),
+            { status: 200 }
+          );
+        }
         return new Response(JSON.stringify({ coins: {} }), { status: 200 });
       })
     );
@@ -458,6 +480,80 @@ describe("getTronStaking (network stubbed)", () => {
     expect(s.pendingUnfreezes).toHaveLength(0);
     expect(s.claimableRewards.amount).toBe("0");
     expect(s.totalStakedUsd).toBe(0);
+    // Fresh account still exposes the free-bandwidth pool.
+    expect(s.resources?.bandwidth.free.availableUnits).toBe(600);
+    expect(s.resources?.bandwidth.staked.limitUnits).toBe(0);
+    expect(s.resources?.energy.limitUnits).toBe(0);
+  });
+
+  it("exposes the live resource meter (bandwidth free + staked, energy, voting power)", async () => {
+    const s = await getTronStaking(addr);
+    expect(s.resources).toBeDefined();
+    expect(s.resources!.bandwidth.free).toEqual({
+      usedUnits: 100,
+      limitUnits: 600,
+      availableUnits: 500,
+    });
+    expect(s.resources!.bandwidth.staked).toEqual({
+      usedUnits: 500,
+      limitUnits: 1200,
+      availableUnits: 700,
+    });
+    expect(s.resources!.energy).toEqual({
+      usedUnits: 10_000,
+      limitUnits: 50_000,
+      availableUnits: 40_000,
+    });
+    expect(s.resources!.votingPower).toEqual({
+      usedUnits: 120,
+      limitUnits: 150,
+      availableUnits: 30,
+    });
+  });
+
+  it("clamps availableUnits to zero when TronGrid reports used > limit (over-spent window)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+          return new Response(JSON.stringify({ data: [{ frozenV2: [] }] }), { status: 200 });
+        }
+        if (url === "https://api.trongrid.io/wallet/getReward") {
+          return new Response(JSON.stringify({ reward: 0 }), { status: 200 });
+        }
+        if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+          return new Response(
+            JSON.stringify({ freeNetUsed: 800, freeNetLimit: 600 }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({ coins: {} }), { status: 200 });
+      })
+    );
+    const s = await getTronStaking(addr);
+    expect(s.resources!.bandwidth.free.availableUnits).toBe(0);
+  });
+
+  it("omits resources when /wallet/getaccountresource fails (rest of the slice still returns)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://api.trongrid.io/v1/accounts/")) {
+          return new Response(JSON.stringify({ data: [{ frozenV2: [] }] }), { status: 200 });
+        }
+        if (url === "https://api.trongrid.io/wallet/getReward") {
+          return new Response(JSON.stringify({ reward: 0 }), { status: 200 });
+        }
+        if (url === "https://api.trongrid.io/wallet/getaccountresource") {
+          return new Response("upstream error", { status: 503 });
+        }
+        return new Response(JSON.stringify({ coins: {} }), { status: 200 });
+      })
+    );
+    const s = await getTronStaking(addr);
+    expect(s.resources).toBeUndefined();
+    expect(s.frozen).toHaveLength(0);
+    expect(s.claimableRewards.amount).toBe("0");
   });
 
   it("throws on malformed wallet address", async () => {

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -497,7 +497,12 @@ describe("renderVerificationBlock includes URL, hash, and the encouragement nudg
     expect(rendered).toContain("TRON");
     expect(rendered).toContain("no browser decoder URL");
     expect(rendered).toContain("tronscan");
-    expect(rendered).toContain(stamped.verification!.payloadHash);
+    // No payload-hash line: TRON app clear-signs every supported action,
+    // so there's no on-device hash for the user to match. txID (below)
+    // is the cross-check anchor.
+    expect(rendered).not.toContain(stamped.verification!.payloadHash);
+    expect(rendered).not.toContain("echoed at send time");
+    expect(rendered).toContain(stamped.txID);
     expect(rendered).not.toContain("SHOW THIS ENTIRE BLOCK TO THE USER VERBATIM");
   });
 });


### PR DESCRIPTION
## Summary

Two related TRON resource-awareness features sharing the `/wallet/getaccountresource` endpoint:

- **Resource meter in `get_tron_staking`** (commit b27e2ac): surfaces live bandwidth/energy pools (free + staked) and remaining units alongside existing staking data. Agent can answer "can I afford this tx?" without forcing the user to read TronGrid's raw shape.

- **Pre-flight bandwidth check in all 7 `prepare_tron_*` builders** (commit c54d3fc): catches `BANDWITH_ERROR` at prepare time, before the Ledger prompt. Computes signed-tx byte length from `raw_data_hex` + 68-byte signature envelope, confirms free+staked bandwidth covers it OR liquid TRX can cover the 1000-sun/byte burn. Throws with an actionable message (top up TRX / wait for free-pool regen / freeze for bandwidth) otherwise.

Motivation: a real vote-cast flow signed on Ledger then failed at broadcast because the account had neither bandwidth nor TRX for the burn. The pre-flight prevents that doom-loop — if the tx can't be broadcast, the user never sees the Ledger prompt.

## Test plan

- [x] 435/435 tests pass (added 5 new pre-flight cases + shared mock helper)
- [x] `npm run build` clean
- [ ] Live: run `get_tron_staking` on a paired account, confirm `resources` block renders
- [ ] Live: attempt `prepare_tron_vote` from a bandwidth-starved account with low TRX — verify prepare-time error rather than sign-then-fail

Generated with Claude Code