### PR TITLE
fix: Morpho/Staking coverage diagnostics + polygon MATIC→POL price (#92, #93, #94)

### DIFF
--- a/src/data/prices.ts
+++ b/src/data/prices.ts
@@ -19,11 +19,20 @@ const LLAMA_CHAIN: Record<SupportedChain, string> = {
 };
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-/** Coingecko ID for each chain's native asset. Ethereum + Arbitrum + Base + Optimism share ETH; Polygon uses MATIC. */
+/**
+ * Coingecko ID for each chain's native asset.
+ * Ethereum / Arbitrum / Base / Optimism share ETH.
+ * Polygon native was renamed MATIC → POL in Sept 2024; CoinGecko renamed the
+ * coin from `matic-network` (DefiLlama now returns `{"coins":{}}` for that
+ * key) to `polygon-ecosystem-token`. Issue #94 traced missing polygon-native
+ * USD valuations on portfolio totals to the stale key. Verified empirically
+ * against `coins.llama.fi/prices/current/...` — the new key returns POL at
+ * current price; the old key returns empty.
+ */
 const NATIVE_COINGECKO_ID: Record<SupportedChain, string> = {
   ethereum: "coingecko:ethereum",
   arbitrum: "coingecko:ethereum",
-  polygon: "coingecko:matic-network",
+  polygon: "coingecko:polygon-ecosystem-token",
   base: "coingecko:ethereum",
   optimism: "coingecko:ethereum",
 };

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -21,6 +21,7 @@ import type {
   TokenAmount,
   TronPortfolioSlice,
   TronStakingSlice,
+  UnpricedAsset,
 } from "../../types/index.js";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 
@@ -133,6 +134,9 @@ export async function getPortfolioSummary(
   // Aggregate coverage: a subsystem is considered errored across the group if
   // ANY wallet's fetch failed — because the group-level total will be short
   // that wallet's contribution. Notes get merged to the worst (errored) state.
+  const aggregatedUnpricedDetail = perWallet.flatMap(
+    (p) => p.coverage.unpricedAssetsDetail ?? [],
+  );
   const mergedCoverage: PortfolioCoverage = {
     aave: mergeCoverage(perWallet.map((p) => p.coverage.aave)),
     compound: mergeCoverage(perWallet.map((p) => p.coverage.compound)),
@@ -140,6 +144,9 @@ export async function getPortfolioSummary(
     uniswapV3: mergeCoverage(perWallet.map((p) => p.coverage.uniswapV3)),
     staking: mergeCoverage(perWallet.map((p) => p.coverage.staking)),
     unpricedAssets: perWallet.reduce((s, p) => s + p.coverage.unpricedAssets, 0),
+    ...(aggregatedUnpricedDetail.length > 0
+      ? { unpricedAssetsDetail: aggregatedUnpricedDetail }
+      : {}),
   };
 
   return {
@@ -185,6 +192,60 @@ export function formatCompoundErrorNote(
   return `${generic} Failures: ${lines.join("; ")}. Call get_compound_positions for the full per-market read.`;
 }
 
+/**
+ * Build the human-readable `coverage.morpho.note` when one or more per-chain
+ * event-log discoveries failed. Mirrors `formatCompoundErrorNote` structurally
+ * — same reasoning: the generic "event-log discovery failed on at least one
+ * chain" string left the agent with no way to tell the user WHICH chain's
+ * scan was broken (issue #92).
+ *
+ * Exported for unit testing; getPortfolioSummary is the real caller.
+ */
+export function formatMorphoErrorNote(
+  erroredChains?: { chain: SupportedChain; error: string }[],
+): string {
+  const generic =
+    "Morpho Blue event-log discovery failed on at least one chain — some positions may be missing from totals.";
+  if (!erroredChains || erroredChains.length === 0) return generic;
+  const MAX_ERR = 120;
+  const lines = erroredChains.map(({ chain, error }) => {
+    const trimmed =
+      error.length > MAX_ERR ? `${error.slice(0, MAX_ERR)}…` : error;
+    return `${chain}: ${trimmed}`;
+  });
+  return `${generic} Failures: ${lines.join("; ")}. Call get_morpho_positions with an explicit chain for a fast-path read.`;
+}
+
+/**
+ * Build the human-readable `coverage.staking.note` when Lido or EigenLayer
+ * failed. The previous generic "Staking (Lido/EigenLayer) fetch failed"
+ * string couldn't distinguish between a flaky Lido read, a flaky EigenLayer
+ * read, or both — and because the prior code used `Promise.all` internally,
+ * a single-source failure zeroed both. `getStakingPositions` now returns
+ * per-source detail so the note can name the failing source(s) while the
+ * healthy source's positions still flow through (issue #93).
+ *
+ * Exported for unit testing.
+ */
+export function formatStakingErrorNote(
+  erroredSources?: { source: "lido" | "eigenlayer"; error: string }[],
+): string {
+  const generic =
+    "Staking fetch failed — some positions may be missing from totals.";
+  if (!erroredSources || erroredSources.length === 0) {
+    // Fall back to the old wording if no structured detail is available —
+    // keeps callers that hit the empty-array branch honest about what broke.
+    return "Staking (Lido/EigenLayer) fetch failed — positions not included.";
+  }
+  const MAX_ERR = 120;
+  const lines = erroredSources.map(({ source, error }) => {
+    const trimmed =
+      error.length > MAX_ERR ? `${error.slice(0, MAX_ERR)}…` : error;
+    return `${source}: ${trimmed}`;
+  });
+  return `${generic} Failures: ${lines.join("; ")}. The other staking source(s) still loaded where applicable.`;
+}
+
 function mergeCoverage(entries: { covered: boolean; errored?: boolean; note?: string }[]) {
   const anyErrored = entries.some((e) => e.errored);
   const allCovered = entries.every((e) => e.covered);
@@ -227,6 +288,19 @@ async function buildWalletSummary(
   // failed on at least one market" message (issue #88).
   let compoundErroredMarkets:
     | { chain: SupportedChain; market: string; error: string }[]
+    | undefined;
+  // Per-chain Morpho Blue discovery failures — same pattern as compound. The
+  // Morpho fan-out already runs per-chain with a `.catch` that flips the
+  // errored flag; we additionally capture the chain + raw error so the note
+  // can name WHICH chain's RPC / event-log scan was failing (issue #92).
+  const morphoErroredChains: { chain: SupportedChain; error: string }[] = [];
+  // Per-source Lido/EigenLayer staking failures. Previously `getStakingPositions`
+  // used `Promise.all` — if EITHER Lido OR EigenLayer threw, the whole staking
+  // response rejected and the aggregator coverage flag couldn't tell them
+  // apart. `getStakingPositions` now returns `erroredSources` with one entry
+  // per failing source (issue #93).
+  let stakingErroredSources:
+    | { source: "lido" | "eigenlayer"; error: string }[]
     | undefined;
   const [
     nativeAmounts,
@@ -281,11 +355,18 @@ async function buildWalletSummary(
         }),
       // Morpho has no multi-chain list endpoint; fan out per-chain and swallow
       // per-chain failures individually so one bad RPC doesn't drop the whole
-      // Morpho bucket. If any chain throws, the overall coverage is errored.
+      // Morpho bucket. If any chain throws, the overall coverage is errored —
+      // and we capture the per-chain raw error so coverage.morpho.note can
+      // name the failing chain + reason (mirrors #91's compound pattern for
+      // issue #92).
       Promise.all(
         chains.map((c) =>
-          getMorphoPositions({ wallet, chain: c }).catch(() => {
+          getMorphoPositions({ wallet, chain: c }).catch((e) => {
             errors.morpho = true;
+            morphoErroredChains.push({
+              chain: c,
+              error: e instanceof Error ? e.message : String(e),
+            });
             return { wallet, positions: [] };
           })
         )
@@ -294,10 +375,30 @@ async function buildWalletSummary(
         errors.lp = true;
         return emptyPositions as never;
       }),
-      getStakingPositions({ wallet, chains }).catch(() => {
-        errors.staking = true;
-        return emptyPositions as never;
-      }),
+      getStakingPositions({ wallet, chains })
+        .then((r) => {
+          // Same shape as the compound handler: allSettled inside
+          // getStakingPositions means the top-level promise now succeeds
+          // even when one source errored. Flip the aggregator coverage
+          // flag and capture per-source detail for the note (issue #93).
+          if (r.errored) {
+            errors.staking = true;
+            if (r.erroredSources && r.erroredSources.length > 0) {
+              stakingErroredSources = r.erroredSources;
+            }
+          }
+          return r;
+        })
+        .catch((e) => {
+          errors.staking = true;
+          stakingErroredSources = [
+            {
+              source: "lido",
+              error: e instanceof Error ? e.message : String(e),
+            },
+          ];
+          return emptyPositions as never;
+        }),
       // TRON reads are only attempted when the caller passed a tronAddress.
       // `null` means "not attempted" (coverage.tron left as
       // covered:false,errored:false — same semantics as Morpho without
@@ -382,16 +483,44 @@ async function buildWalletSummary(
     perChain[c] = round(chainNative + chainErc20 + chainLending + chainLp + chainStaking, 2);
   });
 
-  const tronUnpriced = tronSlice
-    ? [...tronSlice.native, ...tronSlice.trc20].filter((t) => t.priceMissing).length
-    : 0;
-  const solanaUnpriced = solanaSlice
-    ? [...solanaSlice.native, ...solanaSlice.spl].filter((t) => t.priceMissing).length
-    : 0;
-  const unpricedAssets =
-    [...native, ...erc20].filter((t) => t.priceMissing).length +
-    tronUnpriced +
-    solanaUnpriced;
+  // Tag each unpriced EVM balance with its chain at construction — TokenAmount
+  // itself has no `chain` field (positional via the `chains` array), so we
+  // zip here. Native and ERC-20 are collected separately per chain, so we
+  // reuse the index alignment already established by nativeAmounts /
+  // erc20Amounts above.
+  const evmUnpricedDetail: UnpricedAsset[] = [];
+  chains.forEach((c, i) => {
+    const n = nativeAmounts[i];
+    if (n && n.amount !== "0" && n.priceMissing) {
+      evmUnpricedDetail.push({ chain: c, symbol: n.symbol, amount: n.formatted });
+    }
+    for (const t of erc20Amounts[i] ?? []) {
+      if (t.priceMissing) {
+        evmUnpricedDetail.push({ chain: c, symbol: t.symbol, amount: t.formatted });
+      }
+    }
+  });
+  const tronUnpricedDetail: UnpricedAsset[] = tronSlice
+    ? [...tronSlice.native, ...tronSlice.trc20]
+        .filter((t) => t.priceMissing)
+        .map((t) => ({ chain: "tron" as const, symbol: t.symbol, amount: t.formatted }))
+    : [];
+  const solanaUnpricedDetail: UnpricedAsset[] = solanaSlice
+    ? [...solanaSlice.native, ...solanaSlice.spl]
+        .filter((t) => t.priceMissing)
+        .map((t) => ({ chain: "solana" as const, symbol: t.symbol, amount: t.formatted }))
+    : [];
+  // Structured list of which specific tokens couldn't be priced (issue #94).
+  // Before this existed, `unpricedAssets: N` was just a counter — the agent
+  // couldn't tell the user "your 705 MATIC on polygon wasn't priced and
+  // isn't in the total". Now the agent has symbol + amount + chain for each
+  // unpriced asset and can surface a concrete warning.
+  const unpricedAssetsDetail: UnpricedAsset[] = [
+    ...evmUnpricedDetail,
+    ...tronUnpricedDetail,
+    ...solanaUnpricedDetail,
+  ];
+  const unpricedAssets = unpricedAssetsDetail.length;
   const coverage: PortfolioCoverage = {
     aave: { covered: !errors.aave, ...(errors.aave ? { errored: true, note: "Aave fetch failed — positions not included in totals." } : {}) },
     compound: {
@@ -403,9 +532,22 @@ async function buildWalletSummary(
           }
         : {}),
     },
-    morpho: { covered: !errors.morpho, ...(errors.morpho ? { errored: true, note: "Morpho Blue event-log discovery failed on at least one chain — some positions may be missing from totals." } : {}) },
+    morpho: {
+      covered: !errors.morpho,
+      ...(errors.morpho
+        ? { errored: true, note: formatMorphoErrorNote(morphoErroredChains) }
+        : {}),
+    },
     uniswapV3: { covered: !errors.lp, ...(errors.lp ? { errored: true, note: "Uniswap V3 LP fetch failed — positions not included." } : {}) },
-    staking: { covered: !errors.staking, ...(errors.staking ? { errored: true, note: "Staking (Lido/EigenLayer) fetch failed — positions not included." } : {}) },
+    staking: {
+      covered: !errors.staking,
+      ...(errors.staking
+        ? {
+            errored: true,
+            note: formatStakingErrorNote(stakingErroredSources),
+          }
+        : {}),
+    },
     ...(tronAddress
       ? {
           tron: errors.tron
@@ -424,6 +566,7 @@ async function buildWalletSummary(
         }
       : {}),
     unpricedAssets,
+    ...(unpricedAssetsDetail.length > 0 ? { unpricedAssetsDetail } : {}),
   };
 
   // Merge balance + staking into a single TRON slice for the breakdown so

--- a/src/modules/staking/index.ts
+++ b/src/modules/staking/index.ts
@@ -11,16 +11,59 @@ import { SUPPORTED_CHAINS } from "../../types/index.js";
 export async function getStakingPositions(args: GetStakingPositionsArgs): Promise<{
   wallet: string;
   positions: StakingPosition[];
+  /**
+   * True if any source (Lido, EigenLayer) failed. Combined with
+   * `erroredSources` — a flaky Lido RPC no longer zeroes EigenLayer data
+   * (issue #93). Omitted when both sources succeeded so the happy-path
+   * response stays unchanged.
+   */
+  errored?: boolean;
+  /**
+   * Per-source failure detail for callers that need to surface which source
+   * was unavailable (portfolio coverage notes) without losing the other
+   * source's positions.
+   */
+  erroredSources?: { source: "lido" | "eigenlayer"; error: string }[];
 }> {
   const wallet = args.wallet as `0x${string}`;
   const chains: SupportedChain[] = (args.chains as SupportedChain[]) ?? [...SUPPORTED_CHAINS];
 
-  const [lido, eigen] = await Promise.all([
+  // allSettled so a flaky Lido RPC (say, balanceOf reverting under rate-limit)
+  // no longer short-circuits the EigenLayer read. Previously `Promise.all`
+  // rejected the whole function on either source failing — the aggregator's
+  // `.catch(() => { errors.staking = true; return emptyPositions })` then
+  // dropped BOTH sources, making `coverage.staking.errored:true` ambiguous.
+  // Returning per-source detail lets the aggregator produce a note that
+  // names the failing source(s) (issue #93).
+  const [lidoResult, eigenResult] = await Promise.allSettled([
     getLidoPositions(wallet, chains),
     chains.includes("ethereum") ? getEigenLayerPositions(wallet) : Promise.resolve([]),
   ]);
 
-  return { wallet, positions: [...lido, ...eigen] };
+  const positions: StakingPosition[] = [];
+  const erroredSources: { source: "lido" | "eigenlayer"; error: string }[] = [];
+  if (lidoResult.status === "fulfilled") {
+    positions.push(...lidoResult.value);
+  } else {
+    erroredSources.push({
+      source: "lido",
+      error: lidoResult.reason instanceof Error ? lidoResult.reason.message : String(lidoResult.reason),
+    });
+  }
+  if (eigenResult.status === "fulfilled") {
+    positions.push(...eigenResult.value);
+  } else {
+    erroredSources.push({
+      source: "eigenlayer",
+      error: eigenResult.reason instanceof Error ? eigenResult.reason.message : String(eigenResult.reason),
+    });
+  }
+
+  return {
+    wallet,
+    positions,
+    ...(erroredSources.length > 0 ? { errored: true, erroredSources } : {}),
+  };
 }
 
 const PERIOD_DAYS: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90, "1y": 365 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,28 @@ export interface PortfolioCoverage {
   solana?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
+  /**
+   * Structured list of which specific tokens couldn't be priced — one entry
+   * per affected balance. Previously only `unpricedAssets: N` (a count) was
+   * surfaced, which left the agent unable to tell the user WHICH balance
+   * was dropped from USD totals. With this list the agent can produce a
+   * concrete warning like "705 MATIC on polygon couldn't be priced and isn't
+   * included in the total" instead of a bare integer. Absent when
+   * `unpricedAssets === 0` to keep happy-path responses lean (issue #94).
+   */
+  unpricedAssetsDetail?: UnpricedAsset[];
+}
+
+/**
+ * A single unpriced balance the portfolio couldn't value in USD. The chain
+ * is a string union spanning EVM + TRON + Solana so one array describes the
+ * cross-chain set without needing per-chain buckets.
+ */
+export interface UnpricedAsset {
+  chain: SupportedChain | "tron" | "solana";
+  symbol: string;
+  /** Human-readable balance (already-decimals-applied), e.g. "705.141". */
+  amount: string;
 }
 
 export interface LendingPosition {

--- a/test/native-prices.test.ts
+++ b/test/native-prices.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Issue #94: Polygon native was renamed MATIC → POL in Sept 2024. CoinGecko
+ * renamed the coin `matic-network` → `polygon-ecosystem-token`; DefiLlama's
+ * coins endpoint started returning `{"coins":{}}` for the old key. The
+ * portfolio summary's native-balance USD valuation silently dropped to
+ * `priceMissing: true` for polygon, excluding the balance from totals.
+ *
+ * This test pins the key DefiLlama expects today. We don't hit the network
+ * — a live-network test would be flaky against external infra — instead we
+ * mock the fetch and assert the queryToLlamaKey path emits the current key.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("native-token price lookup (#94)", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("queries DefiLlama with `coingecko:polygon-ecosystem-token` for polygon native, NOT the deprecated `matic-network` key", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      // `getTokenPrices` runs the key list through `encodeURIComponent`,
+      // so `:` becomes `%3A` in the URL. Decode before substring-matching.
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes("coingecko:polygon-ecosystem-token")) {
+        return new Response(
+          JSON.stringify({
+            coins: {
+              "coingecko:polygon-ecosystem-token": {
+                price: 0.094,
+                symbol: "POL",
+                timestamp: Date.now() / 1000,
+              },
+            },
+          }),
+        );
+      }
+      if (decoded.includes("coingecko:matic-network")) {
+        // Old key — DefiLlama started returning empty after the rebrand.
+        return new Response(JSON.stringify({ coins: {} }));
+      }
+      return new Response(JSON.stringify({ coins: {} }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getTokenPrice } = await import("../src/data/prices.js");
+    const price = await getTokenPrice("polygon", "native");
+    expect(price).toBeCloseTo(0.094);
+
+    // Also verify the URL we actually hit — catches a regression where the
+    // key is right but some other rewrite strips the coingecko prefix.
+    const urlsCalled = fetchMock.mock.calls.map(
+      ([u]) => decodeURIComponent(u as string),
+    );
+    expect(
+      urlsCalled.some((u) => u.includes("coingecko:polygon-ecosystem-token")),
+    ).toBe(true);
+    // Regression guard: the old key must not be what we send anymore.
+    expect(urlsCalled.some((u) => u.includes("coingecko:matic-network"))).toBe(
+      false,
+    );
+  });
+});

--- a/test/portfolio-compound-coverage.test.ts
+++ b/test/portfolio-compound-coverage.test.ts
@@ -1,12 +1,18 @@
 /**
- * Issue #88 regression: `coverage.compound.note` used to be a generic
- * "fetch failed on at least one market" string, leaving the agent with no
- * way to tell the user which market/chain was broken or whether it was
- * worth retrying. The portfolio aggregator now plumbs the per-market
- * failure detail from `getCompoundPositions.erroredMarkets` into the note.
+ * Issues #88 (Compound V3), #92 (Morpho Blue), #93 (Lido / EigenLayer) —
+ * coverage notes used to be generic "X fetch failed" strings leaving the
+ * agent unable to tell the user which subsystem/source/chain was broken
+ * or whether the failure was worth retrying. Each coverage bucket now
+ * carries per-failure detail (chain + market + raw error; chain + raw
+ * error; source + raw error), formatted into the `note` field via
+ * dedicated helpers.
  */
 import { describe, it, expect } from "vitest";
-import { formatCompoundErrorNote } from "../src/modules/portfolio/index.js";
+import {
+  formatCompoundErrorNote,
+  formatMorphoErrorNote,
+  formatStakingErrorNote,
+} from "../src/modules/portfolio/index.js";
 
 describe("formatCompoundErrorNote (#88)", () => {
   it("falls back to the generic message when no per-market detail is available", () => {
@@ -66,5 +72,66 @@ describe("formatCompoundErrorNote (#88)", () => {
     expect(parts[0]).toContain("ethereum/cUSDCv3");
     expect(parts[1]).toContain("ethereum/cWETHv3");
     expect(parts[2]).toContain("polygon/cUSDCv3");
+  });
+});
+
+describe("formatMorphoErrorNote (#92)", () => {
+  it("falls back to the generic message when no per-chain detail is available", () => {
+    const note = formatMorphoErrorNote(undefined);
+    expect(note).toMatch(/event-log discovery failed on at least one chain/);
+    expect(note).not.toMatch(/Failures:/);
+  });
+
+  it("appends per-chain + raw error text when details are present", () => {
+    const note = formatMorphoErrorNote([
+      { chain: "ethereum", error: "archive node returned 503" },
+      { chain: "base", error: "rate limit exceeded" },
+    ]);
+    expect(note).toMatch(/ethereum: archive node returned 503/);
+    expect(note).toMatch(/base: rate limit exceeded/);
+    // Pointer to the narrower fast-path tool — same pattern as compound.
+    expect(note).toContain("get_morpho_positions");
+  });
+
+  it("truncates very long error strings so the note stays readable", () => {
+    const giant = "x".repeat(500);
+    const note = formatMorphoErrorNote([
+      { chain: "arbitrum", error: giant },
+    ]);
+    expect(note).not.toContain(giant);
+    expect(note).toMatch(/…/);
+    expect(note).toContain("arbitrum:");
+  });
+});
+
+describe("formatStakingErrorNote (#93)", () => {
+  it("falls back to the generic Lido+EigenLayer wording when no per-source detail is available", () => {
+    // Preserves the pre-fix string so callers hitting the empty-array
+    // branch (top-level promise reject with no erroredSources payload)
+    // still get a readable note. Split-by-source messaging only fires
+    // when we have structured detail.
+    const note = formatStakingErrorNote(undefined);
+    expect(note).toMatch(/Lido\/EigenLayer/);
+  });
+
+  it("names the specific failing source(s) when per-source detail is present", () => {
+    const note = formatStakingErrorNote([
+      { source: "lido", error: "stETH balanceOf reverted" },
+    ]);
+    expect(note).toMatch(/lido: stETH balanceOf reverted/);
+    // Must NOT claim EigenLayer failed when it didn't — the whole point of
+    // the allSettled refactor is that EigenLayer's positions still flow
+    // through when Lido is down.
+    expect(note).not.toMatch(/eigenlayer:/);
+    expect(note).toMatch(/other staking source/i);
+  });
+
+  it("handles the both-sources-errored case cleanly", () => {
+    const note = formatStakingErrorNote([
+      { source: "lido", error: "stETH balanceOf reverted" },
+      { source: "eigenlayer", error: "strategyList() out of gas" },
+    ]);
+    expect(note).toMatch(/lido:/);
+    expect(note).toMatch(/eigenlayer:/);
   });
 });

--- a/test/staking-partial-failure.test.ts
+++ b/test/staking-partial-failure.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #93 core fix: getStakingPositions used to wrap Lido + EigenLayer
+ * fetches in `Promise.all`, so either source rejecting caused the whole
+ * function to throw. The portfolio aggregator's `.catch` then dropped BOTH
+ * sources' positions and set `coverage.staking.errored: true` with no way
+ * to tell WHICH source was broken. This test pins the allSettled refactor —
+ * one source failing must no longer zero the other.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("getStakingPositions — per-source failure isolation (#93)", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  const WALLET = "0x8F9dE85C01070D2762d29A6Dd7ffEcC965b34361";
+
+  it("returns EigenLayer positions even when Lido throws", async () => {
+    vi.doMock("../src/modules/staking/lido.js", async () => ({
+      getLidoPositions: vi.fn().mockRejectedValue(new Error("stETH RPC down")),
+      getLidoApr: vi.fn(),
+      estimateLidoRewards: vi.fn(),
+    }));
+    vi.doMock("../src/modules/staking/eigenlayer.js", async () => ({
+      getEigenLayerPositions: vi.fn().mockResolvedValue([
+        {
+          protocol: "eigenlayer" as const,
+          chain: "ethereum" as const,
+          strategy: "0xDEADBEEFdeadbeefdeadbeefdeadbeefdeadbeef",
+          token: {
+            token: "0xAE7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+            symbol: "stETH",
+            decimals: 18,
+            amount: "1000000000000000000",
+            formatted: "1.0",
+          },
+          stakedAmount: {
+            token: "0xAE7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+            symbol: "stETH",
+            decimals: 18,
+            amount: "1000000000000000000",
+            formatted: "1.0",
+            valueUsd: 2500,
+          },
+          operator: null,
+        },
+      ]),
+    }));
+    const { getStakingPositions } = await import(
+      "../src/modules/staking/index.js"
+    );
+    const r = await getStakingPositions({ wallet: WALLET });
+    // EigenLayer position survives despite Lido's failure — the whole point
+    // of the allSettled refactor.
+    expect(r.positions).toHaveLength(1);
+    expect(r.positions[0].protocol).toBe("eigenlayer");
+    // But the response clearly flags that Lido was unavailable.
+    expect(r.errored).toBe(true);
+    expect(r.erroredSources).toHaveLength(1);
+    expect(r.erroredSources![0].source).toBe("lido");
+    expect(r.erroredSources![0].error).toMatch(/stETH RPC down/);
+  });
+
+  it("returns Lido positions even when EigenLayer throws", async () => {
+    vi.doMock("../src/modules/staking/lido.js", async () => ({
+      getLidoPositions: vi.fn().mockResolvedValue([
+        {
+          protocol: "lido" as const,
+          chain: "ethereum" as const,
+          token: "stETH",
+          stakedAmount: {
+            token: "0xAE7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+            symbol: "stETH",
+            decimals: 18,
+            amount: "2000000000000000000",
+            formatted: "2.0",
+            valueUsd: 5000,
+          },
+        },
+      ]),
+      getLidoApr: vi.fn(),
+      estimateLidoRewards: vi.fn(),
+    }));
+    vi.doMock("../src/modules/staking/eigenlayer.js", async () => ({
+      getEigenLayerPositions: vi
+        .fn()
+        .mockRejectedValue(new Error("strategyList() revert")),
+    }));
+    const { getStakingPositions } = await import(
+      "../src/modules/staking/index.js"
+    );
+    const r = await getStakingPositions({ wallet: WALLET });
+    expect(r.positions).toHaveLength(1);
+    expect(r.positions[0].protocol).toBe("lido");
+    expect(r.errored).toBe(true);
+    expect(r.erroredSources![0].source).toBe("eigenlayer");
+    expect(r.erroredSources![0].error).toMatch(/strategyList/);
+  });
+
+  it("returns no errored flag when both sources succeed (happy path unchanged)", async () => {
+    vi.doMock("../src/modules/staking/lido.js", async () => ({
+      getLidoPositions: vi.fn().mockResolvedValue([]),
+      getLidoApr: vi.fn(),
+      estimateLidoRewards: vi.fn(),
+    }));
+    vi.doMock("../src/modules/staking/eigenlayer.js", async () => ({
+      getEigenLayerPositions: vi.fn().mockResolvedValue([]),
+    }));
+    const { getStakingPositions } = await import(
+      "../src/modules/staking/index.js"
+    );
+    const r = await getStakingPositions({ wallet: WALLET });
+    expect(r.positions).toEqual([]);
+    expect(r.errored).toBeUndefined();
+    expect(r.erroredSources).toBeUndefined();
+  });
+
+  it("captures both-source failures in one response (no short-circuit)", async () => {
+    vi.doMock("../src/modules/staking/lido.js", async () => ({
+      getLidoPositions: vi.fn().mockRejectedValue(new Error("lido err")),
+      getLidoApr: vi.fn(),
+      estimateLidoRewards: vi.fn(),
+    }));
+    vi.doMock("../src/modules/staking/eigenlayer.js", async () => ({
+      getEigenLayerPositions: vi
+        .fn()
+        .mockRejectedValue(new Error("eigen err")),
+    }));
+    const { getStakingPositions } = await import(
+      "../src/modules/staking/index.js"
+    );
+    const r = await getStakingPositions({ wallet: WALLET });
+    expect(r.positions).toEqual([]);
+    expect(r.errored).toBe(true);
+    expect(r.erroredSources).toHaveLength(2);
+    const sources = r.erroredSources!.map((e) => e.source).sort();
+    expect(sources).toEqual(["eigenlayer", "lido"]);
+  });
+});


### PR DESCRIPTION
## Summary

Three follow-ups to the portfolio-coverage / data-quality theme kicked off by #91.

### #92 — Morpho Blue coverage diagnostic parity

Mirror #91's Compound pattern: the per-chain `getMorphoPositions` fan-out in `getPortfolioSummary` was swallowing per-chain errors into a single boolean, leaving `coverage.morpho.note` as a generic *"event-log discovery failed on at least one chain."* `.catch` now captures `{chain, error}` into `morphoErroredChains`; new `formatMorphoErrorNote` renders the detail into the note plus a pointer to `get_morpho_positions` for narrow follow-up. Closes #92.

### #93 — Staking per-source failure isolation + diagnostic

`getStakingPositions` used `Promise.all` internally — if Lido OR EigenLayer threw, the whole call rejected and the aggregator's `.catch` zeroed both. Refactored to `Promise.allSettled` with per-source error capture; response now carries `errored: true` + `erroredSources: [{source, error}, …]` when applicable (happy-path shape unchanged). Consequence: **a flaky Lido RPC no longer zeroes the user's EigenLayer position, and vice versa**. Portfolio consumes the new fields; `formatStakingErrorNote` renders the note naming the specific failing source(s). Closes #93.

### #94 — Polygon native MATIC→POL price + unpriced-asset detail

Two asks in one issue:

1. **Root-cause price fix.** Polygon native was rebranded MATIC → POL in Sept 2024; CoinGecko renamed the coin `matic-network` → `polygon-ecosystem-token`. DefiLlama's `coins.llama.fi` started returning `{\"coins\":{}}` for the old key. I verified this empirically before committing:

   - `GET coins.llama.fi/prices/current/coingecko:matic-network` → `{\"coins\":{}}` (deprecated)
   - `GET coins.llama.fi/prices/current/coingecko:polygon-ecosystem-token` → `{price: 0.094, symbol: \"POL\", …}` ✓

   Updated `NATIVE_COINGECKO_ID.polygon` accordingly.

2. **Surface unpriced-asset detail.** Previously `coverage.unpricedAssets: N` was a bare count; the agent couldn't tell the user *\"your 705 MATIC on polygon wasn't priced and isn't in the total.\"* Added `coverage.unpricedAssetsDetail?: UnpricedAsset[]` (new exported type in `src/types/index.ts`) carrying `{chain, symbol, amount}` per affected balance. Omitted when the list is empty so happy-path shape is unchanged. Multi-wallet aggregation concatenates per-wallet lists via `flatMap`.

   Closes #94.

## Scope note

Does NOT attempt to fix the root-cause flakiness for #92 / #93 — same reasoning as #91: without reproducible RPC traces, the actionable fix IS the diagnostic improvement. Once these notes start naming specific chains/sources/errors in the wild, the next bug report can target the actual RPC failure with a known trace.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 50 files / 679 tests green (11 new across the three fixes)
  - `test/portfolio-compound-coverage.test.ts` extended with Morpho + Staking note helpers
  - `test/staking-partial-failure.test.ts` (new) — 4 cases for `Promise.allSettled` isolation
  - `test/native-prices.test.ts` (new) — pins the polygon key with a fetch mock; regression guard ensures the deprecated `coingecko:matic-network` is never what we send
- [x] `npm run build` clean
- [x] Live-API spot-check against DefiLlama for the key swap (see issue description)

## Why one commit

Hunks for the three fixes interleave across ~10 regions of `src/modules/portfolio/index.ts`. Splitting via `git add -p` across ~300 lines was fragile; bundled into one commit with all three issue numbers in the footer. The PR description (this) breaks them out for review; the commit message body and test files keep the three scopes independently searchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)