### PR TITLE
feat(session): emit re-pair guidance when peerUnreachable is set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -882,7 +882,8 @@ async function main() {
         "session exists whose topic ends with the last 8 chars of the `topic` field (surface those 8 chars in your prompt, e.g. \"…a1b2c3d4\"). If no matching session " +
         "is listed there, a different peer is impersonating Ledger Live — do NOT proceed. The physical Ledger device's on-screen confirmation is still the final check " +
         "on tx contents, but the topic cross-check is what binds the WC session to the user's real Ledger Live install. " +
-        "The `tron` array is read from the cache populated by `pair_ledger_tron`; `send_transaction` re-probes USB on every TRON sign, so the cache cannot be spoofed into approving a tx for the wrong account.",
+        "The `tron` array is read from the cache populated by `pair_ledger_tron`; `send_transaction` re-probes USB on every TRON sign, so the cache cannot be spoofed into approving a tx for the wrong account. " +
+        "If the response has `peerUnreachable: true`, the WalletConnect relay couldn't confirm Ledger Live is connected — the cached `accounts` are still fine for address resolution (read-only questions about balances / history / portfolio), but BEFORE any signing flow you MUST ask the user whether to re-pair via `pair_ledger_live`. The exact call-to-action text is in `peerUnreachableGuidance`; splice it verbatim into your reply rather than paraphrasing. Never auto-re-pair on a read-only request.",
       inputSchema: getLedgerStatusInput.shape,
     },
     handler(getLedgerStatus)

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -51,6 +51,17 @@ export interface SessionStatus {
    */
   peerUnreachable?: boolean;
   /**
+   * Actionable guidance for the agent, populated only when `peerUnreachable`
+   * is true. The cached `accounts` / `accountDetails` are still usable for
+   * address resolution (e.g. "my first wallet" → 0x…) but any signing
+   * attempt will hang on the unresponsive relay, so the agent should
+   * proactively prompt the user to re-pair before proceeding to a
+   * prepare_* / send flow. Kept as a string rather than a boolean so the
+   * exact call-to-action lives alongside the flag and the agent can splice
+   * it verbatim into its reply.
+   */
+  peerUnreachableGuidance?: string;
+  /**
    * Present when the user has run `pair_ledger_tron` at least once. TRON
    * doesn't share WalletConnect with EVM — signing goes over USB HID — so
    * this section is independent of the `paired`/`accounts` fields above
@@ -74,6 +85,13 @@ export const PEER_TRUST_WARNING =
   "The paired wallet/URL above is NOT on the Ledger-first-party allowlist; ask the user " +
   "to confirm before calling send_transaction. The ultimate check is that the tx shows up on the " +
   "user's physical Ledger device for on-screen approval.";
+
+export const PEER_UNREACHABLE_GUIDANCE =
+  "WalletConnect session is cached locally but the relay couldn't confirm Ledger Live is currently connected. " +
+  "Cached addresses below are fine for referring to the user's wallet(s) — keep using them for balance/history/portfolio queries — " +
+  "but any signing flow (prepare_* → send_transaction) will hang on the unresponsive peer. " +
+  "Before the next signing operation, ASK the user: 'WalletConnect looks disconnected. Want me to re-pair Ledger Live now via pair_ledger_live?' " +
+  "Only call pair_ledger_live on explicit confirmation. Do NOT auto-re-pair on read-only requests.";
 
 /**
  * Hosts the server treats as first-party Ledger WC peers. Exact match or any
@@ -127,7 +145,9 @@ export async function getSessionStatus(): Promise<SessionStatus> {
     ...(meta?.url ? { peerUrl: meta.url } : {}),
     ...(meta?.description ? { peerDescription: meta.description } : {}),
     ...(warnPeer ? { peerTrustWarning: PEER_TRUST_WARNING } : {}),
-    ...(unreachable ? { peerUnreachable: true } : {}),
+    ...(unreachable
+      ? { peerUnreachable: true, peerUnreachableGuidance: PEER_UNREACHABLE_GUIDANCE }
+      : {}),
     ...tronSection,
   };
 }


### PR DESCRIPTION
## Summary

Your observation from live use: after you disconnected the WalletConnect session in Ledger Live, `get_ledger_status` still returned cached addresses with `peerUnreachable: true`. The flag was there but the agent had no clear directive to *do* anything with it — it flagged the condition in prose and carried on.

This PR adds two complementary nudges so the agent proactively offers to re-pair:

1. **New `peerUnreachableGuidance` field** on the session-status response, populated only when `peerUnreachable: true`. Contains the exact call-to-action:
   > *WalletConnect looks disconnected. Want me to re-pair Ledger Live now via pair_ledger_live?*
   Designed to be spliced verbatim, not paraphrased.
2. **Tool-description directive** on `get_ledger_status`: if `peerUnreachable: true`, cached `accounts` are fine for address resolution (balances / history / portfolio), but BEFORE any signing flow the agent MUST ask the user whether to re-pair. Never auto-re-pair on a read-only request.

## What does NOT change

- **Cache semantics** — cached addresses stay cached, exactly as today. You explicitly wanted to keep that behavior.
- **Detection logic** — `peerUnreachable` detection (via the WC relay ping with 5s timeout) is unchanged.
- **No new tool calls** — this is pure in-band guidance the agent sees alongside the data it already consumed.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 522/522 pass
- [ ] Manual live check after merge: close WC session in Ledger Live → ask agent to list wallets → agent should now proactively ask to re-pair instead of just flagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)