### PR TITLE
chore(deps): override uuid to ^14.0.0 (Snyk SNYK-JS-UUID-16133035)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,19 +4027,6 @@
         "node": ">=6.14.2"
       }
     },
-    "node_modules/rpc-websockets/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/rpc-websockets/node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -4779,12 +4766,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,9 @@
     "typescript": "^5.6.0",
     "vitest": "^4.1.4"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "engines": {
     "node": ">=18.17.0"
   }


### PR DESCRIPTION
## Summary

Snyk flagged \`uuid@11.1.0\` pulled in transitively via \`@solana/web3.js\`:

\`\`\`
@solana/web3.js@1.98.4
  ├── jayson@4.3.0
  │   └── uuid@8.3.2
  └── rpc-websockets@9.3.8
      └── uuid@11.1.0
\`\`\`

Advisory: **SNYK-JS-UUID-16133035** / **GHSA-w5hq-g745-h8pq** — moderate, *\"Improper Validation of Specified Index, Position, or Offset in Input\"*. Affects the buffer-based UUID generation path (`v3`/`v5`/`v6` when `buf` is supplied): out-of-range offsets cause silent partial writes into caller-provided buffers. **Fixed in uuid@14.0.0.**

## Reachability assessment (is our code actually at risk?)

**No.** The attack requires attacker-controlled `buf`/`offset` parameters to a buffer-mode UUID call. Our code path:

1. **We don't use `uuid` directly.** Our code uses Node's built-in `crypto.randomUUID()` (grep for `from \"uuid\"` in `src/` returns zero hits).
2. **rpc-websockets uses only `uuid.v1()`** — no buffer argument (`node_modules/rpc-websockets/dist/index.cjs:374: socket._id = uuid.v1();`). v1 has no attacker-accessible buf/offset entry.
3. **jayson uses uuid similarly** for RPC-id generation — also no buf/offset path.

So the flaw is not exploitable in VaultPilot MCP as shipped. But the flagged version still sits in the lockfile and shows up in Snyk / Dependabot scans, so pinning keeps the tree on a vendor-supported patch — the right default posture for a self-custody wallet tool.

## Fix

Add an npm `overrides` entry pinning all uuid instances to `^14.0.0`. Both transitive paths pick up the patched version and the tree dedupes to a single install:

\`\`\`
└─┬ @solana/web3.js@1.98.4
  ├─┬ jayson@4.3.0
  │ └── uuid@14.0.0 overridden
  └─┬ rpc-websockets@9.3.8
    └── uuid@14.0.0 deduped
\`\`\`

uuid@14's `v1` export is API-compatible with what rpc-websockets + jayson use — build clean, 579/579 tests still green.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 579/579
- [x] \`npm ls uuid\` shows the override applied
- [x] \`npm audit\` no longer flags uuid

## Out of scope

A separate unrelated moderate hono advisory (GHSA-458j-xx4x-4375) surfaced in `npm audit` after this fix. That's a different package, different transitive path (via LiFi SDK), different analysis. Worth filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)