### PR TITLE
chore(lifi): set integrator to "vaultpilot-mcp"

### DIFF
--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -7,7 +7,7 @@ let initialized = false;
 export function initLifi(): void {
   if (initialized) return;
   createConfig({
-    integrator: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+    integrator: "vaultpilot-mcp",
     // We don't execute routes through LiFi — we just fetch tx data and hand it to WalletConnect.
   });
   initialized = true;


### PR DESCRIPTION
## Summary
- Revert the LiFi SDK `integrator` string from the address set in PR #58 back to `"vaultpilot-mcp"`.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 481/481 pass