### PR TITLE
fix(render): drop pair-consistency + blind-sign lines for clear-sign-only txs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,7 @@ function previewSendHandler(
     };
     previewToken: string;
     decoderUrl?: string;
+    clearSignOnly?: boolean;
   }>,
 ) {
   return async (args: { handle: string }) => {
@@ -380,6 +381,7 @@ function previewSendHandler(
               to: result.to,
               valueWei: result.valueWei,
               ...(result.decoderUrl ? { decoderUrl: result.decoderUrl } : {}),
+              ...(result.clearSignOnly ? { clearSignOnly: true } : {}),
             }),
           },
         ],

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -29,6 +29,7 @@ import {
   payloadFingerprint,
   tronPayloadFingerprint,
 } from "../../signing/verification.js";
+import { isClearSignOnlyTx } from "../../signing/render-verification.js";
 import { getClient, verifyChainId } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
 import { resolveTokenMeta } from "../shared/token-meta.js";
@@ -595,6 +596,16 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
    * output, forcing the user to scroll up.
    */
   decoderUrl?: string;
+  /**
+   * True for the three Ledger clear-sign-only tx types: native ETH send
+   * (empty calldata), ERC-20 `transfer`, ERC-20 `approve`. The preview
+   * handler uses this to render a reduced CHECKS PERFORMED template —
+   * no PAIR-CONSISTENCY HASH line, no BLIND-SIGN branch of NEXT ON-DEVICE
+   * (both are noise for these tx types; Ledger clear-signs decoded
+   * fields and the hash-match path never fires). No security posture
+   * change; the server still pins and re-hashes at send time.
+   */
+  clearSignOnly?: boolean;
 }> {
   if (hasTronHandle(args.handle)) {
     throw new Error(
@@ -605,6 +616,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
   }
   const tx = consumeHandle(args.handle);
   const decoderUrl = tx.verification?.decoderUrl;
+  const clearSignOnly = isClearSignOnlyTx(tx);
   const existing = getPinnedGas(args.handle);
   if (existing && !args.refresh) {
     return {
@@ -621,6 +633,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
       },
       previewToken: existing.previewToken,
       ...(decoderUrl ? { decoderUrl } : {}),
+      ...(clearSignOnly ? { clearSignOnly: true } : {}),
     };
   }
   await runEvmPreSignGuards(tx);
@@ -671,6 +684,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     previewToken,
     ...(existing ? { refreshed: true } : {}),
     ...(decoderUrl ? { decoderUrl } : {}),
+    ...(clearSignOnly ? { clearSignOnly: true } : {}),
   };
 }
 

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -16,11 +16,49 @@ import type { SupportedChain, TxVerification, UnsignedTronTx, UnsignedTx } from 
  */
 const ERC20_APPROVE_SELECTOR = "0x095ea7b3";
 
