### PR TITLE
feat(verification-artifact): include `from` so the second agent can auto-check recipient-vs-signer

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -782,6 +782,12 @@ const SECOND_AGENT_INSTRUCTIONS = [
   "  3. Flag red flags: unlimited approvals (uint256.max), unknown destinations,",
   "     nested delegatecalls, transfers to addresses that don't match the stated",
   "     recipient, approvals to spenders that are not well-known protocol routers.",
+  "     Specifically: if the calldata embeds a recipient / `to` / unwrap target",
+  "     (e.g. unwrapWETH9's recipient, a bridge's destination, a transfer's `to`),",
+  "     compare it to payload.from. If they match, it is the signer's own wallet",
+  "     — that is the expected case for swaps/unwraps/withdrawals. If they DIFFER,",
+  "     the user is sending value to a third party and should confirm that",
+  "     destination was intentional.",
   "  4. If you cannot decode the selector (not in your training data), say so — do",
   "     not guess. 'I don't know this selector' is the correct answer when true.",
   "  5. Remind the user: before tapping 'Approve' on the Ledger, match the hash shown",
@@ -820,6 +826,15 @@ export interface EvmVerificationArtifact {
   handle: string;
   chain: SupportedChain;
   chainId: number;
+  /**
+   * The signer / paired wallet. Surfaced on the artifact (and inside the
+   * pasteable payload) so the second agent can auto-check "is the recipient
+   * embedded in the calldata the signer's own wallet or a third party?" —
+   * the common case that a second agent otherwise has to flag uncertainly.
+   * Optional on the type because UnsignedTx.from is optional, but populated
+   * in practice for every tx our prepare_* tools produce.
+   */
+  from?: `0x${string}`;
   to: `0x${string}`;
   value: string;
   data: `0x${string}`;
@@ -887,6 +902,7 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       data: tx.data,
       payloadHash: tx.verification.payloadHash,
     };
+    if (tx.from) pasteablePayload.from = tx.from;
     if (pin) pasteablePayload.preSignHash = pin.preSignHash;
     const artifact: EvmVerificationArtifact = {
       artifactVersion: "v1",
@@ -899,6 +915,7 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       payloadHash: tx.verification.payloadHash,
       pasteableBlock: buildPasteableBlock(pasteablePayload),
     };
+    if (tx.from) artifact.from = tx.from;
     if (pin) artifact.preSignHash = pin.preSignHash;
     return artifact;
   }

--- a/test/verification-artifact.test.ts
+++ b/test/verification-artifact.test.ts
@@ -48,6 +48,10 @@ describe("get_verification_artifact — second-agent copy-paste artifact", () =>
     expect(artifact.value).toBe(stamped.value);
     expect(artifact.data).toBe(stamped.data);
     expect(artifact.payloadHash).toBe(stamped.verification!.payloadHash);
+    // `from` must be surfaced so the second agent can auto-check whether
+    // in-calldata recipients (unwrapWETH9 target, bridge dest, transfer `to`)
+    // match the signer or are a third party.
+    expect(artifact.from).toBe(SENDER);
 
     // preview_send has not been called, so preSignHash must not be present.
     expect(artifact.preSignHash).toBeUndefined();
@@ -68,6 +72,9 @@ describe("get_verification_artifact — second-agent copy-paste artifact", () =>
     expect(artifact.pasteableBlock).toContain(stamped.data);
     expect(artifact.pasteableBlock).toContain(stamped.to);
     expect(artifact.pasteableBlock).toContain(stamped.verification!.payloadHash);
+    // `from` must appear inside the pasted payload too — the second agent
+    // reads payload.from to perform the recipient-vs-signer comparison.
+    expect(artifact.pasteableBlock).toContain(SENDER);
     // Old field name must be gone — future refactors should not resurrect it.
     const bag = artifact as unknown as Record<string, unknown>;
     expect(bag.instructionsForSecondAgent).toBeUndefined();


### PR DESCRIPTION
## Summary
- Surface `from` on the EVM verification artifact and inside the pasteable payload
- Extend the canned second-agent prompt to explicitly compare embedded recipients against `payload.from`
- TRON artifact already carried `from` — only the EVM path needed this

## Motivation
The second-agent verification artifact exists so the user can paste a prepared tx into an independent LLM and get an adversarial from-scratch decode. Observed in practice with `prepare_uniswap_swap`: the second agent repeatedly flagged in-calldata recipients (unwrapWETH9's recipient, bridge destinations, transfer `to`) as "not the signer" — because the payload carried no signer to compare against. User has to manually confirm every time.

With `from` in the payload plus an explicit rule in the prompt, the second agent can auto-resolve the common case (signer == embedded recipient → expected self-targeted op like a swap unwrap or withdrawal) and only escalate when the embedded recipient differs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 471/471 pass
- [x] New assertions in `test/verification-artifact.test.ts`: `artifact.from === SENDER` and `pasteableBlock` contains SENDER
- [ ] Manual: run `prepare_uniswap_swap` → `get_verification_artifact(handle)` and paste into a second LLM; confirm it auto-identifies the unwrap recipient as the signer

🤖 Generated with [Claude Code](https://claude.com/claude-code)