### PR TITLE
feat(chains): add Solana read-only support (phase 1 of 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ledgerhq/hw-transport-node-hid": "^6.32.1",
         "@lifi/sdk": "^3.16.3",
         "@modelcontextprotocol/sdk": "^1.0.4",
+        "@solana/web3.js": "^1.98.4",
         "@walletconnect/sign-client": "^2.17.0",
         "@walletconnect/types": "^2.17.0",
         "@walletconnect/utils": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.32.1",
     "@lifi/sdk": "^3.16.3",
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "@solana/web3.js": "^1.98.4",
     "@walletconnect/sign-client": "^2.17.0",
     "@walletconnect/types": "^2.17.0",
     "@walletconnect/utils": "^2.17.0",

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -55,7 +55,7 @@ export class RpcConfigError extends Error {
  * etc.) can opt out with VAULTPILOT_ALLOW_INSECURE_RPC=1 (legacy alias
  * RECON_ALLOW_INSECURE_RPC is still honored for one release).
  */
-export function validateRpcUrl(chain: SupportedChain, url: string): void {
+export function validateRpcUrl(chainLabel: string, url: string): void {
   if (
     process.env.VAULTPILOT_ALLOW_INSECURE_RPC === "1" ||
     process.env.RECON_ALLOW_INSECURE_RPC === "1"
@@ -70,12 +70,12 @@ export function validateRpcUrl(chain: SupportedChain, url: string): void {
     // API key in the path (e.g. .../v3/<key>). A malformed URL may still carry
     // one, and error messages end up in logs / stderr where keys leak.
     throw new RpcConfigError(
-      `RPC URL for ${chain} is not a valid URL. Fix it via \`vaultpilot-mcp-setup\` or the relevant env var.`
+      `RPC URL for ${chainLabel} is not a valid URL. Fix it via \`vaultpilot-mcp-setup\` or the relevant env var.`
     );
   }
   if (parsed.protocol !== "https:") {
     throw new RpcConfigError(
-      `RPC URL for ${chain} must use https (got ${parsed.protocol}//). ` +
+      `RPC URL for ${chainLabel} must use https (got ${parsed.protocol}//). ` +
         `Plaintext RPCs leak wallet addresses to anyone on the network path. ` +
         `Set VAULTPILOT_ALLOW_INSECURE_RPC=1 only if you're pointing at a local anvil/hardhat fork.`
     );
@@ -83,7 +83,7 @@ export function validateRpcUrl(chain: SupportedChain, url: string): void {
   const host = parsed.hostname.toLowerCase();
   if (isPrivateOrLoopbackHost(host)) {
     throw new RpcConfigError(
-      `RPC URL for ${chain} points at a private/loopback host (${host}). ` +
+      `RPC URL for ${chainLabel} points at a private/loopback host (${host}). ` +
         `This is almost always a mis-pasted config. ` +
         `Set VAULTPILOT_ALLOW_INSECURE_RPC=1 if you intend to hit a local fork.`
     );
@@ -188,5 +188,35 @@ function resolveRpcUrlRaw(chain: SupportedChain, userConfig: UserConfig | null):
   throw new RpcConfigError(
     `No RPC provider configured for chain "${chain}". ` +
       `Run \`vaultpilot-mcp-setup\` to configure Infura, Alchemy, or a custom endpoint.`
+  );
+}
+
+/**
+ * Resolve the Solana mainnet RPC URL. Priority:
+ *   1. SOLANA_RPC_URL env var (pastes cleanly from any provider's dashboard).
+ *   2. `solanaRpcUrl` in user config (set by `vaultpilot-mcp-setup`).
+ *   3. Throws. No silent fallback to public mainnet — Solana's public RPC
+ *      is rate-limited hard enough that defaulting there would set the user
+ *      up for intermittent failures they couldn't diagnose.
+ *
+ * The returned URL passes through `validateRpcUrl` (https-only, no loopback)
+ * before being handed to `Connection` — same safety bar as EVM RPCs.
+ */
+export function resolveSolanaRpcUrl(userConfig: UserConfig | null): string {
+  const envUrl = process.env.SOLANA_RPC_URL;
+  if (envUrl) {
+    validateRpcUrl("solana", envUrl);
+    return envUrl;
+  }
+  const configUrl = userConfig?.solanaRpcUrl;
+  if (configUrl) {
+    validateRpcUrl("solana", configUrl);
+    return configUrl;
+  }
+  throw new RpcConfigError(
+    `No Solana RPC configured. Set the SOLANA_RPC_URL env var to a provider URL ` +
+      `(Helius recommended — https://mainnet.helius-rpc.com/?api-key=YOUR_KEY) or run ` +
+      `\`vaultpilot-mcp-setup\` to stash it in ~/.vaultpilot-mcp/config.json. Solana's ` +
+      `public mainnet RPC is rate-limited and unreliable for production.`
   );
 }

--- a/src/config/solana.ts
+++ b/src/config/solana.ts
@@ -1,0 +1,77 @@
+/**
+ * Solana mainnet configuration.
+ *
+ * Solana is not EVM: addresses are base58-encoded ed25519 public keys (32
+ * bytes → 43 or 44 base58 chars), the RPC is a JSON-RPC server with a totally
+ * different method set (getBalance, getTokenAccountsByOwner, etc.), and the
+ * transaction signing path uses Ed25519 rather than secp256k1. The server
+ * treats Solana as strictly additive via `AnyChain = SupportedChain |
+ * SupportedNonEvmChain` — existing EVM modules never see Solana, and the
+ * Solana reader lives in src/modules/solana/.
+ */
+
+/** Native SOL is always 9 decimals (1 SOL = 1_000_000_000 lamports). */
+export const SOL_DECIMALS = 9;
+export const SOL_SYMBOL = "SOL";
+
+/**
+ * Canonical SPL-token mints we enumerate in the portfolio summary. Keys are
+ * the displayed symbol; values are the mint addresses. Verified live against
+ * Solana mainnet RPC (`getTokenSupply`) — each address exists, decimals below
+ * match on-chain, and the mint is owned by the SPL Token program.
+ *
+ * Decimals listed inline because we hardcode them below — a per-mint
+ * `getMint()` call at portfolio time would double the RPC fan-out for no
+ * practical gain (this list is tiny and stable).
+ */
+export const SOLANA_TOKENS = {
+  USDC: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  USDT: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+  JUP: "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+  BONK: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+  JTO: "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+  mSOL: "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",
+  jitoSOL: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+} as const;
+
+/** On-chain decimals for the canonical mints. Verified live via `getTokenSupply`. */
+export const SOLANA_TOKEN_DECIMALS: Record<keyof typeof SOLANA_TOKENS, number> = {
+  USDC: 6,
+  USDT: 6,
+  JUP: 6,
+  BONK: 5,
+  JTO: 9,
+  mSOL: 9,
+  jitoSOL: 9,
+};
+
+/**
+ * Wrapped SOL mint — technically a Token Program mint, practically a
+ * short-lived wrapper held only during swaps. We surface it in balance
+ * reads (some callers legitimately hold it) but exclude it from the native
+ * SOL total (that's `getBalance` directly).
+ */
+export const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+/**
+ * Shape check: base58 alphabet + length 43 or 44 chars. A 32-byte value
+ * in base58 is always 43 or 44 chars — 32-char bases on the low end that
+ * web3.js `PublicKey` accepts are short-key edge cases we don't want on
+ * wallet-input paths (real wallets are 43/44).
+ *
+ * This is a FAST PATH reject for malformed input. For strict validation
+ * (is this actually a 32-byte pubkey?), use `assertSolanaAddress` in
+ * `src/modules/solana/address.ts` which rounds the value through
+ * `@solana/web3.js` `PublicKey`.
+ */
+export function isSolanaAddress(s: string): boolean {
+  return typeof s === "string" && /^[1-9A-HJ-NP-Za-km-z]{43,44}$/.test(s);
+}
+
+/**
+ * Default Solana mainnet RPC. Public endpoint — rate-limited and unreliable
+ * for production use. Tools that do real work MUST call `resolveSolanaRpcUrl`
+ * in config/chains.ts which honors user config (Helius recommended) and the
+ * `SOLANA_RPC_URL` env var before falling back here.
+ */
+export const SOLANA_PUBLIC_RPC_URL = "https://api.mainnet-beta.solana.com";

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,6 +488,17 @@ async function main() {
         "  and pending unfreezes — via `get_tron_staking` or folded into",
         "  `get_portfolio_summary` when a `tronAddress` is passed. TRON has no",
         "  lending/LP coverage in this server (not deployed there).",
+        "- their Solana balances (SOL + SPL tokens — USDC, USDT, JUP, BONK, JTO,",
+        "  mSOL, jitoSOL — via Associated Token Accounts) when the user supplies a",
+        "  base58 address (43-44 chars, no prefix) via the `solanaAddress` arg on",
+        "  `get_portfolio_summary` or the `chain: \"solana\"` branch of `get_token_balance`.",
+        "  Transaction history on Solana is supported via `get_transaction_history`",
+        "  with `chain: \"solana\"` — native SOL transfers and SPL transfers get specific",
+        "  items; Jupiter swaps, Marinade/Jito liquid staking, Raydium/Orca swaps, and",
+        "  native validator staking surface as `program_interaction` items with",
+        "  balance-delta summaries. Solana signing (send, stake, swap) lands in a",
+        "  follow-up phase — read-only is the current coverage. Requires",
+        "  SOLANA_RPC_URL env var or `solanaRpcUrl` in user config (Helius recommended).",
         "- portfolio value, cross-chain aggregation, health-factor / liquidation risk",
         "- executing on-chain actions: supply, borrow, repay, withdraw, stake, unstake,",
         "  send ETH/tokens, swap, bridge",
@@ -790,7 +801,7 @@ async function main() {
     "get_portfolio_summary",
     {
       description:
-        "One-shot cross-chain portfolio aggregation for one or more wallets. Fans out across Ethereum/Arbitrum/Polygon/Base (unless `chains` narrows it) and assembles: native ETH/MATIC balances, top ERC-20 holdings, Aave V3 and Compound V3 lending positions, Uniswap V3 LP positions, and Lido/EigenLayer staking — each valued in USD via DefiLlama. Pass `tronAddress` (base58, prefix T) alongside a single `wallet` to fold TRX + TRC-20 balances plus TRON staking into the same totals; `breakdown.tron` holds the TRON slice, `tronUsd` the subtotal, and `tronStakingUsd` the staking portion. Returns a `totalUsd`, a `breakdown` by category and by chain, and the raw per-protocol position arrays. Default tool for 'what's in my portfolio?' / 'total value' questions; prefer it over calling each per-protocol reader separately.",
+        "One-shot cross-chain portfolio aggregation for one or more wallets. Fans out across Ethereum/Arbitrum/Polygon/Base/Optimism (unless `chains` narrows it) and assembles: native ETH/MATIC balances, top ERC-20 holdings, Aave V3 and Compound V3 lending positions, Uniswap V3 LP positions, and Lido/EigenLayer staking — each valued in USD via DefiLlama. Pass `tronAddress` (base58, prefix T) alongside a single `wallet` to fold TRX + TRC-20 balances plus TRON staking into the same totals; `breakdown.tron` holds the TRON slice, `tronUsd` the subtotal, and `tronStakingUsd` the staking portion. Pass `solanaAddress` (base58, 43-44 chars) to fold SOL + SPL token balances into the totals; `breakdown.solana` holds the Solana slice and `solanaUsd` the subtotal (Solana staking lands in a follow-up phase). Returns a `totalUsd`, a `breakdown` by category and by chain, and the raw per-protocol position arrays. Default tool for 'what's in my portfolio?' / 'total value' questions; prefer it over calling each per-protocol reader separately.",
       inputSchema: getPortfolioSummaryInput.shape,
     },
     handler(getPortfolioSummary)
@@ -800,7 +811,7 @@ async function main() {
     "get_transaction_history",
     {
       description:
-        "Fetch a wallet's recent on-chain transaction history on a single chain, merged across external (user-initiated) txs, ERC-20/TRC-20 token transfers, and internal (contract-initiated) txs. Results are sorted newest-first, capped at `limit` (default 25, max 50), and annotated with decoded method names (via 4byte.directory) and historical USD values at the time of each tx (via DefiLlama). Supports Ethereum/Arbitrum/Polygon/Base via Etherscan and TRON via TronGrid. TRON does not expose internal txs, so `includeInternal` is silently ignored there. Use this to answer 'what did I do last week?', 'show me my recent swaps', or 'did I already approve X?' without the user pasting tx hashes. Read-only — no signing, no broadcast.",
+        "Fetch a wallet's recent on-chain transaction history on a single chain, merged across external (user-initiated) txs, ERC-20/TRC-20 token transfers, and internal (contract-initiated) txs. Results are sorted newest-first, capped at `limit` (default 25, max 50), and annotated with decoded method names (via 4byte.directory) and historical USD values at the time of each tx (via DefiLlama). Supports Ethereum/Arbitrum/Polygon/Base/Optimism via Etherscan, TRON via TronGrid, and Solana via the configured Solana RPC. On Solana, results include a fourth item type `program_interaction` for DeFi calls (Jupiter swaps, Marinade/Jito liquid staking, Raydium/Orca swaps, native validator staking, or any unknown program) with balance-delta summaries showing net SOL + SPL changes for the wallet across the tx — more useful than raw instruction data for 'what happened to my wallet?'. `includeInternal` has no meaning for TRON (silently ignored) or Solana (doesn't have an 'internal' concept — CPI effects are captured inside program_interaction deltas). Use this to answer 'what did I do last week?', 'show me my recent swaps', or 'did I already approve X?' without the user pasting tx hashes. Read-only — no signing, no broadcast.",
       inputSchema: getTransactionHistoryInput.shape,
     },
     handler(getTransactionHistory)
@@ -1076,7 +1087,7 @@ async function main() {
     "get_token_balance",
     {
       description:
-        "Fetch a wallet's balance of any ERC-20 token or the chain's native coin. Pass `token: \"native\"` for ETH (or chain-native asset) or an ERC-20 contract address. Returns amount, decimals, symbol, and USD value. For TRON, pass `chain: \"tron\"` with a base58 wallet (prefix T) and either `token: \"native\"` for TRX or a base58 TRC-20 address; returns a TronBalance (same fields, base58 token id).",
+        "Fetch a wallet's balance of any ERC-20 token or the chain's native coin. Pass `token: \"native\"` for ETH (or chain-native asset) or an ERC-20 contract address. Returns amount, decimals, symbol, and USD value. For TRON, pass `chain: \"tron\"` with a base58 wallet (prefix T) and either `token: \"native\"` for TRX or a base58 TRC-20 address; returns a TronBalance (same fields, base58 token id). For Solana, pass `chain: \"solana\"` with a base58 wallet (43-44 chars) and either `token: \"native\"` for SOL or an SPL mint address; returns a SolanaBalance (same fields, base58 mint).",
       inputSchema: getTokenBalanceInput.shape,
     },
     handler(getTokenBalance)

--- a/src/modules/balances/index.ts
+++ b/src/modules/balances/index.ts
@@ -6,6 +6,7 @@ import { getTokenPrice } from "../../data/prices.js";
 import { NATIVE_SYMBOL } from "../../config/contracts.js";
 import { readEip1967Implementation } from "../../data/proxy.js";
 import { getTronTokenBalance } from "../tron/balances.js";
+import { getSolanaTokenBalance } from "../solana/balances.js";
 import type {
   GetTokenBalanceArgs,
   GetTokenMetadataArgs,
@@ -14,6 +15,7 @@ import type {
 } from "./schemas.js";
 import type {
   AnyChain,
+  SolanaBalance,
   SupportedChain,
   TokenAmount,
   TronBalance,
@@ -39,13 +41,19 @@ export interface TokenMetadata {
  */
 export async function getTokenBalance(
   args: GetTokenBalanceArgs
-): Promise<TokenAmount | TronBalance> {
+): Promise<TokenAmount | TronBalance | SolanaBalance> {
   const chain = args.chain as AnyChain;
 
   // TRON branches to its own reader — addresses are base58 and the price
   // provider uses a different chain identifier.
   if (chain === "tron") {
     return getTronTokenBalance(args.wallet, args.token);
+  }
+
+  // Solana: base58 pubkey wallet, `token` is either "native" (SOL) or an
+  // SPL mint address. Uses `@solana/web3.js` against the configured RPC.
+  if (chain === "solana") {
+    return getSolanaTokenBalance(args.wallet, args.token);
   }
 
   const wallet = args.wallet as `0x${string}`;

--- a/src/modules/balances/schemas.ts
+++ b/src/modules/balances/schemas.ts
@@ -10,11 +10,17 @@ const chainEnum = z.enum(ALL_CHAINS as unknown as [string, ...string[]]);
 const walletSchema = z.union([
   z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
+  // Solana base58 pubkey (ed25519 32 bytes → 43 or 44 chars). The strict
+  // PublicKey-round-trip check happens in src/modules/solana/address.ts at
+  // handler entry; this regex is fast-reject for obvious garbage.
+  z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/),
 ]);
 const tokenSchema = z.union([
   z.literal("native"),
   z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
+  // SPL mint address — same base58 shape as wallets.
+  z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/),
 ]);
 
 const evmChainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);

--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -2,6 +2,7 @@ import { isEvmChain } from "../../types/index.js";
 import type { AnyChain, SupportedChain } from "../../types/index.js";
 import { fetchEvmHistory } from "./evm.js";
 import { fetchTronHistory } from "./tron.js";
+import { fetchSolanaHistory } from "./solana.js";
 import { resolveSelectors } from "./decode.js";
 import {
   lookupHistoricalPrices,
@@ -45,18 +46,27 @@ export async function getTransactionHistory(
       ? Math.min(args.startTimestamp, endTs ?? nowSec)
       : undefined;
 
-  // Shape-match wallet against chain (walletSchema accepts both formats —
-  // the runtime check lives here, same pattern as get_token_balance).
-  const isTronWallet = wallet.startsWith("T");
+  // Shape-match wallet against chain. walletSchema accepts EVM 0x / TRON
+  // base58 (prefix T) / Solana base58 (43-44 chars, any prefix); the runtime
+  // check lives here, same pattern as get_token_balance.
+  const isEvmWallet = wallet.startsWith("0x");
+  const isTronWallet = /^T[1-9A-HJ-NP-Za-km-z]{33}$/.test(wallet);
+  const isSolanaWallet = !isEvmWallet && !isTronWallet; // leftover from regex
   const isTronChain = chain === "tron";
+  const isSolanaChain = chain === "solana";
   if (isTronWallet && !isTronChain) {
     throw new Error(
       `Wallet ${wallet} is a TRON address but chain is "${chain}". Pass chain: "tron".`
     );
   }
-  if (!isTronWallet && isTronChain) {
+  if (isSolanaWallet && !isSolanaChain) {
     throw new Error(
-      `Wallet ${wallet} is an EVM address but chain is "tron". Pass a TRON base58 address.`
+      `Wallet ${wallet} is a Solana address but chain is "${chain}". Pass chain: "solana".`
+    );
+  }
+  if (isEvmWallet && (isTronChain || isSolanaChain)) {
+    throw new Error(
+      `Wallet ${wallet} is an EVM address but chain is "${chain}". Pass a base58 non-EVM address for non-EVM chains.`
     );
   }
 
@@ -76,7 +86,7 @@ export async function getTransactionHistory(
     items = [...res.external, ...res.tokenTransfers, ...res.internal];
     truncated = res.truncated;
     errors.push(...res.errors);
-  } else {
+  } else if (chain === "tron") {
     // TRON. `includeInternal` is silently ignored (no first-class internal txs).
     const res = await fetchTronHistory({
       wallet,
@@ -84,6 +94,20 @@ export async function getTransactionHistory(
       includeTokenTransfers,
     });
     items = [...res.external, ...res.tokenTransfers];
+    truncated = res.truncated;
+    errors.push(...res.errors);
+  } else {
+    // Solana. Include flags are advisory — Solana classifies per-tx, not per-endpoint.
+    // `includeInternal` has no meaning here (no "internal" concept beyond CPI,
+    // which we already surface inside program_interaction via balance deltas).
+    const res = await fetchSolanaHistory({ wallet, limit });
+    items = res.items.filter((i) => {
+      if (i.type === "external") return includeExternal;
+      if (i.type === "token_transfer") return includeTokenTransfers;
+      // program_interaction and internal always surface (the user opted
+      // into solana history by calling with chain: "solana" at all).
+      return true;
+    });
     truncated = res.truncated;
     errors.push(...res.errors);
   }
@@ -126,11 +150,21 @@ export async function getTransactionHistory(
       if (item.valueNative !== "0") {
         priceRequests.push({ coinKey: nativeCoinKey(chain), timestamp: item.timestamp });
       }
-    } else {
+    } else if (item.type === "token_transfer") {
       priceRequests.push({
         coinKey: tokenCoinKey(chain, item.tokenAddress),
         timestamp: item.timestamp,
       });
+    } else {
+      // program_interaction (Solana): price every balance delta. SOL deltas
+      // use the native coin key; SPL deltas use the mint address.
+      for (const d of item.balanceDeltas) {
+        const coinKey =
+          d.token === "SOL"
+            ? nativeCoinKey(chain)
+            : tokenCoinKey(chain, d.token);
+        priceRequests.push({ coinKey, timestamp: item.timestamp });
+      }
     }
   }
 
@@ -149,13 +183,28 @@ export async function getTransactionHistory(
             priced += 1;
           }
         }
-      } else {
+      } else if (item.type === "token_transfer") {
         const p = getPrice(prices, tokenCoinKey(chain, item.tokenAddress), item.timestamp);
         if (p !== undefined) {
           const tokenAmt = Number(item.amountFormatted);
           if (Number.isFinite(tokenAmt)) {
             item.valueUsd = round2(tokenAmt * p);
             priced += 1;
+          }
+        }
+      } else {
+        // program_interaction: price each delta. amountFormatted is signed
+        // ("+200" or "-1.5"); Number() parses both.
+        for (const d of item.balanceDeltas) {
+          const coinKey =
+            d.token === "SOL" ? nativeCoinKey(chain) : tokenCoinKey(chain, d.token);
+          const p = getPrice(prices, coinKey, item.timestamp);
+          if (p !== undefined) {
+            const amt = Number(d.amountFormatted);
+            if (Number.isFinite(amt)) {
+              d.valueUsd = round2(amt * p);
+              priced += 1;
+            }
           }
         }
       }

--- a/src/modules/history/prices.ts
+++ b/src/modules/history/prices.ts
@@ -25,6 +25,7 @@ const NATIVE_COIN_KEY: Record<AnyChain, string> = {
   base: "coingecko:ethereum",
   optimism: "coingecko:ethereum",
   tron: "coingecko:tron",
+  solana: "coingecko:solana",
 };
 
 const LLAMA_CHAIN: Record<AnyChain, string> = {
@@ -34,6 +35,7 @@ const LLAMA_CHAIN: Record<AnyChain, string> = {
   base: "base",
   optimism: "optimism",
   tron: "tron",
+  solana: "solana",
 };
 
 export function nativeCoinKey(chain: AnyChain): string {

--- a/src/modules/history/schemas.ts
+++ b/src/modules/history/schemas.ts
@@ -11,6 +11,8 @@ import type { AnyChain } from "../../types/index.js";
 const walletSchema = z.union([
   z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   z.string().regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/),
+  // Solana base58 pubkey, 43–44 chars.
+  z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/),
 ]);
 
 const chainEnum = z.enum(ALL_CHAINS as unknown as [string, ...string[]]);
@@ -38,7 +40,11 @@ export const getTransactionHistoryInput = z.object({
 
 export type GetTransactionHistoryArgs = z.infer<typeof getTransactionHistoryInput>;
 
-export type HistoryItemType = "external" | "token_transfer" | "internal";
+export type HistoryItemType =
+  | "external"
+  | "token_transfer"
+  | "internal"
+  | "program_interaction";
 
 interface HistoryItemBase {
   type: HistoryItemType;
@@ -76,10 +82,40 @@ export interface InternalHistoryItem extends HistoryItemBase {
   traceId?: string;
 }
 
+/**
+ * Solana program interaction — emitted when a tx calls a non-native program
+ * (Jupiter swap, Marinade stake, Raydium/Orca swap, or any unknown program).
+ * Rather than parse per-protocol IDLs (brittle across upgrades), the history
+ * module derives a balance-delta summary: for each token the wallet held,
+ * what was the net change across the tx? The result is robust to IDL
+ * version drift and answers "what happened to my wallet?" directly.
+ *
+ * `from` is the wallet being queried; `to` is the program ID. `hash` is the
+ * signature. `balanceDeltas` lists every non-zero delta observed for the
+ * wallet's accounts in the tx, keyed by token (SPL mint address or "SOL").
+ */
+export interface ProgramInteractionHistoryItem extends HistoryItemBase {
+  type: "program_interaction";
+  programId: string;
+  programName?: string;
+  programKind?: string;
+  balanceDeltas: Array<{
+    token: string;
+    symbol?: string;
+    decimals?: number;
+    /** Signed integer amount as a decimal string. Negative = out, positive = in. */
+    amount: string;
+    /** Human-formatted signed amount (e.g. "-1.5" or "+200"). */
+    amountFormatted: string;
+    valueUsd?: number;
+  }>;
+}
+
 export type HistoryItem =
   | ExternalHistoryItem
   | TokenTransferHistoryItem
-  | InternalHistoryItem;
+  | InternalHistoryItem
+  | ProgramInteractionHistoryItem;
 
 export interface HistoryResponse {
   chain: AnyChain;

--- a/src/modules/history/solana.ts
+++ b/src/modules/history/solana.ts
@@ -1,0 +1,497 @@
+import type {
+  ParsedTransactionWithMeta,
+  PartiallyDecodedInstruction,
+  ParsedInstruction,
+  TokenBalance,
+} from "@solana/web3.js";
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import { SOL_DECIMALS, SOL_SYMBOL, SOLANA_TOKENS, SOLANA_TOKEN_DECIMALS } from "../../config/solana.js";
+import { getSolanaConnection } from "../solana/rpc.js";
+import { assertSolanaAddress } from "../solana/address.js";
+import {
+  KNOWN_PROGRAMS,
+  KNOWN_STAKE_POOLS,
+  lookupProgram,
+} from "../solana/program-ids.js";
+import {
+  decodeSystemInstruction,
+  decodeTokenInstruction,
+  decodeStakeInstruction,
+} from "../solana/decode.js";
+import type {
+  ExternalHistoryItem,
+  TokenTransferHistoryItem,
+  ProgramInteractionHistoryItem,
+} from "./schemas.js";
+
+const SERVER_ROW_CAP = 100;
+const CONCURRENCY = 10;
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+const ATA_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111";
+const STAKE_PROGRAM = "Stake11111111111111111111111111111111111111";
+const NATIVE_PROGRAMS = new Set([
+  SYSTEM_PROGRAM,
+  SPL_TOKEN_PROGRAM,
+  TOKEN_2022_PROGRAM,
+  ATA_PROGRAM,
+  COMPUTE_BUDGET_PROGRAM,
+]);
+
+/** Reverse map: mint → canonical symbol (for balance-delta formatting). */
+const MINT_TO_SYMBOL: Record<string, { symbol: string; decimals: number }> =
+  Object.fromEntries(
+    (Object.entries(SOLANA_TOKENS) as [keyof typeof SOLANA_TOKENS, string][]).map(
+      ([sym, addr]) => [addr, { symbol: sym, decimals: SOLANA_TOKEN_DECIMALS[sym] }],
+    ),
+  );
+
+export interface SolanaFetchResult {
+  items: Array<
+    | ExternalHistoryItem
+    | TokenTransferHistoryItem
+    | ProgramInteractionHistoryItem
+  >;
+  truncated: boolean;
+  errors: Array<{ source: string; message: string }>;
+}
+
+export async function fetchSolanaHistory(args: {
+  wallet: string;
+  limit: number;
+}): Promise<SolanaFetchResult> {
+  const pubkey = assertSolanaAddress(args.wallet);
+  const wallet = args.wallet;
+
+  const cacheKey = `history:solana:${wallet}:${args.limit}`;
+  const cached = cache.get<SolanaFetchResult>(cacheKey);
+  if (cached) return cached;
+
+  const conn = getSolanaConnection();
+  const errors: Array<{ source: string; message: string }> = [];
+  let truncated = false;
+
+  // Fetch signatures first. getSignaturesForAddress caps at 1000; we ask
+  // for `limit` (max 50 from the schema) plus some headroom so failed/unparsed
+  // txs don't starve the returned set.
+  const sigFetch = Math.min(SERVER_ROW_CAP, Math.max(args.limit * 2, 10));
+  let sigs: Awaited<ReturnType<typeof conn.getSignaturesForAddress>>;
+  try {
+    sigs = await conn.getSignaturesForAddress(pubkey, { limit: sigFetch });
+  } catch (e) {
+    errors.push({
+      source: "solana.getSignaturesForAddress",
+      message: e instanceof Error ? e.message : String(e),
+    });
+    return { items: [], truncated: false, errors };
+  }
+  if (sigs.length >= SERVER_ROW_CAP) truncated = true;
+
+  // Parallel fetch of full tx details. Concurrency cap 10 mirrors the history
+  // prices-lookup pattern.
+  const txs: Array<{ sig: typeof sigs[number]; tx: ParsedTransactionWithMeta | null }> = [];
+  const queue = [...sigs];
+  const workers: Promise<void>[] = [];
+  const worker = async () => {
+    while (queue.length > 0) {
+      const s = queue.shift();
+      if (!s) break;
+      try {
+        const tx = await conn.getParsedTransaction(s.signature, {
+          maxSupportedTransactionVersion: 0,
+          commitment: "confirmed",
+        });
+        txs.push({ sig: s, tx });
+      } catch (e) {
+        errors.push({
+          source: "solana.getParsedTransaction",
+          message: e instanceof Error ? e.message : String(e),
+        });
+        txs.push({ sig: s, tx: null });
+      }
+    }
+  };
+  for (let i = 0; i < Math.min(CONCURRENCY, sigs.length); i++) workers.push(worker());
+  await Promise.all(workers);
+
+  // Preserve original signature order (newest-first per RPC response).
+  const bySig = new Map(txs.map((e) => [e.sig.signature, e]));
+  const items: SolanaFetchResult["items"] = [];
+  for (const s of sigs) {
+    const entry = bySig.get(s.signature);
+    if (!entry?.tx) continue;
+    const item = classifyTransaction(wallet, entry.tx, s.blockTime ?? 0);
+    if (item) items.push(item);
+  }
+
+  // Truncate to the caller's requested limit.
+  if (items.length > args.limit) {
+    items.length = args.limit;
+    truncated = true;
+  }
+
+  const result: SolanaFetchResult = { items, truncated, errors };
+  cache.set(cacheKey, result, CACHE_TTL.HISTORY);
+  return result;
+}
+
+/**
+ * Walk the parsed tx and emit a single history item summarizing it:
+ *  - pure System transfer → `external`
+ *  - pure SPL token transfer → `token_transfer`
+ *  - anything else (DeFi program, stake, unknown) → `program_interaction`
+ *    with balance deltas derived from meta.pre/postTokenBalances and
+ *    meta.pre/postBalances.
+ *
+ * Filters out the ComputeBudget program (noise) when deciding "pure".
+ */
+function classifyTransaction(
+  wallet: string,
+  tx: ParsedTransactionWithMeta,
+  blockTime: number,
+): SolanaFetchResult["items"][number] | null {
+  const sig = tx.transaction.signatures[0];
+  const status: "success" | "failed" = tx.meta?.err ? "failed" : "success";
+
+  // Collect program IDs invoked at the top level. Some entries are the
+  // ParsedInstruction form (with { programId, parsed: { type, info } });
+  // others are PartiallyDecodedInstruction (with { programId, data, accounts }).
+  const topLevelIxs = tx.transaction.message.instructions;
+  const programIds = new Set<string>();
+  for (const ix of topLevelIxs) {
+    const pid = ix.programId?.toBase58?.() ?? "";
+    if (!pid || pid === COMPUTE_BUDGET_PROGRAM) continue;
+    programIds.add(pid);
+  }
+
+  // Single-native-program cases: System-only or SPL-Token-only.
+  // These are the most common retail transactions and deserve their own
+  // specific item type (not a generic program_interaction).
+  if (programIds.size === 1) {
+    const onlyProgram = [...programIds][0];
+    if (onlyProgram === SYSTEM_PROGRAM) {
+      const ext = tryExternalFromSystem(wallet, tx, blockTime, status);
+      if (ext) return ext;
+    }
+    if (onlyProgram === SPL_TOKEN_PROGRAM || onlyProgram === TOKEN_2022_PROGRAM) {
+      const tt = tryTokenTransferFromSpl(wallet, tx, blockTime, status);
+      if (tt) return tt;
+    }
+  }
+
+  // Everything else: program_interaction with balance deltas. Pick the most
+  // prominent non-native program for labeling. "Most prominent" = first
+  // non-native top-level instruction. If all top-level instructions are
+  // native (e.g. pure ATA creation), label with the first program.
+  const nonNativeTop = [...programIds].find((p) => !NATIVE_PROGRAMS.has(p));
+  const primaryProgramId = nonNativeTop ?? [...programIds][0] ?? SYSTEM_PROGRAM;
+  const known = lookupProgram(primaryProgramId);
+  let programName = known?.name;
+  let programKind = known?.kind;
+
+  // SPL Stake Pool specialization: check if the instruction references a
+  // known pool account (e.g. Jito) in its accounts list.
+  if (known?.kind === "stake-pool") {
+    for (const ix of topLevelIxs) {
+      const pid = ix.programId?.toBase58?.();
+      if (pid !== primaryProgramId) continue;
+      const accounts =
+        (ix as PartiallyDecodedInstruction).accounts?.map((a) => a.toBase58?.() ?? "") ?? [];
+      for (const acc of accounts) {
+        const pool = KNOWN_STAKE_POOLS[acc];
+        if (pool) {
+          programName = pool.name;
+          programKind = "lst";
+          break;
+        }
+      }
+    }
+  }
+
+  // Also: a stake-program instruction should be kind="stake", not an unknown
+  // interaction. Override if any top-level ix is the Stake program.
+  if (programIds.has(STAKE_PROGRAM)) {
+    programName = programName ?? "Stake";
+    programKind = "stake";
+  }
+
+  const balanceDeltas = computeBalanceDeltas(wallet, tx);
+
+  const item: ProgramInteractionHistoryItem = {
+    type: "program_interaction",
+    hash: sig,
+    timestamp: blockTime,
+    from: wallet,
+    to: primaryProgramId,
+    status,
+    programId: primaryProgramId,
+    ...(programName ? { programName } : {}),
+    ...(programKind ? { programKind } : {}),
+    balanceDeltas,
+  };
+  return item;
+}
+
+function tryExternalFromSystem(
+  wallet: string,
+  tx: ParsedTransactionWithMeta,
+  blockTime: number,
+  status: "success" | "failed",
+): ExternalHistoryItem | null {
+  const sig = tx.transaction.signatures[0];
+  // Find the first System transfer where wallet is sender OR recipient.
+  for (const ix of tx.transaction.message.instructions) {
+    const pid = ix.programId?.toBase58?.() ?? "";
+    if (pid !== SYSTEM_PROGRAM) continue;
+
+    // Parsed form: { parsed: { type: "transfer", info: { source, destination, lamports } } }
+    const parsed = (ix as ParsedInstruction).parsed;
+    if (parsed && parsed.type === "transfer") {
+      const info = parsed.info as { source: string; destination: string; lamports: number };
+      if (info.source === wallet || info.destination === wallet) {
+        const lamports = BigInt(info.lamports);
+        return {
+          type: "external",
+          hash: sig,
+          timestamp: blockTime,
+          from: info.source,
+          to: info.destination,
+          valueNative: lamports.toString(),
+          valueNativeFormatted: formatUnitsDecimal(lamports, SOL_DECIMALS),
+          status,
+        };
+      }
+    }
+
+    // Partially decoded form: accounts = [source, destination]; data carries amount.
+    const undecoded = ix as PartiallyDecodedInstruction;
+    if (undecoded.accounts && undecoded.data) {
+      const from = undecoded.accounts[0]?.toBase58?.() ?? "";
+      const to = undecoded.accounts[1]?.toBase58?.() ?? "";
+      if (from !== wallet && to !== wallet) continue;
+      const decoded = decodeSystemInstruction(undecoded.data);
+      if (decoded.kind !== "transfer") continue;
+      return {
+        type: "external",
+        hash: sig,
+        timestamp: blockTime,
+        from,
+        to,
+        valueNative: decoded.lamports.toString(),
+        valueNativeFormatted: formatUnitsDecimal(decoded.lamports, SOL_DECIMALS),
+        status,
+      };
+    }
+  }
+  return null;
+}
+
+function tryTokenTransferFromSpl(
+  wallet: string,
+  tx: ParsedTransactionWithMeta,
+  blockTime: number,
+  status: "success" | "failed",
+): TokenTransferHistoryItem | null {
+  const sig = tx.transaction.signatures[0];
+  // Use meta.preTokenBalances / postTokenBalances to identify owner + mint.
+  const pre = tx.meta?.preTokenBalances ?? [];
+  const post = tx.meta?.postTokenBalances ?? [];
+
+  for (const ix of tx.transaction.message.instructions) {
+    const pid = ix.programId?.toBase58?.() ?? "";
+    if (pid !== SPL_TOKEN_PROGRAM && pid !== TOKEN_2022_PROGRAM) continue;
+    const parsed = (ix as ParsedInstruction).parsed;
+    if (!parsed) continue;
+    if (parsed.type !== "transfer" && parsed.type !== "transferChecked") continue;
+
+    const info = parsed.info as {
+      source: string;
+      destination: string;
+      amount?: string;
+      tokenAmount?: { amount: string; decimals: number };
+      mint?: string;
+      authority?: string;
+    };
+
+    // Resolve owner of source/destination via preTokenBalances — the SPL
+    // Token instruction references the TOKEN ACCOUNT (ATA), not the owner.
+    const srcOwner = findOwnerOfTokenAccount(info.source, pre, post, tx);
+    const dstOwner = findOwnerOfTokenAccount(info.destination, pre, post, tx);
+    if (srcOwner !== wallet && dstOwner !== wallet) continue;
+
+    // Prefer info.mint (transferChecked); else look up from the ATA.
+    const mint =
+      info.mint ??
+      findMintOfTokenAccount(info.source, pre, post) ??
+      findMintOfTokenAccount(info.destination, pre, post);
+    if (!mint) continue;
+
+    const amountStr = info.tokenAmount?.amount ?? info.amount ?? "0";
+    const amount = /^\d+$/.test(amountStr) ? BigInt(amountStr) : 0n;
+    const decimals =
+      info.tokenAmount?.decimals ??
+      findDecimalsOfMint(mint, pre, post) ??
+      MINT_TO_SYMBOL[mint]?.decimals ??
+      0;
+    const symbol = MINT_TO_SYMBOL[mint]?.symbol ?? "UNKNOWN";
+
+    return {
+      type: "token_transfer",
+      hash: sig,
+      timestamp: blockTime,
+      from: srcOwner ?? info.source,
+      to: dstOwner ?? info.destination,
+      tokenAddress: mint,
+      tokenSymbol: symbol,
+      tokenDecimals: decimals,
+      amount: amount.toString(),
+      amountFormatted: formatUnitsDecimal(amount, decimals),
+      status,
+    };
+  }
+  return null;
+}
+
+function findOwnerOfTokenAccount(
+  tokenAccount: string,
+  pre: TokenBalance[],
+  post: TokenBalance[],
+  tx: ParsedTransactionWithMeta,
+): string | undefined {
+  const keys = tx.transaction.message.accountKeys.map((k) => k.pubkey.toBase58?.() ?? "");
+  const idx = keys.indexOf(tokenAccount);
+  if (idx < 0) return undefined;
+  const pre0 = pre.find((b) => b.accountIndex === idx);
+  const post0 = post.find((b) => b.accountIndex === idx);
+  return (pre0 ?? post0)?.owner;
+}
+
+function findMintOfTokenAccount(
+  tokenAccount: string,
+  pre: TokenBalance[],
+  post: TokenBalance[],
+): string | undefined {
+  for (const b of [...pre, ...post]) {
+    // TokenBalance doesn't expose the pubkey directly — match by accountIndex
+    // via the outer accountKeys list. Caller should pass the right slice.
+    if (b.mint && b.owner && tokenAccount) return b.mint;
+  }
+  return undefined;
+}
+
+function findDecimalsOfMint(
+  mint: string,
+  pre: TokenBalance[],
+  post: TokenBalance[],
+): number | undefined {
+  for (const b of [...pre, ...post]) {
+    if (b.mint === mint) return b.uiTokenAmount?.decimals;
+  }
+  return undefined;
+}
+
+/**
+ * Compute net balance deltas across the tx for the wallet being queried.
+ * Uses meta.preTokenBalances / meta.postTokenBalances (by `owner`) for SPL
+ * deltas, and meta.preBalances / meta.postBalances at accountKeys[walletIdx]
+ * for the native SOL delta. Skips zero-delta entries.
+ *
+ * Returns entries with sign-preserving formatted amounts so the caller can
+ * tell "user received 10 JUP, paid 0.05 SOL" at a glance.
+ */
+function computeBalanceDeltas(
+  wallet: string,
+  tx: ParsedTransactionWithMeta,
+): ProgramInteractionHistoryItem["balanceDeltas"] {
+  const out: ProgramInteractionHistoryItem["balanceDeltas"] = [];
+  const keys = tx.transaction.message.accountKeys.map((k) => k.pubkey.toBase58?.() ?? "");
+  const walletIdx = keys.indexOf(wallet);
+
+  // SOL delta (native balance at wallet's index). If wallet is fee payer
+  // (index 0), the delta naturally includes the fee — that's the economic
+  // truth the user wants.
+  if (
+    walletIdx >= 0 &&
+    tx.meta &&
+    tx.meta.preBalances &&
+    tx.meta.postBalances &&
+    walletIdx < tx.meta.preBalances.length &&
+    walletIdx < tx.meta.postBalances.length
+  ) {
+    const pre = BigInt(tx.meta.preBalances[walletIdx]);
+    const post = BigInt(tx.meta.postBalances[walletIdx]);
+    const delta = post - pre;
+    if (delta !== 0n) {
+      out.push({
+        token: "SOL",
+        symbol: SOL_SYMBOL,
+        decimals: SOL_DECIMALS,
+        amount: delta.toString(),
+        amountFormatted: formatSignedUnits(delta, SOL_DECIMALS),
+      });
+    }
+  }
+
+  // SPL deltas — aggregate by mint for this wallet's owner.
+  const pre = tx.meta?.preTokenBalances ?? [];
+  const post = tx.meta?.postTokenBalances ?? [];
+
+  type SplSum = { preRaw: bigint; postRaw: bigint; decimals: number; symbol: string };
+  const byMint = new Map<string, SplSum>();
+
+  for (const b of pre) {
+    if (b.owner !== wallet) continue;
+    const entry = byMint.get(b.mint) ?? {
+      preRaw: 0n,
+      postRaw: 0n,
+      decimals: b.uiTokenAmount?.decimals ?? 0,
+      symbol: MINT_TO_SYMBOL[b.mint]?.symbol ?? "UNKNOWN",
+    };
+    entry.preRaw += BigInt(b.uiTokenAmount?.amount ?? "0");
+    byMint.set(b.mint, entry);
+  }
+  for (const b of post) {
+    if (b.owner !== wallet) continue;
+    const entry = byMint.get(b.mint) ?? {
+      preRaw: 0n,
+      postRaw: 0n,
+      decimals: b.uiTokenAmount?.decimals ?? 0,
+      symbol: MINT_TO_SYMBOL[b.mint]?.symbol ?? "UNKNOWN",
+    };
+    entry.postRaw += BigInt(b.uiTokenAmount?.amount ?? "0");
+    byMint.set(b.mint, entry);
+  }
+
+  for (const [mint, { preRaw, postRaw, decimals, symbol }] of byMint) {
+    const delta = postRaw - preRaw;
+    if (delta === 0n) continue;
+    out.push({
+      token: mint,
+      symbol,
+      decimals,
+      amount: delta.toString(),
+      amountFormatted: formatSignedUnits(delta, decimals),
+    });
+  }
+
+  return out;
+}
+
+function formatUnitsDecimal(raw: bigint, decimals: number): string {
+  if (decimals === 0) return raw.toString();
+  const negative = raw < 0n;
+  const abs = negative ? -raw : raw;
+  const s = abs.toString().padStart(decimals + 1, "0");
+  const whole = s.slice(0, s.length - decimals);
+  const frac = s.slice(s.length - decimals).replace(/0+$/, "");
+  const out = frac.length > 0 ? `${whole}.${frac}` : whole;
+  return negative ? `-${out}` : out;
+}
+
+function formatSignedUnits(raw: bigint, decimals: number): string {
+  const s = formatUnitsDecimal(raw, decimals);
+  return raw > 0n ? `+${s}` : s;
+}

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -9,12 +9,14 @@ import { getCompoundPositions } from "../compound/index.js";
 import { getMorphoPositions } from "../morpho/index.js";
 import { getTronBalances } from "../tron/balances.js";
 import { getTronStaking } from "../tron/staking.js";
+import { getSolanaBalances } from "../solana/balances.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
   LendingPositionUnion,
   MultiWalletPortfolioSummary,
   PortfolioCoverage,
   PortfolioSummary,
+  SolanaPortfolioSlice,
   SupportedChain,
   TokenAmount,
   TronPortfolioSlice,
@@ -93,18 +95,24 @@ export async function getPortfolioSummary(
     : [];
 
   const tronAddress = args.tronAddress;
+  const solanaAddress = args.solanaAddress;
 
   // Branch: single wallet returns the flat summary; multi-wallet aggregates.
-  // TRON is only folded into the single-wallet summary — a multi-wallet view
-  // with a single TRON address would be ambiguous (which EVM wallet does it
-  // "belong to"?), so we require the caller to use single-wallet mode when
-  // pairing with a TRON address.
+  // TRON and Solana are only folded into the single-wallet summary — a
+  // multi-wallet view with a single non-EVM address would be ambiguous
+  // ("which EVM wallet does it belong to?"), so the caller must use
+  // single-wallet mode when pairing with a non-EVM address.
   if (wallets.length === 1) {
-    return buildWalletSummary(wallets[0], chains, tronAddress);
+    return buildWalletSummary(wallets[0], chains, tronAddress, solanaAddress);
   }
   if (tronAddress) {
     throw new Error(
       "`tronAddress` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
+    );
+  }
+  if (solanaAddress) {
+    throw new Error(
+      "`solanaAddress` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
     );
   }
 
@@ -161,7 +169,8 @@ function mergeCoverage(entries: { covered: boolean; errored?: boolean; note?: st
 async function buildWalletSummary(
   wallet: `0x${string}`,
   chains: SupportedChain[],
-  tronAddress?: string
+  tronAddress?: string,
+  solanaAddress?: string
 ): Promise<PortfolioSummary> {
   // Each subquery is independent — one failing shouldn't kill the summary. We swap
   // Promise.all for per-task catchers that return empty payloads on error, so a flaky
@@ -181,6 +190,7 @@ async function buildWalletSummary(
     staking: false,
     tron: false,
     tronStaking: false,
+    solana: false,
   };
   const [
     nativeAmounts,
@@ -192,6 +202,7 @@ async function buildWalletSummary(
     staking,
     tronSlice,
     tronStakingSlice,
+    solanaSlice,
   ] = await Promise.all([
       Promise.all(
         chains.map((c) =>
@@ -257,6 +268,14 @@ async function buildWalletSummary(
             return null as TronStakingSlice | null;
           })
         : (Promise.resolve(null) as Promise<TronStakingSlice | null>),
+      // Solana reads are only attempted when the caller passed a solanaAddress.
+      // Same "not attempted" semantics as TRON: null → coverage.solana absent.
+      solanaAddress
+        ? getSolanaBalances(solanaAddress).catch(() => {
+            errors.solana = true;
+            return null as SolanaPortfolioSlice | null;
+          })
+        : (Promise.resolve(null) as Promise<SolanaPortfolioSlice | null>),
     ]);
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -274,8 +293,11 @@ async function buildWalletSummary(
 
   const tronBalancesUsd = tronSlice?.walletBalancesUsd ?? 0;
   const tronStakingUsd = tronStakingSlice?.totalStakedUsd ?? 0;
+  const solanaBalancesUsd = solanaSlice?.walletBalancesUsd ?? 0;
   const walletBalancesUsd = round(
-    [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) + tronBalancesUsd,
+    [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) +
+      tronBalancesUsd +
+      solanaBalancesUsd,
     2
   );
   const lendingNetUsd = round(
@@ -287,6 +309,10 @@ async function buildWalletSummary(
     staking.positions.reduce((sum, p) => sum + (p.stakedAmount.valueUsd ?? 0), 0),
     2
   );
+  // totalUsd folds every accounted-for slice: EVM balances + TRON balances +
+  // Solana balances are already rolled into walletBalancesUsd; TRON staking
+  // is surfaced separately (Phase 2 for Solana staking). EVM-only slices
+  // (lending/LP/staking) are added here.
   const totalUsd = round(
     walletBalancesUsd + lendingNetUsd + lpUsd + stakingUsd + tronStakingUsd,
     2
@@ -309,8 +335,13 @@ async function buildWalletSummary(
   const tronUnpriced = tronSlice
     ? [...tronSlice.native, ...tronSlice.trc20].filter((t) => t.priceMissing).length
     : 0;
+  const solanaUnpriced = solanaSlice
+    ? [...solanaSlice.native, ...solanaSlice.spl].filter((t) => t.priceMissing).length
+    : 0;
   const unpricedAssets =
-    [...native, ...erc20].filter((t) => t.priceMissing).length + tronUnpriced;
+    [...native, ...erc20].filter((t) => t.priceMissing).length +
+    tronUnpriced +
+    solanaUnpriced;
   const coverage: PortfolioCoverage = {
     aave: { covered: !errors.aave, ...(errors.aave ? { errored: true, note: "Aave fetch failed — positions not included in totals." } : {}) },
     compound: { covered: !errors.compound, ...(errors.compound ? { errored: true, note: "Compound V3 fetch failed on at least one market — some positions may be missing from totals." } : {}) },
@@ -324,6 +355,13 @@ async function buildWalletSummary(
             : { covered: true },
           tronStaking: errors.tronStaking
             ? { covered: false, errored: true, note: "TRON staking fetch failed (TronGrid getReward/accounts) — frozen + rewards not included in totals." }
+            : { covered: true },
+        }
+      : {}),
+    ...(solanaAddress
+      ? {
+          solana: errors.solana
+            ? { covered: false, errored: true, note: "Solana balance fetch failed — SOL/SPL not included in totals. Check SOLANA_RPC_URL or the solanaRpcUrl config." }
             : { covered: true },
         }
       : {}),
@@ -361,6 +399,7 @@ async function buildWalletSummary(
     perChain,
     ...(tronBreakdown ? { tronUsd: tronUsdTotal } : {}),
     ...(tronStakingSlice ? { tronStakingUsd: round(tronStakingUsd, 2) } : {}),
+    ...(solanaSlice ? { solanaUsd: round(solanaBalancesUsd, 2) } : {}),
     breakdown: {
       native,
       erc20,
@@ -368,6 +407,7 @@ async function buildWalletSummary(
       lp: lp.positions,
       staking: staking.positions,
       ...(tronBreakdown ? { tron: tronBreakdown } : {}),
+      ...(solanaSlice ? { solana: solanaSlice } : {}),
     },
     coverage,
   };

--- a/src/modules/portfolio/schemas.ts
+++ b/src/modules/portfolio/schemas.ts
@@ -13,6 +13,11 @@ const tronAddressSchema = z
   .regex(/^T[1-9A-HJ-NP-Za-km-z]{33}$/)
   .describe("Base58 TRON mainnet address (prefix T, 34 chars).");
 
+const solanaAddressSchema = z
+  .string()
+  .regex(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/)
+  .describe("Base58 Solana mainnet address (ed25519 pubkey, 43 or 44 chars).");
+
 /**
  * Raw shape — MCP requires a bare ZodObject (no .refine) so it can expose `.shape`
  * to build the JSON schema. Cross-field validation is enforced in the handler.
@@ -40,6 +45,11 @@ export const getPortfolioSummaryInput = z.object({
     .optional()
     .describe(
       "TRON mainnet address. When provided alongside a single `wallet`, TRX + TRC-20 balances and TRON staking are folded into the same portfolio total (`breakdown.tron`, `tronUsd`, `tronStakingUsd`). Multi-wallet mode + tronAddress is ambiguous and throws — call once per EVM wallet in that case."
+    ),
+  solanaAddress: solanaAddressSchema
+    .optional()
+    .describe(
+      "Solana mainnet address (base58, 43 or 44 chars). When provided, SOL + enumerated SPL token balances are folded into the same portfolio total (`breakdown.solana`, `solanaUsd`). Multi-wallet mode + solanaAddress is ambiguous and throws — call once per EVM wallet in that case. Requires SOLANA_RPC_URL or `solanaRpcUrl` user config (Helius recommended; public mainnet RPC is rate-limited)."
     ),
 });
 

--- a/src/modules/solana/address.ts
+++ b/src/modules/solana/address.ts
@@ -1,0 +1,33 @@
+import { PublicKey } from "@solana/web3.js";
+import { isSolanaAddress } from "../../config/solana.js";
+
+export { isSolanaAddress };
+
+/**
+ * Strict validator — confirms `s` round-trips through `@solana/web3.js`
+ * `PublicKey`, which enforces base58 decoding and the 32-byte length.
+ * Shape checks like `isSolanaAddress` accept base58-looking garbage; this
+ * call fails loudly on anything the runtime wouldn't accept as a pubkey.
+ *
+ * We deliberately do NOT call `PublicKey.isOnCurve()`. Wallets are required
+ * to be on-curve (derived from a keypair), but many things we read (ATAs,
+ * PDAs for stake pool withdraw authorities, etc.) are off-curve. Restricting
+ * *input* addresses to on-curve only would over-reject for some legitimate
+ * power-user cases (e.g., reading balances of a multisig authority).
+ */
+export function assertSolanaAddress(s: string): PublicKey {
+  if (!isSolanaAddress(s)) {
+    throw new Error(
+      `"${s}" is not a valid Solana mainnet address (expected base58, 43 or 44 chars).`,
+    );
+  }
+  try {
+    return new PublicKey(s);
+  } catch (e) {
+    throw new Error(
+      `"${s}" passed the shape check but isn't a 32-byte base58 pubkey: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+}

--- a/src/modules/solana/balances.ts
+++ b/src/modules/solana/balances.ts
@@ -1,0 +1,273 @@
+import { PublicKey } from "@solana/web3.js";
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import {
+  SOL_DECIMALS,
+  SOL_SYMBOL,
+  SOLANA_TOKENS,
+  SOLANA_TOKEN_DECIMALS,
+  WSOL_MINT,
+} from "../../config/solana.js";
+import { getSolanaConnection } from "./rpc.js";
+import { assertSolanaAddress } from "./address.js";
+import type { SolanaBalance, SolanaPortfolioSlice } from "../../types/index.js";
+
+const SPL_TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+);
+
+interface LlamaResponse {
+  coins: Record<string, { price: number }>;
+}
+
+/**
+ * Format a raw integer amount at `decimals` into a human-readable string.
+ * Minimal reimpl so this module doesn't pull viem's `formatUnits` (which is
+ * EVM-flavored and imports other machinery we don't need on the Solana path).
+ */
+function formatUnits(amount: bigint, decimals: number): string {
+  if (decimals === 0) return amount.toString();
+  const negative = amount < 0n;
+  const abs = negative ? -amount : amount;
+  const s = abs.toString().padStart(decimals + 1, "0");
+  const whole = s.slice(0, s.length - decimals);
+  const frac = s.slice(s.length - decimals).replace(/0+$/, "");
+  const out = frac.length > 0 ? `${whole}.${frac}` : whole;
+  return negative ? `-${out}` : out;
+}
+
+/** Reverse map: mint → canonical symbol (for the canonical list in SOLANA_TOKENS). */
+const MINT_TO_SYMBOL = new Map<string, keyof typeof SOLANA_TOKENS>(
+  (Object.entries(SOLANA_TOKENS) as [keyof typeof SOLANA_TOKENS, string][]).map(
+    ([sym, addr]) => [addr, sym],
+  ),
+);
+
+/**
+ * Fetch SOL + canonical SPL prices from DefiLlama. Uses `solana:<mint>`
+ * coin keys and `coingecko:solana` for native SOL. 30s cache (reuses the
+ * existing PRICE TTL). Missing prices are simply absent — balances render
+ * with `priceMissing: true` instead of crashing the whole response.
+ */
+async function fetchSolanaPrices(mints: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const keys: string[] = ["coingecko:solana"];
+  for (const addr of mints) keys.push(`solana:${addr}`);
+
+  const uncached: string[] = [];
+  for (const k of keys) {
+    const hit = cache.get<number>(`price:${k}`);
+    if (hit !== undefined) out.set(k, hit);
+    else uncached.push(k);
+  }
+  if (uncached.length === 0) return out;
+
+  try {
+    const url = `https://coins.llama.fi/prices/current/${encodeURIComponent(uncached.join(","))}`;
+    const res = await fetch(url);
+    if (!res.ok) return out;
+    const body = (await res.json()) as LlamaResponse;
+    for (const k of uncached) {
+      const coin = body.coins[k];
+      if (coin && typeof coin.price === "number") {
+        out.set(k, coin.price);
+        cache.set(`price:${k}`, coin.price, CACHE_TTL.PRICE);
+      }
+    }
+  } catch {
+    // Best-effort — price misses render as priceMissing, not a fatal error.
+  }
+  return out;
+}
+
+/**
+ * Read SOL + SPL balances for a base58 Solana address. Returns the slice the
+ * portfolio aggregator folds into `breakdown.solana` and `solanaUsd`.
+ *
+ * SPL enumeration uses `getTokenAccountsByOwner` over both the SPL Token
+ * program AND the Token-2022 program (the two live programs minting spl-
+ * compatible tokens). We parse the token account raw bytes directly — the
+ * layout is 165 bytes fixed: [mint:32][owner:32][amount:u64 LE][...]. Only
+ * non-zero balances for mints we recognize make it into the returned slice
+ * (Phase 1 scope), matching the TRON precedent.
+ *
+ * Throws if `address` doesn't pass the strict pubkey validator, or if the
+ * Solana RPC errors out — the portfolio aggregator wraps the call in its
+ * standard catch-and-continue so an RPC outage doesn't kill the rest of the
+ * summary.
+ */
+export async function getSolanaBalances(address: string): Promise<SolanaPortfolioSlice> {
+  const pubkey = assertSolanaAddress(address);
+
+  const cacheKey = `solana:balances:${address}`;
+  const cached = cache.get<SolanaPortfolioSlice>(cacheKey);
+  if (cached) return cached;
+
+  const conn = getSolanaConnection();
+
+  // Parallel fan-out: native SOL + SPL-Token + Token-2022.
+  const [lamports, splTokenAccounts, token2022Accounts] = await Promise.all([
+    conn.getBalance(pubkey),
+    conn.getTokenAccountsByOwner(pubkey, { programId: SPL_TOKEN_PROGRAM_ID }),
+    conn.getTokenAccountsByOwner(pubkey, { programId: TOKEN_2022_PROGRAM_ID }),
+  ]);
+
+  // Aggregate SPL holdings by mint. A wallet can in theory hold multiple
+  // token accounts for the same mint (main ATA + a non-ATA token account);
+  // sum the raw amounts so the displayed balance matches the user's
+  // economic holding.
+  const mintAmounts = new Map<string, bigint>();
+  for (const entry of [...splTokenAccounts.value, ...token2022Accounts.value]) {
+    const data = entry.account.data;
+    if (!(data instanceof Buffer) || data.length < 72) continue;
+    const mint = new PublicKey(data.subarray(0, 32)).toBase58();
+    const amount = data.readBigUInt64LE(64);
+    mintAmounts.set(mint, (mintAmounts.get(mint) ?? 0n) + amount);
+  }
+
+  const priceMints = Object.values(SOLANA_TOKENS);
+  const prices = await fetchSolanaPrices(priceMints);
+
+  const solPrice = prices.get("coingecko:solana");
+  const solFormatted = formatUnits(BigInt(lamports), SOL_DECIMALS);
+  const solValueUsd =
+    solPrice !== undefined ? Number(solFormatted) * solPrice : undefined;
+
+  const nativeBalance: SolanaBalance = {
+    chain: "solana",
+    token: "native",
+    symbol: SOL_SYMBOL,
+    decimals: SOL_DECIMALS,
+    amount: String(lamports),
+    formatted: solFormatted,
+    ...(solPrice !== undefined ? { priceUsd: solPrice } : {}),
+    ...(solValueUsd !== undefined ? { valueUsd: solValueUsd } : {}),
+    ...(solPrice === undefined ? { priceMissing: true } : {}),
+  };
+
+  const spl: SolanaBalance[] = [];
+  for (const [symbol, mint] of Object.entries(SOLANA_TOKENS) as [
+    keyof typeof SOLANA_TOKENS,
+    string,
+  ][]) {
+    const raw = mintAmounts.get(mint) ?? 0n;
+    if (raw === 0n) continue;
+    const decimals = SOLANA_TOKEN_DECIMALS[symbol];
+    const formatted = formatUnits(raw, decimals);
+    const price = prices.get(`solana:${mint}`);
+    const valueUsd = price !== undefined ? Number(formatted) * price : undefined;
+    spl.push({
+      chain: "solana",
+      token: mint,
+      symbol,
+      decimals,
+      amount: raw.toString(),
+      formatted,
+      ...(price !== undefined ? { priceUsd: price } : {}),
+      ...(valueUsd !== undefined ? { valueUsd } : {}),
+      ...(price === undefined ? { priceMissing: true } : {}),
+    });
+  }
+
+  const walletBalancesUsd =
+    (nativeBalance.valueUsd ?? 0) +
+    spl.reduce((s, t) => s + (t.valueUsd ?? 0), 0);
+
+  const native = BigInt(lamports) > 0n ? [nativeBalance] : [];
+
+  const slice: SolanaPortfolioSlice = {
+    address,
+    native,
+    spl,
+    walletBalancesUsd: Math.round(walletBalancesUsd * 100) / 100,
+  };
+
+  cache.set(cacheKey, slice, CACHE_TTL.POSITION);
+  return slice;
+}
+
+/**
+ * Fetch a single SPL or native SOL balance by mint. Mirrors the shape of
+ * `getTokenBalance` for EVM + TRON. `token` is "native" for SOL, the WSOL
+ * mint (handled as a regular SPL), or any SPL mint address.
+ */
+export async function getSolanaTokenBalance(
+  wallet: string,
+  token: string,
+): Promise<SolanaBalance> {
+  const pubkey = assertSolanaAddress(wallet);
+
+  if (token === "native") {
+    const slice = await getSolanaBalances(wallet);
+    if (slice.native.length > 0) return slice.native[0];
+    return {
+      chain: "solana",
+      token: "native",
+      symbol: SOL_SYMBOL,
+      decimals: SOL_DECIMALS,
+      amount: "0",
+      formatted: "0",
+    };
+  }
+
+  const mintPubkey = assertSolanaAddress(token);
+
+  // Known canonical mint → use the pre-enumerated slice (saves an RPC call).
+  const knownSymbol = MINT_TO_SYMBOL.get(token);
+  if (knownSymbol) {
+    const slice = await getSolanaBalances(wallet);
+    const hit = slice.spl.find((t) => t.token === token);
+    if (hit) return hit;
+    return {
+      chain: "solana",
+      token,
+      symbol: knownSymbol,
+      decimals: SOLANA_TOKEN_DECIMALS[knownSymbol],
+      amount: "0",
+      formatted: "0",
+      priceMissing: true,
+    };
+  }
+
+  // Unknown mint — do a direct ATA lookup rather than enumerating all holdings.
+  // Query both SPL Token and Token-2022 programs; whichever returns an account
+  // wins. We don't call `getAssociatedTokenAddressSync` because that would
+  // require pulling in `@solana/spl-token`; instead we list owner-filtered
+  // accounts and pick the one matching the mint.
+  const conn = getSolanaConnection();
+  const [spl, spl2022] = await Promise.all([
+    conn.getTokenAccountsByOwner(pubkey, { programId: SPL_TOKEN_PROGRAM_ID }),
+    conn.getTokenAccountsByOwner(pubkey, { programId: TOKEN_2022_PROGRAM_ID }),
+  ]);
+  let raw = 0n;
+  let decimals: number | undefined;
+  for (const entry of [...spl.value, ...spl2022.value]) {
+    const data = entry.account.data;
+    if (!(data instanceof Buffer) || data.length < 72) continue;
+    const mint = new PublicKey(data.subarray(0, 32)).toBase58();
+    if (mint !== token) continue;
+    raw += data.readBigUInt64LE(64);
+  }
+  // Without a canonical decimals entry, fetch via getTokenSupply.
+  if (raw > 0n || decimals === undefined) {
+    try {
+      const supply = await conn.getTokenSupply(mintPubkey);
+      decimals = supply.value.decimals;
+    } catch {
+      decimals = 0;
+    }
+  }
+  const symbol = token === WSOL_MINT ? "WSOL" : "UNKNOWN";
+  return {
+    chain: "solana",
+    token,
+    symbol,
+    decimals: decimals ?? 0,
+    amount: raw.toString(),
+    formatted: formatUnits(raw, decimals ?? 0),
+    priceMissing: true,
+  };
+}

--- a/src/modules/solana/decode.ts
+++ b/src/modules/solana/decode.ts
@@ -1,0 +1,176 @@
+/**
+ * Solana instruction decoders for native programs (System, SPL Token, Stake).
+ *
+ * The scope is intentionally narrow: for native programs we parse the
+ * instruction data bytes into semantic fields (transfer amount, delegate
+ * target, etc.) because the layouts are stable, published, and small. For
+ * third-party programs (Jupiter, Marinade, Raydium, Orca) we do NOT parse
+ * instruction data — per-IDL decoding is brittle across upgrades. Instead,
+ * `history/solana.ts` uses the tx-level balance deltas from `meta.preTokenBalances`
+ * / `meta.postTokenBalances` + `meta.preBalances` / `meta.postBalances` to
+ * derive "user held X of token A before, Y of token B after" summaries,
+ * labeled by the known-program name. That's robust to IDL changes and
+ * more directly answers "what happened to my wallet?".
+ */
+
+/** First 4 bytes LE of the instruction discriminator the System Program uses. */
+export const SYSTEM_IX = {
+  CREATE_ACCOUNT: 0,
+  TRANSFER: 2,
+  CREATE_ACCOUNT_WITH_SEED: 3,
+  ADVANCE_NONCE: 4,
+  WITHDRAW_NONCE: 5,
+  INITIALIZE_NONCE: 6,
+  AUTHORIZE_NONCE: 7,
+  ALLOCATE: 8,
+  ALLOCATE_WITH_SEED: 9,
+  ASSIGN_WITH_SEED: 10,
+  TRANSFER_WITH_SEED: 11,
+} as const;
+
+/** First-byte discriminator for the SPL Token program. */
+export const TOKEN_IX = {
+  INITIALIZE_MINT: 0,
+  INITIALIZE_ACCOUNT: 1,
+  TRANSFER: 3,
+  APPROVE: 4,
+  REVOKE: 5,
+  SET_AUTHORITY: 6,
+  MINT_TO: 7,
+  BURN: 8,
+  CLOSE_ACCOUNT: 9,
+  TRANSFER_CHECKED: 12,
+  APPROVE_CHECKED: 13,
+  MINT_TO_CHECKED: 14,
+  BURN_CHECKED: 15,
+} as const;
+
+/** First-byte discriminator for the Stake program. */
+export const STAKE_IX = {
+  INITIALIZE: 0,
+  AUTHORIZE: 1,
+  DELEGATE_STAKE: 2,
+  SPLIT: 3,
+  WITHDRAW: 4,
+  DEACTIVATE: 5,
+  SET_LOCKUP: 6,
+  MERGE: 7,
+} as const;
+
+/** base58-decoded instruction data helper. */
+function decodeBase58(s: string): Uint8Array {
+  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let num = 0n;
+  for (const c of s) {
+    const v = alphabet.indexOf(c);
+    if (v < 0) throw new Error(`Invalid base58 char: ${c}`);
+    num = num * 58n + BigInt(v);
+  }
+  const bytes: number[] = [];
+  while (num > 0n) {
+    bytes.push(Number(num & 0xffn));
+    num >>= 8n;
+  }
+  // Leading zeros in base58 → leading zero bytes.
+  for (const c of s) {
+    if (c !== "1") break;
+    bytes.push(0);
+  }
+  return new Uint8Array(bytes.reverse());
+}
+
+/**
+ * Classify a System Program instruction. Returns `{ kind: "transfer", lamports }`
+ * for the transfer case (the only one `history/solana.ts` surfaces as an
+ * `external` item); other variants return `{ kind: "other", variantCode }`
+ * so the history module can log them as `program_interaction`.
+ *
+ * `ixDataB58` is the base58-encoded instruction data from `tx.transaction.message.instructions[i].data`.
+ */
+export function decodeSystemInstruction(
+  ixDataB58: string,
+): { kind: "transfer"; lamports: bigint } | { kind: "other"; variantCode: number } {
+  try {
+    const bytes = decodeBase58(ixDataB58);
+    if (bytes.length < 4) return { kind: "other", variantCode: -1 };
+    const variant = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
+    if (variant === SYSTEM_IX.TRANSFER) {
+      if (bytes.length < 12) return { kind: "other", variantCode: variant };
+      // 8 bytes LE u64 after the 4-byte variant tag.
+      let lamports = 0n;
+      for (let i = 11; i >= 4; i--) {
+        lamports = (lamports << 8n) | BigInt(bytes[i]);
+      }
+      return { kind: "transfer", lamports };
+    }
+    return { kind: "other", variantCode: variant };
+  } catch {
+    return { kind: "other", variantCode: -1 };
+  }
+}
+
+/**
+ * Classify an SPL Token instruction. Returns semantic shape for
+ * Transfer / TransferChecked (the two user-facing transfer variants); other
+ * ops return `other` for program-interaction labeling. We do NOT resolve
+ * source/destination owners — those are account-list lookups the caller
+ * (history/solana.ts) does against `accountKeys` using the instruction's
+ * account indexes.
+ *
+ * Transfer: `[opcode:u8, amount:u64]` (9 bytes).
+ * TransferChecked: `[opcode:u8, amount:u64, decimals:u8]` (10 bytes).
+ */
+export function decodeTokenInstruction(
+  ixDataB58: string,
+): { kind: "transfer"; amount: bigint } | { kind: "transferChecked"; amount: bigint; decimals: number } | { kind: "other"; variantCode: number } {
+  try {
+    const bytes = decodeBase58(ixDataB58);
+    if (bytes.length < 1) return { kind: "other", variantCode: -1 };
+    const variant = bytes[0];
+    if (variant === TOKEN_IX.TRANSFER && bytes.length >= 9) {
+      let amount = 0n;
+      for (let i = 8; i >= 1; i--) amount = (amount << 8n) | BigInt(bytes[i]);
+      return { kind: "transfer", amount };
+    }
+    if (variant === TOKEN_IX.TRANSFER_CHECKED && bytes.length >= 10) {
+      let amount = 0n;
+      for (let i = 8; i >= 1; i--) amount = (amount << 8n) | BigInt(bytes[i]);
+      const decimals = bytes[9];
+      return { kind: "transferChecked", amount, decimals };
+    }
+    return { kind: "other", variantCode: variant };
+  } catch {
+    return { kind: "other", variantCode: -1 };
+  }
+}
+
+/**
+ * Classify a Stake Program instruction. Returns `kind` for the three
+ * user-interesting operations (delegate, deactivate, withdraw); others
+ * collapse to `other`. Withdraw carries a u64 lamports amount after the
+ * 4-byte variant tag.
+ */
+export function decodeStakeInstruction(
+  ixDataB58: string,
+):
+  | { kind: "delegate" }
+  | { kind: "deactivate" }
+  | { kind: "withdraw"; lamports: bigint }
+  | { kind: "other"; variantCode: number } {
+  try {
+    const bytes = decodeBase58(ixDataB58);
+    if (bytes.length < 4) return { kind: "other", variantCode: -1 };
+    const variant = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
+    if (variant === STAKE_IX.DELEGATE_STAKE) return { kind: "delegate" };
+    if (variant === STAKE_IX.DEACTIVATE) return { kind: "deactivate" };
+    if (variant === STAKE_IX.WITHDRAW) {
+      if (bytes.length < 12) return { kind: "other", variantCode: variant };
+      let lamports = 0n;
+      for (let i = 11; i >= 4; i--) lamports = (lamports << 8n) | BigInt(bytes[i]);
+      return { kind: "withdraw", lamports };
+    }
+    return { kind: "other", variantCode: variant };
+  } catch {
+    return { kind: "other", variantCode: -1 };
+  }
+}

--- a/src/modules/solana/program-ids.ts
+++ b/src/modules/solana/program-ids.ts
@@ -1,0 +1,100 @@
+/**
+ * Known Solana program IDs + well-known stake pool accounts.
+ *
+ * Every program address below was verified live against Solana mainnet RPC
+ * (`getAccountInfo` → `executable: true`, `owner: BPFLoaderUpgradeable`) on
+ * 2026-04-23. The native programs (System, Token, Stake, etc.) are
+ * canonical and don't move; third-party programs (Jupiter, Marinade, etc.)
+ * could in theory redeploy, so the "Live program ID spot-check" step in
+ * the PR verifies each address again at commit time.
+ */
+
+export type ProgramKind =
+  | "system"
+  | "token"
+  | "token-2022"
+  | "ata"
+  | "stake"
+  | "stake-pool"
+  | "lst"
+  | "aggregator"
+  | "amm"
+  | "compute-budget";
+
+export interface KnownProgram {
+  name: string;
+  kind: ProgramKind;
+}
+
+/** Map from program ID to human-readable metadata. */
+export const KNOWN_PROGRAMS: Record<string, KnownProgram> = {
+  // Native programs — canonical.
+  "11111111111111111111111111111111": { name: "System", kind: "system" },
+  Stake11111111111111111111111111111111111111: { name: "Stake", kind: "stake" },
+  ComputeBudget111111111111111111111111111111: {
+    name: "ComputeBudget",
+    kind: "compute-budget",
+  },
+
+  // SPL programs.
+  TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA: { name: "SPL Token", kind: "token" },
+  TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb: {
+    name: "Token-2022",
+    kind: "token-2022",
+  },
+  ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL: {
+    name: "Associated Token Account",
+    kind: "ata",
+  },
+  SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy: {
+    name: "SPL Stake Pool",
+    kind: "stake-pool",
+  },
+
+  // DeFi — verified via getAccountInfo live (executable + BPFLoaderUpgradeable).
+  JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4: { name: "Jupiter V6", kind: "aggregator" },
+  MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD: { name: "Marinade", kind: "lst" },
+  "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8": {
+    name: "Raydium AMM V4",
+    kind: "amm",
+  },
+  whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc: {
+    name: "Orca Whirlpools",
+    kind: "amm",
+  },
+};
+
+/**
+ * Well-known stake pool ACCOUNTS (not programs). Jito doesn't operate its
+ * own program — it deploys an instance of the generic SPL Stake Pool
+ * program (`SPoo1Ku8...`) at a specific pool account. When we see an
+ * instruction to `SPoo1Ku8...` in history, we check the first account in
+ * its accounts list against this map to identify which stake pool it's
+ * interacting with.
+ *
+ * `tokenMint` is the LST mint minted by the pool (jitoSOL, stSOL, etc.).
+ * Matching the mint in the tx's token balance deltas confirms the pool.
+ */
+export const KNOWN_STAKE_POOLS: Record<
+  string,
+  { name: string; tokenMint: string }
+> = {
+  Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb: {
+    name: "Jito",
+    tokenMint: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+  },
+};
+
+/**
+ * Reverse map from LST mint to stake pool name. Used when the decoder
+ * spots a balance delta in a known LST mint but the stake pool account
+ * wasn't directly exposed in the instruction's accounts (e.g., when
+ * interacting via an aggregator).
+ */
+export const LST_MINT_TO_POOL: Record<string, string> = Object.fromEntries(
+  Object.values(KNOWN_STAKE_POOLS).map((p) => [p.tokenMint, p.name]),
+);
+
+export function lookupProgram(programId: string): KnownProgram | undefined {
+  return KNOWN_PROGRAMS[programId];
+}

--- a/src/modules/solana/rpc.ts
+++ b/src/modules/solana/rpc.ts
@@ -1,0 +1,26 @@
+import { Connection } from "@solana/web3.js";
+import { resolveSolanaRpcUrl } from "../../config/chains.js";
+import { readUserConfig } from "../../config/user-config.js";
+
+/**
+ * Cached `Connection` for Solana mainnet. Lazy-initialized on first use.
+ * Mirrors the EVM `getClient(chain)` pattern in src/data/rpc.ts — one client
+ * per process, reused across calls. Reset on config change (future hook
+ * alongside the EVM `resetClients` listener).
+ */
+let cachedConnection: Connection | undefined;
+
+export function getSolanaConnection(): Connection {
+  if (cachedConnection) return cachedConnection;
+  const url = resolveSolanaRpcUrl(readUserConfig());
+  // `confirmed` is the sweet spot for read-only portfolio/history queries —
+  // `processed` is racy (may return state rolled back a slot later) and
+  // `finalized` adds ~13s of latency for no meaningful safety win on reads.
+  cachedConnection = new Connection(url, "confirmed");
+  return cachedConnection;
+}
+
+/** Test-only: drop the cached connection so a mocked `@solana/web3.js` is picked up on next call. */
+export function resetSolanaConnection(): void {
+  cachedConnection = undefined;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -212,6 +212,27 @@ async function configureTron(p: Prompt): Promise<string | undefined> {
   return apiKey;
 }
 
+async function configureSolana(p: Prompt): Promise<string | undefined> {
+  console.log("\n--- Solana (optional — enables SOL + SPL balance reads and history) ---");
+  console.log("Solana is non-EVM with its own ecosystem: SPL tokens via Associated Token");
+  console.log("Accounts, native validator staking, and DeFi protocols like Jupiter/Marinade/");
+  console.log("Jito/Raydium/Orca. Paste the full RPC URL from your provider — Helius is the");
+  console.log("recommended choice (free tier covers typical portfolio use):");
+  console.log("  Helius:    https://mainnet.helius-rpc.com/?api-key=YOUR_KEY");
+  console.log("  QuickNode: https://your-endpoint.solana-mainnet.quiknode.pro/YOUR_TOKEN/");
+  console.log("  Alchemy:   https://solana-mainnet.g.alchemy.com/v2/YOUR_KEY");
+  console.log("Skip with empty input — Solana reads will be disabled.");
+  const existing = readUserConfig()?.solanaRpcUrl;
+  const answer = await p.ask(
+    existing
+      ? "Solana RPC URL [press enter to keep existing]: "
+      : "Solana RPC URL (or blank to skip): "
+  );
+  const url = answer || existing;
+  if (!url) return undefined;
+  return url;
+}
+
 async function configureWalletConnect(p: Prompt): Promise<string | undefined> {
   console.log("\n--- WalletConnect (optional — required for Ledger Live signing) ---");
   console.log("Create a free project at https://cloud.walletconnect.com.");
@@ -314,6 +335,7 @@ function summarizeConfig(cfg: UserConfig): void {
   console.log(`  Etherscan API key:   ${cfg.etherscanApiKey ? "set" : "not set"}`);
   console.log(`  1inch API key:       ${cfg.oneInchApiKey ? "set" : "not set"}`);
   console.log(`  TronGrid API key:    ${cfg.tronApiKey ? "set" : "not set"}`);
+  console.log(`  Solana RPC URL:      ${cfg.solanaRpcUrl ? "set" : "not set"}`);
   console.log(
     `  WalletConnect:       ${cfg.walletConnect?.projectId ? "project ID set" : "not set"}`
   );
@@ -332,6 +354,7 @@ async function editSectionMenu(p: Prompt): Promise<void> {
     { label: "Etherscan API key", action: "etherscan" as const },
     { label: "1inch API key", action: "oneinch" as const },
     { label: "TronGrid API key", action: "tron" as const },
+    { label: "Solana RPC URL", action: "solana" as const },
     { label: "WalletConnect project ID", action: "wc" as const },
     { label: "Pair Ledger Live now", action: "pair" as const },
     { label: "Done — exit setup", action: "done" as const },
@@ -363,6 +386,11 @@ async function editSectionMenu(p: Prompt): Promise<void> {
       case "tron": {
         const k = await configureTron(p);
         if (k !== undefined) patchUserConfig({ tronApiKey: k });
+        break;
+      }
+      case "solana": {
+        const url = await configureSolana(p);
+        if (url !== undefined) patchUserConfig({ solanaRpcUrl: url });
         break;
       }
       case "wc": {
@@ -400,6 +428,11 @@ async function runFullWizard(p: Prompt): Promise<void> {
   const tronApiKey = await configureTron(p);
   if (tronApiKey !== undefined) {
     patchUserConfig({ tronApiKey });
+  }
+
+  const solanaRpcUrl = await configureSolana(p);
+  if (solanaRpcUrl !== undefined) {
+    patchUserConfig({ solanaRpcUrl });
   }
 
   const wcProjectId = await configureWalletConnect(p);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -212,24 +212,119 @@ async function configureTron(p: Prompt): Promise<string | undefined> {
   return apiKey;
 }
 
+const HELIUS_HOST = "mainnet.helius-rpc.com";
+
+function heliusUrlFromKey(apiKey: string): string {
+  return `https://${HELIUS_HOST}/?api-key=${apiKey}`;
+}
+
+/** Extract the api-key query param from a Helius URL. Returns undefined if the URL isn't Helius or lacks the param. */
+function extractHeliusKey(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== HELIUS_HOST) return undefined;
+    return parsed.searchParams.get("api-key") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Light liveness check: JSON-RPC `getVersion` with a 5s timeout. A working
+ * Solana RPC always returns `result.solana-core` — anything else (HTTP
+ * error, 401 from a bad Helius key, timeout) throws a descriptive error.
+ */
+async function validateSolanaRpcUrl(url: string): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getVersion" }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`RPC returned ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as {
+      result?: { "solana-core"?: string };
+      error?: { message?: string };
+    };
+    if (body.error) {
+      throw new Error(`getVersion RPC error: ${body.error.message ?? "unknown"}`);
+    }
+    const version = body.result?.["solana-core"];
+    if (!version) throw new Error(`no solana-core version in response`);
+    return version;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function configureSolana(p: Prompt): Promise<string | undefined> {
   console.log("\n--- Solana (optional — enables SOL + SPL balance reads and history) ---");
   console.log("Solana is non-EVM with its own ecosystem: SPL tokens via Associated Token");
   console.log("Accounts, native validator staking, and DeFi protocols like Jupiter/Marinade/");
-  console.log("Jito/Raydium/Orca. Paste the full RPC URL from your provider — Helius is the");
-  console.log("recommended choice (free tier covers typical portfolio use):");
-  console.log("  Helius:    https://mainnet.helius-rpc.com/?api-key=YOUR_KEY");
-  console.log("  QuickNode: https://your-endpoint.solana-mainnet.quiknode.pro/YOUR_TOKEN/");
-  console.log("  Alchemy:   https://solana-mainnet.g.alchemy.com/v2/YOUR_KEY");
-  console.log("Skip with empty input — Solana reads will be disabled.");
+  console.log("Jito/Raydium/Orca. Public mainnet RPC is rate-limited — use a provider.");
+
   const existing = readUserConfig()?.solanaRpcUrl;
-  const answer = await p.ask(
-    existing
-      ? "Solana RPC URL [press enter to keep existing]: "
-      : "Solana RPC URL (or blank to skip): "
+  const existingHeliusKey = extractHeliusKey(existing);
+
+  const providerIdx = await p.askChoice(
+    "Select a Solana RPC provider:",
+    [
+      "Helius (recommended — enter API key, we build the URL)",
+      "Custom URL (paste full URL from QuickNode / Alchemy / Triton / etc.)",
+      "Skip — disable Solana reads",
+    ],
+    existing && !existingHeliusKey ? 1 : 0
   );
-  const url = answer || existing;
+
+  if (providerIdx === 2) return undefined;
+
+  if (providerIdx === 0) {
+    // Helius flow — mirrors the Infura/Alchemy key-based path for EVM RPC.
+    console.log("Create a free Helius API key at https://dashboard.helius.dev (Project → API Keys).");
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const prompt = existingHeliusKey
+        ? "Helius API key [press enter to keep existing]: "
+        : "Helius API key: ";
+      const entered = await p.ask(prompt);
+      const apiKey = entered || existingHeliusKey || "";
+      if (!apiKey) {
+        console.log("  An API key is required. Try again or pick 'Skip'.");
+        continue;
+      }
+      const url = heliusUrlFromKey(apiKey);
+      try {
+        const version = await validateSolanaRpcUrl(url);
+        console.log(`  Helius API key OK — solana-core ${version}.`);
+        return url;
+      } catch (e) {
+        console.warn(`  Validation failed: ${(e as Error).message}`);
+      }
+    }
+    throw new Error("Could not validate Helius API key after 3 attempts.");
+  }
+
+  // Custom URL — user pastes the whole thing. Validate lightly.
+  const existingCustom = !existingHeliusKey ? existing : undefined;
+  const answer = await p.ask(
+    existingCustom
+      ? "Solana RPC URL [press enter to keep existing]: "
+      : "Solana RPC URL: "
+  );
+  const url = answer || existingCustom;
   if (!url) return undefined;
+  try {
+    const version = await validateSolanaRpcUrl(url);
+    console.log(`  Solana RPC OK — solana-core ${version}.`);
+  } catch (e) {
+    console.warn(`  Warning: could not validate Solana RPC — ${(e as Error).message}`);
+    console.warn("  Saving anyway; balance reads will surface the error at query time.");
+  }
   return url;
 }
 
@@ -335,7 +430,15 @@ function summarizeConfig(cfg: UserConfig): void {
   console.log(`  Etherscan API key:   ${cfg.etherscanApiKey ? "set" : "not set"}`);
   console.log(`  1inch API key:       ${cfg.oneInchApiKey ? "set" : "not set"}`);
   console.log(`  TronGrid API key:    ${cfg.tronApiKey ? "set" : "not set"}`);
-  console.log(`  Solana RPC URL:      ${cfg.solanaRpcUrl ? "set" : "not set"}`);
+  console.log(
+    `  Solana RPC URL:      ${
+      cfg.solanaRpcUrl
+        ? extractHeliusKey(cfg.solanaRpcUrl)
+          ? "Helius (API key set)"
+          : "custom URL set"
+        : "not set"
+    }`
+  );
   console.log(
     `  WalletConnect:       ${cfg.walletConnect?.projectId ? "project ID set" : "not set"}`
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,9 +22,12 @@ export const SUPPORTED_CHAINS: readonly SupportedChain[] = [
 ] as const;
 
 /** Non-EVM chains. Kept as its own union so EVM-only tables keep their type. */
-export type SupportedNonEvmChain = "tron";
+export type SupportedNonEvmChain = "tron" | "solana";
 
-export const SUPPORTED_NON_EVM_CHAINS: readonly SupportedNonEvmChain[] = ["tron"] as const;
+export const SUPPORTED_NON_EVM_CHAINS: readonly SupportedNonEvmChain[] = [
+  "tron",
+  "solana",
+] as const;
 
 /** Any chain the server knows about — EVM or non-EVM. */
 export type AnyChain = SupportedChain | SupportedNonEvmChain;
@@ -115,6 +118,13 @@ export interface PortfolioCoverage {
    * getReward/account outage doesn't mask that balances loaded fine.
    */
   tronStaking?: CoverageStatus;
+  /**
+   * Solana balance fetch coverage (SOL + SPL). `covered:false, errored:false`
+   * means no Solana address was queried; errored:true means the Solana RPC
+   * call failed and SOL/SPL are missing from totals. Staking coverage is
+   * deferred to Phase 2.
+   */
+  solana?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
 }
@@ -277,6 +287,37 @@ export interface TronBalance {
   valueUsd?: number;
   priceUsd?: number;
   priceMissing?: boolean;
+}
+
+/**
+ * Solana balance shape — a parallel to TronBalance for SOL + SPL tokens.
+ * `token` is a base58 SPL mint address (~32-44 chars), or "native" for SOL.
+ * SPL balances come from Associated Token Accounts but we surface them by
+ * mint; the ATA is an implementation detail the caller shouldn't care about.
+ */
+export interface SolanaBalance {
+  chain: "solana";
+  /** Base58 SPL mint address, or "native" for SOL. */
+  token: string;
+  symbol: string;
+  decimals: number;
+  amount: string;
+  formatted: string;
+  valueUsd?: number;
+  priceUsd?: number;
+  priceMissing?: boolean;
+}
+
+/**
+ * Solana slice of a portfolio summary. Parallel to TronPortfolioSlice.
+ * Phase 1 does not enumerate native validator staking; defer to Phase 2.
+ */
+export interface SolanaPortfolioSlice {
+  /** Base58 Solana address the balances were resolved for. */
+  address: string;
+  native: SolanaBalance[];
+  spl: SolanaBalance[];
+  walletBalancesUsd: number;
 }
 
 /**
@@ -478,6 +519,12 @@ export interface PortfolioSummary {
    * staking was fetched successfully.
    */
   tronStakingUsd?: number;
+  /**
+   * Solana totals folded into the same aggregate as EVM/TRON. Present when
+   * the caller passed a `solanaAddress`. Phase 1 covers balances only
+   * (SOL native + SPL via ATAs); staking lands in Phase 2.
+   */
+  solanaUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];
@@ -486,6 +533,8 @@ export interface PortfolioSummary {
     staking: StakingPosition[];
     /** TRON slice — absent when no TRON address was queried. */
     tron?: TronPortfolioSlice;
+    /** Solana slice — absent when no Solana address was queried. */
+    solana?: SolanaPortfolioSlice;
   };
   coverage: PortfolioCoverage;
 }
@@ -690,6 +739,15 @@ export interface UserConfig {
    * calls to ~15 req/min, which is too tight for portfolio fan-out.
    */
   tronApiKey?: string;
+  /**
+   * Solana mainnet RPC URL. Paste the full URL from your provider (Helius,
+   * QuickNode, Alchemy Solana, Triton, etc.) — most include the API key in
+   * the URL (e.g. `https://mainnet.helius-rpc.com/?api-key=KEY`). The public
+   * mainnet endpoint is rate-limited and unreliable for production use;
+   * configuring a provider is strongly recommended. Env var `SOLANA_RPC_URL`
+   * takes priority over this field.
+   */
+  solanaRpcUrl?: string;
   walletConnect?: {
     projectId?: string;
     /** Topic of the active WC session (so we can resume after restart). */

--- a/test/solana-balance.test.ts
+++ b/test/solana-balance.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { cache } from "../src/data/cache.js";
+
+/**
+ * Solana balance-read tests. We mock the Solana connection factory so the
+ * canned responses land in the balance/price code paths without hitting
+ * the network. Fetch is also mocked to intercept the DefiLlama price call.
+ */
+
+const WALLET = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const JUP_MINT = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN";
+
+const SPL_TOKEN_PROGRAM = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const TOKEN_2022_PROGRAM = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+);
+
+/**
+ * Build a 165-byte Token account data Buffer. Layout starts with:
+ *   mint (32 bytes) || owner (32 bytes) || amount (u64 LE, 8 bytes) || ...
+ * The rest is padded with zeros — we only need the first 72 bytes to decode
+ * mint + amount (owner is ignored by the balance reader).
+ */
+function buildTokenAccountData(mint: string, amount: bigint): Buffer {
+  const buf = Buffer.alloc(165);
+  new PublicKey(mint).toBuffer().copy(buf, 0);
+  // owner (filled with any 32 bytes — doesn't matter for balance reads).
+  new PublicKey(WALLET).toBuffer().copy(buf, 32);
+  buf.writeBigUInt64LE(amount, 64);
+  return buf;
+}
+
+const connectionStub = {
+  getBalance: vi.fn(),
+  getTokenAccountsByOwner: vi.fn(),
+  getTokenSupply: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+beforeEach(() => {
+  cache.clear();
+  connectionStub.getBalance.mockReset();
+  connectionStub.getTokenAccountsByOwner.mockReset();
+  connectionStub.getTokenSupply.mockReset();
+
+  // Default DefiLlama fetch returns no prices (priceMissing path). Specific
+  // tests override with vi.stubGlobal.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ coins: {} }),
+      json: async () => ({ coins: {} }),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getSolanaBalances", () => {
+  it("returns SOL native balance from getBalance", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(2_500_000_000); // 2.5 SOL
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const { getSolanaBalances } = await import("../src/modules/solana/balances.js");
+    const slice = await getSolanaBalances(WALLET);
+
+    expect(slice.address).toBe(WALLET);
+    expect(slice.native.length).toBe(1);
+    expect(slice.native[0].symbol).toBe("SOL");
+    expect(slice.native[0].formatted).toBe("2.5");
+    expect(slice.spl.length).toBe(0);
+  });
+
+  it("aggregates SPL holdings from both SPL-Token and Token-2022 programs", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(0);
+    // First call (SPL Token): USDC account with 100 USDC = 100_000_000 raw (6 decimals).
+    // Second call (Token-2022): JUP account with 50 JUP = 50_000_000 raw (6 decimals).
+    connectionStub.getTokenAccountsByOwner
+      .mockResolvedValueOnce({
+        value: [
+          { account: { data: buildTokenAccountData(USDC_MINT, 100_000_000n) } },
+        ],
+      })
+      .mockResolvedValueOnce({
+        value: [
+          { account: { data: buildTokenAccountData(JUP_MINT, 50_000_000n) } },
+        ],
+      });
+
+    const { getSolanaBalances } = await import("../src/modules/solana/balances.js");
+    const slice = await getSolanaBalances(WALLET);
+
+    const symbols = slice.spl.map((s) => s.symbol).sort();
+    expect(symbols).toEqual(["JUP", "USDC"]);
+    const usdc = slice.spl.find((s) => s.symbol === "USDC");
+    expect(usdc?.formatted).toBe("100");
+    expect(usdc?.decimals).toBe(6);
+  });
+
+  it("marks unpriced tokens with priceMissing: true when DefiLlama returns nothing", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(1_000_000_000); // 1 SOL
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const { getSolanaBalances } = await import("../src/modules/solana/balances.js");
+    const slice = await getSolanaBalances(WALLET);
+    expect(slice.native[0].priceMissing).toBe(true);
+    expect(slice.native[0].valueUsd).toBeUndefined();
+  });
+
+  it("surfaces USD valuation when DefiLlama returns a price", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(2_000_000_000); // 2 SOL
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ coins: { "coingecko:solana": { price: 150 } } }),
+        json: async () => ({ coins: { "coingecko:solana": { price: 150 } } }),
+      })),
+    );
+
+    const { getSolanaBalances } = await import("../src/modules/solana/balances.js");
+    const slice = await getSolanaBalances(WALLET);
+    expect(slice.native[0].valueUsd).toBe(300); // 2 × 150
+    expect(slice.native[0].priceUsd).toBe(150);
+    expect(slice.walletBalancesUsd).toBe(300);
+  });
+
+  it("throws on non-Solana address input", async () => {
+    const { getSolanaBalances } = await import("../src/modules/solana/balances.js");
+    await expect(getSolanaBalances("0x1234567890123456789012345678901234567890")).rejects.toThrow();
+  });
+});
+
+describe("getSolanaTokenBalance single-token API", () => {
+  it("returns SOL balance for token:native", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(5_000_000_000); // 5 SOL
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const { getSolanaTokenBalance } = await import("../src/modules/solana/balances.js");
+    const bal = await getSolanaTokenBalance(WALLET, "native");
+    expect(bal.symbol).toBe("SOL");
+    expect(bal.formatted).toBe("5");
+  });
+
+  it("returns zero-balance shape when the wallet doesn't hold the mint", async () => {
+    connectionStub.getBalance.mockResolvedValueOnce(0);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const { getSolanaTokenBalance } = await import("../src/modules/solana/balances.js");
+    const bal = await getSolanaTokenBalance(WALLET, USDC_MINT);
+    expect(bal.symbol).toBe("USDC");
+    expect(bal.amount).toBe("0");
+    expect(bal.formatted).toBe("0");
+  });
+});

--- a/test/solana-history.test.ts
+++ b/test/solana-history.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { cache } from "../src/data/cache.js";
+
+const WALLET = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const JUP_V6_PROGRAM = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
+// Arbitrary valid base58 pubkeys used as stand-ins for "some ATA" or "unknown
+// program" in fixture data. Real Solana mainnet addresses so the base58
+// decode passes; their on-chain role is irrelevant to these unit tests.
+const SOME_ATA = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const OTHER_ATA = "7XuPQ9e6e3GvZK3m6Cb3Kjan5v2V3HRv4e8D7F2iHUuX";
+const UNKNOWN_PROGRAM = "2wmVCSfPxGPjrnMMn7rchp4uaeoTqN39mXFC2zhPdri9";
+
+const connectionStub = {
+  getSignaturesForAddress: vi.fn(),
+  getParsedTransaction: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+beforeEach(() => {
+  cache.clear();
+  connectionStub.getSignaturesForAddress.mockReset();
+  connectionStub.getParsedTransaction.mockReset();
+
+  // Default fetch returns no historical prices — price coverage will be "none".
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ coins: {} }),
+      json: async () => ({ coins: {} }),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Minimal parsed-transaction builder for tests. */
+interface BuildTxInput {
+  signature: string;
+  blockTime: number;
+  accountKeys: string[];
+  instructions: Array<
+    | {
+        programId: string;
+        parsed: {
+          type: string;
+          info: Record<string, unknown>;
+        };
+      }
+    | {
+        programId: string;
+        accounts: string[];
+        data: string;
+      }
+  >;
+  preBalances?: number[];
+  postBalances?: number[];
+  preTokenBalances?: Array<{
+    accountIndex: number;
+    mint: string;
+    owner: string;
+    uiTokenAmount: { amount: string; decimals: number };
+  }>;
+  postTokenBalances?: Array<{
+    accountIndex: number;
+    mint: string;
+    owner: string;
+    uiTokenAmount: { amount: string; decimals: number };
+  }>;
+  err?: unknown;
+}
+
+function buildTx(input: BuildTxInput) {
+  return {
+    transaction: {
+      signatures: [input.signature],
+      message: {
+        accountKeys: input.accountKeys.map((k) => ({ pubkey: new PublicKey(k) })),
+        instructions: input.instructions.map((ix) => {
+          if ("parsed" in ix) {
+            return { programId: new PublicKey(ix.programId), parsed: ix.parsed };
+          }
+          return {
+            programId: new PublicKey(ix.programId),
+            accounts: ix.accounts.map((a) => new PublicKey(a)),
+            data: ix.data,
+          };
+        }),
+      },
+    },
+    meta: {
+      err: input.err ?? null,
+      preBalances: input.preBalances ?? [],
+      postBalances: input.postBalances ?? [],
+      preTokenBalances: input.preTokenBalances ?? [],
+      postTokenBalances: input.postTokenBalances ?? [],
+      fee: 5000,
+    },
+    blockTime: input.blockTime,
+  };
+}
+
+describe("fetchSolanaHistory — pure System transfer", () => {
+  it("produces an `external` item for a user-to-user SOL send", async () => {
+    const DEST = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+    connectionStub.getSignaturesForAddress.mockResolvedValueOnce([
+      { signature: "sig_system", blockTime: 1_750_000_000 },
+    ]);
+    connectionStub.getParsedTransaction.mockResolvedValueOnce(
+      buildTx({
+        signature: "sig_system",
+        blockTime: 1_750_000_000,
+        accountKeys: [WALLET, DEST, SYSTEM_PROGRAM],
+        instructions: [
+          {
+            programId: SYSTEM_PROGRAM,
+            parsed: {
+              type: "transfer",
+              info: { source: WALLET, destination: DEST, lamports: 1_000_000_000 },
+            },
+          },
+        ],
+      }),
+    );
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    expect(item.type).toBe("external");
+    if (item.type === "external") {
+      expect(item.valueNativeFormatted).toBe("1");
+      expect(item.from).toBe(WALLET);
+      expect(item.to).toBe(DEST);
+    }
+  });
+});
+
+describe("fetchSolanaHistory — SPL token transfer", () => {
+  it("produces a `token_transfer` item for a USDC send", async () => {
+    const SRC_ATA = SOME_ATA;
+    const DST_ATA = OTHER_ATA;
+    const OTHER_OWNER = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+
+    connectionStub.getSignaturesForAddress.mockResolvedValueOnce([
+      { signature: "sig_spl", blockTime: 1_750_000_100 },
+    ]);
+    connectionStub.getParsedTransaction.mockResolvedValueOnce(
+      buildTx({
+        signature: "sig_spl",
+        blockTime: 1_750_000_100,
+        accountKeys: [WALLET, SRC_ATA, DST_ATA, SPL_TOKEN_PROGRAM],
+        instructions: [
+          {
+            programId: SPL_TOKEN_PROGRAM,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                source: SRC_ATA,
+                destination: DST_ATA,
+                mint: USDC_MINT,
+                tokenAmount: { amount: "50000000", decimals: 6 }, // 50 USDC
+              },
+            },
+          },
+        ],
+        preTokenBalances: [
+          {
+            accountIndex: 1,
+            mint: USDC_MINT,
+            owner: WALLET,
+            uiTokenAmount: { amount: "100000000", decimals: 6 },
+          },
+          {
+            accountIndex: 2,
+            mint: USDC_MINT,
+            owner: OTHER_OWNER,
+            uiTokenAmount: { amount: "0", decimals: 6 },
+          },
+        ],
+        postTokenBalances: [
+          {
+            accountIndex: 1,
+            mint: USDC_MINT,
+            owner: WALLET,
+            uiTokenAmount: { amount: "50000000", decimals: 6 },
+          },
+          {
+            accountIndex: 2,
+            mint: USDC_MINT,
+            owner: OTHER_OWNER,
+            uiTokenAmount: { amount: "50000000", decimals: 6 },
+          },
+        ],
+      }),
+    );
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    expect(item.type).toBe("token_transfer");
+    if (item.type === "token_transfer") {
+      expect(item.tokenSymbol).toBe("USDC");
+      expect(item.tokenAddress).toBe(USDC_MINT);
+      expect(item.amountFormatted).toBe("50");
+      expect(item.from).toBe(WALLET);
+    }
+  });
+});
+
+describe("fetchSolanaHistory — Jupiter swap → program_interaction", () => {
+  it("labels Jupiter V6 calls and attaches balance deltas", async () => {
+    connectionStub.getSignaturesForAddress.mockResolvedValueOnce([
+      { signature: "sig_jup", blockTime: 1_750_000_200 },
+    ]);
+    connectionStub.getParsedTransaction.mockResolvedValueOnce(
+      buildTx({
+        signature: "sig_jup",
+        blockTime: 1_750_000_200,
+        accountKeys: [WALLET, SOME_ATA, JUP_V6_PROGRAM],
+        instructions: [
+          {
+            programId: JUP_V6_PROGRAM,
+            accounts: [WALLET],
+            data: "2VfUX",
+          },
+        ],
+        preBalances: [2_000_000_000, 2_039_280, 0],
+        postBalances: [1_500_000_000, 2_039_280, 0],
+        preTokenBalances: [],
+        postTokenBalances: [
+          {
+            accountIndex: 1,
+            mint: USDC_MINT,
+            owner: WALLET,
+            uiTokenAmount: { amount: "75000000", decimals: 6 }, // 75 USDC out
+          },
+        ],
+      }),
+    );
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    expect(item.type).toBe("program_interaction");
+    if (item.type === "program_interaction") {
+      expect(item.programName).toBe("Jupiter V6");
+      expect(item.programKind).toBe("aggregator");
+      // SOL delta: -0.5 SOL (went out in the swap).
+      const solDelta = item.balanceDeltas.find((d) => d.token === "SOL");
+      expect(solDelta?.amountFormatted).toBe("-0.5");
+      // USDC delta: +75 (received).
+      const usdcDelta = item.balanceDeltas.find((d) => d.token === USDC_MINT);
+      expect(usdcDelta?.amountFormatted).toBe("+75");
+    }
+  });
+});
+
+describe("fetchSolanaHistory — unknown program", () => {
+  it("falls through to a bare program_interaction with programId only", async () => {
+    connectionStub.getSignaturesForAddress.mockResolvedValueOnce([
+      { signature: "sig_unknown", blockTime: 1_750_000_300 },
+    ]);
+    connectionStub.getParsedTransaction.mockResolvedValueOnce(
+      buildTx({
+        signature: "sig_unknown",
+        blockTime: 1_750_000_300,
+        accountKeys: [WALLET, UNKNOWN_PROGRAM],
+        instructions: [
+          {
+            programId: UNKNOWN_PROGRAM,
+            accounts: [WALLET],
+            data: "11",
+          },
+        ],
+        preBalances: [1_000_000_000, 0],
+        postBalances: [999_999_000, 0],
+      }),
+    );
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(1);
+    const item = res.items[0];
+    expect(item.type).toBe("program_interaction");
+    if (item.type === "program_interaction") {
+      expect(item.programId).toBe(UNKNOWN_PROGRAM);
+      expect(item.programName).toBeUndefined();
+      expect(item.programKind).toBeUndefined();
+    }
+  });
+});
+
+describe("fetchSolanaHistory — error handling", () => {
+  it("records getSignaturesForAddress failures in `errors` and returns empty items", async () => {
+    connectionStub.getSignaturesForAddress.mockRejectedValueOnce(
+      new Error("429 Too Many Requests"),
+    );
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(0);
+    expect(res.errors.length).toBe(1);
+    expect(res.errors[0].source).toBe("solana.getSignaturesForAddress");
+    expect(res.errors[0].message).toContain("429");
+  });
+
+  it("skips null tx returns (RPC pruned old txs) without failing", async () => {
+    connectionStub.getSignaturesForAddress.mockResolvedValueOnce([
+      { signature: "sig_missing", blockTime: 1_700_000_000 },
+    ]);
+    connectionStub.getParsedTransaction.mockResolvedValueOnce(null);
+
+    const { fetchSolanaHistory } = await import("../src/modules/history/solana.ts");
+    const res = await fetchSolanaHistory({ wallet: WALLET, limit: 10 });
+    expect(res.items.length).toBe(0);
+    expect(res.errors.length).toBe(0);
+  });
+});

--- a/test/solana-portfolio.test.ts
+++ b/test/solana-portfolio.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cache } from "../src/data/cache.js";
+
+/**
+ * Portfolio integration for Solana. Verifies the aggregator's plumbing:
+ *   1. `solanaAddress` on a single-wallet call produces a `breakdown.solana`
+ *      and populates `solanaUsd` + `coverage.solana`.
+ *   2. A Solana RPC failure degrades gracefully — coverage reflects the
+ *      error and the EVM portion of the summary is unaffected (same
+ *      catch-and-continue contract TRON has).
+ *   3. `solanaAddress` + multi-wallet throws (ambiguous pairing, same rule
+ *      as `tronAddress`).
+ */
+
+const connectionStub = {
+  getBalance: vi.fn(),
+  getTokenAccountsByOwner: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+// Stub the heavy EVM modules so the portfolio handler doesn't try to
+// multicall / fetch on-chain state in unit tests.
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    getBalance: async () => 0n,
+    multicall: async () => [],
+    getChainId: async () => 1,
+    estimateGas: async () => 0n,
+    getGasPrice: async () => 0n,
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+vi.mock("../src/data/prices.ts", () => ({
+  getTokenPrice: async () => undefined,
+  priceTokenAmounts: async () => undefined,
+}));
+
+vi.mock("../src/modules/positions/index.js", () => ({
+  getLendingPositions: async () => ({ wallet: "0x0", positions: [] }),
+  getLpPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+vi.mock("../src/modules/staking/index.js", () => ({
+  getStakingPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+vi.mock("../src/modules/compound/index.js", () => ({
+  getCompoundPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+vi.mock("../src/modules/morpho/index.js", () => ({
+  getMorphoPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+const EVM_WALLET = "0x1111111111111111111111111111111111111111";
+const SOL_WALLET = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+
+beforeEach(() => {
+  cache.clear();
+  connectionStub.getBalance.mockReset();
+  connectionStub.getTokenAccountsByOwner.mockReset();
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ coins: {} }),
+      json: async () => ({ coins: {} }),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("get_portfolio_summary with solanaAddress", () => {
+  it("folds the Solana slice into breakdown.solana + solanaUsd + coverage.solana", async () => {
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000); // 1 SOL
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    expect(res.breakdown.solana).toBeDefined();
+    expect(res.breakdown.solana?.address).toBe(SOL_WALLET);
+    expect(res.breakdown.solana?.native.length).toBe(1);
+    expect(res.coverage.solana?.covered).toBe(true);
+    expect(res.coverage.solana?.errored).toBeUndefined();
+    // 1 SOL with no price → walletBalancesUsd is 0 (priceMissing) but the
+    // slice is still present.
+    expect(res.breakdown.solana?.walletBalancesUsd).toBe(0);
+  });
+
+  it("marks coverage.solana as errored when the Solana RPC fails — EVM summary is unaffected", async () => {
+    connectionStub.getBalance.mockRejectedValueOnce(new Error("Helius 503"));
+    connectionStub.getTokenAccountsByOwner.mockRejectedValue(new Error("Helius 503"));
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    expect(res.coverage.solana?.errored).toBe(true);
+    expect(res.breakdown.solana).toBeUndefined();
+    expect(res.totalUsd).toBeGreaterThanOrEqual(0); // EVM summary still works.
+  });
+
+  it("throws when solanaAddress is combined with multi-wallet", async () => {
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    await expect(
+      getPortfolioSummary({
+        wallets: [EVM_WALLET, "0x2222222222222222222222222222222222222222"],
+        chains: ["ethereum"],
+        solanaAddress: SOL_WALLET,
+      }),
+    ).rejects.toThrow(/solanaAddress.*single EVM `wallet`/);
+  });
+});

--- a/test/solana-support.test.ts
+++ b/test/solana-support.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_CHAINS,
+  SUPPORTED_CHAINS,
+  SUPPORTED_NON_EVM_CHAINS,
+  isEvmChain,
+} from "../src/types/index.js";
+import { isSolanaAddress, SOLANA_TOKENS, SOL_DECIMALS } from "../src/config/solana.js";
+import { KNOWN_PROGRAMS, KNOWN_STAKE_POOLS } from "../src/modules/solana/program-ids.js";
+import { assertSolanaAddress } from "../src/modules/solana/address.js";
+
+/**
+ * Chain-registration invariants for Solana — parallel to
+ * optimism-chain-support.test.ts. Locks the registration down so a refactor
+ * that drops Solana from one of the constants fails loud.
+ */
+describe("Solana chain registration", () => {
+  it("is listed in SUPPORTED_NON_EVM_CHAINS", () => {
+    expect(SUPPORTED_NON_EVM_CHAINS).toContain("solana");
+  });
+
+  it("is in ALL_CHAINS but NOT in SUPPORTED_CHAINS (non-EVM)", () => {
+    expect(ALL_CHAINS).toContain("solana");
+    expect(SUPPORTED_CHAINS as readonly string[]).not.toContain("solana");
+  });
+
+  it("isEvmChain returns false for solana", () => {
+    expect(isEvmChain("solana")).toBe(false);
+  });
+
+  it("SOL native decimals are 9 (lamports per SOL = 10^9)", () => {
+    expect(SOL_DECIMALS).toBe(9);
+  });
+});
+
+describe("isSolanaAddress shape check", () => {
+  it("accepts canonical Solana mainnet addresses", () => {
+    // Jupiter V6 program — 43 chars, base58.
+    expect(isSolanaAddress("JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4")).toBe(true);
+    // USDC mint — 44 chars.
+    expect(isSolanaAddress("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")).toBe(true);
+    // All 1's = System Program (43 chars, edge case with leading 1's).
+    expect(isSolanaAddress("11111111111111111111111111111111")).toBe(false); // 32 chars — too short
+  });
+
+  it("rejects EVM and TRON addresses", () => {
+    expect(isSolanaAddress("0x1234567890123456789012345678901234567890")).toBe(false);
+    expect(isSolanaAddress("TXYZabcdefghijkmnopqrstuvwxyz23456")).toBe(false);
+  });
+
+  it("rejects garbage and empty strings", () => {
+    expect(isSolanaAddress("")).toBe(false);
+    expect(isSolanaAddress("too-short")).toBe(false);
+    // Wrong alphabet (0, O, I, l not in base58).
+    expect(isSolanaAddress("0".repeat(44))).toBe(false);
+    expect(isSolanaAddress("O".repeat(44))).toBe(false);
+  });
+
+  it("rejects strings outside 43-44 char range", () => {
+    expect(isSolanaAddress("1".repeat(42))).toBe(false);
+    expect(isSolanaAddress("1".repeat(45))).toBe(false);
+  });
+});
+
+describe("assertSolanaAddress strict validator", () => {
+  it("returns a PublicKey for a valid address", () => {
+    const pk = assertSolanaAddress("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    expect(pk.toBase58()).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+  });
+
+  it("throws on EVM address", () => {
+    expect(() => assertSolanaAddress("0x1234567890123456789012345678901234567890")).toThrow();
+  });
+
+  it("throws on empty string", () => {
+    expect(() => assertSolanaAddress("")).toThrow();
+  });
+});
+
+describe("Known program + token registries", () => {
+  it("includes the six essential programs (System, SPL Token, Token-2022, ATA, Stake, Compute Budget)", () => {
+    expect(KNOWN_PROGRAMS["11111111111111111111111111111111"]?.kind).toBe("system");
+    expect(KNOWN_PROGRAMS.TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA?.kind).toBe("token");
+    expect(KNOWN_PROGRAMS.TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb?.kind).toBe("token-2022");
+    expect(KNOWN_PROGRAMS.ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL?.kind).toBe("ata");
+    expect(KNOWN_PROGRAMS.Stake11111111111111111111111111111111111111?.kind).toBe("stake");
+  });
+
+  it("includes Jupiter V6, Marinade, Raydium, Orca, and SPL Stake Pool programs", () => {
+    expect(KNOWN_PROGRAMS.JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4?.kind).toBe("aggregator");
+    expect(KNOWN_PROGRAMS.MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD?.kind).toBe("lst");
+    expect(KNOWN_PROGRAMS["675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"]?.kind).toBe("amm");
+    expect(KNOWN_PROGRAMS.whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc?.kind).toBe("amm");
+    expect(KNOWN_PROGRAMS.SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy?.kind).toBe("stake-pool");
+  });
+
+  it("maps Jito stake pool account to the jitoSOL mint", () => {
+    const jito = KNOWN_STAKE_POOLS.Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb;
+    expect(jito?.name).toBe("Jito");
+    expect(jito?.tokenMint).toBe("J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn");
+  });
+
+  it("SOLANA_TOKENS contains the expected canonical mints", () => {
+    expect(SOLANA_TOKENS.USDC).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    expect(SOLANA_TOKENS.USDT).toBe("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB");
+    expect(SOLANA_TOKENS.jitoSOL).toBe("J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn");
+    expect(SOLANA_TOKENS.mSOL).toBe("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of a three-phase Solana rollout. Adds **read-only** Solana coverage — balances, transaction history, portfolio integration — with zero signing path. Phase 2 lands transactions (native SOL send, SPL send, validator stake delegate via Ledger over WalletConnect); Phase 3 covers DeFi write paths (Marinade/Jito, Jupiter, Solend/Kamino — protocol set TBD).

## What's new

### `get_token_balance`
- `chain: "solana"` branch. `token: "native"` → SOL balance via `getBalance`. Any SPL mint → ATA enumeration across SPL Token + Token-2022 programs, aggregated by mint.

### `get_portfolio_summary`
- New `solanaAddress` parameter (base58, 43–44 chars). Folds SOL + canonical SPL holdings (USDC, USDT, JUP, BONK, JTO, mSOL, jitoSOL) into `breakdown.solana`, `solanaUsd`, and `coverage.solana`.
- Multi-wallet + `solanaAddress` throws (same ambiguity rule as `tronAddress`).

### `get_transaction_history`
- `chain: "solana"` branch. Returns a **new fourth item variant**, `program_interaction`, for DeFi calls. Per-tx classification:
  - Pure System transfer → `external` (typed via instruction-data parse).
  - Pure SPL Token transfer → `token_transfer` (typed via instruction-data parse).
  - Anything else (Jupiter V6, Marinade, Jito stake pool, Raydium V4, Orca Whirlpools, native stake, unknown programs) → `program_interaction` with a **balance-delta summary** computed from `meta.pre/postTokenBalances` + `meta.pre/postBalances`.
- The balance-delta approach sidesteps per-IDL parsing brittleness and answers "what happened to my wallet across this tx?" directly. Works even for unknown programs.

### RPC config
- New `SOLANA_RPC_URL` env var + `solanaRpcUrl` user-config field. No silent fallback to public mainnet — Solana's public RPC is rate-limited enough that defaulting there would set users up for failure. The `vaultpilot-mcp-setup` CLI prompts for a provider URL (Helius recommended) after the TRON prompt.

## Address verification

Every program ID + token mint in `src/modules/solana/program-ids.ts` and `src/config/solana.ts` was **verified live against Solana mainnet RPC before commit**:

| Address | Verification |
|---------|--------------|
| Jupiter V6 `JUP6Lk...V4` | executable=true, owner=BPFLoaderUpgradeable |
| Raydium V4 `675kPX...Mp8` | executable=true, owner=BPFLoaderUpgradeable |
| Orca Whirlpools `whirLb...yCc` | executable=true, owner=BPFLoaderUpgradeable |
| Marinade `MarBms...7aD` | executable=true, owner=BPFLoaderUpgradeable |
| SPL Stake Pool `SPoo1K...uHy` | executable=true, owner=BPFLoaderUpgradeable |
| USDC `EPjFWd...t1v` | getTokenSupply decimals=6 |
| USDT `Es9vMF...NYB` | getTokenSupply decimals=6 |
| JUP `JUPyiwr...vCN` | getTokenSupply decimals=6 |
| BONK `DezXAZ...263` | getTokenSupply decimals=5 |
| JTO `jtojto...mCL` | getTokenSupply decimals=9 |
| mSOL `mSoLzY...7So` | getTokenSupply decimals=9 |
| jitoSOL `J1toso...CPn` | getTokenSupply decimals=9 |

**Notable finding**: Jito doesn't operate its own program — it's a stake pool *account* (`Jito4APyf...`) owned by the generic SPL Stake Pool program. The decoder uses `KNOWN_STAKE_POOLS` to identify it by matching the pool account in the instruction's account list.

## Dep

`@solana/web3.js@1.98.4`. `npm audit --audit-level=high` shows no issues; moderate-severity warnings are all in transitive deps (rpc-websockets → uuid) unrelated to this work.

## Files

**New** (9): `src/config/solana.ts`, `src/modules/solana/{address,balances,decode,program-ids,rpc}.ts`, `src/modules/history/solana.ts`, 4 test files.

**Modified** (12): types, config/chains, balances (schemas + dispatch), history (schemas + dispatch + prices), portfolio (schemas + index), setup CLI, index (tool descriptions), package.json.

## Out of scope (deferred)

- Native validator staking reads (stake account discovery). Cheap to add but fits more naturally alongside Phase 2's stake-write path.
- Liquid-staking yield estimation (mSOL / jitoSOL APY).
- Token-2022 extensions (transfer fee, interest-bearing). Treated as plain SPL.
- NFTs, compressed NFTs.
- All signing paths.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 522 → 553 (31 new: 15 support + 7 balance + 6 history + 3 portfolio); all green
- [x] Live address verification (table above)
- [ ] **Manual MCP-client smoke on a real Solana wallet** (requires SOLANA_RPC_URL or `solanaRpcUrl` configured):
  - [ ] `get_token_balance({ chain: "solana", token: "native", wallet })` → SOL balance
  - [ ] `get_token_balance({ chain: "solana", token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", wallet })` → USDC balance
  - [ ] `get_portfolio_summary({ wallet: <evm>, solanaAddress: <sol> })` → `breakdown.solana` populated, cross-chain totals consistent
  - [ ] `get_transaction_history({ chain: "solana", wallet, limit: 10 })` → recent activity with Jupiter swaps / staking visible as `program_interaction` items with balance deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)