### PR TITLE
feat(solana): phase 3 A+B — v0/ALT foundation + Jupiter swap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ import {
   prepareSolanaSplSend,
   prepareSolanaNonceInit,
   prepareSolanaNonceClose,
+  getSolanaSwapQuote,
+  prepareSolanaSwap,
   prepareAaveSupply,
   prepareAaveWithdraw,
   prepareAaveBorrow,
@@ -87,6 +89,8 @@ import {
   prepareSolanaSplSendInput,
   prepareSolanaNonceInitInput,
   prepareSolanaNonceCloseInput,
+  getSolanaSwapQuoteInput,
+  prepareSolanaSwapInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -1198,6 +1202,42 @@ async function main() {
       inputSchema: prepareSolanaNonceCloseInput.shape,
     },
     handler(prepareSolanaNonceClose)
+  );
+
+  server.registerTool(
+    "get_solana_swap_quote",
+    {
+      description:
+        "READ-ONLY — fetch a Jupiter v6 swap quote for previewing the route, expected output, slippage, " +
+        "and price impact before committing to a transaction. Parallel to EVM's `get_swap_quote` (which uses LiFi). " +
+        "Calls the Jupiter aggregator at lite-api.jup.ag/swap/v1/quote, returns the opaque quoteResponse " +
+        "(which must be passed back verbatim to `prepare_solana_swap`) plus human-facing fields (symbols, " +
+        "amounts with decimals applied, route labels like 'Meteora DLMM' / 'Raydium CLMM', price impact %). " +
+        "Pass raw integer amounts in base units (e.g., '1000000' for 1 USDC). For native SOL, use the wrapped-SOL " +
+        "mint So11111111111111111111111111111111111111112 — Jupiter auto-wraps/unwraps at swap time.",
+      inputSchema: getSolanaSwapQuoteInput.shape,
+    },
+    handler(getSolanaSwapQuote)
+  );
+
+  server.registerTool(
+    "prepare_solana_swap",
+    {
+      description:
+        "Build an unsigned Jupiter-routed swap DRAFT. Takes the `quote` object returned by " +
+        "`get_solana_swap_quote` and calls Jupiter's /swap-instructions endpoint to get the deconstructed " +
+        "instruction list, then composes the final v0 tx: [nonceAdvance, ...computeBudget, ...setup, " +
+        "swap, cleanup?, ...other]. DURABLE NONCE REQUIRED — if the wallet hasn't run " +
+        "`prepare_solana_nonce_init`, this errors pointing to it. Uses v0 VersionedTransaction with " +
+        "Address Lookup Tables (Jupiter routes commonly exceed legacy-tx account limits). Returns a " +
+        "compact preview + opaque handle; NOT yet signable — when the user says 'send', call " +
+        "`preview_solana_send(handle)` to pin the current nonce value, then `send_transaction`. " +
+        "BLIND-SIGN REQUIRED on Ledger (Jupiter's program ID isn't in the Solana app's clear-sign " +
+        "registry), so the user must match the Message Hash on-device — surfaced in the CHECKS block " +
+        "emitted by `preview_solana_send`.",
+      inputSchema: prepareSolanaSwapInput.shape,
+    },
+    handler(prepareSolanaSwap)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -90,6 +90,8 @@ import type {
   PrepareSolanaSplSendArgs,
   PrepareSolanaNonceInitArgs,
   PrepareSolanaNonceCloseArgs,
+  GetSolanaSwapQuoteArgs,
+  PrepareSolanaSwapArgs,
   PreviewSendArgs,
   SendTransactionArgs,
   GetTransactionStatusArgs,
@@ -247,6 +249,37 @@ export async function prepareSolanaNonceClose(
   args: PrepareSolanaNonceCloseArgs,
 ): Promise<PreparedSolanaTx> {
   return buildSolanaNonceClose({ wallet: args.wallet });
+}
+
+export async function getSolanaSwapQuote(args: GetSolanaSwapQuoteArgs) {
+  const { getJupiterQuote } = await import("../solana/jupiter.js");
+  return getJupiterQuote({
+    inputMint: args.inputMint,
+    outputMint: args.outputMint,
+    amount: args.amount,
+    slippageBps: args.slippageBps,
+    swapMode: args.swapMode,
+  });
+}
+
+export async function prepareSolanaSwap(
+  args: PrepareSolanaSwapArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildJupiterSwap } = await import("../solana/jupiter.js");
+  // The `quote` arg is the full Jupiter QuoteResponse — typed loosely as
+  // Record<string, unknown> at the schema boundary, narrowed here by the
+  // Jupiter module (which expects a JupiterQuote shape).
+  const prepared = await buildJupiterSwap({
+    wallet: args.wallet,
+    quote: args.quote as never, // JupiterQuote is a superset of Record<string, unknown>
+    ...(args.prioritizationFeeLamports !== undefined
+      ? { prioritizationFeeLamports: args.prioritizationFeeLamports }
+      : {}),
+  });
+  // buildJupiterSwap returns a narrower type (PreparedJupiterSwap). The
+  // handlers all converge on PreparedSolanaTx, and jupiter_swap is already
+  // in that action union, so the assignment is shape-compatible.
+  return prepared as PreparedSolanaTx;
 }
 
 /**
@@ -1256,7 +1289,7 @@ export interface SolanaVerificationArtifact {
   artifactVersion: "v1";
   handle: string;
   chain: "solana";
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close";
+  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
   from: string;
   messageBase64: string;
   recentBlockhash: string;

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -89,6 +89,61 @@ export const prepareSolanaNonceCloseInput = z.object({
   ),
 });
 
+export const getSolanaSwapQuoteInput = z.object({
+  inputMint: solanaAddressSchema.describe(
+    "Base58 mint address of the token being sold. For native SOL use the wrapped-SOL " +
+      "mint So11111111111111111111111111111111111111112 — Jupiter auto-wraps/unwraps."
+  ),
+  outputMint: solanaAddressSchema.describe(
+    "Base58 mint address of the token being bought. Same wrapped-SOL convention as inputMint."
+  ),
+  amount: z
+    .string()
+    .regex(/^\d+$/)
+    .describe(
+      "Raw integer amount in base units (NOT decimal-adjusted). For ExactIn swaps " +
+        "this is how much inputMint to sell; for ExactOut it's how much outputMint to buy. " +
+        "Example: to sell 1 USDC (6 decimals), pass '1000000'."
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(10000)
+    .default(50)
+    .describe("Slippage tolerance in basis points. 50 bps = 0.5%. Default 50."),
+  swapMode: z
+    .enum(["ExactIn", "ExactOut"])
+    .default("ExactIn")
+    .describe(
+      "ExactIn: sell exactly `amount` inputMint, receive at least minOutput. " +
+        "ExactOut: buy exactly `amount` outputMint, sell at most maxInput."
+    ),
+});
+
+export const prepareSolanaSwapInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet executing the swap. Must have an initialized durable-nonce account — " +
+      "run prepare_solana_nonce_init first if not set up yet."
+  ),
+  quote: z
+    .record(z.unknown())
+    .describe(
+      "The full `quote` object returned by get_solana_swap_quote. Pass it back verbatim " +
+        "— Jupiter computes a signature over the quote and rejects /swap-instructions if " +
+        "any field is mutated."
+    ),
+  prioritizationFeeLamports: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe(
+      "Optional priority fee in lamports. Omit to let Jupiter pick based on the local " +
+        "fee market (recommended)."
+    ),
+});
+
 export const getLedgerStatusInput = z.object({});
 
 const baseAaveAction = z.object({
@@ -318,6 +373,8 @@ export type PairLedgerSolanaArgs = z.infer<typeof pairLedgerSolanaInput>;
 export type PrepareSolanaNativeSendArgs = z.infer<typeof prepareSolanaNativeSendInput>;
 export type PrepareSolanaSplSendArgs = z.infer<typeof prepareSolanaSplSendInput>;
 export type PrepareSolanaNonceInitArgs = z.infer<typeof prepareSolanaNonceInitInput>;
+export type GetSolanaSwapQuoteArgs = z.infer<typeof getSolanaSwapQuoteInput>;
+export type PrepareSolanaSwapArgs = z.infer<typeof prepareSolanaSwapInput>;
 export type PrepareSolanaNonceCloseArgs = z.infer<typeof prepareSolanaNonceCloseInput>;
 export type PrepareAaveSupplyArgs = z.infer<typeof prepareAaveSupplyInput>;
 export type PrepareAaveWithdrawArgs = z.infer<typeof prepareAaveWithdrawInput>;

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -109,7 +109,7 @@ export interface SolanaNativeSendParams {
  */
 export interface PreparedSolanaTx {
   handle: string;
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close";
+  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
   chain: "solana";
   from: string;
   description: string;
@@ -128,7 +128,7 @@ export interface PreparedSolanaTx {
  * relays the message verbatim to the user, who then runs
  * `prepare_solana_nonce_init` before retrying the send.
  */
-function throwNonceRequired(wallet: string): never {
+export function throwNonceRequired(wallet: string): never {
   throw new Error(
     `Solana nonce account not initialized for ${wallet}. Durable-nonce protection is required ` +
       `for all Solana sends in this server — the ~90s recentBlockhash window was eating into the ` +
@@ -221,6 +221,7 @@ export async function buildSolanaNativeSend(
 
   const nonceAccountStr = noncePubkey.toBase58();
   const draft: SolanaTxDraft = {
+    kind: "legacy",
     draftTx,
     meta: {
       action: "native_send",
@@ -401,6 +402,7 @@ export async function buildSolanaSplSend(
     totalFee + (recipient.needsCreation ? SPL_TOKEN_ACCOUNT_RENT_LAMPORTS : 0);
   const nonceAccountStr = noncePubkey.toBase58();
   const draft: SolanaTxDraft = {
+    kind: "legacy",
     draftTx,
     meta: {
       action: "spl_send",
@@ -518,6 +520,7 @@ export async function buildSolanaNonceInit(
 
   const nonceAccountStr = noncePubkey.toBase58();
   const draft: SolanaTxDraft = {
+    kind: "legacy",
     draftTx,
     meta: {
       action: "nonce_init",
@@ -606,6 +609,7 @@ export async function buildSolanaNonceClose(
 
   const nonceAccountStr = noncePubkey.toBase58();
   const draft: SolanaTxDraft = {
+    kind: "legacy",
     draftTx,
     meta: {
       action: "nonce_close",

--- a/src/modules/solana/alt.ts
+++ b/src/modules/solana/alt.ts
@@ -1,0 +1,82 @@
+import {
+  AddressLookupTableAccount,
+  type Connection,
+  type PublicKey,
+} from "@solana/web3.js";
+
+/**
+ * Address Lookup Table (ALT) resolver — fetches on-chain ALT accounts and
+ * caches them per-process so multiple verifier runs don't re-hit the RPC
+ * for stable ALT contents.
+ *
+ * ALTs are a Solana v0-message feature: a tx can reference a "lookup table"
+ * address + an index into that table instead of embedding the full 32-byte
+ * pubkey in the message. This is what lets Jupiter routes fit 40+ accounts
+ * into a message — legacy transactions cap out around 35. To verify a v0
+ * message's accounts (e.g., in the CHECK 1 instruction-decode rendering),
+ * you MUST resolve ALT indices via the ALT's on-chain `state.addresses`
+ * list; there's no on-message-only way to do it.
+ *
+ * Cache notes:
+ *   - ALT contents are append-only (once an address is written to an ALT,
+ *     it never changes at that index) so caching the `AddressLookupTableAccount`
+ *     indefinitely is safe for the resolve-indices-to-pubkeys case.
+ *   - But ALTs can be EXTENDED: a later ExtendLookupTable ix adds more
+ *     addresses. If a tx references an index beyond what our cached state
+ *     knows about, we'd miss the resolution. Mitigation: the cache is
+ *     keyed by ALT pubkey; we invalidate on any tx whose highest index
+ *     exceeds the cached `state.addresses.length` (caller checks + calls
+ *     `invalidateAlt`). In practice rare — Jupiter's routing ALTs are
+ *     stable, and a cache miss just re-fetches.
+ *   - In-process Map (no TTL). Process lifetime matches a single MCP
+ *     server session; we want ALT reads to be cheap for back-to-back
+ *     verifier runs in the same session.
+ */
+const altCache = new Map<string, AddressLookupTableAccount>();
+
+/**
+ * Resolve ALT pubkeys to on-chain `AddressLookupTableAccount` instances,
+ * in the same order as the input. Throws on any ALT that doesn't exist
+ * on chain — a tx referencing a missing ALT is unverifiable, and silently
+ * dropping it would hide an on-chain correctness problem from the agent's
+ * CHECK 1 decode.
+ */
+export async function resolveAddressLookupTables(
+  conn: Connection,
+  altPubkeys: PublicKey[],
+): Promise<AddressLookupTableAccount[]> {
+  if (altPubkeys.length === 0) return [];
+
+  const results = await Promise.all(
+    altPubkeys.map(async (key) => {
+      const cacheKey = key.toBase58();
+      const cached = altCache.get(cacheKey);
+      if (cached) return cached;
+      const res = await conn.getAddressLookupTable(key);
+      if (!res.value) {
+        throw new Error(
+          `Address lookup table ${cacheKey} does not exist on chain — a v0 tx references ` +
+            `it but the account is missing. Cannot verify the tx's ALT-indexed accounts. ` +
+            `Refuse to sign until this is resolved (likely an MCP-side reference to a fabricated ALT).`,
+        );
+      }
+      altCache.set(cacheKey, res.value);
+      return res.value;
+    }),
+  );
+  return results;
+}
+
+/**
+ * Drop a cache entry — call this when a tx references an index beyond
+ * what the cached ALT knows about (suggests the ALT was extended since
+ * last fetch). The next `resolveAddressLookupTables` call will re-fetch.
+ */
+export function invalidateAlt(altPubkey: PublicKey): void {
+  altCache.delete(altPubkey.toBase58());
+}
+
+/** Test-only: reset the cache between test suites. */
+export function clearAltCache(): void {
+  altCache.clear();
+}

--- a/src/modules/solana/jupiter.ts
+++ b/src/modules/solana/jupiter.ts
@@ -1,0 +1,383 @@
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import { resolveAddressLookupTables } from "./alt.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import { SOLANA_TOKEN_DECIMALS, SOLANA_TOKENS } from "../../config/solana.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+
+/**
+ * Jupiter swap integration — uses the `/swap-instructions` endpoint rather
+ * than `/swap`.
+ *
+ * Why instructions, not the pre-built transaction:
+ * Jupiter's `/swap` returns a fully-assembled base64 VersionedTransaction.
+ * That would work, but we'd have to deserialize it, surgically prepend our
+ * `SystemProgram.nonceAdvance` as ix[0], then re-serialize — fragile
+ * surgery on bytes the user already inspected once. `/swap-instructions`
+ * returns the constituent pieces (compute-budget, setup, swap, cleanup,
+ * ALTs) so we can compose `[nonceAdvance, ...computeBudget, ...setup,
+ * swap, cleanup?, ...other]` cleanly and let Milestone A's v0 pin build
+ * the MessageV0 from scratch with our nonce value in recentBlockhash.
+ *
+ * Base URL: `https://lite-api.jup.ag/swap/v1` — Jupiter's public tier,
+ * no API key required. The authenticated `api.jup.ag` endpoint is a drop-
+ * in (same OpenAPI spec) if the user needs higher rate limits; switching
+ * is a one-constant change.
+ */
+const JUPITER_BASE = "https://lite-api.jup.ag/swap/v1";
+
+/**
+ * Minimal shape of Jupiter's `QuoteResponse`. We preserve the full opaque
+ * object to pass back to `/swap-instructions` (adding/removing fields on
+ * our side would invalidate Jupiter's signing of the quote), but we
+ * surface a typed subset for downstream callers and for constructing
+ * human-readable previews.
+ */
+export interface JupiterQuote {
+  inputMint: string;
+  inAmount: string;
+  outputMint: string;
+  outAmount: string;
+  otherAmountThreshold: string;
+  swapMode: "ExactIn" | "ExactOut";
+  slippageBps: number;
+  priceImpactPct: string;
+  routePlan: Array<{
+    swapInfo: {
+      ammKey: string;
+      label: string;
+      inputMint: string;
+      outputMint: string;
+      inAmount: string;
+      outAmount: string;
+    };
+    percent: number;
+  }>;
+  contextSlot?: number;
+  // Everything else (platformFee, mostReliableAmmsQuoteReport, etc.) we
+  // preserve opaquely — the full object is what /swap-instructions needs.
+  [key: string]: unknown;
+}
+
+interface JupiterRawInstruction {
+  programId: string;
+  accounts: Array<{ pubkey: string; isSigner: boolean; isWritable: boolean }>;
+  data: string; // base64
+}
+
+interface JupiterSwapInstructionsResponse {
+  computeBudgetInstructions: JupiterRawInstruction[];
+  setupInstructions: JupiterRawInstruction[];
+  swapInstruction: JupiterRawInstruction;
+  cleanupInstruction: JupiterRawInstruction | null;
+  otherInstructions: JupiterRawInstruction[];
+  addressLookupTableAddresses: string[];
+}
+
+function toWeb3Instruction(raw: JupiterRawInstruction): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(raw.programId),
+    keys: raw.accounts.map((a) => ({
+      pubkey: new PublicKey(a.pubkey),
+      isSigner: a.isSigner,
+      isWritable: a.isWritable,
+    })),
+    data: Buffer.from(raw.data, "base64"),
+  });
+}
+
+/** Wrapped-SOL mint — Jupiter auto-wraps/unwraps, so users swap "SOL" via this mint. */
+const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+/**
+ * Reverse map: mint address → canonical symbol + decimals (for known tokens).
+ * Handles wSOL specially (the swap table in `config/solana.ts` tracks SPL
+ * tokens the portfolio cares about; wSOL is a Jupiter-interop concern
+ * only, not a holdable balance, so it's not in SOLANA_TOKENS).
+ *
+ * Near-duplicate of the helper in actions.ts — kept local to avoid an
+ * import cycle. If this grows to more than the two call sites, extract to
+ * a shared module.
+ */
+function resolveKnownMint(
+  mint: string,
+): { symbol: string; decimals: number } | null {
+  if (mint === WSOL_MINT) return { symbol: "SOL", decimals: 9 };
+  for (const [sym, addr] of Object.entries(SOLANA_TOKENS) as [
+    keyof typeof SOLANA_TOKENS,
+    string,
+  ][]) {
+    if (addr === mint) {
+      return { symbol: sym, decimals: SOLANA_TOKEN_DECIMALS[sym] };
+    }
+  }
+  return null;
+}
+
+/** Format a raw token integer amount into human units given decimals. */
+function formatTokenUnits(raw: string, decimals: number): string {
+  const rawBig = BigInt(raw);
+  if (decimals === 0) return rawBig.toString();
+  const base = 10n ** BigInt(decimals);
+  const whole = rawBig / base;
+  const frac = rawBig % base;
+  if (frac === 0n) return whole.toString();
+  const fracStr = frac.toString().padStart(decimals, "0").replace(/0+$/, "");
+  return `${whole}.${fracStr}`;
+}
+
+export interface JupiterQuoteParams {
+  inputMint: string;
+  outputMint: string;
+  /** Raw integer amount in base units (e.g. "1000000" for 1 USDC). */
+  amount: string;
+  slippageBps: number;
+  swapMode?: "ExactIn" | "ExactOut";
+}
+
+/**
+ * Fetch a Jupiter quote. Read-only — no on-chain or signing side effects.
+ * Returns the opaque `quoteResponse` object the user will hand back to
+ * `buildJupiterSwap` (or `prepare_solana_swap`) along with a few derived
+ * human-facing fields for the preview.
+ */
+export async function getJupiterQuote(
+  p: JupiterQuoteParams,
+): Promise<{
+  quote: JupiterQuote;
+  human: {
+    inputSymbol: string;
+    outputSymbol: string;
+    inputAmountHuman: string;
+    outputAmountHuman: string;
+    minOutputHuman: string;
+    priceImpactPct: string;
+    routeLabels: string[];
+  };
+}> {
+  // Validate mints look like Solana pubkeys up front — Jupiter's error
+  // otherwise comes back as a 400 with opaque JSON.
+  assertSolanaAddress(p.inputMint);
+  assertSolanaAddress(p.outputMint);
+
+  const qs = new URLSearchParams({
+    inputMint: p.inputMint,
+    outputMint: p.outputMint,
+    amount: p.amount,
+    slippageBps: String(p.slippageBps),
+    swapMode: p.swapMode ?? "ExactIn",
+    // Constrain route size — Jupiter can otherwise route through 60+ accounts
+    // which pushes v0 txs toward the 1232-byte packet ceiling. 40 is a safe
+    // cap that still lets most routes through (Jupiter's own UI default).
+    maxAccounts: "40",
+  });
+  const res = await fetch(`${JUPITER_BASE}/quote?${qs}`);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Jupiter /quote failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
+    );
+  }
+  const quote = (await res.json()) as JupiterQuote;
+
+  // Derive human-facing fields. Unknown mints → use raw amounts with
+  // decimals=0 as a conservative fallback (caller still sees the raw
+  // base-units string so no precision loss).
+  const inputInfo = resolveKnownMint(quote.inputMint);
+  const outputInfo = resolveKnownMint(quote.outputMint);
+  const inputSymbol = inputInfo?.symbol ?? "UNKNOWN";
+  const outputSymbol = outputInfo?.symbol ?? "UNKNOWN";
+  const inputAmountHuman = inputInfo
+    ? formatTokenUnits(quote.inAmount, inputInfo.decimals)
+    : quote.inAmount;
+  const outputAmountHuman = outputInfo
+    ? formatTokenUnits(quote.outAmount, outputInfo.decimals)
+    : quote.outAmount;
+  const minOutputHuman = outputInfo
+    ? formatTokenUnits(quote.otherAmountThreshold, outputInfo.decimals)
+    : quote.otherAmountThreshold;
+  const routeLabels = quote.routePlan.map((r) => r.swapInfo.label);
+
+  return {
+    quote,
+    human: {
+      inputSymbol,
+      outputSymbol,
+      inputAmountHuman,
+      outputAmountHuman,
+      minOutputHuman,
+      priceImpactPct: quote.priceImpactPct,
+      routeLabels,
+    },
+  };
+}
+
+export interface JupiterSwapParams {
+  wallet: string;
+  quote: JupiterQuote;
+  /** Optional priority fee in lamports. Defaults to "auto" (Jupiter's recommendation). */
+  prioritizationFeeLamports?: number | "auto";
+}
+
+export interface PreparedJupiterSwap {
+  handle: string;
+  action: "jupiter_swap";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  nonceAccount: string;
+}
+
+/**
+ * Build the Jupiter swap tx as a v0 MessageV0 draft. Composition:
+ *
+ *   ix[0]                   = SystemProgram.nonceAdvance   (our durable-nonce)
+ *   ix[1..k]                = Jupiter's compute-budget ixs (set CU limit + price)
+ *   ix[k+1..m]              = Jupiter's setup ixs          (create ATAs if needed, wrap SOL, etc.)
+ *   ix[m+1]                 = Jupiter's swap ix            (the actual route)
+ *   ix[m+2]                 = Jupiter's cleanup ix         (close temp WSOL account, etc. — optional)
+ *   ix[m+3..n]              = Jupiter's other ixs          (jito tip if priorityFee set that way)
+ *
+ * Jupiter's `/swap-instructions` also returns `addressLookupTableAddresses`
+ * — the ALTs that compress the account list so the v0 message fits. We
+ * resolve those via Milestone A's `resolveAddressLookupTables` helper so
+ * Milestone A's v0 pin path can compile MessageV0 with them at preview
+ * time. Without the ALTs the account list wouldn't fit.
+ *
+ * Nonce-required preflight: same gate as every other Solana send — if the
+ * wallet hasn't run `prepare_solana_nonce_init`, we throw a structured
+ * error pointing to that tool.
+ */
+export async function buildJupiterSwap(
+  p: JupiterSwapParams,
+): Promise<PreparedJupiterSwap> {
+  const fromPubkey = assertSolanaAddress(p.wallet);
+  const conn = getSolanaConnection();
+
+  // Durable-nonce preflight (shared helper from actions.ts).
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(p.wallet);
+
+  // Fetch Jupiter's deconstructed ix list. NOTE: we pass the quote
+  // verbatim — Jupiter computes a signature over the quote object and
+  // will reject on /swap-instructions if we mutate any field.
+  const body = {
+    userPublicKey: p.wallet,
+    quoteResponse: p.quote,
+    // Skip shared-account routing to preserve the ability to pass our
+    // own nonce authority in instruction accounts. useSharedAccounts
+    // worked in testing but costs us control; Jupiter's fallback path
+    // creates any intermediate ATAs the user's wallet actually needs.
+    useSharedAccounts: true,
+    wrapAndUnwrapSol: true,
+    // dynamicComputeUnitLimit simulates the swap server-side to size the
+    // CU limit properly. Adds one RPC call but reduces priority-fee
+    // overpay and improves landing rates. Recommended by Jupiter for all
+    // normal flows.
+    dynamicComputeUnitLimit: true,
+    // Priority fee: let Jupiter pick by default (it reads the local fee
+    // market). If caller specified an integer, pass it through.
+    ...(typeof p.prioritizationFeeLamports === "number"
+      ? { prioritizationFeeLamports: p.prioritizationFeeLamports }
+      : {}),
+  };
+  const res = await fetch(`${JUPITER_BASE}/swap-instructions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const rawBody = await res.text();
+    throw new Error(
+      `Jupiter /swap-instructions failed (HTTP ${res.status}): ${rawBody.slice(0, 500)}`,
+    );
+  }
+  const j = (await res.json()) as JupiterSwapInstructionsResponse;
+
+  // Compose the full ix list with our nonce advance at ix[0].
+  const instructions: TransactionInstruction[] = [
+    buildAdvanceNonceIx(noncePubkey, fromPubkey),
+    ...j.computeBudgetInstructions.map(toWeb3Instruction),
+    ...j.setupInstructions.map(toWeb3Instruction),
+    toWeb3Instruction(j.swapInstruction),
+    ...(j.cleanupInstruction ? [toWeb3Instruction(j.cleanupInstruction)] : []),
+    ...j.otherInstructions.map(toWeb3Instruction),
+  ];
+
+  // Resolve ALTs (may be empty for simple routes).
+  const altPubkeys = j.addressLookupTableAddresses.map((s) => new PublicKey(s));
+  const alts = await resolveAddressLookupTables(conn, altPubkeys);
+
+  // Build human-facing description for the bullet summary.
+  const inputInfo = resolveKnownMint(p.quote.inputMint);
+  const outputInfo = resolveKnownMint(p.quote.outputMint);
+  const inSym = inputInfo?.symbol ?? p.quote.inputMint;
+  const outSym = outputInfo?.symbol ?? p.quote.outputMint;
+  const inAmt = inputInfo
+    ? formatTokenUnits(p.quote.inAmount, inputInfo.decimals)
+    : p.quote.inAmount;
+  const outAmt = outputInfo
+    ? formatTokenUnits(p.quote.outAmount, outputInfo.decimals)
+    : p.quote.outAmount;
+  const minOut = outputInfo
+    ? formatTokenUnits(p.quote.otherAmountThreshold, outputInfo.decimals)
+    : p.quote.otherAmountThreshold;
+  const routeLabels = p.quote.routePlan.map((r) => r.swapInfo.label).join(" → ");
+
+  const nonceAccountStr = noncePubkey.toBase58();
+  const draft: SolanaTxDraft = {
+    kind: "v0",
+    payerKey: fromPubkey,
+    instructions,
+    addressLookupTableAccounts: alts,
+    meta: {
+      action: "jupiter_swap",
+      from: p.wallet,
+      description: `Swap ${inAmt} ${inSym} → ${outAmt} ${outSym} via Jupiter (${routeLabels}); min output ${minOut} ${outSym} @ ${p.quote.slippageBps} bps slippage`,
+      decoded: {
+        functionName: "solana.jupiter.swap",
+        args: {
+          from: p.wallet,
+          inputMint: p.quote.inputMint,
+          outputMint: p.quote.outputMint,
+          inputSymbol: inSym,
+          outputSymbol: outSym,
+          inputAmount: `${inAmt} ${inSym}`,
+          outputAmount: `${outAmt} ${outSym}`,
+          minOutput: `${minOut} ${outSym}`,
+          slippageBps: String(p.quote.slippageBps),
+          priceImpactPct: p.quote.priceImpactPct,
+          route: routeLabels,
+          addressLookupTables: String(alts.length),
+          nonceAccount: nonceAccountStr,
+        },
+      },
+      nonce: {
+        account: nonceAccountStr,
+        authority: fromPubkey.toBase58(),
+        value: nonceState.nonce,
+      },
+    },
+  };
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "jupiter_swap",
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: nonceAccountStr,
+  };
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -849,7 +849,7 @@ export function renderTronVerificationBlock(tx: UnsignedTronTx & { verification:
  */
 export interface RenderableSolanaPrepareResult {
   handle: string;
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close";
+  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -875,6 +875,8 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "durable-nonce init (one-time setup)";
     case "nonce_close":
       return "durable-nonce close (reclaim rent-exempt seed)";
+    case "jupiter_swap":
+      return "Jupiter swap";
   }
 }
 
@@ -1120,6 +1122,7 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   const isNativeSend = tx.action === "native_send";
   const isNonceInit = tx.action === "nonce_init";
   const isNonceClose = tx.action === "nonce_close";
+  const isJupiterSwap = tx.action === "jupiter_swap";
 
   // SPECIAL CASE — nonce_init is the one Solana action where ALL the
   // standard checks are pure ceremony. Why:
@@ -1183,8 +1186,19 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
 
   // Send-type txs (native_send / spl_send / nonce_close) all carry
   // ix[0] = SystemProgram.nonceAdvance for durable-nonce protection.
-  const hasAdvanceNonceIx = isNativeSend || isSpl || isNonceClose;
-  const ledgerHash = isSpl ? solanaLedgerMessageHash(tx.messageBase64) : null;
+  // Every send-type tx (any action except nonce_init) carries nonceAdvance
+  // as ix[0] — this flag drives the "DURABLE-NONCE MODE" explainer text +
+  // the Nonce bullet in the summary + the expected-shape text for CHECK 1.
+  const hasAdvanceNonceIx =
+    isNativeSend || isSpl || isNonceClose || isJupiterSwap;
+  // The Ledger Solana app only clear-signs a small allowlist of programs
+  // (System Program's transfer/advance/initialize/withdraw, and a few
+  // others). Everything else falls to blind-sign, which shows only the
+  // Message Hash on-device and requires the user to match it against the
+  // hash the server displayed. SPL TransferChecked AND Jupiter swaps both
+  // fall in that bucket.
+  const isBlindSign = isSpl || isJupiterSwap;
+  const ledgerHash = isBlindSign ? solanaLedgerMessageHash(tx.messageBase64) : null;
 
   const checksPayload = {
     instructionDecode: {
@@ -1240,16 +1254,28 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
             "  - Rent-exempt seed: <rent in SOL (~0.00144 SOL)>",
             "  - Fee: <fee in SOL>",
           ]
-        : [
-            // nonce_close
-            "  - Headline: \"Prepared durable-nonce close — returning <balance> SOL to <wallet short>\"",
-            "  - Wallet: <from address>",
-            "  - Nonce account: <nonce-account PDA, will be destroyed>",
-            "  - Destination: <from address (returns to main wallet)>",
-            "  - Withdraw amount: <balance in SOL>",
-            ...(nonceBullet ? [nonceBullet] : []),
-            "  - Fee: <fee in SOL>",
-          ];
+        : isNonceClose
+          ? [
+              "  - Headline: \"Prepared durable-nonce close — returning <balance> SOL to <wallet short>\"",
+              "  - Wallet: <from address>",
+              "  - Nonce account: <nonce-account PDA, will be destroyed>",
+              "  - Destination: <from address (returns to main wallet)>",
+              "  - Withdraw amount: <balance in SOL>",
+              ...(nonceBullet ? [nonceBullet] : []),
+              "  - Fee: <fee in SOL>",
+            ]
+          : [
+              // jupiter_swap
+              "  - Headline: \"Prepared Solana swap — <inputAmount> <inputSymbol> → <outputAmount> <outputSymbol> via Jupiter\"",
+              "  - From: <from address>",
+              "  - Input mint: <inputMint> (<inputSymbol if known>)",
+              "  - Output mint: <outputMint> (<outputSymbol if known>)",
+              "  - Expected output: <outputAmount> <outputSymbol> (min <minOutput> @ <slippageBps> bps)",
+              "  - Route: <route labels joined with →, from decoded.args.route>",
+              "  - Price impact: <priceImpactPct>%",
+              ...(nonceBullet ? [nonceBullet] : []),
+              "  - Fee: <fee in SOL (priority + base)>",
+            ];
 
   const inspectorUrl = solanaInspectorUrl(tx.messageBase64);
 
@@ -1259,7 +1285,12 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // integrity gate and a server-side hash recompute adds nothing — same
   // policy EVM uses for clear-sign txs (native sends, ERC20
   // transfers/approvals).
-  const needsPairConsistency = isSpl;
+  // CHECK 2 (pair-consistency hash recompute) fires when the device would
+  // blind-sign — without the hash, the on-device screen has nothing but a
+  // hash to match against, so we need to bind the displayed bytes to the
+  // displayed hash. Clear-sign actions (native_send, nonce_close) skip CHECK
+  // 2 because the on-device decoded fields ARE the integrity gate.
+  const needsPairConsistency = isBlindSign;
   // Combined CHECK 1 + CHECK 2 script — single Bash invocation, single
   // approval prompt, two verdicts. Mirrors EVM CHECK 2's template shape
   // (multi-line `node -e "..."` with `<messageBase64 from the prepare_*
@@ -1268,35 +1299,59 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // What the script computes:
   //   - ledgerHash = base58(sha256(msg)) — same value the Ledger Solana
   //     app derives and shows on blind-sign. PublicKey(<32-byte buffer>)
-  //     .toBase58() does base58 encoding.
-  //   - instructions[] = per-ix { programId, accounts, dataHex }
-  //     extracted via @solana/web3.js's `Message.from(buf)`. Account keys
-  //     are base58 pubkeys (PublicKey.toBase58 — recognizable). dataHex
-  //     is decoded from the base58 `ix.data` field via a small inline
-  //     bs58→hex helper (bs58 v6 is ESM-only so `require('bs58')` fails;
-  //     we keep the decoder to one short line — same shape as EVM's inline
-  //     fee-cost math, recognizable arithmetic, no "messy script" surface).
+  //     .toBase58() does base58 encoding (works for raw sha256 digests).
+  //   - instructions[] = per-ix { programId, accounts, dataHex } extracted
+  //     via @solana/web3.js. The script auto-detects message version:
+  //       - legacy (no 0x80 prefix): `Message.from(buf)` — instruction data
+  //         is base58, decoded via the inline bs58→hex helper below (bs58 v6
+  //         is ESM-only so `require('bs58')` fails; the decoder is one line).
+  //       - v0 (0x80 prefix): `VersionedMessage.deserialize(buf)` — fetches
+  //         Address Lookup Table accounts via an RPC Connection, flattens
+  //         static + ALT-resolved account keys, then reads `compiledInstructions`
+  //         (data is already a Uint8Array, no base58 decode needed).
+  //     The v0 branch requires network access (to fetch ALTs); the script
+  //     reads the RPC URL from `SOLANA_RPC_URL` env var with a fallback to
+  //     the public mainnet-beta endpoint.
   //
   // The agent inspects the JSON output and reports BOTH verdicts:
   //   - CHECK 1 ✓/✗ on instruction structure (programId + accounts +
   //     dataHex tag) matching the bullet summary
   //   - CHECK 2 ✓/✗ on ledgerHash matching the displayed value
   const combinedCheckScript = [
-    `    node -e "const {Message, PublicKey} = require('@solana/web3.js');`,
+    `    node -e "const {Message, VersionedMessage, PublicKey, Connection} = require('@solana/web3.js');`,
     `    const {createHash} = require('crypto');`,
     `    const m = '<messageBase64 from the preview_solana_send result>';`,
     `    const buf = Buffer.from(m, 'base64');`,
-    `    const msg = Message.from(buf);`,
     `    const A = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';`,
     `    const b58 = s => { if (!s.length) return ''; let n=0n; for (const c of s) n=n*58n+BigInt(A.indexOf(c)); let z=0; while (z<s.length&&s[z]==='1') z++; const h=n.toString(16); return '00'.repeat(z)+(h.length%2?'0'+h:h); };`,
-    `    console.log(JSON.stringify({`,
-    `      ledgerHash: new PublicKey(createHash('sha256').update(buf).digest()).toBase58(),`,
-    `      instructions: msg.instructions.map(ix => ({`,
-    `        programId: msg.accountKeys[ix.programIdIndex].toBase58(),`,
-    `        accounts: ix.accounts.map(i => msg.accountKeys[i].toBase58()),`,
-    `        dataHex: b58(ix.data),`,
-    `      })),`,
-    `    }, null, 2));"`,
+    `    const ledgerHash = new PublicKey(createHash('sha256').update(buf).digest()).toBase58();`,
+    `    (async () => {`,
+    `      let instructions;`,
+    `      if (buf[0] & 0x80) {`,
+    `        const msg = VersionedMessage.deserialize(buf);`,
+    `        const conn = new Connection(process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com');`,
+    `        const alts = [];`,
+    `        for (const lookup of msg.addressTableLookups) {`,
+    `          const res = await conn.getAddressLookupTable(lookup.accountKey);`,
+    `          if (!res.value) throw new Error('ALT not found on chain: ' + lookup.accountKey.toBase58());`,
+    `          alts.push(res.value);`,
+    `        }`,
+    `        const keys = msg.getAccountKeys({addressLookupTableAccounts: alts}).keySegments().flat();`,
+    `        instructions = msg.compiledInstructions.map(ix => ({`,
+    `          programId: keys[ix.programIdIndex].toBase58(),`,
+    `          accounts: ix.accountKeyIndexes.map(i => keys[i].toBase58()),`,
+    `          dataHex: Buffer.from(ix.data).toString('hex'),`,
+    `        }));`,
+    `      } else {`,
+    `        const msg = Message.from(buf);`,
+    `        instructions = msg.instructions.map(ix => ({`,
+    `          programId: msg.accountKeys[ix.programIdIndex].toBase58(),`,
+    `          accounts: ix.accounts.map(i => msg.accountKeys[i].toBase58()),`,
+    `          dataHex: b58(ix.data),`,
+    `        }));`,
+    `      }`,
+    `      console.log(JSON.stringify({ledgerHash, instructions}, null, 2));`,
+    `    })();"`,
   ];
 
   const lines = [
@@ -1444,9 +1499,9 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     "        (protects against a coordinated agent compromise)",
     "    ────────────────────────────────",
     "    NEXT ON-DEVICE — final check happens on your Ledger screen:",
-    ...(isSpl
+    ...(isSpl || isJupiterSwap
       ? [
-          "      • BLIND-SIGN (this tx — Solana app shows 'Message Hash'):",
+          `      • BLIND-SIGN (this tx — ${isJupiterSwap ? "Jupiter routing" : "SPL TransferChecked"} is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):`,
           `          check the value on-device is exactly **\`${ledgerHash}\`**.`,
           "          Any difference → REJECT.",
           "          Prerequisite: Allow blind signing must be ON in Solana app Settings.",
@@ -1475,7 +1530,7 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
             ]),
     "    ════════════════════════════════",
     "",
-    ...(isSpl
+    ...(isBlindSign
       ? [
           "Render the Message Hash with BOTH bold AND single-backtick inline",
           "code — i.e. `**\\`<hash>\\`**` — exactly as shown in the template",
@@ -1520,10 +1575,10 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     "  decodes the bytes from scratch. Do NOT pre-decode the bytes yourself",
     "  in the same reply. Before/after the pasteableBlock, remind the user to",
     "  compare the second agent's plain-English description against what they",
-    isSpl
+    isBlindSign
       ? "  asked for and match the Message Hash inside the paste block against"
       : "  asked for and confirm the on-device decoded fields match what the",
-    isSpl
+    isBlindSign
       ? "  the Ledger screen before approving."
       : "  Solana app clear-signs before approving.",
     "",

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { Transaction } from "@solana/web3.js";
+import {
+  MessageV0,
+  type AddressLookupTableAccount,
+  type PublicKey,
+  type Transaction,
+  type TransactionInstruction,
+} from "@solana/web3.js";
 import type { UnsignedSolanaTx } from "../types/index.js";
 import { buildSolanaVerification } from "./verification.js";
 
@@ -33,7 +39,7 @@ const TX_TTL_MS = 15 * 60_000;
  * cost, etc. Mirrors the non-message fields of `UnsignedSolanaTx`.
  */
 export interface SolanaDraftMeta {
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close";
+  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
   from: string;
   description: string;
   decoded: {
@@ -64,14 +70,41 @@ export interface SolanaDraftMeta {
 }
 
 /**
- * A Solana tx draft awaiting a blockhash pin. `draftTx` carries the
- * instruction list + fee payer but no `recentBlockhash` — that gets set
- * by `preview_solana_send` right before serialization.
+ * A Solana tx draft awaiting a blockhash pin.
+ *
+ * Message-format discriminated union: `kind: "legacy"` for `new Transaction()`
+ * (the Phase 1/2 shape), `kind: "v0"` for `VersionedMessage` / `MessageV0`
+ * (Phase 3 onward). The store doesn't care which; `pinSolanaHandle` branches
+ * on the discriminant to pick the right serialize path. Neither variant
+ * carries a blockhash at draft time — that gets set by `preview_solana_send`
+ * right before signing.
+ *
+ * Jupiter returns a ready-made v0 tx; Kamino/MarginFi sometimes need ALTs
+ * too. Legacy Transaction has no ALT support, so those flows MUST use the
+ * v0 variant. Existing native_send / spl_send / nonce_init / nonce_close
+ * can stay legacy — they all fit comfortably under the 35-account legacy
+ * limit.
  */
-export interface SolanaTxDraft {
+export interface SolanaLegacyDraft {
+  kind: "legacy";
   draftTx: Transaction;
   meta: SolanaDraftMeta;
 }
+
+export interface SolanaV0Draft {
+  kind: "v0";
+  payerKey: PublicKey;
+  instructions: TransactionInstruction[];
+  /**
+   * ALT accounts the v0 message references (if any). Empty array is fine —
+   * a v0 message without lookups is still valid and distinguishable from
+   * legacy by the `0x80` version prefix.
+   */
+  addressLookupTableAccounts: AddressLookupTableAccount[];
+  meta: SolanaDraftMeta;
+}
+
+export type SolanaTxDraft = SolanaLegacyDraft | SolanaV0Draft;
 
 interface StoredSolanaTx {
   draft: SolanaTxDraft;
@@ -156,9 +189,26 @@ export function pinSolanaHandle(
         `update meta.nonce.value to the same string before calling pin.`,
     );
   }
-  const { draftTx } = entry.draft;
-  draftTx.recentBlockhash = freshBlockhash;
-  const messageBytes = draftTx.serializeMessage();
+
+  // Serialize the message bytes. Legacy and v0 take different paths —
+  // legacy mutates `draftTx.recentBlockhash` then calls `serializeMessage()`;
+  // v0 compiles a fresh MessageV0 with the blockhash/nonce baked in and
+  // then calls `serialize()`. Either way the downstream consumer (Ledger
+  // signer, broadcast path) sees an opaque `messageBase64` and doesn't
+  // need to care which version produced it.
+  let messageBytes: Buffer;
+  if (entry.draft.kind === "legacy") {
+    entry.draft.draftTx.recentBlockhash = freshBlockhash;
+    messageBytes = entry.draft.draftTx.serializeMessage();
+  } else {
+    const msg = MessageV0.compile({
+      payerKey: entry.draft.payerKey,
+      instructions: entry.draft.instructions,
+      recentBlockhash: freshBlockhash,
+      addressLookupTableAccounts: entry.draft.addressLookupTableAccounts,
+    });
+    messageBytes = Buffer.from(msg.serialize());
+  }
   const messageBase64 = messageBytes.toString("base64");
 
   const pinnedBase: UnsignedSolanaTx = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -667,7 +667,7 @@ export interface UnsignedSolanaTx {
    * - `nonce_close` — teardown: nonceAdvance + nonceWithdraw. Drains the
    *   rent-exempt balance back to the user's main wallet.
    */
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close";
+  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/solana-jupiter.test.ts
+++ b/test/solana-jupiter.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+/**
+ * Jupiter swap tests — mock the lite-api.jup.ag HTTP API via global fetch,
+ * plus the Solana RPC connection (ALT fetch, nonce-account presence). Every
+ * path-level concern is covered: quote formatting, instruction composition
+ * with nonceAdvance prepended, ALT resolution, error paths.
+ */
+
+// Canonical mainnet mints (from src/config/solana.ts SOLANA_TOKENS).
+const WSOL = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+// Mock the ALT resolver — we don't care about the Connection-level fetch
+// in these tests; we just want to verify `buildJupiterSwap` hands the
+// addressLookupTableAddresses through to the resolver and stashes the
+// resolved accounts on the draft.
+const resolveAltMock = vi.fn();
+vi.mock("../src/modules/solana/alt.js", () => ({
+  resolveAddressLookupTables: (...args: unknown[]) => resolveAltMock(...args),
+  clearAltCache: () => {},
+  invalidateAlt: () => {},
+}));
+
+// Mock the nonce-account lookup — Jupiter builder calls this in its preflight.
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    authority: new PublicKey(WALLET),
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  resolveAltMock.mockReset();
+  resolveAltMock.mockResolvedValue([]); // default: no ALTs resolved
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Minimal well-formed Jupiter /quote response (per their OpenAPI spec). */
+const SAMPLE_QUOTE = {
+  inputMint: WSOL,
+  inAmount: "1000000000", // 1 SOL (9 decimals)
+  outputMint: USDC_MINT,
+  outAmount: "170000000", // 170 USDC (6 decimals)
+  otherAmountThreshold: "169150000", // ~0.5% slippage
+  swapMode: "ExactIn",
+  slippageBps: 50,
+  priceImpactPct: "0.0001",
+  routePlan: [
+    {
+      swapInfo: {
+        ammKey: "HXpGFJGCEEFdV31tDmjDBaJMEB1fKLiAoKoWr3Fnonid",
+        label: "Meteora DLMM",
+        inputMint: WSOL,
+        outputMint: USDC_MINT,
+        inAmount: "1000000000",
+        outAmount: "170000000",
+      },
+      percent: 100,
+    },
+  ],
+  contextSlot: 324307186,
+  timeTaken: 0.012,
+};
+
+describe("getJupiterQuote", () => {
+  it("hits lite-api.jup.ag/swap/v1/quote with the right params and surfaces human fields for known mints", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    const { quote, human } = await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("https://lite-api.jup.ag/swap/v1/quote?");
+    expect(url).toContain(`inputMint=${WSOL}`);
+    expect(url).toContain(`outputMint=${USDC_MINT}`);
+    expect(url).toContain("amount=1000000000");
+    expect(url).toContain("slippageBps=50");
+    expect(url).toContain("swapMode=ExactIn");
+    // maxAccounts cap keeps v0 txs under the 1232-byte packet ceiling.
+    expect(url).toContain("maxAccounts=40");
+
+    // Raw quote passed through verbatim (we need to pass it back to /swap).
+    expect(quote.inputMint).toBe(WSOL);
+    expect(quote.outputMint).toBe(USDC_MINT);
+    expect(quote.routePlan).toHaveLength(1);
+
+    // Human fields: canonical mint → symbol + decimals.
+    expect(human.inputSymbol).toBe("SOL");
+    expect(human.outputSymbol).toBe("USDC");
+    expect(human.inputAmountHuman).toBe("1"); // 1_000_000_000 lamports = 1 SOL
+    expect(human.outputAmountHuman).toBe("170"); // 170_000_000 micro-USDC = 170 USDC
+    expect(human.minOutputHuman).toBe("169.15");
+    expect(human.routeLabels).toEqual(["Meteora DLMM"]);
+    expect(human.priceImpactPct).toBe("0.0001");
+  });
+
+  it("surfaces the Jupiter error body on HTTP failure", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => '{"error":"Invalid mint"}',
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await expect(
+      getJupiterQuote({
+        inputMint: WSOL,
+        outputMint: USDC_MINT,
+        amount: "1000000000",
+        slippageBps: 50,
+      }),
+    ).rejects.toThrow(/Jupiter \/quote failed \(HTTP 400\):.*Invalid mint/);
+  });
+});
+
+describe("buildJupiterSwap", () => {
+  it("refuses with the shared 'nonce init required' error when the wallet has no nonce account", async () => {
+    await setNonceMissing();
+    const { buildJupiterSwap } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await expect(
+      buildJupiterSwap({ wallet: WALLET, quote: SAMPLE_QUOTE as never }),
+    ).rejects.toThrow(/prepare_solana_nonce_init first/);
+  });
+
+  it("composes the v0 ix list with nonceAdvance first + resolves ALTs + stashes everything on a v0 draft", async () => {
+    await setNoncePresent();
+    // Jupiter /swap-instructions response — one compute-budget ix, one
+    // setup (ATA create), one swap, one cleanup (unwrap WSOL), plus one
+    // ALT address.
+    const jupResponse = {
+      computeBudgetInstructions: [
+        {
+          programId: "ComputeBudget111111111111111111111111111111",
+          accounts: [],
+          data: Buffer.from([0x02, 0x10, 0x27, 0x00, 0x00]).toString("base64"),
+        },
+      ],
+      setupInstructions: [
+        {
+          programId: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          accounts: [
+            { pubkey: WALLET, isSigner: true, isWritable: true },
+          ],
+          data: "",
+        },
+      ],
+      swapInstruction: {
+        programId: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+        accounts: [
+          { pubkey: WALLET, isSigner: true, isWritable: true },
+        ],
+        data: Buffer.from([0xe5, 0x17]).toString("base64"),
+      },
+      cleanupInstruction: {
+        programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        accounts: [
+          { pubkey: WALLET, isSigner: true, isWritable: true },
+        ],
+        data: Buffer.from([0x09]).toString("base64"),
+      },
+      otherInstructions: [],
+      addressLookupTableAddresses: [
+        "GxS6FiQ9RbErBB48mE34U4Jv13MdEJov4R1e5KgFzRFY",
+      ],
+    };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => jupResponse,
+    });
+    resolveAltMock.mockResolvedValueOnce([
+      // Opaque AddressLookupTableAccount stand-in; Milestone A's v0 pin
+      // is what actually consumes it, and that path is covered in
+      // test/solana-v0-alt.test.ts.
+      { key: new PublicKey("GxS6FiQ9RbErBB48mE34U4Jv13MdEJov4R1e5KgFzRFY") },
+    ]);
+
+    const { buildJupiterSwap } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    const prepared = await buildJupiterSwap({
+      wallet: WALLET,
+      quote: SAMPLE_QUOTE as never,
+    });
+
+    // Confirm /swap-instructions was called with useSharedAccounts + wrap +
+    // dynamicComputeUnitLimit (the three defaults that matter for this path).
+    const [url, req] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://lite-api.jup.ag/swap/v1/swap-instructions");
+    expect(req.method).toBe("POST");
+    const body = JSON.parse(req.body as string);
+    expect(body.userPublicKey).toBe(WALLET);
+    expect(body.useSharedAccounts).toBe(true);
+    expect(body.wrapAndUnwrapSol).toBe(true);
+    expect(body.dynamicComputeUnitLimit).toBe(true);
+    // The quote object is echoed verbatim so Jupiter can verify its own
+    // signature over it.
+    expect(body.quoteResponse).toEqual(SAMPLE_QUOTE);
+
+    // ALT resolver was called with the one ALT Jupiter returned.
+    expect(resolveAltMock).toHaveBeenCalledTimes(1);
+    const altArg = resolveAltMock.mock.calls[0][1] as PublicKey[];
+    expect(altArg).toHaveLength(1);
+    expect(altArg[0].toBase58()).toBe(
+      "GxS6FiQ9RbErBB48mE34U4Jv13MdEJov4R1e5KgFzRFY",
+    );
+
+    // Prepared shape — action, description, decoded.args, nonceAccount.
+    expect(prepared.action).toBe("jupiter_swap");
+    expect(prepared.chain).toBe("solana");
+    expect(prepared.from).toBe(WALLET);
+    expect(prepared.description).toContain("via Jupiter");
+    expect(prepared.description).toContain("Meteora DLMM");
+    expect(prepared.description).toContain("50 bps");
+    expect(prepared.decoded.functionName).toBe("solana.jupiter.swap");
+    expect(prepared.decoded.args.inputSymbol).toBe("SOL");
+    expect(prepared.decoded.args.outputSymbol).toBe("USDC");
+    expect(prepared.decoded.args.slippageBps).toBe("50");
+    expect(prepared.decoded.args.route).toBe("Meteora DLMM");
+    expect(prepared.decoded.args.addressLookupTables).toBe("1");
+    expect(prepared.nonceAccount).toBeDefined();
+
+    // Confirm the draft in the tx-store is a v0 variant with nonceAdvance
+    // first and Jupiter's ix list appended in order.
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    expect(draft.kind).toBe("v0");
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    // ix[0] = nonceAdvance (System Program, tag 04000000).
+    expect(draft.instructions[0].programId.toBase58()).toBe(
+      "11111111111111111111111111111111",
+    );
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+    // ix[1] = Jupiter's compute-budget ix (we passed it as ComputeBudget111).
+    expect(draft.instructions[1].programId.toBase58()).toBe(
+      "ComputeBudget111111111111111111111111111111",
+    );
+    // ix[2] = setup ATA (ATokenGP...knL).
+    expect(draft.instructions[2].programId.toBase58()).toBe(
+      "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    );
+    // ix[3] = Jupiter swap ix (JUP6Lk...V4).
+    expect(draft.instructions[3].programId.toBase58()).toBe(
+      "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+    );
+    // ix[4] = cleanup (SPL Token — unwrap WSOL or similar).
+    expect(draft.instructions[4].programId.toBase58()).toBe(
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    );
+    // ALTs stashed on the draft for the v0 pin to consume.
+    expect(draft.addressLookupTableAccounts).toHaveLength(1);
+    // Nonce meta survives for pinSolanaHandle's consistency guard.
+    expect(draft.meta.nonce?.account).toBe(prepared.nonceAccount);
+    expect(draft.meta.nonce?.authority).toBe(WALLET);
+  });
+
+  it("surfaces the Jupiter error body on /swap-instructions HTTP failure", async () => {
+    await setNoncePresent();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "upstream router error",
+    });
+    const { buildJupiterSwap } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await expect(
+      buildJupiterSwap({ wallet: WALLET, quote: SAMPLE_QUOTE as never }),
+    ).rejects.toThrow(
+      /Jupiter \/swap-instructions failed \(HTTP 500\):.*upstream router error/,
+    );
+  });
+});
+
+describe("renderSolanaAgentTaskBlock — jupiter_swap handling", () => {
+  it("treats Jupiter as a blind-sign action (Message Hash on-device, CHECK 2 runs)", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const { solanaLedgerMessageHash } = await import(
+      "../src/signing/verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "jupiter_swap" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description: "Swap 1 SOL → 170 USDC via Jupiter (Meteora DLMM)",
+      decoded: {
+        functionName: "solana.jupiter.swap",
+        args: { inputSymbol: "SOL", outputSymbol: "USDC" },
+      },
+      nonce: {
+        account: "NonceAcct1",
+        authority: WALLET,
+        value: "Gfnhk",
+      },
+    };
+    const expectedHash = solanaLedgerMessageHash(tx.messageBase64);
+    const block = renderSolanaAgentTaskBlock(tx);
+    // Blind-sign branch on on-device line.
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain("Jupiter routing");
+    expect(block).toContain(`**\`${expectedHash}\`**`);
+    expect(block).toContain("Allow blind signing");
+    // CHECK 2 (pair-consistency hash) runs for blind-sign.
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    // Summary shape mentions Jupiter + route.
+    expect(block).toContain("via Jupiter");
+    // DURABLE-NONCE MODE explainer (Jupiter uses nonceAdvance too).
+    expect(block).toContain("DURABLE-NONCE MODE");
+    expect(block).toContain("Nonce:");
+  });
+});

--- a/test/solana-ledger-hash.test.ts
+++ b/test/solana-ledger-hash.test.ts
@@ -209,24 +209,36 @@ describe("renderSolanaAgentTaskBlock", () => {
     expect(block).not.toContain("--input-type=module -e");
     expect(block).not.toMatch(/MSG_B64=/);
     expect(block).not.toMatch(/process\.env\.MSG_B64/);
-    // Combined script: imports BOTH Message (for decode) and PublicKey
-    // (for hash base58).
-    expect(block).toMatch(/node -e "const \{Message, PublicKey\} = require\('@solana\/web3\.js'\);/);
+    // Combined script: imports Message + VersionedMessage + PublicKey +
+    // Connection. Version branching added in Milestone A (Phase 3) so the
+    // same script handles legacy (SPL sends, native sends, nonce_close) AND
+    // v0 messages with ALT-indexed accounts (Jupiter swaps, Kamino/MarginFi
+    // flows that need ALTs).
+    expect(block).toMatch(
+      /node -e "const \{Message, VersionedMessage, PublicKey, Connection\} = require\('@solana\/web3\.js'\);/,
+    );
     expect(block).toContain(
       "const m = '<messageBase64 from the preview_solana_send result>';",
     );
+    // Version detection: 0x80 prefix = v0, otherwise legacy.
+    expect(block).toContain("if (buf[0] & 0x80) {");
+    // Legacy branch uses Message.from; v0 branch uses VersionedMessage.deserialize.
     expect(block).toContain("const msg = Message.from(buf);");
-    // Inline base58→hex helper (one line, recognizable arithmetic — same
-    // pattern flavor as EVM's inline fee-cost math).
+    expect(block).toContain("const msg = VersionedMessage.deserialize(buf);");
+    // v0 branch resolves ALTs via a Connection.
+    expect(block).toContain("conn.getAddressLookupTable(lookup.accountKey)");
+    // Inline base58→hex helper (for legacy data field, which is base58).
     expect(block).toContain(
       "const A = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';",
     );
     expect(block).toContain("const b58 = s =>");
+    // v0 data is already a byte array; no base58 decode needed.
+    expect(block).toContain("Buffer.from(ix.data).toString('hex')");
     // Output: BOTH ledgerHash AND instructions[] — single JSON.
     expect(block).toContain(
-      "ledgerHash: new PublicKey(createHash('sha256').update(buf).digest()).toBase58()",
+      "const ledgerHash = new PublicKey(createHash('sha256').update(buf).digest()).toBase58();",
     );
-    expect(block).toContain("instructions: msg.instructions.map(ix => ({");
+    expect(block).toContain("console.log(JSON.stringify({ledgerHash, instructions}, null, 2));");
     expect(block).toContain("programId: msg.accountKeys[ix.programIdIndex].toBase58()");
     expect(block).toContain("dataHex: b58(ix.data)");
     // CHECK 1 verdict is now {✓|✗|⚠} (agent-determined), NOT permanent ⚠.

--- a/test/solana-v0-alt.test.ts
+++ b/test/solana-v0-alt.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  AddressLookupTableAccount,
+  Connection,
+  Keypair,
+  MessageV0,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  VersionedMessage,
+} from "@solana/web3.js";
+import {
+  issueSolanaDraftHandle,
+  pinSolanaHandle,
+  retireSolanaHandle,
+  type SolanaV0Draft,
+  type SolanaDraftMeta,
+} from "../src/signing/solana-tx-store.js";
+import {
+  resolveAddressLookupTables,
+  clearAltCache,
+} from "../src/modules/solana/alt.js";
+import { solanaLedgerMessageHash } from "../src/signing/verification.js";
+
+/**
+ * Milestone A: v0 + ALT foundation. Tests that
+ *   (1) the draft store's discriminated union round-trips v0 drafts through
+ *       `issueSolanaDraftHandle` → `pinSolanaHandle`,
+ *   (2) the resulting bytes are a well-formed VersionedMessage (first byte
+ *       0x80, VersionedMessage.deserialize accepts),
+ *   (3) `meta.nonce.value` still drives the blockhash/nonce field for v0,
+ *   (4) the ALT resolver fetches + caches per-process, and throws cleanly
+ *       when an ALT is missing,
+ *   (5) `solanaLedgerMessageHash` is message-version-agnostic — sha256 over
+ *       raw bytes, unchanged by v0.
+ */
+
+const WALLET = Keypair.generate().publicKey;
+
+function sampleV0Ix(to: PublicKey): TransactionInstruction {
+  return SystemProgram.transfer({
+    fromPubkey: WALLET,
+    toPubkey: to,
+    lamports: 1,
+  });
+}
+
+function sampleMeta(nonceValue: string): SolanaDraftMeta {
+  return {
+    action: "native_send",
+    from: WALLET.toBase58(),
+    description: "v0 draft round-trip",
+    decoded: {
+      functionName: "solana.system.transfer",
+      args: { amount: "1 lamport" },
+    },
+    nonce: {
+      account: Keypair.generate().publicKey.toBase58(),
+      authority: WALLET.toBase58(),
+      value: nonceValue,
+    },
+  };
+}
+
+describe("v0 draft pin path", () => {
+  const nonceValue = "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
+
+  it("pins a v0 draft and produces a VersionedMessage (0x80 prefix) that round-trips via VersionedMessage.deserialize", () => {
+    const recipient = Keypair.generate().publicKey;
+    const draft: SolanaV0Draft = {
+      kind: "v0",
+      payerKey: WALLET,
+      instructions: [sampleV0Ix(recipient)],
+      addressLookupTableAccounts: [],
+      meta: sampleMeta(nonceValue),
+    };
+    const { handle } = issueSolanaDraftHandle(draft);
+    const pinned = pinSolanaHandle(handle, nonceValue);
+    const bytes = Buffer.from(pinned.messageBase64, "base64");
+    // 0x80 = v0 prefix; 0x00 = legacy (unset). The high bit is the marker.
+    expect(bytes[0] & 0x80).toBe(0x80);
+    // Round-trip via VersionedMessage.deserialize — must succeed and carry
+    // the same blockhash we pinned.
+    const reparsed = VersionedMessage.deserialize(bytes);
+    expect(reparsed.version).toBe(0);
+    expect(reparsed.recentBlockhash).toBe(nonceValue);
+    // Static account keys include our wallet + recipient + system program.
+    const staticKeys = (reparsed as MessageV0).staticAccountKeys.map((k) =>
+      k.toBase58(),
+    );
+    expect(staticKeys).toContain(WALLET.toBase58());
+    expect(staticKeys).toContain(recipient.toBase58());
+    retireSolanaHandle(handle);
+  });
+
+  it("refuses to pin a v0 draft when meta.nonce.value disagrees with freshBlockhash (consistency guard)", () => {
+    const draft: SolanaV0Draft = {
+      kind: "v0",
+      payerKey: WALLET,
+      instructions: [sampleV0Ix(Keypair.generate().publicKey)],
+      addressLookupTableAccounts: [],
+      meta: sampleMeta(nonceValue),
+    };
+    const { handle } = issueSolanaDraftHandle(draft);
+    // Pass a different value — the guard (same logic as legacy) must fire.
+    expect(() =>
+      pinSolanaHandle(
+        handle,
+        "7kL9TYNkpYYvECe6pTqFE3B6PGsoRftgC6YJ7Lm1XgYs",
+      ),
+    ).toThrow(/pinSolanaHandle consistency check failed/);
+    retireSolanaHandle(handle);
+  });
+
+  it("solanaLedgerMessageHash is message-version-agnostic — sha256(bytes)→base58 is identical for v0 and legacy", () => {
+    // The Ledger Solana app hashes exactly what it receives; the version
+    // prefix is part of the signed bytes. Sanity-check that our server-side
+    // hash function isn't accidentally legacy-specific.
+    const v0Bytes = Buffer.from([0x80, 0x01, 0x02, 0x03]);
+    const legacyBytes = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+    const v0Hash = solanaLedgerMessageHash(v0Bytes.toString("base64"));
+    const legacyHash = solanaLedgerMessageHash(legacyBytes.toString("base64"));
+    // Both are valid base58 pubkey-length strings (32-byte sha256 → base58).
+    expect(v0Hash).toMatch(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/);
+    expect(legacyHash).toMatch(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/);
+    expect(v0Hash).not.toBe(legacyHash);
+  });
+});
+
+describe("resolveAddressLookupTables", () => {
+  let getAltMock: ReturnType<typeof vi.fn>;
+  let connStub: Connection;
+
+  beforeEach(() => {
+    getAltMock = vi.fn();
+    connStub = { getAddressLookupTable: getAltMock } as unknown as Connection;
+    clearAltCache();
+  });
+
+  afterEach(() => {
+    clearAltCache();
+  });
+
+  it("fetches each ALT once, caches by pubkey base58, and returns them in request order", async () => {
+    const altA = new PublicKey("3uYn8vWyFNt42zcDiBvUtJEL6dFTAtzRLPMe7jyKmqiA");
+    const altB = new PublicKey("4xvR8Yw1HfZVNbBvF1RxtEnQKDLkzqGMcjbxN9j2pmTL");
+
+    // Mock returns — wrapping in RpcResponseAndContext shape with `value` field.
+    const altAAccount = new AddressLookupTableAccount({
+      key: altA,
+      state: { deactivationSlot: BigInt(0), lastExtendedSlot: 0, lastExtendedSlotStartIndex: 0, authority: undefined, addresses: [] },
+    });
+    const altBAccount = new AddressLookupTableAccount({
+      key: altB,
+      state: { deactivationSlot: BigInt(0), lastExtendedSlot: 0, lastExtendedSlotStartIndex: 0, authority: undefined, addresses: [] },
+    });
+    getAltMock
+      .mockResolvedValueOnce({ value: altAAccount, context: { slot: 1 } })
+      .mockResolvedValueOnce({ value: altBAccount, context: { slot: 1 } });
+
+    const result = await resolveAddressLookupTables(connStub, [altA, altB]);
+    expect(result).toHaveLength(2);
+    expect(result[0].key.toBase58()).toBe(altA.toBase58());
+    expect(result[1].key.toBase58()).toBe(altB.toBase58());
+    expect(getAltMock).toHaveBeenCalledTimes(2);
+
+    // Second call with the same pubkeys hits the cache — NO additional RPC calls.
+    const cached = await resolveAddressLookupTables(connStub, [altA, altB]);
+    expect(cached[0]).toBe(result[0]); // Same object reference — cache hit.
+    expect(getAltMock).toHaveBeenCalledTimes(2); // Unchanged.
+  });
+
+  it("throws a clear error when an ALT doesn't exist on chain (unverifiable tx)", async () => {
+    const missing = new PublicKey("3uYn8vWyFNt42zcDiBvUtJEL6dFTAtzRLPMe7jyKmqiA");
+    getAltMock.mockResolvedValueOnce({ value: null, context: { slot: 1 } });
+
+    await expect(
+      resolveAddressLookupTables(connStub, [missing]),
+    ).rejects.toThrow(/does not exist on chain/);
+  });
+
+  it("is a no-op for an empty ALT list (skips the RPC round-trip)", async () => {
+    const result = await resolveAddressLookupTables(connStub, []);
+    expect(result).toEqual([]);
+    expect(getAltMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/verification-artifact.test.ts
+++ b/test/verification-artifact.test.ts
@@ -187,6 +187,7 @@ describe("get_verification_artifact — second-agent copy-paste artifact", () =>
       },
     };
     const { handle: splHandle } = issueSolanaDraftHandle({
+      kind: "legacy",
       draftTx: splDraftTx,
       meta: splMeta,
     });
@@ -226,6 +227,7 @@ describe("get_verification_artifact — second-agent copy-paste artifact", () =>
       },
     };
     const { handle: nativeHandle } = issueSolanaDraftHandle({
+      kind: "legacy",
       draftTx: nativeDraftTx,
       meta: nativeMeta,
     });


### PR DESCRIPTION
## Summary

Solana Phase 3, first half: foundation for v0 messages + Address Lookup Tables, plus Jupiter swap as the first consumer.

- **Milestone A** — `SolanaTxDraft` becomes a discriminated union (`legacy` vs `v0`). `pinSolanaHandle` branches on `kind`: legacy keeps `tx.serializeMessage()`; v0 uses `MessageV0.compile().serialize()`. New `src/modules/solana/alt.ts` resolves ALTs through a per-process cache. The inline CHECK 1 + CHECK 2 verifier script detects message version via `buf[0] & 0x80` and flattens ALT-indexed accounts back to the same base58 list the legacy path emits.
- **Milestone B** — `src/modules/solana/jupiter.ts` builds quotes + swap transactions against [lite-api.jup.ag/swap/v1](https://lite-api.jup.ag/swap/v1) (`/quote` + `/swap-instructions`). Composes `[nonceAdvance, ...computeBudget, ...setup, swap, cleanup, ...other]` so the tx stays durable-nonce-protected during on-device review. Two new tools: `get_solana_swap_quote` (read-only route preview) and `prepare_solana_swap` (builds the draft, action `jupiter_swap`, BLIND-SIGN path).

## Out of scope — deferred to follow-up sessions

- **MarginFi lending** — scope-probed during this session; SDK's high-level `createMarginfiAccount` requires an ephemeral `Keypair` as signer (Ledger-incompatible). The IDL exposes `marginfi_account_initialize_pda` which is Ledger-compatible but not wrapped by the SDK; next session drops to `@coral-xyz/anchor` codegen. Plan's "Next-session notes" section captures the implementation caveats.
- **Kamino lending** — uses `@solana/kit` (not `@solana/web3.js` v1), plus obligation lifecycle + Scope oracle refresh + elevation groups + multi-tx returns. Needs its own plan cycle (type-bridge + multi-tx send pipeline). See the plan's Roadmap section.

## Test plan

- [x] `test/solana-v0-alt.test.ts` — v0 draft round-trip, ALT resolver cache, missing-ALT error
- [x] `test/solana-jupiter.test.ts` — quote HTTP shape, nonce-missing preflight, full build ix composition, render-verification Jupiter branch
- [x] `test/solana-ledger-hash.test.ts` + `test/verification-artifact.test.ts` regression fixups (new draft shape + v0-aware verifier)
- [ ] Devnet v0 dry-run with Jupiter (small SOL → USDC)
- [ ] Mainnet Jupiter swap (0.01 SOL → USDC) end-to-end with Ledger — confirm CHECK 1 names Jupiter v6, CHECK 2 hash matches on-device "Message Hash"

🤖 Generated with [Claude Code](https://claude.com/claude-code)