### PR TITLE
refactor + audit hardening: boilerplate dedup + 6 security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,10 @@ ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
+# The node:alpine image ships a pre-created unprivileged `node` user/group.
+# Running as root gives a compromise inside the process write access to the
+# whole container filesystem; dropping to `node` keeps the blast radius
+# confined to /app and /tmp. No network/USB privileges are needed — TRON
+# signing runs on the host, this image is for EVM-only read surfaces.
+USER node
 ENTRYPOINT ["node", "dist/index.js"]

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, formatUnits, parseEther, parseUnits } from "viem";
+import { encodeFunctionData, formatUnits, isAddress, parseEther, parseUnits } from "viem";
 import qrcodeTerminal from "qrcode-terminal";
 import {
   initiatePairing,
@@ -266,10 +266,29 @@ export async function prepareEigenLayerDeposit(args: PrepareEigenLayerDepositArg
 
 // ----- Native + ERC-20 transfers -----
 
+/**
+ * Accept recipient addresses that are either all-lowercase hex (no checksum
+ * intent) or valid EIP-55 checksummed. Reject mixed-case with a wrong
+ * checksum — that is the class of error where a user pasted an address with
+ * a single-character case typo; viem's bare `as 0x${string}` cast would
+ * otherwise pass it through silently. viem's `isAddress(x, { strict: true })`
+ * encodes exactly this policy.
+ */
+function assertRecipient(addr: string): `0x${string}` {
+  if (!isAddress(addr, { strict: true })) {
+    throw new Error(
+      `Invalid recipient address ${addr}: failed EIP-55 checksum or malformed hex. ` +
+        `If you pasted a mixed-case address, a single-character case typo is the most ` +
+        `likely cause — re-check the source.`,
+    );
+  }
+  return addr as `0x${string}`;
+}
+
 export async function prepareNativeSend(args: PrepareNativeSendArgs): Promise<UnsignedTx> {
   const wallet = args.wallet as `0x${string}`;
   const chain = args.chain as SupportedChain;
-  const to = args.to as `0x${string}`;
+  const to = assertRecipient(args.to);
   const value = parseEther(args.amount);
   return enrichTx({
     chain,
@@ -286,7 +305,7 @@ export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<Unsi
   const wallet = args.wallet as `0x${string}`;
   const chain = args.chain as SupportedChain;
   const token = args.token as `0x${string}`;
-  const to = args.to as `0x${string}`;
+  const to = assertRecipient(args.to);
   const meta = await resolveTokenMeta(chain, token);
 
   let amountWei: bigint;
@@ -523,9 +542,13 @@ async function runEvmPreSignGuards(tx: UnsignedTx): Promise<void> {
  * appears. `send_transaction` then reads the stashed pin verbatim and
  * forwards it through WalletConnect, so the on-device hash is deterministic.
  *
- * Re-entrant: calling `previewSend` twice on the same handle overwrites the
- * prior pin. This is intentional — if the user pauses for minutes, gas
- * conditions drift and a fresh pin (with a fresh hash) is the right fix.
+ * Re-entrant with an explicit opt-in: calling `previewSend` a second time on
+ * the same handle returns the existing pin verbatim. Pass `refresh: true` to
+ * re-pin (e.g. if the user paused for minutes and wants fresh fees). Without
+ * this guard, a buggy or adversarial agent could silently swap the pre-sign
+ * hash between the moment the user reads it in chat and the moment Ledger
+ * displays it — the hash-match UX would still catch the change, but the
+ * guard makes the default deterministic.
  */
 export async function previewSend(args: PreviewSendArgs): Promise<{
   handle: string;
@@ -539,6 +562,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     maxPriorityFeePerGas: string;
     gas: string;
   };
+  refreshed?: boolean;
 }> {
   if (hasTronHandle(args.handle)) {
     throw new Error(
@@ -548,6 +572,22 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     );
   }
   const tx = consumeHandle(args.handle);
+  const existing = getPinnedGas(args.handle);
+  if (existing && !args.refresh) {
+    return {
+      handle: args.handle,
+      chain: tx.chain,
+      to: tx.to,
+      valueWei: tx.value,
+      preSignHash: existing.preSignHash,
+      pinned: {
+        nonce: existing.nonce,
+        maxFeePerGas: existing.maxFeePerGas.toString(),
+        maxPriorityFeePerGas: existing.maxPriorityFeePerGas.toString(),
+        gas: existing.gas.toString(),
+      },
+    };
+  }
   await runEvmPreSignGuards(tx);
   const from =
     tx.from ?? ((await getConnectedAccounts())[0] as `0x${string}` | undefined);
@@ -588,6 +628,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
       maxPriorityFeePerGas: pinned.maxPriorityFeePerGas.toString(),
       gas: pinned.gas.toString(),
     },
+    ...(existing ? { refreshed: true } : {}),
   };
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -132,7 +132,17 @@ export const previewSendInput = z.object({
         "returns the LEDGER BLIND-SIGN HASH block so the user can see and confirm the " +
         "hash BEFORE the Ledger device prompt appears. A follow-up send_transaction " +
         "call forwards the pinned fields verbatim. Handles expire 15 minutes after " +
-        "prepare; a fresh preview_send call can be made to refresh the pin if fees drift."
+        "prepare. Once a pin exists, re-calling preview_send on the same handle returns " +
+        "the existing pin unchanged unless `refresh: true` is passed."
+    ),
+  refresh: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true to re-pin nonce/fees/gas (e.g. after the user paused for minutes and " +
+        "wants fresh fees). Default is false: the existing pin and its pre-sign hash are " +
+        "returned verbatim, so the hash the user matched in chat cannot silently drift " +
+        "between preview and send."
     ),
 });
 

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -334,6 +334,26 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
     );
   }
 
+  // Exact-in invariant: the approval amount and the swap tx's transferFrom target
+  // are both derived from `quote.action.fromAmount`, while the preview text
+  // (description, decoded.args) echoes the user's `args.amount`. If LiFi returns
+  // a `fromAmount` different from what we asked for, those two values drift and
+  // the user signs bytes that pull more (or less) than the MCP preview shows.
+  // The existing `toUsd / fromUsd > 10` gate is asymmetric and does not catch
+  // proportional inflation. Refuse on any drift — we literally passed
+  // `fromAmount` in, any different value in the response is hostile or buggy.
+  if (!isExactOut) {
+    const quotedFromWei = BigInt(quote.action.fromAmount);
+    if (quotedFromWei !== BigInt(amountWei)) {
+      throw new Error(
+        `LiFi returned fromAmount=${quotedFromWei} for an exact-in quote of ${amountWei} ` +
+          `(${args.amount} ${quote.action.fromToken.symbol}). The approval and swap bytes ` +
+          `would pull a different amount than the MCP preview displays — refusing to return ` +
+          `calldata. Re-run get_swap_quote.`
+      );
+    }
+  }
+
   // Sanity-check the quote before returning signable calldata. LiFi has been observed
   // returning toAmount scaled wrong on certain aggregator integrations (e.g. 10 USDC →
   // ~4500 ETH). The calldata embeds the bogus minOut and won't execute, but we refuse

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -240,7 +240,11 @@ async function pairLedgerLiveFlow(p: Prompt): Promise<void> {
       resolve();
     })
   );
