### PR TITLE
Release 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@ledgerhq/hw-app-trx": "^6.34.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Bumps `package.json` + `server.json` to `0.5.1`. Cuts a release covering everything merged since `v0.5.0`.

## What's shipping since 0.5.0

### New tools

- `get_verification_artifact` — second-agent cross-verification via a sparse, copy-paste-ready JSON payload (PR #48).
- `prepare_uniswap_swap` — direct Uniswap V3 routing for clear-signed swaps (PR #51).
- `get_market_incident_status` — Aave V3 + Compound V3 + Morpho Blue incident/pause surfaces (PR #42 bundle).
- `get_compound_market_info` — Compound V3 market facts + governance state (PR #42 bundle).
- `get_token_metadata` — ERC-20 symbol/decimals/name lookup (PR #42 bundle).

### Defenses / gates

- **`previewToken` + `userDecision: "send"` gate on `send_transaction`** (PR #53) — closes accidental `preview_send` → `send_transaction` collapse. Schema-enforced; clear-error refusal on miss/mismatch.
- **`from` in `get_verification_artifact`** (PR #52) — enables in-calldata recipient-vs-signer auto-check.
- **Peer-trust warning allowlist** (PR #54) — `get_ledger_status` only emits `peerTrustWarning` when the paired WC peer host is NOT on the `*.ledger.com` allowlist. Quiets the common case; still loud on unknowns.
- **Pre-flight checks** (PRs #42, #43, #44) — Aave reserve state, Compound pause state, TRON bandwidth/energy before tx build.

### UX / behavior

- Priority-fee floor lowered from `1.5` → `0.5` gwei (PR #54).
- Proactive capability-request offers (PR #50) — agent offers a `request_capability` call when a gap is encountered, instead of just narrating it.
- Richer `simulate_transaction` revert decoding (PR #42 bundle).
- `simulate_position_change` extended to Compound V3 + Morpho Blue (PR #42 bundle).
- TRON post-broadcast polling tuned per-chain (PR #43); TRON preview + verify-decode block.
- Governance pause state surfaced in position readers (PR #42 bundle).

### Docs + chore

- README Security-section refresh — defenses table + threat-catch mapping updated for `previewToken` gate, `from` auto-check, server-side second-agent verification roadmap entry (PR #54).
- `CLAUDE.md` added with preflight / git / tool-use / incident guidance (PR #45).
- Refactor: token-meta + approval-chain dedup (PR #47).
- Security audit findings closed (PR #46).
- `.gitignore`: `.context/` (crypto-audit scratch), `.claude/` (local Claude Code state).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 479/479 pass
- [ ] Merge → create GH release `v0.5.1` → CI publishes to npm (OIDC provenance) + MCP registry via `.github/workflows/publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)