### PR TITLE
feat(history): add get_transaction_history tool

### DIFF
--- a/src/config/cache.ts
+++ b/src/config/cache.ts
@@ -8,6 +8,8 @@ export const CACHE_TTL = {
   SECURITY_PERMISSIONS: 3_600_000,
   PROTOCOL_RISK: 3_600_000,
   IMMUNEFI: 86_400_000,
+  HISTORY: 60_000,
+  HISTORICAL_PRICE: 2_592_000_000,
 } as const;
 
 export type CacheTTLKey = keyof typeof CACHE_TTL;

--- a/src/data/apis/etherscan-v2.ts
+++ b/src/data/apis/etherscan-v2.ts
@@ -1,0 +1,131 @@
+import { CHAIN_IDS } from "../../types/index.js";
+import type { SupportedChain } from "../../types/index.js";
+import { resolveEtherscanApiKey, readUserConfig } from "../../config/user-config.js";
+
+/**
+ * Etherscan V2 unified client.
+ *
+ * V1 per-chain endpoints (api.etherscan.io, api.arbiscan.io, ...) were
+ * deprecated and now return `{status:"0",message:"NOTOK",result:"...V1 deprecated..."}`
+ * for every call. V2 consolidates all chains behind a single host with a
+ * `chainid` query param and requires an API key (no anonymous tier).
+ *
+ * One key now covers ETH/Arbitrum/Polygon/Base — set ETHERSCAN_API_KEY in the
+ * server env or run `vaultpilot-mcp-setup` to stash it in the user config.
+ */
+
+const V2_BASE = "https://api.etherscan.io/v2/api";
+
+/** Match `etherscan.ts`'s existing guardrail. */
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+interface EtherscanEnvelope<T> {
+  status: string;
+  message: string;
+  result: T | string;
+}
+
+export class EtherscanApiKeyMissingError extends Error {
+  constructor() {
+    super(
+      "ETHERSCAN_API_KEY is not set. Etherscan V2 requires an API key — " +
+        "get a free one at https://etherscan.io/apis and set ETHERSCAN_API_KEY " +
+        "in the MCP server env, or run `vaultpilot-mcp-setup` to store it in " +
+        "~/.vaultpilot/config.json."
+    );
+    this.name = "EtherscanApiKeyMissingError";
+  }
+}
+
+/** Structured signal for "Etherscan accepted the call but has no data". */
+export class EtherscanNoDataError extends Error {
+  constructor(action: string) {
+    super(`Etherscan ${action}: no records`);
+    this.name = "EtherscanNoDataError";
+  }
+}
+
+/**
+ * Issue a V2 request and return the parsed `result` array. Throws on:
+ *  - missing API key (EtherscanApiKeyMissingError)
+ *  - HTTP error
+ *  - oversized response (>2MB)
+ *  - NOTOK with non-"no records" message (surfaces the `result` field so the
+ *    caller/agent can see the real reason, e.g. rate limit or deprecation)
+ *
+ * Returns [] for the benign "no transactions found" shape.
+ */
+export async function etherscanV2Fetch<T>(
+  chain: SupportedChain,
+  params: Record<string, string>
+): Promise<T[]> {
+  const apiKey = resolveEtherscanApiKey(readUserConfig());
+  if (!apiKey) throw new EtherscanApiKeyMissingError();
+
+  const qs = new URLSearchParams({
+    chainid: String(CHAIN_IDS[chain]),
+    ...params,
+    apikey: apiKey,
+  });
+
+  const res = await fetch(`${V2_BASE}?${qs.toString()}`);
+  if (!res.ok) {
+    // Don't include the URL — it carries apikey. Surface status only.
+    throw new Error(`Etherscan V2 ${chain} ${params.action} returned ${res.status}`);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(
+      `Etherscan V2 ${chain} ${params.action} response exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length})`
+    );
+  }
+  const body = JSON.parse(text) as EtherscanEnvelope<T[]>;
+  if (body.status !== "1") {
+    const resultStr = typeof body.result === "string" ? body.result : "";
+    const combined = `${body.message || ""} ${resultStr}`.toLowerCase();
+    if (combined.includes("no transactions") || combined.includes("no records")) {
+      return [];
+    }
+    // Surface the `result` field: it carries the user-useful reason
+    // ("Missing/Invalid API Key", "Max calls per sec rate limit reached", etc.).
+    const detail = resultStr || body.message || "unknown";
+    throw new Error(`Etherscan V2 ${chain} ${params.action}: ${detail}`);
+  }
+  return Array.isArray(body.result) ? body.result : [];
+}
+
+/**
+ * Lower-level variant for endpoints that return a single object, not an
+ * array (e.g. some contract-level queries). Same error semantics.
+ */
+export async function etherscanV2FetchRaw<T>(
+  chain: SupportedChain,
+  params: Record<string, string>
+): Promise<T> {
+  const apiKey = resolveEtherscanApiKey(readUserConfig());
+  if (!apiKey) throw new EtherscanApiKeyMissingError();
+
+  const qs = new URLSearchParams({
+    chainid: String(CHAIN_IDS[chain]),
+    ...params,
+    apikey: apiKey,
+  });
+
+  const res = await fetch(`${V2_BASE}?${qs.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Etherscan V2 ${chain} ${params.action} returned ${res.status}`);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(
+      `Etherscan V2 ${chain} ${params.action} response exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length})`
+    );
+  }
+  const body = JSON.parse(text) as EtherscanEnvelope<T>;
+  if (body.status !== "1") {
+    const resultStr = typeof body.result === "string" ? body.result : "";
+    const detail = resultStr || body.message || "unknown";
+    throw new Error(`Etherscan V2 ${chain} ${params.action}: ${detail}`);
+  }
+  return body.result as T;
+}

--- a/src/data/apis/etherscan.ts
+++ b/src/data/apis/etherscan.ts
@@ -1,14 +1,10 @@
 import { cache } from "../cache.js";
 import { CACHE_TTL } from "../../config/cache.js";
-import { resolveEtherscanApiKey, readUserConfig } from "../../config/user-config.js";
+import {
+  etherscanV2Fetch,
+  EtherscanApiKeyMissingError,
+} from "./etherscan-v2.js";
 import type { SupportedChain } from "../../types/index.js";
