### PR TITLE
feat(weth): add prepare_weth_unwrap tool (closes #72)

### DIFF
--- a/src/abis/weth.ts
+++ b/src/abis/weth.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal WETH9 ABI — just the two entry points we use for the native
+ * unwrap path. Wrap is reachable via `prepare_native_send` (sending ETH to
+ * the WETH contract triggers the fallback → `deposit()`), so we don't need
+ * `deposit` here. Unwrap needs `withdraw(uint256)` and we spot-check
+ * `balanceOf` for the "max" resolver and the pre-build balance guard.
+ */
+export const wethAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "wad", type: "uint256" }],
+    outputs: [],
+  },
+] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
   prepareLidoUnstake,
   prepareEigenLayerDeposit,
   prepareNativeSend,
+  prepareWethUnwrap,
   prepareTokenSend,
   previewSend,
   sendTransaction,
@@ -80,6 +81,7 @@ import {
   prepareLidoUnstakeInput,
   prepareEigenLayerDepositInput,
   prepareNativeSendInput,
+  prepareWethUnwrapInput,
   prepareTokenSendInput,
   previewSendInput,
   sendTransactionInput,
@@ -1234,6 +1236,16 @@ async function main() {
       inputSchema: prepareNativeSendInput.shape,
     },
     txHandler("prepare_native_send", prepareNativeSend)
+  );
+
+  server.registerTool(
+    "prepare_weth_unwrap",
+    {
+      description:
+        "Build an unsigned WETH → native ETH unwrap transaction via a direct `WETH.withdraw(uint256)` call on the canonical WETH9 contract for the target chain. Supported chains: ethereum, arbitrum, polygon, base, optimism. Pass an explicit decimal amount (e.g. `\"0.5\"`) or the literal `\"max\"` to unwrap the full WETH balance. WETH is always 18 decimals. No approval is required — the wallet burns its own balance and receives native ETH back in the same call; the call is cheaper than routing through a DEX/aggregator. Balance is checked pre-build and the call refuses with a clear message if the wallet is short, rather than letting the tx revert on-chain. For the symmetric wrap direction (native ETH → WETH), use `prepare_native_send` with the WETH contract as `to` — sending ETH to the WETH9 fallback triggers `deposit()` automatically.",
+      inputSchema: prepareWethUnwrapInput.shape,
+    },
+    txHandler("prepare_weth_unwrap", prepareWethUnwrap)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -44,6 +44,7 @@ import {
   buildLidoUnstake,
   buildEigenLayerDeposit,
 } from "../staking/actions.js";
+import { buildWethUnwrap } from "../weth/actions.js";
 import { getTokenPrice } from "../../data/prices.js";
 import type {
   PairLedgerTronArgs,
@@ -55,6 +56,7 @@ import type {
   PrepareLidoUnstakeArgs,
   PrepareEigenLayerDepositArgs,
   PrepareNativeSendArgs,
+  PrepareWethUnwrapArgs,
   PrepareTokenSendArgs,
   PreviewSendArgs,
   SendTransactionArgs,
@@ -301,6 +303,16 @@ export async function prepareNativeSend(args: PrepareNativeSendArgs): Promise<Un
     description: `Send ${args.amount} native coin to ${to} on ${chain}`,
     decoded: { functionName: "transfer", args: { to, amount: args.amount } },
   });
+}
+
+export async function prepareWethUnwrap(args: PrepareWethUnwrapArgs): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildWethUnwrap({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      amount: args.amount,
+    }),
+  );
 }
 
 export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<UnsignedTx> {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -88,6 +88,17 @@ export const prepareNativeSendInput = z.object({
     ),
 });
 