-  console.log(`URI: ${pairing.uri}\n`);
+  // The URI carries the WalletConnect topic + a one-shot symmetric key. It
+  // isn't long-lived key material, but anyone who pairs with it first wins
+  // the session, so keep it out of long-lived logs and terminal scrollback
+  // shared with others.
+  console.log(`URI (sensitive — don't share; one-time pairing secret): ${pairing.uri}\n`);
   console.log("Waiting for you to approve the session in Ledger Live (Ctrl-C to cancel)...");
 
   try {

--- a/src/signing/tron-usb-signer.ts
+++ b/src/signing/tron-usb-signer.ts
@@ -154,6 +154,30 @@ async function openTronApp() {
 }
 
 /**
+ * HID handles are exclusive — two concurrent attempts to open the Ledger USB
+ * transport race and the loser sees "cannot open device". That's only a DoS
+ * today (never a wrong-tx-signed), but it's a noisy failure the moment two
+ * MCP tools run in parallel (e.g. `get_ledger_status` refreshes while a sign
+ * is in flight). Serialize all transport-using calls through a module-local
+ * queue so a second caller waits for the first to finish closing instead of
+ * failing.
+ */
+let usbLock: Promise<void> = Promise.resolve();
+async function withUsbLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = usbLock;
+  let release!: () => void;
+  usbLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
  * Query the device for its TRON address at `path`. Used by `pair_ledger_tron`
  * to cache the address for subsequent sign calls, and as the identity check
  * before signing.
@@ -161,21 +185,23 @@ async function openTronApp() {
 export async function getTronLedgerAddress(
   path: string = DEFAULT_TRON_PATH
 ): Promise<{ address: string; publicKey: string; path: string; appVersion: string }> {
-  const { app, transport, appVersion } = await openTronApp();
-  try {
-    const { address, publicKey } = await app.getAddress(path, false);
-    if (!isTronAddress(address)) {
-      throw new Error(
-        `Ledger returned an address that doesn't look like a TRON mainnet address: "${address}". ` +
-          `Is the TRON (not Tron-classic / testnet) app open on the device?`
-      );
+  return withUsbLock(async () => {
+    const { app, transport, appVersion } = await openTronApp();
+    try {
+      const { address, publicKey } = await app.getAddress(path, false);
+      if (!isTronAddress(address)) {
+        throw new Error(
+          `Ledger returned an address that doesn't look like a TRON mainnet address: "${address}". ` +
+            `Is the TRON (not Tron-classic / testnet) app open on the device?`
+        );
+      }
+      return { address, publicKey, path, appVersion };
+    } catch (e) {
+      throw mapLedgerError(e, "getAddress");
+    } finally {
+      await transport.close().catch(() => {});
     }
-    return { address, publicKey, path, appVersion };
-  } catch (e) {
-    throw mapLedgerError(e, "getAddress");
-  } finally {
-    await transport.close().catch(() => {});
-  }
+  });
 }
 
 export interface TronSignRequest {
@@ -206,31 +232,33 @@ export async function signTronTxOnLedger(
   req: TronSignRequest
 ): Promise<{ signature: string; signerAddress: string }> {
   const path = req.path ?? DEFAULT_TRON_PATH;
-  const { app, transport } = await openTronApp();
-  try {
-    const { address } = await app.getAddress(path, false);
-    if (address !== req.expectedFrom) {
-      throw new Error(
-        `Ledger device address (${address}) does not match the prepared tx's \`from\` ` +
-          `(${req.expectedFrom}). Either connect the Ledger that holds keys for \`from\`, ` +
-          `or re-prepare the tx for the Ledger-derived address (\`pair_ledger_tron\`).`
+  return withUsbLock(async () => {
+    const { app, transport } = await openTronApp();
+    try {
+      const { address } = await app.getAddress(path, false);
+      if (address !== req.expectedFrom) {
+        throw new Error(
+          `Ledger device address (${address}) does not match the prepared tx's \`from\` ` +
+            `(${req.expectedFrom}). Either connect the Ledger that holds keys for \`from\`, ` +
+            `or re-prepare the tx for the Ledger-derived address (\`pair_ledger_tron\`).`
+        );
+      }
+      const signature = await app.signTransaction(
+        path,
+        req.rawDataHex,
+        req.tokenSignatures ?? []
       );
+      // Ledger returns the signature as a hex string (65 bytes: r || s || v).
+      if (!/^[0-9a-fA-F]{130}$/.test(signature)) {
+        throw new Error(
+          `Ledger returned an unexpected signature shape (length ${signature.length}). Expected 130 hex chars.`
+        );
+      }
+      return { signature, signerAddress: address };
+    } catch (e) {
+      throw mapLedgerError(e, "signTransaction");
+    } finally {
+      await transport.close().catch(() => {});
     }
-    const signature = await app.signTransaction(
-      path,
-      req.rawDataHex,
-      req.tokenSignatures ?? []
-    );
-    // Ledger returns the signature as a hex string (65 bytes: r || s || v).
-    if (!/^[0-9a-fA-F]{130}$/.test(signature)) {
-      throw new Error(
-        `Ledger returned an unexpected signature shape (length ${signature.length}). Expected 130 hex chars.`
-      );
-    }
-    return { signature, signerAddress: address };
-  } catch (e) {
-    throw mapLedgerError(e, "signTransaction");
-  } finally {
-    await transport.close().catch(() => {});
-  }
+  });
 }

--- a/test/audit/01-swap-exact-in-approval-divergence.test.ts
+++ b/test/audit/01-swap-exact-in-approval-divergence.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { decodeFunctionData } from "viem";
+import { erc20Abi } from "../../src/abis/erc20.js";
+
+/**
+ * Audit finding R-A1 (Medium): swap exact-in path trusts LiFi's
+ * `quote.action.fromAmount` verbatim for the ERC-20 approval bytes and for the
+ * swap-tx pull amount, while the human-readable preview text
+ * (`description`, `decoded.args`) echoes the user-supplied `args.amount`.
+ *
+ * There is no server-side assertion that
+ *   BigInt(quote.action.fromAmount) === parseUnits(args.amount, decimals)
+ * on the exact-in path.
+ *
+ * A hostile / MITM'd / buggy LiFi response can inflate `fromAmount` (and
+ * scale `toAmount` proportionally so `toUsd / fromUsd` stays < 10 and the
+ * existing sanity gate does not fire). The server then:
+ *   - builds `approve(Diamond, INFLATED)` with description
+ *     "Approve {args.amount} ..." (the small, user-visible lie), and
+ *   - builds the swap tx with description
+ *     "Swap {args.amount} X → ~{quote.toAmount} Y" (same lie on fromDisplay).
+ *
+ * What you preview ≠ what you sign. This test reproduces the divergence.
+ * Fix hypothesis: insert an assert on exact-in that the returned fromAmount
+ * equals the parsed user amount (or refuses outside a tight tolerance).
+ */
+
+// USDC mainnet, USDT mainnet, LiFi Diamond.
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const LIFI_DIAMOND = "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE";
+
+describe("R-A1 — swap exact-in approval/description divergence (audit)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("../../src/config/user-config.js", () => ({
+      readUserConfig: () => null,
+      resolveOneInchApiKey: () => undefined,
+    }));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("refuses exact-in quote whose fromAmount drifts from args.amount (post-fix)", async () => {
+    // User asks for exact-in: 100 USDC → USDT.
+    // Hostile LiFi returns fromAmount = 10,000 USDC (100× the ask) with
+    // proportionally-scaled toAmount so the `toUsd/fromUsd > 10` check
+    // does not trigger. Stablecoin pair chosen so the ratio stays near 1.
+    //
+    // The mitigation is a post-decimals-check invariant in prepareSwap that
+    // compares `BigInt(quote.action.fromAmount)` with `parseUnits(args.amount,
+    // decimals)` on the exact-in branch. If they differ, refuse to return
+    // calldata — the approval + swap bytes would otherwise pull a different
+    // amount than the MCP preview displays.
+    const INFLATED_FROM_WEI = 10_000_000_000n; // 10,000 USDC at 6 decimals
+    const SCALED_TO_WEI = 9_950_000_000n; // 9,950 USDT at 6 decimals (~0.5%)
+
+    vi.doMock("../../src/modules/swap/lifi.js", () => ({
+      fetchQuote: async () => ({
+        tool: "uniswap",
+        action: {
+          fromToken: {
+            symbol: "USDC",
+            decimals: 6,
+            address: USDC,
+            priceUSD: "1",
+          },
+          toToken: {
+            symbol: "USDT",
+            decimals: 6,
+            address: USDT,
+            priceUSD: "1",
+          },
+          fromAmount: INFLATED_FROM_WEI.toString(),
+        },
+        estimate: {
+          fromAmount: INFLATED_FROM_WEI.toString(),
+          toAmount: SCALED_TO_WEI.toString(),
+          toAmountMin: (SCALED_TO_WEI - SCALED_TO_WEI / 200n).toString(),
+          approvalAddress: LIFI_DIAMOND,
+          executionDuration: 30,
+          feeCosts: [],
+          gasCosts: [],
+        },
+        transactionRequest: {
+          to: LIFI_DIAMOND,
+          data: "0xdeadbeef", // opaque Diamond calldata — irrelevant for this PoC
+          value: "0x0",
+          gasLimit: "0x30d40",
+        },
+      }),
+      fetchStatus: async () => ({}),
+    }));
+
+    // Stub RPC so decimals & allowance reads succeed without a network.
+    vi.doMock("../../src/data/rpc.js", () => ({
+      getClient: () => ({
+        readContract: async ({ functionName }: { functionName: string }) => {
+          if (functionName === "decimals") return 6;
+          if (functionName === "allowance") return 0n;
+          return 0;
+        },
+      }),
+      resetClients: () => {},
+    }));
+
+    const { prepareSwap } = await import("../../src/modules/swap/index.js");
+
+    await expect(
+      prepareSwap({
+        wallet: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: USDC,
+        toToken: USDT,
+        amount: "100", // user asks to swap 100 USDC, exact-in
+        // no slippageBps override — defaults to 50 (LiFi default)
+      }),
+    ).rejects.toThrow(/fromAmount/i);
+  });
+
+  it("happy path: matching fromAmount passes the invariant", async () => {
+    // Sanity check — a normal LiFi response where fromAmount equals the user's
+    // parsed input should produce a valid approval + swap chain as before.
+    const MATCHING_FROM_WEI = 100_000_000n; // 100 USDC
+
+    vi.doMock("../../src/modules/swap/lifi.js", () => ({
+      fetchQuote: async () => ({
+        tool: "uniswap",
+        action: {
+          fromToken: { symbol: "USDC", decimals: 6, address: USDC, priceUSD: "1" },
+          toToken: { symbol: "USDT", decimals: 6, address: USDT, priceUSD: "1" },
+          fromAmount: MATCHING_FROM_WEI.toString(),
+        },
+        estimate: {
+          fromAmount: MATCHING_FROM_WEI.toString(),
+          toAmount: "99500000",
+          toAmountMin: "99000000",
+          approvalAddress: LIFI_DIAMOND,
+          executionDuration: 30,
+          feeCosts: [],
+          gasCosts: [],
+        },
+        transactionRequest: {
+          to: LIFI_DIAMOND,
+          data: "0xdeadbeef",
+          value: "0x0",
+          gasLimit: "0x30d40",
+        },
+      }),
+      fetchStatus: async () => ({}),
+    }));
+    vi.doMock("../../src/data/rpc.js", () => ({
+      getClient: () => ({
+        readContract: async ({ functionName }: { functionName: string }) => {
+          if (functionName === "decimals") return 6;
+          if (functionName === "allowance") return 0n;
+          return 0;
+        },
+      }),
+      resetClients: () => {},
+    }));
+
+    const { prepareSwap } = await import("../../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: USDC,
+      toToken: USDT,
+      amount: "100",
+    });
+
+    expect(tx.decoded?.functionName).toBe("approve");
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    const [, amountEncoded] = decoded.args as [`0x${string}`, bigint];
+    expect(amountEncoded).toBe(MATCHING_FROM_WEI);
+  });
+
+});
+
+// ## Proof Explanation
+// 1. The user calls prepare_swap with amount="100" USDC (exact-in).
+// 2. A hostile/MITM'd LiFi returns fromAmount=10_000_000_000 (10,000 USDC)
+//    and a proportionally scaled toAmount so the existing toUsd/fromUsd > 10
+//    sanity check does not trigger.
+// 3. prepareSwap's exact-in invariant (added as VP-01 mitigation) asserts
+//    `BigInt(quote.action.fromAmount) === BigInt(parseUnits(args.amount, decimals))`
+//    right after the decimals cross-check. Any drift throws — no calldata is
+//    returned, the user never signs a tx whose bytes pull a different amount
+//    than the preview claims.
+// 4. The first test asserts the thrown error references `fromAmount`.
+// 5. The second test is a happy-path regression: when LiFi's response is
+//    honest (fromAmount matches the parsed user input), the approval bytes
+//    decode to the correct amount and the flow continues to produce the
+//    approve + swap chain.


### PR DESCRIPTION
## Summary
- **Refactor (88b06cd):** dedup token-meta + approval-chain boilerplate across action builders (Aave, Compound, Morpho, Lido, EigenLayer, sends). Shared helpers live in `src/modules/shared/{token-meta,approval}.ts`.
- **Security hardening (b606722):** 1 Medium + 5 defensive fixes surfaced by a full-surface audit of the tx-construction pipeline:
  - **swap exact-in (Medium):** `prepareSwap` now asserts `BigInt(quote.action.fromAmount) === parseUnits(args.amount, decimals)` right after the decimals cross-check. Without this, a hostile/MITM'd LiFi response could inflate `fromAmount` (with `toAmount` scaled proportionally to dodge the `toUsd/fromUsd > 10` gate) so the approval + swap bytes pull more than the MCP preview displays.
  - **EIP-55 on recipient:** `prepareNativeSend` / `prepareTokenSend` now reject mixed-case recipients with a wrong EIP-55 checksum via `isAddress(x, { strict: true })`; all-lowercase still accepted. Catches single-character case typos before bytes reach Ledger.
  - **`preview_send` pin guard:** re-calls return the existing pin verbatim unless `refresh: true` is passed. The `preSignHash` the user matched in chat can no longer silently drift before Ledger displays it.
  - **TRON USB serialization:** `getTronLedgerAddress` / `signTronTxOnLedger` run under a module-local promise-chain lock so concurrent HID opens queue instead of colliding on the exclusive transport.
  - **Pairing URI label:** printed URI is now labeled `(sensitive — don't share; one-time pairing secret)`.
  - **Dockerfile:** runtime stage drops to `USER node`.
- New regression test `test/audit/01-swap-exact-in-approval-divergence.test.ts` covers the Medium fix (refusal on drift + happy-path regression).

## Test plan
- [x] `npx vitest run` — 444/444 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: run a real LiFi swap through `prepare_swap` → `preview_send` → `send_transaction` on testnet or small mainnet amount, confirm no regression in the normal flow
- [ ] Manual: call `preview_send` twice on the same handle, confirm second call returns the same `preSignHash` without `refresh: true`
- [ ] Manual: attempt `prepare_native_send` with a mixed-case-wrong-checksum recipient, confirm refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)