### PR TITLE
chore(lifi): set integrator address to 0xC0f5b7f7703BA95dC7C09D4eF50A830622234075

### DIFF
--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -7,7 +7,7 @@ let initialized = false;
 export function initLifi(): void {
   if (initialized) return;
   createConfig({
-    integrator: "vaultpilot-mcp",
+    integrator: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
     // We don't execute routes through LiFi — we just fetch tx data and hand it to WalletConnect.
   });
   initialized = true;

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -624,7 +624,7 @@ describe("decodeCalldata — LiFi Diamond", () => {
       functionName: "swapTokensMultipleV3ERC20ToNative",
       args: [
         `0x${"00".repeat(32)}` as `0x${string}`,
-        "vaultpilot-mcp",
+        "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
         "",
         SENDER,
         42_000_000_000_000_000n,


### PR DESCRIPTION
## Summary

- Set the LiFi `integrator` identifier to the on-chain address `0xC0f5b7f7703BA95dC7C09D4eF50A830622234075` in `createConfig`. This is the string that LiFi forwards as `_integrator` in the diamond swap calldata.
- Update the round-trip decode test sample value for consistency.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 479/479 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)