+export const prepareWethUnwrapInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  amount: z
+    .string()
+    .describe(
+      'Human-readable WETH amount, NOT raw wei. Example: "0.5" for 0.5 WETH. ' +
+        'Pass "max" to unwrap the full WETH balance. WETH is always 18 decimals on every supported chain.'
+    ),
+});
+
 export const prepareTokenSendInput = z.object({
   wallet: walletSchema,
   chain: chainEnum.default("ethereum"),
@@ -215,6 +226,7 @@ export type PrepareLidoStakeArgs = z.infer<typeof prepareLidoStakeInput>;
 export type PrepareLidoUnstakeArgs = z.infer<typeof prepareLidoUnstakeInput>;
 export type PrepareEigenLayerDepositArgs = z.infer<typeof prepareEigenLayerDepositInput>;
 export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
+export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;
 export type PrepareTokenSendArgs = z.infer<typeof prepareTokenSendInput>;
 export type PreviewSendArgs = z.infer<typeof previewSendInput>;
 export type SendTransactionArgs = z.infer<typeof sendTransactionInput>;

--- a/src/modules/weth/actions.ts
+++ b/src/modules/weth/actions.ts
@@ -1,0 +1,97 @@
+import { encodeFunctionData, formatUnits, parseEther } from "viem";
+import { wethAbi } from "../../abis/weth.js";
+import { CONTRACTS } from "../../config/contracts.js";
+import { getClient } from "../../data/rpc.js";
+import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+
+/**
+ * Resolve the canonical WETH9 contract for a supported chain. All current
+ * deployments use 18 decimals (same as native ETH), so we don't expose
+ * `decimals` — the builder hardcodes 18. Verified 2026-04 against each
+ * chain's block explorer.
+ */
+function getWethAddress(chain: SupportedChain): `0x${string}` {
+  const tokens = (CONTRACTS[chain] as { tokens?: Record<string, string> }).tokens;
+  const addr = tokens?.WETH;
+  if (!addr) {
+    throw new Error(
+      `No canonical WETH address registered for chain "${chain}". ` +
+        `Add one to src/config/contracts.ts (CONTRACTS.${chain}.tokens.WETH) first.`,
+    );
+  }
+  return addr as `0x${string}`;
+}
+
+export interface WethUnwrapParams {
+  wallet: `0x${string}`;
+  chain: SupportedChain;
+  /** Human-readable amount ("0.5"), or the literal "max" to unwrap the full WETH balance. */
+  amount: string | "max";
+}
+
+/**
+ * Build an unsigned `WETH.withdraw(uint256)` transaction. No ERC-20 approval
+ * is required — `msg.sender` burns their own balance and receives native
+ * ETH back in the same call.
+ *
+ * `amount: "max"` reads the wallet's WETH balance from chain and uses the
+ * full amount. An explicit amount is parsed at 18 decimals (WETH is always
+ * 18 — verified across ethereum, arbitrum, polygon, base, optimism) and
+ * compared against balance; we refuse pre-sign with a clear message if the
+ * balance is insufficient rather than letting the tx revert on-chain with
+ * an opaque "arithmetic underflow" error.
+ */
+export async function buildWethUnwrap(p: WethUnwrapParams): Promise<UnsignedTx> {
+  const weth = getWethAddress(p.chain);
+  const client = getClient(p.chain);
+
+  let amountWei: bigint;
+  let displayAmount: string;
+
+  if (p.amount === "max") {
+    amountWei = (await client.readContract({
+      address: weth,
+      abi: wethAbi,
+      functionName: "balanceOf",
+      args: [p.wallet],
+    })) as bigint;
+    if (amountWei === 0n) {
+      throw new Error(
+        `Cannot unwrap: wallet ${p.wallet} holds 0 WETH on ${p.chain}.`,
+      );
+    }
+    displayAmount = formatUnits(amountWei, 18);
+  } else {
+    amountWei = parseEther(p.amount);
+    const balance = (await client.readContract({
+      address: weth,
+      abi: wethAbi,
+      functionName: "balanceOf",
+      args: [p.wallet],
+    })) as bigint;
+    if (balance < amountWei) {
+      throw new Error(
+        `Insufficient WETH: wallet ${p.wallet} has ${formatUnits(balance, 18)} WETH on ${p.chain}, ` +
+          `requested ${p.amount}. Reduce the amount or use "max".`,
+      );
+    }
+    displayAmount = p.amount;
+  }
+
+  return {
+    chain: p.chain,
+    to: weth,
+    data: encodeFunctionData({
+      abi: wethAbi,
+      functionName: "withdraw",
+      args: [amountWei],
+    }),
+    value: "0",
+    from: p.wallet,
+    description: `Unwrap ${displayAmount} WETH → ETH on ${p.chain}`,
+    decoded: {
+      functionName: "withdraw",
+      args: { amount: `${displayAmount} WETH` },
+    },
+  };
+}

--- a/test/weth-unwrap.test.ts
+++ b/test/weth-unwrap.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseEther, toFunctionSelector } from "viem";
+import { CONTRACTS } from "../src/config/contracts.js";
+
+/**
+ * Tests for the `prepare_weth_unwrap` builder (issue #72). The builder
+ * consults an RPC `readContract` for the balance check + the `"max"`
+ * resolver, so tests mock `getClient` to a stub.
+ */
+
+const WALLET = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+
+const readContractMock = vi.fn();
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+  }),
+}));
+
+beforeEach(() => {
+  readContractMock.mockReset();
+});
+
+describe("buildWethUnwrap", () => {
+  it("targets the canonical WETH9 address for ethereum", async () => {
+    readContractMock.mockResolvedValueOnce(parseEther("10")); // wallet has 10 WETH
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    const tx = await buildWethUnwrap({ wallet: WALLET, chain: "ethereum", amount: "0.5" });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to.toLowerCase()).toBe(CONTRACTS.ethereum.tokens.WETH.toLowerCase());
+    expect(tx.value).toBe("0");
+    expect(tx.from).toBe(WALLET);
+  });
+
+  it("produces calldata starting with the withdraw(uint256) selector", async () => {
+    readContractMock.mockResolvedValueOnce(parseEther("10"));
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    const tx = await buildWethUnwrap({ wallet: WALLET, chain: "ethereum", amount: "1" });
+    const selector = toFunctionSelector("withdraw(uint256)");
+    expect(tx.data.toLowerCase().startsWith(selector.toLowerCase())).toBe(true);
+    // selector (8) + uint256 (64) = 72 hex chars after 0x.
+    expect(tx.data.length).toBe(2 + 8 + 64);
+  });
+
+  it("resolves `max` via on-chain balanceOf", async () => {
+    const bal = parseEther("3.14");
+    readContractMock.mockResolvedValueOnce(bal);
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    const tx = await buildWethUnwrap({ wallet: WALLET, chain: "ethereum", amount: "max" });
+    expect(tx.description).toContain("3.14 WETH");
+    // The uint256 argument (last 64 hex chars of data) should equal bal in hex, zero-padded.
+    const argHex = tx.data.slice(2 + 8);
+    expect(BigInt("0x" + argHex)).toBe(bal);
+  });
+
+  it("refuses pre-sign when the wallet is short", async () => {
+    readContractMock.mockResolvedValueOnce(parseEther("0.1")); // only 0.1 WETH
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    await expect(
+      buildWethUnwrap({ wallet: WALLET, chain: "ethereum", amount: "1" }),
+    ).rejects.toThrow(/Insufficient WETH/);
+  });
+
+  it("refuses `max` when the wallet holds zero WETH", async () => {
+    readContractMock.mockResolvedValueOnce(0n);
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    await expect(
+      buildWethUnwrap({ wallet: WALLET, chain: "ethereum", amount: "max" }),
+    ).rejects.toThrow(/holds 0 WETH/);
+  });
+
+  it("uses the L2-predeploy WETH address on base and optimism (0x4200…0006)", async () => {
+    readContractMock.mockResolvedValueOnce(parseEther("1"));
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    const baseTx = await buildWethUnwrap({ wallet: WALLET, chain: "base", amount: "0.5" });
+    expect(baseTx.to.toLowerCase()).toBe("0x4200000000000000000000000000000000000006");
+
+    readContractMock.mockResolvedValueOnce(parseEther("1"));
+    const opTx = await buildWethUnwrap({ wallet: WALLET, chain: "optimism", amount: "0.5" });
+    expect(opTx.to.toLowerCase()).toBe("0x4200000000000000000000000000000000000006");
+  });
+
+  it("uses the chain-specific WETH address on arbitrum and polygon", async () => {
+    readContractMock.mockResolvedValueOnce(parseEther("1"));
+    const { buildWethUnwrap } = await import("../src/modules/weth/actions.js");
+    const arbTx = await buildWethUnwrap({ wallet: WALLET, chain: "arbitrum", amount: "0.5" });
+    expect(arbTx.to.toLowerCase()).toBe(CONTRACTS.arbitrum.tokens.WETH.toLowerCase());
+
+    readContractMock.mockResolvedValueOnce(parseEther("1"));
+    const polyTx = await buildWethUnwrap({ wallet: WALLET, chain: "polygon", amount: "0.5" });
+    expect(polyTx.to.toLowerCase()).toBe(CONTRACTS.polygon.tokens.WETH.toLowerCase());
+  });
+});