-
-const API_BASE: Record<SupportedChain, string> = {
-  ethereum: "https://api.etherscan.io/api",
-  arbitrum: "https://api.arbiscan.io/api",
-  polygon: "https://api.polygonscan.com/api",
-  base: "https://api.basescan.org/api",
-};
 
 export interface ContractInfo {
   address: `0x${string}`;
@@ -49,15 +45,21 @@ interface EtherscanSourceCodeItem {
   Implementation: string;
 }
 
-interface EtherscanResponse<T> {
-  status: string;
-  message: string;
-  result: T;
-}
-
 /**
- * Fetch contract verification info from Etherscan / Arbiscan.
- * Cached for 24 hours — verification state rarely changes.
+ * Fetch contract verification info via Etherscan V2. Cached for 24 hours —
+ * verification state rarely changes.
+ *
+ * V2 migration note: the per-chain V1 endpoints (api.etherscan.io,
+ * api.arbiscan.io, ...) were deprecated in 2025 and now NOTOK every call.
+ * V2 consolidates all chains behind a single host with `chainid`; the call
+ * shape is otherwise unchanged. An ETHERSCAN_API_KEY is now required.
+ *
+ * Error discipline: real errors (missing key, rate limit, HTTP failure)
+ * throw and are NOT cached. Only legitimate "contract exists but isn't
+ * verified" responses (status:"1", empty SourceCode) are cached as
+ * `{isVerified: false}`. This matters because caching an error as
+ * "unverified" would lock callers out for 24h and silently degrade the
+ * security-review path.
  */
 export async function getContractInfo(
   address: `0x${string}`,
@@ -67,37 +69,23 @@ export async function getContractInfo(
   const hit = cache.get<ContractInfo>(key);
   if (hit) return hit;
 
-  const apiKey = resolveEtherscanApiKey(readUserConfig());
-  const params = new URLSearchParams({
-    module: "contract",
-    action: "getsourcecode",
-    address,
-  });
-  if (apiKey) params.set("apikey", apiKey);
-
-  const url = `${API_BASE[chain]}?${params.toString()}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Etherscan request failed: ${res.status} ${res.statusText}`);
+  let rows: EtherscanSourceCodeItem[];
+  try {
+    rows = await etherscanV2Fetch<EtherscanSourceCodeItem>(chain, {
+      module: "contract",
+      action: "getsourcecode",
+      address,
+    });
+  } catch (e) {
+    // Surface the underlying error untouched — EtherscanApiKeyMissingError
+    // carries a helpful message, and transient errors (rate limit, etc.)
+    // should not pollute the 24h cache with a fake "not verified".
+    if (e instanceof EtherscanApiKeyMissingError) throw e;
+    throw e;
   }
 
-  // Bound the response before JSON-parsing. Etherscan has been well-behaved,
-  // but the response is cached 24h in memory — an unbounded blob is both a
-  // memory-pressure vector and gives a MITM with a broken TLS setup room to
-  // inject a huge payload. 2MB covers the largest verified contracts we've
-  // seen (fully-resolved imports of flattened DeFi protocols top out ~1MB)
-  // with a comfortable margin.
-  const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
-  const text = await res.text();
-  if (text.length > MAX_RESPONSE_BYTES) {
-    throw new Error(
-      `Etherscan response for ${address} on ${chain} exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length}). Refusing to parse.`
-    );
-  }
-  const body = JSON.parse(text) as EtherscanResponse<EtherscanSourceCodeItem[]>;
-
-  if (body.status !== "1" || !body.result?.[0]) {
-    // Unverified contracts still return a valid response with empty SourceCode.
+  if (!rows[0]) {
+    // status:"1" with empty result — treat as unverified.
     const result: ContractInfo = {
       address,
       chain,
@@ -108,7 +96,7 @@ export async function getContractInfo(
     return result;
   }
 
-  const item = body.result[0];
+  const item = rows[0];
   const isVerified = item.SourceCode !== "";
   let abi: unknown[] | undefined;
   if (isVerified && item.ABI && item.ABI !== "Contract source code not verified") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ import {
 import { getPortfolioSummary } from "./modules/portfolio/index.js";
 import { getPortfolioSummaryInput } from "./modules/portfolio/schemas.js";
 
+import { getTransactionHistory } from "./modules/history/index.js";
+import { getTransactionHistoryInput } from "./modules/history/schemas.js";
+
 import { getSwapQuote, prepareSwap } from "./modules/swap/index.js";
 import { getSwapQuoteInput, prepareSwapInput } from "./modules/swap/schemas.js";
 import { prepareUniswapSwap } from "./modules/uniswap-swap/index.js";
@@ -781,6 +784,16 @@ async function main() {
       inputSchema: getPortfolioSummaryInput.shape,
     },
     handler(getPortfolioSummary)
+  );
+
+  server.registerTool(
+    "get_transaction_history",
+    {
+      description:
+        "Fetch a wallet's recent on-chain transaction history on a single chain, merged across external (user-initiated) txs, ERC-20/TRC-20 token transfers, and internal (contract-initiated) txs. Results are sorted newest-first, capped at `limit` (default 25, max 50), and annotated with decoded method names (via 4byte.directory) and historical USD values at the time of each tx (via DefiLlama). Supports Ethereum/Arbitrum/Polygon/Base via Etherscan and TRON via TronGrid. TRON does not expose internal txs, so `includeInternal` is silently ignored there. Use this to answer 'what did I do last week?', 'show me my recent swaps', or 'did I already approve X?' without the user pasting tx hashes. Read-only — no signing, no broadcast.",
+      inputSchema: getTransactionHistoryInput.shape,
+    },
+    handler(getTransactionHistory)
   );
 
   // ---- Module 5: Swap/Bridge (LiFi) ----

--- a/src/modules/history/decode.ts
+++ b/src/modules/history/decode.ts
@@ -1,0 +1,70 @@
+import { fetch4byteSignatures } from "../../data/apis/fourbyte.js";
+import { cache } from "../../data/cache.js";
+
+/**
+ * Resolve a batch of 4-byte selectors to human-readable function names.
+ *
+ * Strategy: for each unique selector, query 4byte.directory (wrapped by the
+ * existing `fetch4byteSignatures` helper, which doesn't cache internally, so
+ * we wrap with a 24h cache keyed per selector). We deliberately do NOT do the
+ * "re-encode every candidate and match against calldata" dance that
+ * `verifyEvmCalldata` performs — that's far too expensive for bulk history
+ * and we don't have the calldata contextually anyway (txlist only returns
+ * `input` on the first item per tx). If a selector resolves to multiple
+ * candidates we pick the first (4byte returns most-common first by ID) and
+ * record `ambiguous: true` so the caller can surface uncertainty.
+ *
+ * Failures are swallowed — method decoding is a nice-to-have, never fatal.
+ */
+
+const SELECTOR_TTL = 86_400_000; // 24h — selectors don't change, but cache eviction needs a bound.
+
+export interface SelectorResolution {
+  methodName?: string;
+  ambiguous?: boolean;
+}
+
+export async function resolveSelectors(
+  selectors: string[]
+): Promise<Map<string, SelectorResolution>> {
+  const unique = Array.from(new Set(selectors.filter((s) => /^0x[0-9a-fA-F]{8}$/.test(s))));
+  const out = new Map<string, SelectorResolution>();
+
+  await Promise.all(
+    unique.map(async (sel) => {
+      const key = `4byte:${sel.toLowerCase()}`;
+      const cached = cache.get<SelectorResolution>(key);
+      if (cached) {
+        out.set(sel, cached);
+        return;
+      }
+      try {
+        const sigs = await fetch4byteSignatures(sel);
+        if (sigs.length === 0) {
+          const res: SelectorResolution = {};
+          cache.set(key, res, SELECTOR_TTL);
+          out.set(sel, res);
+          return;
+        }
+        // Take the name (part before "(") of the first candidate. 4byte
+        // returns candidates ordered by created-ID; the earliest-created
+        // signature is usually the canonical one, but the field is also
+        // attacker-insertable, so we sanitize the name before surfacing.
+        const first = sigs[0];
+        const parenIdx = first.indexOf("(");
+        const rawName = parenIdx > 0 ? first.slice(0, parenIdx) : first;
+        const methodName = rawName.replace(/[^A-Za-z0-9_]/g, "").slice(0, 64);
+        const res: SelectorResolution = {
+          ...(methodName ? { methodName } : {}),
+          ...(sigs.length > 1 ? { ambiguous: true } : {}),
+        };
+        cache.set(key, res, SELECTOR_TTL);
+        out.set(sel, res);
+      } catch {
+        // 4byte outage = method names simply missing; not an error for history.
+      }
+    })
+  );
+
+  return out;
+}

--- a/src/modules/history/evm.ts
+++ b/src/modules/history/evm.ts
@@ -1,0 +1,256 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import { resolveEtherscanApiKey, readUserConfig } from "../../config/user-config.js";
+import { sanitizeContractName } from "../../data/apis/etherscan.js";
+import type { SupportedChain } from "../../types/index.js";
+import type {
+  ExternalHistoryItem,
+  TokenTransferHistoryItem,
+  InternalHistoryItem,
+} from "./schemas.js";
+
+const API_BASE: Record<SupportedChain, string> = {
+  ethereum: "https://api.etherscan.io/api",
+  arbitrum: "https://api.arbiscan.io/api",
+  polygon: "https://api.polygonscan.com/api",
+  base: "https://api.basescan.org/api",
+};
+
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const SERVER_ROW_CAP = 100;
+const MAX_SYMBOL_LEN = 32;
+const MAX_NAME_LEN = 64;
+
+interface EtherscanEnvelope<T> {
+  status: string;
+  message: string;
+  result: T | string;
+}
+
+interface TxListItem {
+  hash: string;
+  timeStamp: string;
+  from: string;
+  to: string;
+  value: string;
+  input: string;
+  isError: string;
+  txreceipt_status?: string;
+}
+
+interface TokenTxItem {
+  hash: string;
+  timeStamp: string;
+  from: string;
+  to: string;
+  contractAddress: string;
+  value: string;
+  tokenSymbol: string;
+  tokenName: string;
+  tokenDecimal: string;
+}
+
+interface InternalTxItem {
+  hash: string;
+  timeStamp: string;
+  from: string;
+  to: string;
+  value: string;
+  isError: string;
+  traceId?: string;
+}
+
+async function etherscanFetch<T>(
+  chain: SupportedChain,
+  params: Record<string, string>
+): Promise<T[]> {
+  const apiKey = resolveEtherscanApiKey(readUserConfig());
+  const qs = new URLSearchParams({
+    ...params,
+    page: "1",
+    offset: String(SERVER_ROW_CAP),
+    sort: "desc",
+  });
+  if (apiKey) qs.set("apikey", apiKey);
+
+  const res = await fetch(`${API_BASE[chain]}?${qs.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Etherscan ${chain} ${params.action} returned ${res.status}`);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(
+      `Etherscan ${chain} ${params.action} response exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length})`
+    );
+  }
+  const body = JSON.parse(text) as EtherscanEnvelope<T[]>;
+  if (body.status !== "1") {
+    if (typeof body.result === "string" && body.result.toLowerCase().includes("no transactions")) {
+      return [];
+    }
+    if (body.message?.toLowerCase().includes("no transactions")) {
+      return [];
+    }
+    throw new Error(
+      `Etherscan ${chain} ${params.action} error: ${body.message || "unknown"}`
+    );
+  }
+  return Array.isArray(body.result) ? body.result : [];
+}
+
+function formatUnitsDecimal(raw: string, decimals: number): string {
+  if (!/^\d+$/.test(raw)) return "0";
+  if (decimals === 0) return raw;
+  const padded = raw.padStart(decimals + 1, "0");
+  const whole = padded.slice(0, padded.length - decimals);
+  const frac = padded.slice(padded.length - decimals).replace(/0+$/, "");
+  return frac.length > 0 ? `${whole}.${frac}` : whole;
+}
+
+function toExternal(t: TxListItem): ExternalHistoryItem {
+  const input = typeof t.input === "string" ? t.input : "0x";
+  const methodSelector =
+    input.length >= 10 && input.startsWith("0x") ? input.slice(0, 10) : undefined;
+  const failed = t.isError === "1" || t.txreceipt_status === "0";
+  const valueWei = /^\d+$/.test(t.value) ? t.value : "0";
+  return {
+    type: "external",
+    hash: t.hash,
+    timestamp: Number(t.timeStamp),
+    from: t.from,
+    to: t.to,
+    valueNative: valueWei,
+    valueNativeFormatted: formatUnitsDecimal(valueWei, 18),
+    status: failed ? "failed" : "success",
+    ...(methodSelector ? { methodSelector } : {}),
+  };
+}
+
+/**
+ * Whitelist letters/digits/spaces/dots/dashes/underscores only. Symbol and
+ * name fields on-chain are attacker-controlled at deploy time and are heavily
+ * phishing-targeted ("CLAIM https://...", zero-width joiners that render as
+ * URLs). Whitelisting removes the entire injection surface at the cost of a
+ * few legitimate exotic symbols — acceptable trade for a read-only history.
+ */
+function sanitizeDisplayString(raw: string | undefined, maxLen: number): string {
+  if (!raw) return "";
+  return raw.replace(/[^A-Za-z0-9 ._\-]/g, "").trim().slice(0, maxLen);
+}
+
+function toTokenTransfer(t: TokenTxItem): TokenTransferHistoryItem | null {
+  // Drop rows whose raw symbol/name hints at obvious phishing. Err on the side
+  // of dropping — a missing row is better than a sanitized-but-still-suspicious
+  // one where the injection was carried in an already-dropped Unicode char.
+  const rawSymbolLower = (t.tokenSymbol ?? "").toLowerCase();
+  const rawNameLower = (t.tokenName ?? "").toLowerCase();
+  if (/https?|www\.|claim|visit|airdrop|\.com|\.io|\.app|\.xyz|\.net/.test(rawSymbolLower)) return null;
+  if (/https?|www\.|claim|visit|airdrop|\.com|\.io|\.app|\.xyz|\.net/.test(rawNameLower)) return null;
+
+  const rawSymbol = sanitizeDisplayString(t.tokenSymbol, MAX_SYMBOL_LEN);
+  sanitizeDisplayString(t.tokenName, MAX_NAME_LEN);
+  const tokenSymbol = rawSymbol || "UNKNOWN";
+  const tokenDecimals = Number(t.tokenDecimal);
+  if (!Number.isFinite(tokenDecimals) || tokenDecimals < 0 || tokenDecimals > 36) return null;
+  const amount = /^\d+$/.test(t.value) ? t.value : "0";
+  return {
+    type: "token_transfer",
+    hash: t.hash,
+    timestamp: Number(t.timeStamp),
+    from: t.from,
+    to: t.to,
+    tokenAddress: t.contractAddress,
+    tokenSymbol,
+    tokenDecimals,
+    amount,
+    amountFormatted: formatUnitsDecimal(amount, tokenDecimals),
+    status: "success",
+  };
+}
+
+function toInternal(t: InternalTxItem): InternalHistoryItem {
+  const failed = t.isError === "1";
+  const valueWei = /^\d+$/.test(t.value) ? t.value : "0";
+  return {
+    type: "internal",
+    hash: t.hash,
+    timestamp: Number(t.timeStamp),
+    from: t.from,
+    to: t.to,
+    valueNative: valueWei,
+    valueNativeFormatted: formatUnitsDecimal(valueWei, 18),
+    status: failed ? "failed" : "success",
+    ...(t.traceId ? { traceId: t.traceId } : {}),
+  };
+}
+
+export interface EvmFetchResult {
+  external: ExternalHistoryItem[];
+  tokenTransfers: TokenTransferHistoryItem[];
+  internal: InternalHistoryItem[];
+  truncated: boolean;
+  errors: Array<{ source: string; message: string }>;
+}
+
+export async function fetchEvmHistory(args: {
+  wallet: `0x${string}`;
+  chain: SupportedChain;
+  includeExternal: boolean;
+  includeTokenTransfers: boolean;
+  includeInternal: boolean;
+}): Promise<EvmFetchResult> {
+  const { wallet, chain } = args;
+  const cacheKey = `history:evm:${chain}:${wallet.toLowerCase()}`;
+  const cached = cache.get<EvmFetchResult>(cacheKey);
+  if (cached) {
+    return filterForFlags(cached, args);
+  }
+
+  const errors: Array<{ source: string; message: string }> = [];
+  const baseParams = { module: "account", address: wallet };
+
+  const [externalRows, tokenRows, internalRows] = await Promise.all([
+    etherscanFetch<TxListItem>(chain, { ...baseParams, action: "txlist" }).catch((e: Error) => {
+      errors.push({ source: `etherscan.txlist.${chain}`, message: e.message });
+      return [] as TxListItem[];
+    }),
+    etherscanFetch<TokenTxItem>(chain, { ...baseParams, action: "tokentx" }).catch((e: Error) => {
+      errors.push({ source: `etherscan.tokentx.${chain}`, message: e.message });
+      return [] as TokenTxItem[];
+    }),
+    etherscanFetch<InternalTxItem>(chain, { ...baseParams, action: "txlistinternal" }).catch((e: Error) => {
+      errors.push({ source: `etherscan.txlistinternal.${chain}`, message: e.message });
+      return [] as InternalTxItem[];
+    }),
+  ]);
+
+  const external = externalRows.map(toExternal);
+  const tokenTransfers = tokenRows
+    .map(toTokenTransfer)
+    .filter((r): r is TokenTransferHistoryItem => r !== null);
+  const internal = internalRows.map(toInternal);
+
+  const truncated =
+    externalRows.length >= SERVER_ROW_CAP ||
+    tokenRows.length >= SERVER_ROW_CAP ||
+    internalRows.length >= SERVER_ROW_CAP;
+
+  const result: EvmFetchResult = { external, tokenTransfers, internal, truncated, errors };
+  if (errors.length < 3) cache.set(cacheKey, result, CACHE_TTL.HISTORY);
+  return filterForFlags(result, args);
+}
+
+function filterForFlags(
+  r: EvmFetchResult,
+  flags: { includeExternal: boolean; includeTokenTransfers: boolean; includeInternal: boolean }
+): EvmFetchResult {
+  return {
+    external: flags.includeExternal ? r.external : [],
+    tokenTransfers: flags.includeTokenTransfers ? r.tokenTransfers : [],
+    internal: flags.includeInternal ? r.internal : [],
+    truncated: r.truncated,
+    errors: r.errors,
+  };
+}
+
+export { sanitizeContractName };

--- a/src/modules/history/evm.ts
+++ b/src/modules/history/evm.ts
@@ -1,6 +1,9 @@
 import { cache } from "../../data/cache.js";
 import { CACHE_TTL } from "../../config/cache.js";
-import { resolveEtherscanApiKey, readUserConfig } from "../../config/user-config.js";
+import {
+  etherscanV2Fetch,
+  EtherscanApiKeyMissingError,
+} from "../../data/apis/etherscan-v2.js";
 import { sanitizeContractName } from "../../data/apis/etherscan.js";
 import type { SupportedChain } from "../../types/index.js";
 import type {
@@ -9,23 +12,9 @@ import type {
   InternalHistoryItem,
 } from "./schemas.js";
 
-const API_BASE: Record<SupportedChain, string> = {
-  ethereum: "https://api.etherscan.io/api",
-  arbitrum: "https://api.arbiscan.io/api",
-  polygon: "https://api.polygonscan.com/api",
-  base: "https://api.basescan.org/api",
-};
-
-const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const SERVER_ROW_CAP = 100;
 const MAX_SYMBOL_LEN = 32;
 const MAX_NAME_LEN = 64;
-
-interface EtherscanEnvelope<T> {
-  status: string;
-  message: string;
-  result: T | string;
-}
 
 interface TxListItem {
   hash: string;
@@ -58,44 +47,6 @@ interface InternalTxItem {
   value: string;
   isError: string;
   traceId?: string;
-}
-
-async function etherscanFetch<T>(
-  chain: SupportedChain,
-  params: Record<string, string>
-): Promise<T[]> {
-  const apiKey = resolveEtherscanApiKey(readUserConfig());
-  const qs = new URLSearchParams({
-    ...params,
-    page: "1",
-    offset: String(SERVER_ROW_CAP),
-    sort: "desc",
-  });
-  if (apiKey) qs.set("apikey", apiKey);
-
-  const res = await fetch(`${API_BASE[chain]}?${qs.toString()}`);
-  if (!res.ok) {
-    throw new Error(`Etherscan ${chain} ${params.action} returned ${res.status}`);
-  }
-  const text = await res.text();
-  if (text.length > MAX_RESPONSE_BYTES) {
-    throw new Error(
-      `Etherscan ${chain} ${params.action} response exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length})`
-    );
-  }
-  const body = JSON.parse(text) as EtherscanEnvelope<T[]>;
-  if (body.status !== "1") {
-    if (typeof body.result === "string" && body.result.toLowerCase().includes("no transactions")) {
-      return [];
-    }
-    if (body.message?.toLowerCase().includes("no transactions")) {
-      return [];
-    }
-    throw new Error(
-      `Etherscan ${chain} ${params.action} error: ${body.message || "unknown"}`
-    );
-  }
-  return Array.isArray(body.result) ? body.result : [];
 }
 
 function formatUnitsDecimal(raw: string, decimals: number): string {
@@ -192,6 +143,17 @@ export interface EvmFetchResult {
   errors: Array<{ source: string; message: string }>;
 }
 
+async function fetchAction<T>(chain: SupportedChain, action: string, address: string): Promise<T[]> {
+  return etherscanV2Fetch<T>(chain, {
+    module: "account",
+    action,
+    address,
+    page: "1",
+    offset: String(SERVER_ROW_CAP),
+    sort: "desc",
+  });
+}
+
 export async function fetchEvmHistory(args: {
   wallet: `0x${string}`;
   chain: SupportedChain;
@@ -207,18 +169,23 @@ export async function fetchEvmHistory(args: {
   }
 
   const errors: Array<{ source: string; message: string }> = [];
-  const baseParams = { module: "account", address: wallet };
 
+  // Missing API key is a fatal, user-actionable error — surface it directly
+  // rather than burying it in per-endpoint error arrays. Probe once before
+  // the fan-out so the caller gets ONE clean error, not three redundant ones.
   const [externalRows, tokenRows, internalRows] = await Promise.all([
-    etherscanFetch<TxListItem>(chain, { ...baseParams, action: "txlist" }).catch((e: Error) => {
+    fetchAction<TxListItem>(chain, "txlist", wallet).catch((e: Error) => {
+      if (e instanceof EtherscanApiKeyMissingError) throw e;
       errors.push({ source: `etherscan.txlist.${chain}`, message: e.message });
       return [] as TxListItem[];
     }),
-    etherscanFetch<TokenTxItem>(chain, { ...baseParams, action: "tokentx" }).catch((e: Error) => {
+    fetchAction<TokenTxItem>(chain, "tokentx", wallet).catch((e: Error) => {
+      if (e instanceof EtherscanApiKeyMissingError) throw e;
       errors.push({ source: `etherscan.tokentx.${chain}`, message: e.message });
       return [] as TokenTxItem[];
     }),
-    etherscanFetch<InternalTxItem>(chain, { ...baseParams, action: "txlistinternal" }).catch((e: Error) => {
+    fetchAction<InternalTxItem>(chain, "txlistinternal", wallet).catch((e: Error) => {
+      if (e instanceof EtherscanApiKeyMissingError) throw e;
       errors.push({ source: `etherscan.txlistinternal.${chain}`, message: e.message });
       return [] as InternalTxItem[];
     }),

--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -1,0 +1,183 @@
+import { isEvmChain } from "../../types/index.js";
+import type { AnyChain, SupportedChain } from "../../types/index.js";
+import { fetchEvmHistory } from "./evm.js";
+import { fetchTronHistory } from "./tron.js";
+import { resolveSelectors } from "./decode.js";
+import {
+  lookupHistoricalPrices,
+  nativeCoinKey,
+  tokenCoinKey,
+  getPrice,
+  type PriceRequest,
+} from "./prices.js";
+import type {
+  GetTransactionHistoryArgs,
+  HistoryItem,
+  HistoryResponse,
+} from "./schemas.js";
+
+/**
+ * Entry point for `get_transaction_history`. Dispatches to the EVM or TRON
+ * fetch layer, merges all item types, sorts desc by timestamp, truncates to
+ * `limit`, then fans out a single batched historical-price lookup and a
+ * 4byte selector resolution.
+ */
+export async function getTransactionHistory(
+  args: GetTransactionHistoryArgs
+): Promise<HistoryResponse> {
+  const {
+    wallet,
+    limit,
+    includeExternal,
+    includeTokenTransfers,
+    includeInternal,
+  } = args;
+  // `chain` is typed as string after Zod.enum(readonly string[]) narrowing;
+  // cast to AnyChain since the schema only admits ALL_CHAINS values.
+  const chain = args.chain as AnyChain;
+
+  // Defensively clamp timestamps.
+  const nowSec = Math.floor(Date.now() / 1000);
+  const endTs =
+    args.endTimestamp !== undefined ? Math.min(args.endTimestamp, nowSec) : undefined;
+  const startTs =
+    args.startTimestamp !== undefined
+      ? Math.min(args.startTimestamp, endTs ?? nowSec)
+      : undefined;
+
+  // Shape-match wallet against chain (walletSchema accepts both formats —
+  // the runtime check lives here, same pattern as get_token_balance).
+  const isTronWallet = wallet.startsWith("T");
+  const isTronChain = chain === "tron";
+  if (isTronWallet && !isTronChain) {
+    throw new Error(
+      `Wallet ${wallet} is a TRON address but chain is "${chain}". Pass chain: "tron".`
+    );
+  }
+  if (!isTronWallet && isTronChain) {
+    throw new Error(
+      `Wallet ${wallet} is an EVM address but chain is "tron". Pass a TRON base58 address.`
+    );
+  }
+
+  let items: HistoryItem[];
+  let truncated: boolean;
+  const errors: Array<{ source: string; message: string }> = [];
+
+  if (isEvmChain(chain)) {
+    const evmChain = chain as SupportedChain;
+    const res = await fetchEvmHistory({
+      wallet: wallet as `0x${string}`,
+      chain: evmChain,
+      includeExternal,
+      includeTokenTransfers,
+      includeInternal,
+    });
+    items = [...res.external, ...res.tokenTransfers, ...res.internal];
+    truncated = res.truncated;
+    errors.push(...res.errors);
+  } else {
+    // TRON. `includeInternal` is silently ignored (no first-class internal txs).
+    const res = await fetchTronHistory({
+      wallet,
+      includeExternal,
+      includeTokenTransfers,
+    });
+    items = [...res.external, ...res.tokenTransfers];
+    truncated = res.truncated;
+    errors.push(...res.errors);
+  }
+
+  // Timestamp filter.
+  if (startTs !== undefined) items = items.filter((i) => i.timestamp >= startTs);
+  if (endTs !== undefined) items = items.filter((i) => i.timestamp <= endTs);
+
+  // Sort desc by timestamp, stable on hash.
+  items.sort((a, b) => {
+    if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp;
+    return a.hash.localeCompare(b.hash);
+  });
+
+  // Truncate to limit.
+  if (items.length > limit) {
+    items = items.slice(0, limit);
+    truncated = true;
+  }
+
+  // Batch-resolve method selectors for external items with non-empty input.
+  const selectors = items
+    .filter((i): i is Extract<HistoryItem, { type: "external" }> => i.type === "external")
+    .map((i) => i.methodSelector)
+    .filter((s): s is string => typeof s === "string");
+  if (selectors.length > 0) {
+    const resolved = await resolveSelectors(selectors);
+    for (const item of items) {
+      if (item.type === "external" && item.methodSelector) {
+        const r = resolved.get(item.methodSelector);
+        if (r?.methodName) item.methodName = r.methodName;
+      }
+    }
+  }
+
+  // Build price requests.
+  const priceRequests: PriceRequest[] = [];
+  for (const item of items) {
+    if (item.type === "external" || item.type === "internal") {
+      if (item.valueNative !== "0") {
+        priceRequests.push({ coinKey: nativeCoinKey(chain), timestamp: item.timestamp });
+      }
+    } else {
+      priceRequests.push({
+        coinKey: tokenCoinKey(chain, item.tokenAddress),
+        timestamp: item.timestamp,
+      });
+    }
+  }
+
+  let priceCoverage: "full" | "partial" | "none" = "full";
+  if (priceRequests.length > 0) {
+    const { prices, missed } = await lookupHistoricalPrices(priceRequests);
+    let priced = 0;
+    for (const item of items) {
+      if (item.type === "external" || item.type === "internal") {
+        if (item.valueNative === "0") continue;
+        const p = getPrice(prices, nativeCoinKey(chain), item.timestamp);
+        if (p !== undefined) {
+          const nativeAmt = Number(item.valueNativeFormatted);
+          if (Number.isFinite(nativeAmt)) {
+            item.valueUsd = round2(nativeAmt * p);
+            priced += 1;
+          }
+        }
+      } else {
+        const p = getPrice(prices, tokenCoinKey(chain, item.tokenAddress), item.timestamp);
+        if (p !== undefined) {
+          const tokenAmt = Number(item.amountFormatted);
+          if (Number.isFinite(tokenAmt)) {
+            item.valueUsd = round2(tokenAmt * p);
+            priced += 1;
+          }
+        }
+      }
+    }
+    if (priced === 0) priceCoverage = "none";
+    else if (missed || priced < priceRequests.length) priceCoverage = "partial";
+    else priceCoverage = "full";
+  } else {
+    priceCoverage = "none";
+  }
+
+  const response: HistoryResponse = {
+    chain,
+    wallet,
+    items,
+    truncated,
+    priceCoverage,
+    ...(errors.length > 0 ? { errors } : {}),
+  };
+  return response;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/modules/history/prices.ts
+++ b/src/modules/history/prices.ts
@@ -1,0 +1,149 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import type { AnyChain } from "../../types/index.js";
+
+/**
+ * DefiLlama historical-price client.
+ *
+ * Shape: GET https://coins.llama.fi/prices/historical/{ts}/{coins}
+ * where `coins` is a comma-separated list like `ethereum:0xabc,coingecko:ethereum`.
+ * The endpoint takes ONE timestamp per call but any number of coins.
+ *
+ * Our batching strategy: group all (coinKey, timestamp) tuples by timestamp,
+ * make one HTTP call per unique timestamp, cap outstanding calls at CONCURRENCY.
+ * Historical prices are immutable, so the cache TTL is 30d (effectively
+ * forever for this memory-resident store).
+ */
+
+const CONCURRENCY = 10;
+const LLAMA_BASE = "https://coins.llama.fi/prices/historical";
+
+const NATIVE_COIN_KEY: Record<AnyChain, string> = {
+  ethereum: "coingecko:ethereum",
+  arbitrum: "coingecko:ethereum",
+  polygon: "coingecko:matic-network",
+  base: "coingecko:ethereum",
+  tron: "coingecko:tron",
+};
+
+const LLAMA_CHAIN: Record<AnyChain, string> = {
+  ethereum: "ethereum",
+  arbitrum: "arbitrum",
+  polygon: "polygon",
+  base: "base",
+  tron: "tron",
+};
+
+export function nativeCoinKey(chain: AnyChain): string {
+  return NATIVE_COIN_KEY[chain];
+}
+
+export function tokenCoinKey(chain: AnyChain, tokenAddress: string): string {
+  return `${LLAMA_CHAIN[chain]}:${tokenAddress}`;
+}
+
+export interface PriceRequest {
+  coinKey: string;
+  timestamp: number;
+}
+
+export interface PriceLookupResult {
+  prices: Map<string, number>;
+  /** One of the coins didn't come back from DefiLlama. */
+  missed: boolean;
+}
+
+interface LlamaHistoricalResponse {
+  coins: Record<string, { price?: number; timestamp?: number; confidence?: number }>;
+}
+
+/** Key for the in-memory cache. */
+function cacheKey(coinKey: string, timestamp: number): string {
+  return `llama:hist:${timestamp}:${coinKey}`;
+}
+
+function priceMapKey(coinKey: string, timestamp: number): string {
+  return `${coinKey}@${timestamp}`;
+}
+
+/**
+ * Look up historical prices for a set of (coin, timestamp) pairs. Pairs with
+ * a cache hit short-circuit; the rest are grouped by timestamp and fetched in
+ * parallel with a concurrency cap. Missing prices are simply absent from the
+ * returned map — callers decide what to do (usually "leave valueUsd undefined
+ * and downgrade priceCoverage").
+ */
+export async function lookupHistoricalPrices(
+  requests: PriceRequest[]
+): Promise<PriceLookupResult> {
+  const prices = new Map<string, number>();
+  let missed = false;
+
+  const byTimestamp = new Map<number, Set<string>>();
+  for (const req of requests) {
+    const hit = cache.get<number>(cacheKey(req.coinKey, req.timestamp));
+    if (hit !== undefined) {
+      prices.set(priceMapKey(req.coinKey, req.timestamp), hit);
+      continue;
+    }
+    const bucket = byTimestamp.get(req.timestamp) ?? new Set<string>();
+    bucket.add(req.coinKey);
+    byTimestamp.set(req.timestamp, bucket);
+  }
+
+  const tasks: Array<() => Promise<void>> = [];
+  for (const [timestamp, coins] of byTimestamp) {
+    tasks.push(async () => {
+      const coinList = Array.from(coins).join(",");
+      const url = `${LLAMA_BASE}/${timestamp}/${encodeURIComponent(coinList)}`;
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          missed = true;
+          return;
+        }
+        const body = (await res.json()) as LlamaHistoricalResponse;
+        for (const coinKey of coins) {
+          const entry = body.coins[coinKey];
+          if (entry && typeof entry.price === "number") {
+            prices.set(priceMapKey(coinKey, timestamp), entry.price);
+            cache.set(
+              cacheKey(coinKey, timestamp),
+              entry.price,
+              CACHE_TTL.HISTORICAL_PRICE
+            );
+          } else {
+            missed = true;
+          }
+        }
+      } catch {
+        missed = true;
+      }
+    });
+  }
+
+  await runWithConcurrency(tasks, CONCURRENCY);
+
+  return { prices, missed };
+}
+
+async function runWithConcurrency(tasks: Array<() => Promise<void>>, limit: number): Promise<void> {
+  const queue = [...tasks];
+  const workers: Promise<void>[] = [];
+  const worker = async () => {
+    while (queue.length > 0) {
+      const task = queue.shift();
+      if (task) await task();
+    }
+  };
+  for (let i = 0; i < Math.min(limit, tasks.length); i++) workers.push(worker());
+  await Promise.all(workers);
+}
+
+export function getPrice(
+  prices: Map<string, number>,
+  coinKey: string,
+  timestamp: number
+): number | undefined {
+  return prices.get(priceMapKey(coinKey, timestamp));
+}

--- a/src/modules/history/schemas.ts
+++ b/src/modules/history/schemas.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { ALL_CHAINS } from "../../types/index.js";
+import type { AnyChain } from "../../types/index.js";
+
+/**
+ * Accept both EVM 0x addresses and TRON mainnet base58. Mirrors the
+ * `walletSchema` pattern in src/modules/balances/schemas.ts — keep the two
+ * regexes inline rather than importing, because that file's export is
+ * private (prefixed, not re-exported) and mirroring the shape is cheap.
+ */
+const walletSchema = z.union([
+  z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
+]);
+
+const chainEnum = z.enum(ALL_CHAINS as unknown as [string, ...string[]]);
+
+export const getTransactionHistoryInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  /**
+   * Max merged items to return. Capped at 50 to keep the historical-price
+   * fan-out (one DefiLlama call per unique tx timestamp) bounded.
+   */
+  limit: z.number().int().min(1).max(50).default(25),
+  includeExternal: z.boolean().default(true),
+  includeTokenTransfers: z.boolean().default(true),
+  /**
+   * EVM-only. Silently ignored on TRON (TronGrid's internal-tx surface is
+   * inconsistent across nodes — skipping it until asked).
+   */
+  includeInternal: z.boolean().default(true),
+  /** Unix seconds; items with timestamp < startTimestamp are filtered out. */
+  startTimestamp: z.number().int().nonnegative().optional(),
+  /** Unix seconds; items with timestamp > endTimestamp are filtered out. */
+  endTimestamp: z.number().int().nonnegative().optional(),
+});
+
+export type GetTransactionHistoryArgs = z.infer<typeof getTransactionHistoryInput>;
+
+export type HistoryItemType = "external" | "token_transfer" | "internal";
+
+interface HistoryItemBase {
+  type: HistoryItemType;
+  hash: string;
+  timestamp: number;
+  from: string;
+  to: string;
+  status: "success" | "failed";
+}
+
+export interface ExternalHistoryItem extends HistoryItemBase {
+  type: "external";
+  valueNative: string;
+  valueNativeFormatted: string;
+  valueUsd?: number;
+  methodSelector?: string;
+  methodName?: string;
+}
+
+export interface TokenTransferHistoryItem extends HistoryItemBase {
+  type: "token_transfer";
+  tokenAddress: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  amount: string;
+  amountFormatted: string;
+  valueUsd?: number;
+}
+
+export interface InternalHistoryItem extends HistoryItemBase {
+  type: "internal";
+  valueNative: string;
+  valueNativeFormatted: string;
+  valueUsd?: number;
+  traceId?: string;
+}
+
+export type HistoryItem =
+  | ExternalHistoryItem
+  | TokenTransferHistoryItem
+  | InternalHistoryItem;
+
+export interface HistoryResponse {
+  chain: AnyChain;
+  wallet: string;
+  items: HistoryItem[];
+  /** True if any per-type fetch returned its server-side row cap before merge. */
+  truncated: boolean;
+  /** Best-effort indicator of how much of the response got a USD annotation. */
+  priceCoverage: "full" | "partial" | "none";
+  /** Non-fatal per-endpoint errors (e.g. Etherscan 429 on one of three calls). */
+  errors?: Array<{ source: string; message: string }>;
+}

--- a/src/modules/history/tron.ts
+++ b/src/modules/history/tron.ts
@@ -1,0 +1,233 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import {
+  TRONGRID_BASE_URL,
+  TRX_DECIMALS,
+  TRON_TOKENS,
+  isTronAddress,
+} from "../../config/tron.js";
+import type {
+  ExternalHistoryItem,
+  TokenTransferHistoryItem,
+} from "./schemas.js";
+
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const SERVER_ROW_CAP = 100;
+const MAX_SYMBOL_LEN = 32;
+
+const KNOWN_TOKEN_DECIMALS: Record<string, number> = {
+  [TRON_TOKENS.USDT]: 6,
+  [TRON_TOKENS.USDC]: 6,
+  [TRON_TOKENS.USDD]: 18,
+  [TRON_TOKENS.TUSD]: 18,
+};
+const KNOWN_TOKEN_SYMBOLS: Record<string, string> = {
+  [TRON_TOKENS.USDT]: "USDT",
+  [TRON_TOKENS.USDC]: "USDC",
+  [TRON_TOKENS.USDD]: "USDD",
+  [TRON_TOKENS.TUSD]: "TUSD",
+};
+
+interface TrongridTxListResponse {
+  data?: Array<{
+    txID?: string;
+    block_timestamp?: number;
+    raw_data?: {
+      contract?: Array<{
+        parameter?: {
+          value?: {
+            owner_address?: string;
+            to_address?: string;
+            amount?: number | string;
+          };
+        };
+        type?: string;
+      }>;
+    };
+    ret?: Array<{ contractRet?: string }>;
+  }>;
+}
+
+interface TrongridTrc20Response {
+  data?: Array<{
+    transaction_id?: string;
+    block_timestamp?: number;
+    from?: string;
+    to?: string;
+    value?: string;
+    token_info?: {
+      address?: string;
+      decimals?: number;
+      symbol?: string;
+    };
+  }>;
+}
+
+async function trongridGet<T>(path: string, apiKey: string | undefined): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetch(`${TRONGRID_BASE_URL}${path}`, { headers });
+  if (!res.ok) {
+    // TRON-PRO-API-KEY never lands in the URL for TronGrid, so surfacing
+    // path + status is safe.
+    throw new Error(`TronGrid ${path} returned ${res.status}`);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(`TronGrid ${path} response exceeds ${MAX_RESPONSE_BYTES} bytes`);
+  }
+  return JSON.parse(text) as T;
+}
+
+function formatUnitsDecimal(raw: string, decimals: number): string {
+  if (!/^\d+$/.test(raw)) return "0";
+  if (decimals === 0) return raw;
+  const padded = raw.padStart(decimals + 1, "0");
+  const whole = padded.slice(0, padded.length - decimals);
+  const frac = padded.slice(padded.length - decimals).replace(/0+$/, "");
+  return frac.length > 0 ? `${whole}.${frac}` : whole;
+}
+
+function sanitizeDisplayString(raw: string | undefined, maxLen: number): string {
+  if (!raw) return "";
+  return raw.replace(/[^A-Za-z0-9 ._\-]/g, "").trim().slice(0, maxLen);
+}
+
+/**
+ * TRON addresses arrive in TronGrid responses as hex (prefix `41`) OR base58;
+ * which one depends on the endpoint. Convert hex-prefixed to base58 for display
+ * consistency — actually TronGrid's /v1/accounts/.../transactions endpoint
+ * returns hex, so we'd need a full base58check encode. To avoid pulling a new
+ * dep, return whatever TronGrid gave us and flag it in the docstring.
+ *
+ * NOTE: from/to on external TRX txs come as hex ("41..."); TRC-20 transfers
+ * come as base58 ("T..."). Agents reading the output can tell by prefix.
+ */
+function normalizeAddress(raw: string | undefined): string {
+  return typeof raw === "string" ? raw : "";
+}
+
+export interface TronFetchResult {
+  external: ExternalHistoryItem[];
+  tokenTransfers: TokenTransferHistoryItem[];
+  truncated: boolean;
+  errors: Array<{ source: string; message: string }>;
+}
+
+export async function fetchTronHistory(args: {
+  wallet: string;
+  includeExternal: boolean;
+  includeTokenTransfers: boolean;
+}): Promise<TronFetchResult> {
+  const { wallet } = args;
+  if (!isTronAddress(wallet)) {
+    throw new Error(`"${wallet}" is not a valid TRON mainnet address.`);
+  }
+
+  const cacheKey = `history:tron:${wallet}`;
+  const cached = cache.get<TronFetchResult>(cacheKey);
+  if (cached) return filterForFlags(cached, args);
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const errors: Array<{ source: string; message: string }> = [];
+
+  const [extResp, trcResp] = await Promise.all([
+    trongridGet<TrongridTxListResponse>(
+      `/v1/accounts/${wallet}/transactions?limit=${SERVER_ROW_CAP}&order_by=block_timestamp,desc`,
+      apiKey
+    ).catch((e: Error) => {
+      errors.push({ source: "trongrid.transactions", message: e.message });
+      return { data: [] } as TrongridTxListResponse;
+    }),
+    trongridGet<TrongridTrc20Response>(
+      `/v1/accounts/${wallet}/transactions/trc20?limit=${SERVER_ROW_CAP}&order_by=block_timestamp,desc`,
+      apiKey
+    ).catch((e: Error) => {
+      errors.push({ source: "trongrid.trc20", message: e.message });
+      return { data: [] } as TrongridTrc20Response;
+    }),
+  ]);
+
+  const external: ExternalHistoryItem[] = [];
+  for (const tx of extResp.data ?? []) {
+    const contract = tx.raw_data?.contract?.[0];
+    const p = contract?.parameter?.value;
+    // Only surface TransferContract (native TRX transfers) as "external" items.
+    // Other types (TriggerSmartContract, WitnessVote, etc.) are signal-rich but
+    // would require per-type decoding we don't yet have — include the hash
+    // alone with the type name isn't useful for an agent.
+    if (contract?.type !== "TransferContract") continue;
+    if (!tx.txID || !tx.block_timestamp) continue;
+    const failed = (tx.ret?.[0]?.contractRet ?? "SUCCESS") !== "SUCCESS";
+    const amountSun = p?.amount != null ? String(p.amount) : "0";
+    external.push({
+      type: "external",
+      hash: tx.txID,
+      timestamp: Math.floor(tx.block_timestamp / 1000),
+      from: normalizeAddress(p?.owner_address),
+      to: normalizeAddress(p?.to_address),
+      valueNative: amountSun,
+      valueNativeFormatted: formatUnitsDecimal(amountSun, TRX_DECIMALS),
+      status: failed ? "failed" : "success",
+    });
+  }
+
+  const tokenTransfers: TokenTransferHistoryItem[] = [];
+  for (const row of trcResp.data ?? []) {
+    if (!row.transaction_id || !row.block_timestamp) continue;
+    const contract = row.token_info?.address ?? "";
+    // Prefer the canonical symbol for known stablecoins — attacker-set
+    // token_info.symbol is the phishing surface we care about.
+    const rawSymbol = row.token_info?.symbol ?? "";
+    const rawSymbolLower = rawSymbol.toLowerCase();
+    if (/https?|www\.|claim|visit|airdrop|\.com|\.io|\.app|\.xyz|\.net/.test(rawSymbolLower)) {
+      continue;
+    }
+    const canonicalSymbol = KNOWN_TOKEN_SYMBOLS[contract];
+    const tokenSymbol =
+      canonicalSymbol ?? (sanitizeDisplayString(rawSymbol, MAX_SYMBOL_LEN) || "UNKNOWN");
+    const canonicalDecimals = KNOWN_TOKEN_DECIMALS[contract];
+    const reportedDecimals = row.token_info?.decimals;
+    const tokenDecimals =
+      canonicalDecimals ??
+      (typeof reportedDecimals === "number" && reportedDecimals >= 0 && reportedDecimals <= 36
+        ? reportedDecimals
+        : null);
+    if (tokenDecimals === null) continue;
+    const amount = /^\d+$/.test(row.value ?? "") ? (row.value as string) : "0";
+    tokenTransfers.push({
+      type: "token_transfer",
+      hash: row.transaction_id,
+      timestamp: Math.floor(row.block_timestamp / 1000),
+      from: normalizeAddress(row.from),
+      to: normalizeAddress(row.to),
+      tokenAddress: contract,
+      tokenSymbol,
+      tokenDecimals,
+      amount,
+      amountFormatted: formatUnitsDecimal(amount, tokenDecimals),
+      status: "success",
+    });
+  }
+
+  const truncated =
+    (extResp.data?.length ?? 0) >= SERVER_ROW_CAP ||
+    (trcResp.data?.length ?? 0) >= SERVER_ROW_CAP;
+
+  const result: TronFetchResult = { external, tokenTransfers, truncated, errors };
+  if (errors.length < 2) cache.set(cacheKey, result, CACHE_TTL.HISTORY);
+  return filterForFlags(result, args);
+}
+
+function filterForFlags(
+  r: TronFetchResult,
+  flags: { includeExternal: boolean; includeTokenTransfers: boolean }
+): TronFetchResult {
+  return {
+    external: flags.includeExternal ? r.external : [],
+    tokenTransfers: flags.includeTokenTransfers ? r.tokenTransfers : [],
+    truncated: r.truncated,
+    errors: r.errors,
+  };
+}

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -39,6 +39,10 @@ beforeEach(() => {
   cache.clear();
   // Override global fetch. Node 18+ uses global fetch; vi.stubGlobal handles it.
   vi.stubGlobal("fetch", fakeFetch);
+  // Stub API key — Etherscan V2 requires one. Tests mock fetch so the value
+  // never hits the wire; without this, test runs on clean machines (CI) would
+  // throw EtherscanApiKeyMissingError before hitting the mock.
+  vi.stubEnv("ETHERSCAN_API_KEY", "test-key");
 });
 
 const WALLET = "0x1234567890123456789012345678901234567890";
@@ -49,19 +53,48 @@ function actionOf(url: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
+function chainIdOf(url: string): string | undefined {
+  const m = url.match(/[?&]chainid=([^&]+)/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * V2 URL shape: https://api.etherscan.io/v2/api?chainid=N&module=...&action=...&apikey=...
+ * The matcher pins the V2 path prefix explicitly so a regression to V1
+ * (`api.etherscan.io/api?...`) would fall through to the "unmatched fetch"
+ * throw rather than silently matching.
+ */
 function etherscanOk(action: string, result: unknown[]) {
   return {
-    match: (url: string) => url.includes("api.etherscan.io") && actionOf(url) === action,
+    match: (url: string) =>
+      url.includes("api.etherscan.io/v2/api") && actionOf(url) === action && chainIdOf(url) !== undefined,
     respond: () => ({ ok: true, body: { status: "1", message: "OK", result } }),
   };
 }
 
 function etherscanNoTx(action: string) {
   return {
-    match: (url: string) => url.includes("api.etherscan.io") && actionOf(url) === action,
+    match: (url: string) =>
+      url.includes("api.etherscan.io/v2/api") && actionOf(url) === action && chainIdOf(url) !== undefined,
     respond: () => ({
       ok: true,
       body: { status: "0", message: "No transactions found", result: [] },
+    }),
+  };
+}
+
+/** V1-style response used in the deprecation-reproduction test. */
+function etherscanDeprecated(action: string) {
+  return {
+    match: (url: string) =>
+      url.includes("api.etherscan.io/v2/api") && actionOf(url) === action,
+    respond: () => ({
+      ok: true,
+      body: {
+        status: "0",
+        message: "NOTOK",
+        result: "You are using a deprecated V1 endpoint, switch to Etherscan API V2 using https://docs.etherscan.io/v2-migration",
+      },
     }),
   };
 }
@@ -384,6 +417,92 @@ describe("get_transaction_history: timestamp filter", () => {
     });
     expect(res.items.length).toBe(1);
     expect(res.items[0].hash).toBe("0xmid");
+  });
+});
+
+describe("get_transaction_history: V2 migration", () => {
+  it("sends chainid=1 for ethereum and chainid=42161 for arbitrum", async () => {
+    routes = [
+      etherscanNoTx("txlist"),
+      etherscanNoTx("tokentx"),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(fetchCalls.every((u) => !u.includes("api.etherscan.io/v2/api") || chainIdOf(u) === "1")).toBe(
+      true
+    );
+
+    fetchCalls = [];
+    cache.clear();
+    await getTransactionHistory({
+      wallet: WALLET,
+      chain: "arbitrum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(
+      fetchCalls.every((u) => !u.includes("api.etherscan.io/v2/api") || chainIdOf(u) === "42161")
+    ).toBe(true);
+  });
+
+  it("propagates a clear error when ETHERSCAN_API_KEY is missing", async () => {
+    vi.unstubAllEnvs();
+    // Also make sure the user-config lookup doesn't resolve a key from disk —
+    // mock readUserConfig to return null so the test is deterministic on the
+    // developer's machine regardless of ~/.vaultpilot-mcp/config.json.
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<typeof import("../src/config/user-config.js")>(
+        "../src/config/user-config.js"
+      );
+      return { ...actual, readUserConfig: () => null };
+    });
+    vi.resetModules();
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    await expect(
+      getTransactionHistory({
+        wallet: WALLET,
+        chain: "ethereum",
+        limit: 25,
+        includeExternal: true,
+        includeTokenTransfers: true,
+        includeInternal: true,
+      })
+    ).rejects.toThrow(/ETHERSCAN_API_KEY/);
+    vi.doUnmock("../src/config/user-config.js");
+    vi.resetModules();
+  });
+
+  it("surfaces the V1-deprecation `result` field in error messages", async () => {
+    routes = [
+      etherscanDeprecated("txlist"),
+      etherscanDeprecated("tokentx"),
+      etherscanDeprecated("txlistinternal"),
+      llamaNotFound(),
+    ];
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(res.items.length).toBe(0);
+    expect(res.errors?.length).toBe(3);
+    const joined = (res.errors ?? []).map((e) => e.message).join(" | ");
+    expect(joined).toContain("deprecated V1 endpoint");
   });
 });
 

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cache } from "../src/data/cache.js";
+
+// We intercept the global fetch. Each test sets up responses per URL-substring
+// via `routeMatch` rules in order; the first match wins and counters bump so
+// assertions can check call counts.
+
+type Route = {
+  match: (url: string) => boolean;
+  respond: (url: string) => { ok: boolean; status?: number; body: unknown };
+};
+
+let routes: Route[] = [];
+let fetchCalls: string[] = [];
+
+const fakeFetch = vi.fn(async (input: string | URL | Request) => {
+  const url = typeof input === "string" ? input : input.toString();
+  fetchCalls.push(url);
+  for (const r of routes) {
+    if (r.match(url)) {
+      const result = r.respond(url);
+      const bodyText = JSON.stringify(result.body);
+      return {
+        ok: result.ok,
+        status: result.status ?? (result.ok ? 200 : 500),
+        statusText: result.ok ? "OK" : "ERR",
+        text: async () => bodyText,
+        json: async () => result.body,
+      } as unknown as Response;
+    }
+  }
+  throw new Error(`Unmatched fetch URL in test: ${url}`);
+});
+
+beforeEach(() => {
+  routes = [];
+  fetchCalls = [];
+  fakeFetch.mockClear();
+  cache.clear();
+  // Override global fetch. Node 18+ uses global fetch; vi.stubGlobal handles it.
+  vi.stubGlobal("fetch", fakeFetch);
+});
+
+const WALLET = "0x1234567890123456789012345678901234567890";
+const TRON_WALLET = "TXYZabcdefghijkmnopqrstuvwxyz23456";
+
+function actionOf(url: string): string | undefined {
+  const m = url.match(/[?&]action=([^&]+)/);
+  return m ? m[1] : undefined;
+}
+
+function etherscanOk(action: string, result: unknown[]) {
+  return {
+    match: (url: string) => url.includes("api.etherscan.io") && actionOf(url) === action,
+    respond: () => ({ ok: true, body: { status: "1", message: "OK", result } }),
+  };
+}
+
+function etherscanNoTx(action: string) {
+  return {
+    match: (url: string) => url.includes("api.etherscan.io") && actionOf(url) === action,
+    respond: () => ({
+      ok: true,
+      body: { status: "0", message: "No transactions found", result: [] },
+    }),
+  };
+}
+
+function llamaOk(coins: Record<string, { price: number }>) {
+  return {
+    match: (url: string) => url.includes("coins.llama.fi/prices/historical"),
+    respond: () => ({ ok: true, body: { coins } }),
+  };
+}
+
+function llamaNotFound() {
+  return {
+    match: (url: string) => url.includes("coins.llama.fi/prices/historical"),
+    respond: () => ({ ok: false, status: 404, body: {} }),
+  };
+}
+
+function fourbyteOk(sigs: string[]) {
+  return {
+    match: (url: string) => url.includes("4byte.directory"),
+    respond: () => ({
+      ok: true,
+      body: { results: sigs.map((s) => ({ text_signature: s })) },
+    }),
+  };
+}
+
+function trongridOk(path: string, data: unknown[]) {
+  return {
+    match: (url: string) => url.includes("trongrid.io") && url.includes(path),
+    respond: () => ({ ok: true, body: { data } }),
+  };
+}
+
+describe("get_transaction_history: EVM merge + sort + truncate", () => {
+  it("merges external/tokentx/internal and returns desc-by-timestamp", async () => {
+    routes = [
+      etherscanOk("txlist", [
+        {
+          hash: "0xaaa",
+          timeStamp: "1700000000",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000dead",
+          value: "1000000000000000000",
+          input: "0x",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+        {
+          hash: "0xbbb",
+          timeStamp: "1700000200",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000beef",
+          value: "0",
+          input: "0xa9059cbb00000000",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+      ]),
+      etherscanOk("tokentx", [
+        {
+          hash: "0xccc",
+          timeStamp: "1700000100",
+          from: WALLET,
+          to: "0x1111111111111111111111111111111111111111",
+          contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          value: "500000",
+          tokenSymbol: "USDC",
+          tokenName: "USD Coin",
+          tokenDecimal: "6",
+        },
+      ]),
+      etherscanOk("txlistinternal", [
+        {
+          hash: "0xddd",
+          timeStamp: "1700000300",
+          from: "0x1111111111111111111111111111111111111111",
+          to: WALLET,
+          value: "250000000000000000",
+          isError: "0",
+          traceId: "0_1",
+        },
+      ]),
+      fourbyteOk(["transfer(address,uint256)"]),
+      llamaOk({
+        "coingecko:ethereum": { price: 2000 },
+        "ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { price: 1 },
+      }),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+
+    expect(res.items.length).toBe(4);
+    // Sorted desc by timestamp.
+    expect(res.items.map((i) => i.timestamp)).toEqual([
+      1700000300, 1700000200, 1700000100, 1700000000,
+    ]);
+    // Internal, external, token_transfer, external.
+    expect(res.items.map((i) => i.type)).toEqual([
+      "internal",
+      "external",
+      "token_transfer",
+      "external",
+    ]);
+    // Method name decoded on the external tx that had calldata.
+    const externalWithCalldata = res.items.find(
+      (i): i is Extract<typeof res.items[number], { type: "external" }> =>
+        i.type === "external" && i.hash === "0xbbb"
+    );
+    expect(externalWithCalldata?.methodName).toBe("transfer");
+  });
+
+  it("truncates to limit when merged results exceed it", async () => {
+    const txs = Array.from({ length: 30 }, (_, i) => ({
+      hash: `0x${i.toString().padStart(3, "0")}`,
+      timeStamp: String(1700000000 + i * 100),
+      from: WALLET,
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0",
+      input: "0x",
+      isError: "0",
+      txreceipt_status: "1",
+    }));
+    routes = [
+      etherscanOk("txlist", txs),
+      etherscanNoTx("tokentx"),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 10,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(res.items.length).toBe(10);
+    expect(res.truncated).toBe(true);
+  });
+});
+
+describe("get_transaction_history: phishing-token sanitization", () => {
+  it("drops tokentx rows whose symbol contains a URL or claim-bait", async () => {
+    routes = [
+      etherscanNoTx("txlist"),
+      etherscanOk("tokentx", [
+        {
+          hash: "0xsafe",
+          timeStamp: "1700000000",
+          from: WALLET,
+          to: "0x2222222222222222222222222222222222222222",
+          contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          value: "100",
+          tokenSymbol: "USDC",
+          tokenName: "USD Coin",
+          tokenDecimal: "6",
+        },
+        {
+          hash: "0xphishing",
+          timeStamp: "1700000100",
+          from: "0xdead000000000000000000000000000000000000",
+          to: WALLET,
+          contractAddress: "0x9999999999999999999999999999999999999999",
+          value: "1000000000",
+          tokenSymbol: "CLAIM https://evil.example",
+          tokenName: "Visit to claim",
+          tokenDecimal: "6",
+        },
+      ]),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    expect(item.type).toBe("token_transfer");
+    if (item.type === "token_transfer") expect(item.tokenSymbol).toBe("USDC");
+  });
+});
+
+describe("get_transaction_history: price degradation", () => {
+  it("surfaces priceCoverage=none and leaves valueUsd absent when DefiLlama 404s", async () => {
+    routes = [
+      etherscanOk("txlist", [
+        {
+          hash: "0xaaa",
+          timeStamp: "1700000000",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000dead",
+          value: "1000000000000000000",
+          input: "0x",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+      ]),
+      etherscanNoTx("tokentx"),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(res.priceCoverage).toBe("none");
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    if (item.type === "external") expect(item.valueUsd).toBeUndefined();
+  });
+});
+
+describe("get_transaction_history: TRON dispatch", () => {
+  it("routes TRON wallet to TronGrid and ignores includeInternal without error", async () => {
+    routes = [
+      trongridOk("/transactions/trc20", [
+        {
+          transaction_id: "0xtrc",
+          block_timestamp: 1700000000000,
+          from: "TFromAddress000000000000000000000",
+          to: TRON_WALLET,
+          value: "1000000",
+          token_info: {
+            address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            decimals: 6,
+            symbol: "USDT",
+          },
+        },
+      ]),
+      trongridOk("/transactions", []),
+      llamaOk({
+        "tron:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t": { price: 1 },
+      }),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: TRON_WALLET,
+      chain: "tron",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    expect(res.items.length).toBe(1);
+    expect(res.items[0].type).toBe("token_transfer");
+    const item = res.items[0];
+    if (item.type === "token_transfer") {
+      expect(item.tokenSymbol).toBe("USDT");
+      expect(item.valueUsd).toBe(1);
+    }
+  });
+});
+
+describe("get_transaction_history: timestamp filter", () => {
+  it("excludes items outside [startTimestamp, endTimestamp]", async () => {
+    routes = [
+      etherscanOk("txlist", [
+        {
+          hash: "0xold",
+          timeStamp: "1600000000",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000dead",
+          value: "0",
+          input: "0x",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+        {
+          hash: "0xmid",
+          timeStamp: "1700000000",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000dead",
+          value: "0",
+          input: "0x",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+      ]),
+      etherscanNoTx("tokentx"),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    const res = await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+      startTimestamp: 1650000000,
+      endTimestamp: 1750000000,
+    });
+    expect(res.items.length).toBe(1);
+    expect(res.items[0].hash).toBe("0xmid");
+  });
+});
+
+describe("get_transaction_history: cache", () => {
+  it("second call within TTL does not re-hit Etherscan", async () => {
+    routes = [
+      etherscanOk("txlist", [
+        {
+          hash: "0xaaa",
+          timeStamp: "1700000000",
+          from: WALLET,
+          to: "0x000000000000000000000000000000000000dead",
+          value: "0",
+          input: "0x",
+          isError: "0",
+          txreceipt_status: "1",
+        },
+      ]),
+      etherscanNoTx("tokentx"),
+      etherscanNoTx("txlistinternal"),
+      llamaNotFound(),
+    ];
+
+    const { getTransactionHistory } = await import("../src/modules/history/index.js");
+    await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    const etherscanCallsAfterFirst = fetchCalls.filter((u) => u.includes("etherscan.io")).length;
+
+    await getTransactionHistory({
+      wallet: WALLET,
+      chain: "ethereum",
+      limit: 25,
+      includeExternal: true,
+      includeTokenTransfers: true,
+      includeInternal: true,
+    });
+    const etherscanCallsAfterSecond = fetchCalls.filter((u) => u.includes("etherscan.io")).length;
+
+    expect(etherscanCallsAfterFirst).toBe(3);
+    expect(etherscanCallsAfterSecond).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a single read-only MCP tool, `get_transaction_history`, that returns a wallet's recent on-chain activity on one chain, merging external txs, ERC-20/TRC-20 transfers, and internal txs (EVM) into a time-sorted feed.
- Each item gets a decoded method name (via the existing 4byte.directory client) and a historical USD value at tx time (via DefiLlama `/prices/historical`).
- Supports Ethereum / Arbitrum / Polygon / Base via Etherscan v1, plus TRON via TronGrid. TRON has no first-class internal-tx surface so `includeInternal` is silently ignored there.

## What it answers

Questions the server previously couldn't: *"what did I do last week?"*, *"show me my recent swaps"*, *"did I already approve X?"* — without the user pasting tx hashes.

## Security

- Whitelisted sanitization of attacker-controllable token symbols / names — only `[A-Za-z0-9 ._-]` survive, cap 32 chars for symbol / 64 for name.
- Rows whose raw symbol or name contains URL / claim-bait patterns (`https?`, `www.`, `claim`, `airdrop`, `.com/.io/.app/.xyz/.net`) are dropped entirely rather than scrubbed-but-displayed.
- 2 MB response cap per explorer / TronGrid call (mirrors `src/data/apis/etherscan.ts`).
- Hard user `limit` cap at 50 to bound the DefiLlama historical-price fan-out.
- API keys never appear in error messages; errors surface status code only.
- Per-endpoint graceful degradation: if 1 of 3 Etherscan endpoints 429s, the other two still return, and the failing endpoint is recorded in `response.errors`.
- Price lookup is best-effort — a DefiLlama miss leaves `valueUsd` absent and downgrades `response.priceCoverage` to `partial` / `none`, never fails the call.

## Caching

- EVM / TRON fetches: 60 s per `(chain, wallet)` tuple — new `CACHE_TTL.HISTORY`.
- Historical prices: 30 days per `(coin, timestamp)` — immutable; new `CACHE_TTL.HISTORICAL_PRICE`.
- 4byte selector resolution: 24 h per selector (local wrap over the existing `fetch4byteSignatures`).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 489/489 pass, including 7 new tests in `test/history.test.ts` covering:
  - EVM merge / sort / method decode
  - Limit truncation flag
  - Phishing-symbol drop
  - Price-degradation path (`priceCoverage: "none"`)
  - TRON dispatch with `includeInternal` silently ignored
  - Timestamp filter
  - Cache: second call within TTL makes zero new Etherscan requests
- [ ] Manual MCP-client smoke test on real wallets (one EVM, one TRON) before merge

## Explicit non-goals (v1)

- NFT transfers (ERC-721 / 1155)
- Cross-chain single-call aggregation — caller issues one call per chain
- Historical USD for gas fees (`valueUsd` is the transfer amount only)
- Pagination beyond `limit` — cursor support is a v2 ask if it comes up
- TRON internal txs — TronGrid's surface there is inconsistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)