### PR TITLE
chore: align registry descriptions with security tagline

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vaultpilot-mcp",
   "version": "0.5.2",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
-  "description": "MCP server for AI agents (Claude Code, Claude Desktop, Cursor) to manage a self-custodial crypto portfolio through a Ledger hardware wallet. Reads on-chain wallet balances, ENS, token prices, and DeFi positions across Ethereum/Arbitrum/Polygon/Base (Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido stETH, EigenLayer), surfaces liquidation/health-factor alerts and protocol risk scores, then prepares unsigned EVM transactions (supply, borrow, repay, withdraw, stake, unstake, native/ERC-20 send, and LiFi-routed swaps and cross-chain bridges) that the user signs on their Ledger device via WalletConnect — private keys never leave the hardware wallet.",
+  "description": "Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
-  "description": "Self-custodial crypto portfolio: read EVM DeFi, sign on Ledger via WalletConnect.",
+  "description": "Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.",
   "version": "0.5.2",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {


### PR DESCRIPTION
## Summary
- Replace `package.json` and `server.json` `description` fields with the security tagline now used on the GitHub repo and the [TensorBlock awesome-mcp-servers entry (PR #380)](https://github.com/TensorBlock/awesome-mcp-servers/pull/380).
- Both descriptions previously diverged: `server.json` had a short "Self-custodial crypto portfolio…" line, `package.json` had a long technical paragraph. Aligning them keeps the npm and MCP Registry listings consistent with the public positioning.

The change is config-only — no code, no behavior. It will go live on npmjs.com and the MCP Registry on the next release (version bump + publish).

## Test plan
- [x] `git diff` shows only `description` field edits in two JSON files
- [ ] After merge: cut next release (`0.5.3` or whatever's next) so npm + MCP Registry pick up the new copy