### PR DESCRIPTION
## Summary

Adds `prepare_weth_unwrap({ wallet, chain, amount | \"max\" })` — a direct `WETH.withdraw(uint256)` preparer that closes the wrap/unwrap symmetry. Wrap is already reachable today via `prepare_native_send` to the WETH contract (triggers the WETH9 fallback → `deposit()`); unwrap needed its own entry point. Follows the user's memory preference (*wrap/unwrap direct to WETH9, never via LiFi*) and is slightly cheaper gas than routing through the aggregator.

## Supported chains

Matches the rest of the EVM preparers: ethereum, arbitrum, polygon, base, optimism. WETH9 addresses come from the existing `CONTRACTS[chain].tokens.WETH` registry — no new address table. WETH is 18 decimals on every supported chain, so the builder hardcodes that.

## Behavior

- **`amount: \"max\"`** — reads `balanceOf(wallet)` on-chain and unwraps the full balance. Refuses with a clear error when balance is zero (better than silently building a 0-amount tx).
- **Explicit amount** — parsed at 18 decimals, balance checked pre-build. Refuses pre-sign with a descriptive message (`\"Insufficient WETH: wallet 0x… has 0.1 WETH, requested 1. Reduce or use max.\"`) rather than letting the tx revert on-chain with an opaque arithmetic underflow.
- **No approval needed** — `msg.sender` burns their own balance and receives native ETH in the same call.
- Returns `UnsignedTx` → flows through the normal handle → `preview_send` → `send_transaction` pipeline.

## Files

- `src/abis/weth.ts` — minimal WETH9 ABI (`balanceOf` + `withdraw`)
- `src/modules/weth/actions.ts` — `buildWethUnwrap` builder
- `src/modules/execution/index.ts` — `prepareWethUnwrap` handler
- `src/modules/execution/schemas.ts` — `prepareWethUnwrapInput` Zod schema
- `src/index.ts` — tool registration; description references the wrap workflow via `prepare_native_send` so the agent sees both directions in one place
- `test/weth-unwrap.test.ts` — 7 cases

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 560/560 (was 553, +7 new cases):
  - canonical WETH9 on ethereum
  - selector byte-match `withdraw(uint256)` + payload length
  - `max` resolver via `balanceOf`
  - insufficient-balance guard
  - zero-balance guard on `max`
  - L2-predeploy addresses (base/optimism = 0x4200…0006)
  - chain-specific addresses (arbitrum/polygon)
- [ ] Manual check after merge on user's 3rd account (0x8F9dE85C…4361) which surfaced the tool gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)