+/**
+ * ERC-20 `transfer(address,uint256)` selector. Same reason as
+ * `approve`: Ledger's Ethereum app + ERC-20 plugin clear-signs token
+ * transfers on-device (shows recipient + amount + token symbol). The
+ * blind-sign hash-match check never fires for these, and the
+ * pair-consistency recompute adds no information that the clear-sign
+ * screens don't already give the user.
+ */
+const ERC20_TRANSFER_SELECTOR = "0xa9059cbb";
+
 /** Returns false for txs whose verification block should be suppressed. */
 export function shouldRenderVerificationBlock(
   tx: Pick<UnsignedTx, "data">,
 ): boolean {
   return !tx.data.toLowerCase().startsWith(ERC20_APPROVE_SELECTOR);
+}
+
+/**
+ * True for txs the Ledger Ethereum app is guaranteed to clear-sign —
+ * native-value sends (empty calldata), ERC-20 `transfer`, and ERC-20
+ * `approve`. For these, the CHECKS PERFORMED block should be trimmed:
+ *
+ *   - drop the PAIR-CONSISTENCY HASH line entirely (no value; clear-sign
+ *     screens + 4byte-decode cover intent),
+ *   - drop the BLIND-SIGN branch of the NEXT ON-DEVICE section (it
+ *     never fires for these txs, so the instruction is noise under
+ *     device-screen time pressure),
+ *   - expand the CLEAR-SIGN branch to explicitly list native + ERC-20
+ *     transfer + approve so the user sees their tx type named.
+ *
+ * DOES NOT change security guarantees — the server still pins the tuple,
+ * computes the preSignHash, and enforces the payload-hash match at send
+ * time. Only the user-facing render is simplified for the three cases
+ * where extra lines create confusion rather than signal.
+ */
+export function isClearSignOnlyTx(tx: Pick<UnsignedTx, "data">): boolean {
+  const data = tx.data.toLowerCase();
+  // Empty calldata = native send (SystemProgram-equivalent). Any form of
+  // "0x" / "" / "0x0" (some older paths emit without the prefix) counts.
+  if (data === "" || data === "0x") return true;
+  if (data.startsWith(ERC20_APPROVE_SELECTOR)) return true;
+  if (data.startsWith(ERC20_TRANSFER_SELECTOR)) return true;
+  return false;
 }
 
 function truncateHex(data: string, bytelenLabel: boolean): string {
@@ -344,18 +382,36 @@ export function renderPreviewVerifyAgentTaskBlock(args: {
    * the user to scroll back.
    */
   decoderUrl?: string;
+  /**
+   * True when the tx is a Ledger clear-sign-only type (native send,
+   * ERC-20 transfer, ERC-20 approve). When set, the CHECKS PERFORMED
+   * template drops the PAIR-CONSISTENCY HASH line and the BLIND-SIGN
+   * branch of NEXT ON-DEVICE — those are noise for clear-sign-only txs
+   * (the Ledger shows decoded fields; no hash-match ever applies; the
+   * on-device `to` + `value` + token-symbol read covers intent).
+   * Computed server-side via `isClearSignOnlyTx(tx.data)` at preview
+   * time. No security posture change — the server still pins fields and
+   * checks the payload hash at send time.
+   */
+  clearSignOnly?: boolean;
 }): string {
+  const simple = args.clearSignOnly === true;
   const checksPayload = {
     abiDecode: {
       autoRun: true,
       threat: "MCP-side calldata tampering",
       keywords: ["calldata tampering"],
     },
-    pairConsistencyHash: {
-      autoRun: true,
-      threat: "MCP lying about the bytes it will forward to WalletConnect",
-      keywords: ["bytes", "WalletConnect"],
-    },
+    ...(simple
+      ? {}
+      : {
+          pairConsistencyHash: {
+            autoRun: true,
+            threat:
+              "MCP lying about the bytes it will forward to WalletConnect",
+            keywords: ["bytes", "WalletConnect"],
+          },
+        }),
     secondLlm: {
       autoRun: false,
       threat: "coordinated agent compromise",
@@ -364,11 +420,23 @@ export function renderPreviewVerifyAgentTaskBlock(args: {
   };
   const lines = [
     "[AGENT TASK — RUN THESE CHECKS NOW, DO NOT ASK THE USER]",
-    "You MUST run BOTH of the following integrity checks UNPROMPTED and",
-    "report results in a prominent CHECKS PERFORMED block. The user already",
-    "consented to verification by calling preview_send — do NOT surface a",
-    "yes/no menu for these two. They run every send, no exceptions (except",
-    "the narrow native-send case noted on CHECK 2).",
+    ...(simple
+      ? [
+          "You MUST run the ABI DECODE integrity check UNPROMPTED and report",
+          "the result in a prominent CHECKS PERFORMED block. The user already",
+          "consented to verification by calling preview_send — do NOT surface",
+          "a yes/no menu. This tx is a Ledger clear-sign type (native send,",
+          "ERC-20 transfer, or ERC-20 approve), so the PAIR-CONSISTENCY HASH",
+          "check is skipped: Ledger shows decoded fields on-device and the",
+          "hash-match path never fires, so the recompute adds no information",
+          "the user can act on.",
+        ]
+      : [
+          "You MUST run BOTH of the following integrity checks UNPROMPTED and",
+          "report results in a prominent CHECKS PERFORMED block. The user already",
+          "consented to verification by calling preview_send — do NOT surface a",
+          "yes/no menu for these two. They run every send, no exceptions.",
+        ]),
     "",
     "CHECK 1 — AGENT-SIDE ABI DECODE",
     "  Protects against: MCP-side calldata tampering. If the server rewrote",
@@ -394,31 +462,30 @@ export function renderPreviewVerifyAgentTaskBlock(args: {
     "  - If confident, compare your decode against the compact bullet summary",
     "    you showed at prepare time. Report ✓ MATCH or ✗ MISMATCH.",
     "",
-    "CHECK 2 — PAIR-CONSISTENCY HASH",
-    "  Protects against: the server reporting tuple T with preSignHash=hash(Y)",
-    "  where Y≠T, then forwarding Y to WalletConnect. The on-device hash match",
-    "  alone does NOT catch that (device sees hash(Y), chat sees hash(Y), they",
-    "  agree); only a local recompute of hash(T) from the pinned tuple catches",
-    "  the discrepancy.",
-    "",
-    "  Run in-process with viem. The per-call values are spliced in below so",
-    "  you do not have to reconstruct them:",
-    "",
-    "    node -e \"const {keccak256,serializeTransaction}=require('viem');",
-    "    console.log(keccak256(serializeTransaction({type:'eip1559',",
-    `    chainId:<${args.chain}-id>,nonce:${args.pinned.nonce},`,
-    `    maxFeePerGas:${args.pinned.maxFeePerGas}n,`,
-    `    maxPriorityFeePerGas:${args.pinned.maxPriorityFeePerGas}n,`,
-    `    gas:${args.pinned.gas}n,to:'${args.to}',value:${args.valueWei}n,`,
-    "    data:'<data from the prepare_* result>'})))\"",
-    "",
-    `  Compare the output to ${args.preSignHash}. Report ✓ MATCH or ✗ MISMATCH.`,
-    "",
-    "  Native-send skip: when data === \"0x\" the agent already knows the full",
-    "  tuple and `to`/`value` eyeballing on-device covers intent. In that case",
-    "  report this check as \"⏸ N/A for native send — `to` + `value` on-device",
-    "  cover intent\" and proceed.",
-    "",
+    ...(simple
+      ? []
+      : [
+          "CHECK 2 — PAIR-CONSISTENCY HASH",
+          "  Protects against: the server reporting tuple T with preSignHash=hash(Y)",
+          "  where Y≠T, then forwarding Y to WalletConnect. The on-device hash match",
+          "  alone does NOT catch that (device sees hash(Y), chat sees hash(Y), they",
+          "  agree); only a local recompute of hash(T) from the pinned tuple catches",
+          "  the discrepancy.",
+          "",
+          "  Run in-process with viem. The per-call values are spliced in below so",
+          "  you do not have to reconstruct them:",
+          "",
+          "    node -e \"const {keccak256,serializeTransaction}=require('viem');",
+          "    console.log(keccak256(serializeTransaction({type:'eip1559',",
+          `    chainId:<${args.chain}-id>,nonce:${args.pinned.nonce},`,
+          `    maxFeePerGas:${args.pinned.maxFeePerGas}n,`,
+          `    maxPriorityFeePerGas:${args.pinned.maxPriorityFeePerGas}n,`,
+          `    gas:${args.pinned.gas}n,to:'${args.to}',value:${args.valueWei}n,`,
+          "    data:'<data from the prepare_* result>'})))\"",
+          "",
+          `  Compare the output to ${args.preSignHash}. Report ✓ MATCH or ✗ MISMATCH.`,
+          "",
+        ]),
     "CHECKS PAYLOAD (the threat taxonomy + required keywords the user-facing",
     "block below MUST cover — paraphrase naturally but every listed keyword",
     "must appear verbatim somewhere in the matching line):",
@@ -463,37 +530,64 @@ export function renderPreviewVerifyAgentTaskBlock(args: {
           "         browser fallback is unavailable and the second-LLM",
           "         check (option 2 below) is the remaining gap-closer.)",
         ]),
-    "    {✓|⏸} PAIR-CONSISTENCY HASH — <one-line verdict>.",
-    "        (protects against MCP lying about the bytes sent to WalletConnect)",
+    ...(simple
+      ? []
+      : [
+          "    {✓|⏸} PAIR-CONSISTENCY HASH — <one-line verdict>.",
+          "        (protects against MCP lying about the bytes sent to WalletConnect)",
+        ]),
     "    □ SECOND-LLM CHECK — optional, available on request.",
     "        (protects against a coordinated agent compromise)",
     "    ────────────────────────────────",
     "    NEXT ON-DEVICE — final check happens on your Ledger screen:",
-    "      • BLIND-SIGN mode (hash only — swaps, most DeFi):",
-    `          check the hash shown on-device is exactly **\`${args.preSignHash}\`**.`,
-    "          Any difference → REJECT.",
-    "      • CLEAR-SIGN mode (decoded fields — Aave / Lido / 1inch / LiFi /",
-    "        approve plugins): hash matching does NOT apply. Check the",
-    "        function name + key fields (amount, recipient, spender) on-device",
-    "        match the compact summary above. Any difference → REJECT.",
+    ...(simple
+      ? [
+          "      • CLEAR-SIGN (this tx: native ETH send, ERC-20 transfer, or",
+          "        ERC-20 approve — Ledger decodes and shows amount + recipient",
+          "        + token on-device). Hash matching does NOT apply. Confirm",
+          "        the on-device values equal the compact summary above.",
+          "        Any difference → REJECT.",
+        ]
+      : [
+          "      • BLIND-SIGN mode (hash only — swaps, most DeFi):",
+          `          check the hash shown on-device is exactly **\`${args.preSignHash}\`**.`,
+          "          Any difference → REJECT.",
+          "      • CLEAR-SIGN mode (decoded fields — Aave / Lido / 1inch / LiFi /",
+          "        approve / ERC-20 transfer plugins, including native ETH send):",
+          "        hash matching does NOT apply. Check the function name + key",
+          "        fields (amount, recipient, spender) on-device match the",
+          "        compact summary above. Any difference → REJECT.",
+        ]),
     "    ════════════════════════════════",
     "",
-    "The NEXT ON-DEVICE lines are mandatory — do NOT drop them. Users can only",
-    "tell blind-sign from clear-sign when the device prompt actually appears,",
-    "so we must explain BOTH paths. Dropping the clear-sign branch has caused",
-    "live confusion (\"my device shows decoded fields and no hash, so the hash",
-    "check must have failed?\") — it hasn't, the check just does not apply.",
-    "",
-    "Render the blind-sign hash with BOTH bold AND single-backtick inline code",
-    "— i.e. `**\\`0x…\\`**` — exactly as shown in the template above. Backticks",
-    "alone render as muted inline-code color in many chat clients (verified in",
-    "Claude Code: the backticked hash blended into prose and the user could",
-    "not visually pick it out under device-screen time pressure). Bold + code",
-    "combines the two strongest emphasis markers Markdown supports, and reads",
-    "with clear contrast in every client tested. Do NOT strip either marker.",
-    "Whenever you reference the hash elsewhere in your reply (e.g. a summary",
-    "line), use the same `**\\`0x…\\`**` wrapper so the hash looks identical at",
-    "every appearance — inconsistent emphasis slows the user's match-check.",
+    ...(simple
+      ? [
+          "The NEXT ON-DEVICE line is mandatory — do NOT drop it. For this tx",
+          "type (native send / ERC-20 transfer / ERC-20 approve) Ledger will",
+          "clear-sign; no blind-sign hash applies, so the blind-sign branch is",
+          "omitted to keep the checklist scannable under device-screen time",
+          "pressure. Including a hash-match instruction the user cannot act on",
+          "has caused live confusion before.",
+          "",
+        ]
+      : [
+          "The NEXT ON-DEVICE lines are mandatory — do NOT drop them. Users can only",
+          "tell blind-sign from clear-sign when the device prompt actually appears,",
+          "so we must explain BOTH paths. Dropping the clear-sign branch has caused",
+          "live confusion (\"my device shows decoded fields and no hash, so the hash",
+          "check must have failed?\") — it hasn't, the check just does not apply.",
+          "",
+          "Render the blind-sign hash with BOTH bold AND single-backtick inline code",
+          "— i.e. `**\\`0x…\\`**` — exactly as shown in the template above. Backticks",
+          "alone render as muted inline-code color in many chat clients (verified in",
+          "Claude Code: the backticked hash blended into prose and the user could",
+          "not visually pick it out under device-screen time pressure). Bold + code",
+          "combines the two strongest emphasis markers Markdown supports, and reads",
+          "with clear contrast in every client tested. Do NOT strip either marker.",
+          "Whenever you reference the hash elsewhere in your reply (e.g. a summary",
+          "line), use the same `**\\`0x…\\`**` wrapper so the hash looks identical at",
+          "every appearance — inconsistent emphasis slows the user's match-check.",
+        ]),
     "",
     "After the CHECKS PERFORMED block, append EXACTLY one line, no menu:",
     "",

--- a/test/send-hash-pin.test.ts
+++ b/test/send-hash-pin.test.ts
@@ -264,6 +264,122 @@ describe("renderPreviewVerifyAgentTaskBlock", () => {
     // Second-LLM is the remaining gap-closer in this case.
     expect(block).toMatch(/second-LLM/);
   });
+
+  // Clear-sign-only txs (native send, ERC-20 transfer, ERC-20 approve): the
+  // PAIR-CONSISTENCY HASH line and the BLIND-SIGN branch of NEXT ON-DEVICE
+  // were noise under device-screen time pressure (user complaint 2026-04-24
+  // — "add about native eth transfers and erc20 transfers"). For these tx
+  // types the reduced template drops both sections and expands CLEAR-SIGN
+  // to name the tx type explicitly.
+  it("clearSignOnly: true → drops PAIR-CONSISTENCY HASH + BLIND-SIGN branch", async () => {
+    const { renderPreviewVerifyAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderPreviewVerifyAgentTaskBlock({
+      chain: "ethereum",
+      preSignHash: "0xabc",
+      pinned: {
+        nonce: 7,
+        maxFeePerGas: "22000000000",
+        maxPriorityFeePerGas: "2000000000",
+        gas: "21000",
+      },
+      to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      valueWei: "500000000000000000",
+      clearSignOnly: true,
+    });
+    // PAIR-CONSISTENCY HASH verdict line (the user-facing render-template
+    // line the agent copies into its CHECKS PERFORMED block) must be gone.
+    // The opening explanation may still *mention* pair-consistency by name
+    // (explaining why the check was skipped) — that's agent-facing prose,
+    // not part of the template the user sees.
+    expect(block).not.toMatch(/\{✓\|⏸\} PAIR-CONSISTENCY HASH/);
+    // Matching "(protects against MCP lying about the bytes sent to
+    // WalletConnect)" — the threat-clause under the PAIR-CONSISTENCY line —
+    // must also be gone, since that line attaches to the removed verdict.
+    expect(block).not.toMatch(/bytes sent to WalletConnect/);
+    // And the full CHECK 2 section (running the viem recompute) should not
+    // be in the agent-task body either, since the check is skipped.
+    expect(block).not.toMatch(/CHECK 2 — PAIR-CONSISTENCY HASH/);
+    // CHECKS PAYLOAD JSON must not include the pairConsistencyHash key.
+    expect(block).not.toContain('"pairConsistencyHash"');
+    // NEXT ON-DEVICE must still exist (without it, users don't know to
+    // check the Ledger screen at all) but the BLIND-SIGN branch is gone.
+    expect(block).toMatch(/NEXT ON-DEVICE/);
+    expect(block).not.toMatch(/BLIND-SIGN mode/);
+    // The expanded CLEAR-SIGN branch names the tx types this flag covers.
+    expect(block).toMatch(/native ETH send, ERC-20 transfer, or[\s\S]*ERC-20 approve/);
+    // The ABI DECODE check still runs — it's the one integrity check we keep.
+    expect(block).toMatch(/CHECK 1 — AGENT-SIDE ABI DECODE/);
+    expect(block).toContain('"abiDecode"');
+    // SECOND-LLM stays available; it's the user's explicit opt-in path.
+    expect(block).toMatch(/SECOND-LLM CHECK/);
+  });
+
+  it("clearSignOnly defaults to false → full template (regression: swaps / DeFi path unchanged)", async () => {
+    const { renderPreviewVerifyAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderPreviewVerifyAgentTaskBlock({
+      chain: "ethereum",
+      preSignHash: "0xabc",
+      pinned: {
+        nonce: 7,
+        maxFeePerGas: "22000000000",
+        maxPriorityFeePerGas: "2000000000",
+        gas: "21000",
+      },
+      to: "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+      valueWei: "0",
+      // clearSignOnly omitted — full template
+    });
+    expect(block).toMatch(/PAIR-CONSISTENCY HASH/);
+    expect(block).toMatch(/BLIND-SIGN mode/);
+    expect(block).toContain('"pairConsistencyHash"');
+  });
+});
+
+describe("isClearSignOnlyTx selector detection", () => {
+  it("returns true for empty data (native send)", async () => {
+    const { isClearSignOnlyTx } = await import(
+      "../src/signing/render-verification.js"
+    );
+    expect(isClearSignOnlyTx({ data: "0x" as `0x${string}` })).toBe(true);
+  });
+
+  it("returns true for ERC-20 transfer(address,uint256) = 0xa9059cbb", async () => {
+    const { isClearSignOnlyTx } = await import(
+      "../src/signing/render-verification.js"
+    );
+    // transfer(0xrecipient..., 1 USDC) calldata prefix
+    const data = "0xa9059cbb000000000000000000000000c0f5b7f7703ba95dc7c09d4ef50a830622234075000000000000000000000000000000000000000000000000000000000000000a" as `0x${string}`;
+    expect(isClearSignOnlyTx({ data })).toBe(true);
+  });
+
+  it("returns true for ERC-20 approve(address,uint256) = 0x095ea7b3", async () => {
+    const { isClearSignOnlyTx } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const data = "0x095ea7b3000000000000000000000000c0f5b7f7703ba95dc7c09d4ef50a830622234075000000000000000000000000000000000000000000000000000000000000000a" as `0x${string}`;
+    expect(isClearSignOnlyTx({ data })).toBe(true);
+  });
+
+  it("returns false for a LiFi swap selector (protects the swaps path)", async () => {
+    const { isClearSignOnlyTx } = await import(
+      "../src/signing/render-verification.js"
+    );
+    // swapAndStartBridgeTokensViaAcrossV4 — from a live capture
+    const data = "0x1794958f0000000000000000000000000000000000000000000000000000000000000060" as `0x${string}`;
+    expect(isClearSignOnlyTx({ data })).toBe(false);
+  });
+
+  it("returns false for an unknown 4-byte selector", async () => {
+    const { isClearSignOnlyTx } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const data = "0xdeadbeef" as `0x${string}`;
+    expect(isClearSignOnlyTx({ data })).toBe(false);
+  });
 });
 
 describe("renderLedgerHashBlock", () => {


### PR DESCRIPTION
## Summary

Live native-ETH-send session on 2026-04-24 surfaced that the CHECKS PERFORMED block was carrying lines the user couldn't act on:

- **PAIR-CONSISTENCY HASH** rendered as \`⏸ N/A for native send — \\\`to\\\` + \\\`value\\\` on-device cover intent.\` — an N/A line the user had to read past.
- **NEXT ON-DEVICE** emitted the full BLIND-SIGN branch with a hash, even though Ledger's ETH app clear-signs native transfers (the user never sees that hash).

Under device-screen time pressure the extra lines compete with the fields that matter. This PR trims the block for the three tx types where the Ledger ETH app guarantees clear-sign rendering: **native-value transfers**, **ERC-20 \`transfer\`**, and **ERC-20 \`approve\`**.

## What changes when `clearSignOnly: true`

| Piece | Before | After |
|-------|--------|-------|
| PAIR-CONSISTENCY HASH verdict line | \`{✓\|⏸} PAIR-CONSISTENCY HASH — <verdict>\` + threat clause | gone |
| CHECK 2 agent instructions (viem recompute) | full block | gone |
| NEXT ON-DEVICE → BLIND-SIGN branch | shows hash to match | gone |
| NEXT ON-DEVICE → CLEAR-SIGN branch | lists Aave / Lido / 1inch / LiFi / approve plugins | expanded to explicitly name **native ETH send**, **ERC-20 transfer**, and **ERC-20 approve** so the user sees their tx type called out |
| CHECKS PAYLOAD JSON | includes \`pairConsistencyHash\` | key omitted |
| Opening language | \"run BOTH checks\" | \"run the ABI DECODE check\" + one-liner explaining why pair-consistency is skipped |

## What does NOT change

- **Security posture.** The server still pins the EIP-1559 tuple, computes \`preSignHash\`, and enforces the payload-hash match at send time. Only the *user-facing render* is simplified for cases where extra instructions created confusion, not signal.
- **Swaps / DeFi / TRON / Solana paths.** \`clearSignOnly: false\` (the default) renders the full template — a regression test asserts that.
- **ABI DECODE check.** Runs every time regardless — it's the one integrity check that adds information for every tx type.
- **SECOND-LLM CHECK.** Still offered via the \"Reply (2)\" line. User opt-in, unchanged.

## Detection

New exported helper \`isClearSignOnlyTx(tx)\` in \`render-verification.ts\` — same pattern \`shouldRenderVerificationBlock\` already used for approvals. Returns true for empty calldata, \`transfer(address,uint256)\` selector (\`0xa9059cbb\`), and \`approve(address,uint256)\` (\`0x095ea7b3\`).

\`preview_send\` computes the flag from the consumed handle's \`tx.data\` and threads it through the preview response → \`previewSendHandler\` in src/index.ts → \`renderPreviewVerifyAgentTaskBlock\`.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 579/579 (+4 new cases)
  - new: reduced template shape for \`clearSignOnly: true\`
  - new: full template when the flag is absent (regression for swaps/DeFi path)
  - new: selector detection covering empty / transfer / approve / LiFi-swap / unknown
- [ ] Manual live check after merge: re-run the 0.9 ETH transfer → confirm the CHECKS PERFORMED block now only has \`ABI DECODE\` + \`SECOND-LLM CHECK\`, and NEXT ON-DEVICE shows only the CLEAR-SIGN branch with native/ERC-20 language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)