### PR TITLE
fix(pre-sign): recognize WETH9 withdraw/deposit selectors

### DIFF
--- a/src/abis/weth.ts
+++ b/src/abis/weth.ts
@@ -1,9 +1,14 @@
 /**
- * Minimal WETH9 ABI — just the two entry points we use for the native
- * unwrap path. Wrap is reachable via `prepare_native_send` (sending ETH to
- * the WETH contract triggers the fallback → `deposit()`), so we don't need
- * `deposit` here. Unwrap needs `withdraw(uint256)` and we spot-check
- * `balanceOf` for the "max" resolver and the pre-build balance guard.
+ * Minimal WETH9 ABI. Covers the WETH9-specific surface used by prepare_*
+ * tools AND referenced by the pre-sign allowlist / calldata decoder:
+ *   - `withdraw(uint256)` — unwrap WETH → native ETH (prepare_weth_unwrap).
+ *   - `deposit()` — wrap native ETH → WETH. Our prepare_* path for wrap
+ *     uses `prepare_native_send` against WETH9 (fallback() hits deposit),
+ *     which produces empty calldata and bypasses the selector gate. But
+ *     callers may still emit explicit `deposit()` calldata, and we want
+ *     the pre-sign check to recognize it instead of refusing.
+ *   - `balanceOf(address)` — used by the "max" resolver and the
+ *     pre-build balance guard in buildWethUnwrap.
  */
 export const wethAbi = [
   {
@@ -18,6 +23,13 @@ export const wethAbi = [
     name: "withdraw",
     stateMutability: "nonpayable",
     inputs: [{ name: "wad", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "payable",
+    inputs: [],
     outputs: [],
   },
 ] as const;

--- a/src/signing/decode-calldata.ts
+++ b/src/signing/decode-calldata.ts
@@ -13,6 +13,7 @@ import { stETHAbi, lidoWithdrawalQueueAbi } from "../abis/lido.js";
 import { eigenStrategyManagerAbi } from "../abis/eigenlayer-strategy-manager.js";
 import { uniswapPositionManagerAbi } from "../abis/uniswap-position-manager.js";
 import { lifiDiamondAbi } from "../abis/lifi-diamond.js";
+import { wethAbi } from "../abis/weth.js";
 import { CONTRACTS, NATIVE_SYMBOL, TOKEN_META } from "../config/contracts.js";
 import type {
   DecodedArg,
@@ -41,8 +42,18 @@ type DestinationKind =
   | "lido-withdrawalQueue"
   | "eigenlayer-strategyManager"
   | "uniswap-v3-npm"
+  | "weth9"
   | "known-erc20"
   | "lifi-diamond";
+
+/**
+ * WETH9 surface merged with the standard ERC-20 surface: `withdraw(uint256)`
+ * and `deposit()` are WETH9-specific, while `transfer`/`approve`/... are
+ * also emitted against WETH for Uniswap/Compound/Morpho supply flows.
+ * Classifying WETH as plain `known-erc20` would leave the decoder blind to
+ * `withdraw` calldata that `prepare_weth_unwrap` legitimately emits.
+ */
+const weth9Abi = [...erc20Abi, ...wethAbi] as Abi;
 
 interface Destination {
   kind: DestinationKind;
@@ -91,6 +102,13 @@ function classifyDestination(chain: SupportedChain, to: `0x${string}`): Destinat
   }
 
   if (lo === LIFI_DIAMOND) return { kind: "lifi-diamond", abi: lifiDiamondAbi as Abi };
+
+  // WETH9 — matched BEFORE the generic tokens loop so `withdraw(uint256)` /
+  // `deposit()` decode cleanly instead of falling through to plain ERC-20.
+  const wethAddr = (CONTRACTS[chain] as { tokens?: { WETH?: string } }).tokens?.WETH;
+  if (wethAddr && lo === wethAddr.toLowerCase()) {
+    return { kind: "weth9", abi: weth9Abi };
+  }
 
   const tokens = (CONTRACTS[chain] as { tokens?: Record<string, string> }).tokens;
   if (tokens) {
@@ -144,7 +162,8 @@ function formatErc20ArgHuman(
   raw: unknown,
 ): string | undefined {
   if (argType !== "uint256" || typeof raw !== "bigint") return undefined;
-  if (argName !== "amount" && argName !== "value") return undefined;
+  // `wad` is the canonical WETH9 arg name for withdraw(uint256).
+  if (argName !== "amount" && argName !== "value" && argName !== "wad") return undefined;
   const meta = TOKEN_META[chain][to.toLowerCase()];
   if (!meta) return undefined;
   return `${formatUnits(raw, meta.decimals)} ${meta.symbol}`;
@@ -195,7 +214,7 @@ export function decodeCalldata(
       value: stringifyArg(raw),
     };
     const human =
-      dest.kind === "known-erc20"
+      dest.kind === "known-erc20" || dest.kind === "weth9"
         ? formatErc20ArgHuman(chain, to, base.name, input.type, raw)
         : undefined;
     if (input.type === "address" && typeof raw === "string") {

--- a/src/signing/pre-sign-check.ts
+++ b/src/signing/pre-sign-check.ts
@@ -7,6 +7,7 @@ import { cometAbi } from "../abis/compound-comet.js";
 import { morphoBlueAbi } from "../abis/morpho-blue.js";
 import { uniswapPositionManagerAbi } from "../abis/uniswap-position-manager.js";
 import { swapRouter02Abi } from "../abis/uniswap-swap-router-02.js";
+import { wethAbi } from "../abis/weth.js";
 import { CONTRACTS } from "../config/contracts.js";
 import type { SupportedChain, UnsignedTx } from "../types/index.js";
 
@@ -55,6 +56,7 @@ type DestinationKind =
   | "eigenlayer-strategyManager"
   | "uniswap-v3-npm"
   | "uniswap-v3-swap-router"
+  | "weth9"
   | "known-erc20"
   | "lifi-diamond";
 
@@ -86,6 +88,12 @@ const EIGEN_SELECTORS = computeSelectorsFromAbi(eigenStrategyManagerAbi);
 const UNISWAP_NPM_SELECTORS = computeSelectorsFromAbi(uniswapPositionManagerAbi);
 const UNISWAP_SWAP_ROUTER_SELECTORS = computeSelectorsFromAbi(swapRouter02Abi);
 const ERC20_SELECTORS = computeSelectorsFromAbi(erc20Abi);
+// WETH9 is also an ERC-20 (approve/transfer for Uniswap/Compound/Morpho
+// supply flows), so the accepted surface is ERC-20 ∪ {withdraw, deposit}.
+const WETH9_SELECTORS = new Set<string>([
+  ...ERC20_SELECTORS,
+  ...computeSelectorsFromAbi(wethAbi),
+]);
 
 async function classifyDestination(
   chain: SupportedChain,
@@ -139,7 +147,16 @@ async function classifyDestination(
   // LiFi Diamond — accept but skip per-selector check (LiFi's ABI is huge and dynamic).
   if (lo === LIFI_DIAMOND) return { kind: "lifi-diamond", allowedAbi: null };
 
-  // Known ERC-20s (USDC, USDT, DAI, WETH, ...). Tokens ONLY — this path never
+  // WETH9 — matched BEFORE the generic tokens loop so the WETH9-specific
+  // `withdraw` / `deposit` selectors pass the per-selector check. Classified
+  // as plain `known-erc20` those selectors would be rejected even though
+  // `prepare_weth_unwrap` legitimately emits them.
+  const wethAddr = (CONTRACTS[chain].tokens as { WETH?: string } | undefined)?.WETH;
+  if (wethAddr && lo === wethAddr.toLowerCase()) {
+    return { kind: "weth9", allowedAbi: erc20Abi };
+  }
+
+  // Known ERC-20s (USDC, USDT, DAI, ...). Tokens ONLY — this path never
   // covers a protocol contract that exposes transfer-like selectors, because
   // the protocol branches above match first.
   const tokens = CONTRACTS[chain].tokens as Record<string, string> | undefined;
@@ -207,7 +224,8 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
     // not, say, the Aave Pool. approve() on the pool itself is nonsensical.
     if (
       dest.kind !== "known-erc20" &&
-      dest.kind !== "lido-stETH" // stETH IS an ERC-20; approvals to spenders happen on it
+      dest.kind !== "lido-stETH" && // stETH IS an ERC-20; approvals to spenders happen on it
+      dest.kind !== "weth9" // WETH IS an ERC-20; Uniswap/Compound/Morpho supply flows approve it
     ) {
       throw new Error(
         `Pre-sign check: refusing approve() on ${dest.kind} (${tx.to}) — approvals should ` +
@@ -239,7 +257,10 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
   //    we recognize (otherwise the agent is calling transfer() on an arbitrary
   //    contract with matching 4-byte — unlikely but worth rejecting).
   if (selector === SELECTOR.transfer) {
-    if (!dest || (dest.kind !== "known-erc20" && dest.kind !== "lido-stETH")) {
+    if (
+      !dest ||
+      (dest.kind !== "known-erc20" && dest.kind !== "lido-stETH" && dest.kind !== "weth9")
+    ) {
       throw new Error(
         `Pre-sign check: refusing transfer() on ${tx.to} (${tx.chain}) — token is not in our ` +
           `recognized set. Add it to CONTRACTS[${tx.chain}].tokens if this is a legitimate asset.`
@@ -283,6 +304,8 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
         return UNISWAP_NPM_SELECTORS;
       case "uniswap-v3-swap-router":
         return UNISWAP_SWAP_ROUTER_SELECTORS;
+      case "weth9":
+        return WETH9_SELECTORS;
       case "known-erc20":
         return ERC20_SELECTORS;
       case "lifi-diamond":

--- a/test/pre-sign-check.test.ts
+++ b/test/pre-sign-check.test.ts
@@ -29,6 +29,7 @@ const AAVE_POOL_ETH = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2";
 const LIFI_DIAMOND = "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE";
 const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const USDT_ETH = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const WETH_ETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const ATTACKER = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 const WALLET = "0x1111111111111111111111111111111111111111";
 
@@ -329,5 +330,101 @@ describe("Pre-sign check: protocol calls", () => {
         description: "unknown call",
       })
     ).rejects.toThrow(/refusing to sign against unknown contract/);
+  });
+});
+
+describe("Pre-sign check: WETH9-specific selectors", () => {
+  it("accepts WETH.withdraw(uint256) — the prepare_weth_unwrap path", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const { wethAbi } = await import("../src/abis/weth.js");
+    const data = encodeFunctionData({
+      abi: wethAbi,
+      functionName: "withdraw",
+      args: [500_000_100_000_000_000n], // 0.5000001 WETH
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: WETH_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "Unwrap WETH",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("accepts WETH.deposit()", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const { wethAbi } = await import("../src/abis/weth.js");
+    const data = encodeFunctionData({ abi: wethAbi, functionName: "deposit", args: [] });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: WETH_ETH as `0x${string}`,
+        data,
+        value: "1000000000000000000",
+        from: WALLET,
+        description: "Wrap ETH",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("still accepts approve(WETH, SwapRouter02) — ERC-20 approvals on WETH must keep working", async () => {
+    // Uniswap V3 swaps with WETH as the input token need this approval; a naive
+    // fix that made WETH reject ERC-20 selectors would break prepare_uniswap_swap.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const SWAP_ROUTER_02 = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [SWAP_ROUTER_02 as `0x${string}`, maxUint256],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: WETH_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "approve WETH for Uniswap",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("still accepts transfer(WETH, recipient)", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [ATTACKER as `0x${string}`, 100n],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: WETH_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "transfer WETH",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a random selector aimed at WETH9", async () => {
+    // The per-selector gate is the reason we don't just classify WETH as
+    // some catch-all kind. An arbitrary selector on WETH must still refuse.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = "0xdeadbeef" + "00".repeat(32);
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: WETH_ETH as `0x${string}`,
+        data: data as `0x${string}`,
+        value: "0",
+        from: WALLET,
+        description: "bogus call on WETH",
+      })
+    ).rejects.toThrow(/not a known function on weth9/);
   });
 });


### PR DESCRIPTION
## Summary

- `prepare_weth_unwrap` (added in #72) emits `WETH9.withdraw(uint256)` calldata, but the pre-sign check classified WETH as plain `known-erc20` — whose allowed selector set is just ERC-20. `preview_send` rejected every unwrap with `selector 0x2e1a7d4d is not a known function on known-erc20 (0xC02aa…Cc2). Refusing to sign.`, making the tool unreachable from the signing path.
- Fix: introduce a dedicated `weth9` destination kind, matched BEFORE the generic tokens loop in both `pre-sign-check.ts` and `decode-calldata.ts`. Its allowed selector set is ERC-20 ∪ `{withdraw(uint256), deposit()}`, so legitimate flows keep working:
  - WETH unwrap via `prepare_weth_unwrap` ✓
  - WETH wrap via explicit `deposit()` ✓ (the native-send-to-WETH9 fallback path already bypassed the selector gate — empty calldata)
  - `approve(WETH, SwapRouter02)` for Uniswap swaps, `approve(WETH, Comet)` for Compound supply, `approve(WETH, MorphoBlue)` — all still accepted
  - `transfer(WETH, recipient)` still accepted
  - Random selectors on WETH still **rejected** (`weth9` gets its own selector gate, not a catch-all)
- `wethAbi` additionally gains the `deposit()` entry so the decoder renders explicit wrap calldata as `deposit()` instead of `unknown`.

## Discovered while

Unwrapping 0.5 WETH in a live session — the user requested an unwrap across all connected accounts. `prepare_weth_unwrap` built and simulated the tx fine, but `preview_send` refused at the pre-sign gate. Root cause confirmed in `src/signing/pre-sign-check.ts:293-298`: `known-erc20` → `ERC20_SELECTORS` doesn't include `0x2e1a7d4d`.

## Test plan

- [x] `npm test -- pre-sign-check` — 21/21 pass (16 existing + 5 new)
- [x] `npm test -- pre-sign-check weth-unwrap` — 28/28 pass
- New cases in `test/pre-sign-check.test.ts`:
  - accepts `WETH.withdraw(uint256)`
  - accepts `WETH.deposit()`
  - accepts `approve(WETH, SwapRouter02)` — regression guard for Uniswap flow
  - accepts `transfer(WETH, recipient)` — regression guard
  - rejects random selector on WETH (`not a known function on weth9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)