### PR TITLE
feat(solana): phase 3 C+D — MarginFi lending + portfolio integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.3.tgz",
-      "integrity": "sha512-rap58Wh1qbRnGpPGwB60P6rvKF6G+mgo1kPeDySWIAcqkGMjuyQdrZPcHS6w7mKOT8i/f1UQmjow6+7vfuEXKw==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
+      "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
       "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
@@ -99,24 +99,6 @@
       "peerDependencies": {
         "bs58": "^6.0.0"
       }
-    },
-    "node_modules/@bigmi/core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@bigmi/core/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "node_modules/@bitcoinerlab/secp256k1": {
       "version": "1.2.0",
@@ -301,9 +283,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -321,9 +303,9 @@
       "optional": true
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -438,9 +420,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -476,13 +458,13 @@
       }
     },
     "node_modules/@ledgerhq/devices": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.13.0.tgz",
-      "integrity": "sha512-hgGn1kpe/rT0EJ0Qs7rG+1TXA4g6HN2t3dB4DndRTqVqC9aSSbME+ajA0QWLZisxOD3zkwvO4Q0mJ2zARAKyag==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.1.tgz",
+      "integrity": "sha512-q6tOUO963tFPrsJtdzu5juC8xIAIRe6etLSZ+ZhwgUivTHNJbmFFBxMU3p19dwn8VaKRvbw0pxJv+qmokMYpRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/errors": "^6.34.0",
+        "@ledgerhq/logs": "^6.17.0",
         "rxjs": "7.8.2",
         "semver": "7.7.3"
       }
@@ -504,19 +486,16 @@
         "bip32-path": "^0.4.2"
       }
     },
-    "node_modules/@ledgerhq/hw-app-solana/node_modules/@ledgerhq/devices": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.1.tgz",
-      "integrity": "sha512-q6tOUO963tFPrsJtdzu5juC8xIAIRe6etLSZ+ZhwgUivTHNJbmFFBxMU3p19dwn8VaKRvbw0pxJv+qmokMYpRA==",
+    "node_modules/@ledgerhq/hw-app-trx": {
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-trx/-/hw-app-trx-6.36.0.tgz",
+      "integrity": "sha512-/ade9QURbYUJGhtK7VnceNzhQDYy0b1XSI3gMiLlRFwi/L6roBXfZIt272Yul6NiGf45KuNCVHfOW28chcevLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.34.0",
-        "@ledgerhq/logs": "^6.17.0",
-        "rxjs": "7.8.2",
-        "semver": "7.7.3"
+        "@ledgerhq/hw-transport": "6.35.1"
       }
     },
-    "node_modules/@ledgerhq/hw-app-solana/node_modules/@ledgerhq/hw-transport": {
+    "node_modules/@ledgerhq/hw-transport": {
       "version": "6.35.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.1.tgz",
       "integrity": "sha512-YCkk9koo0FzCzHvLVpdrQ3+EQOPMpp/fSednHhk7AiaJC/c+pX6wKevUDp1MLcq7gUHbVOXyYYpqoW6A97w8OA==",
@@ -528,53 +507,32 @@
         "events": "^3.3.0"
       }
     },
-    "node_modules/@ledgerhq/hw-app-trx": {
-      "version": "6.34.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-trx/-/hw-app-trx-6.34.1.tgz",
-      "integrity": "sha512-kWDF+/UEc5LqRx3p8Raqw+yI006bBUMC+Twfutw3NHHb1L1BPJlddbgXkMSGFvbD+mKUhXQIAXC7QUWgco6gYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/hw-transport": "6.34.1"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.34.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.34.1.tgz",
-      "integrity": "sha512-Bg9Qk2vtm0m0cZn9prZV2Hbvh3b42KBh4uomO00derh+eiwsdg5AXBBptAJiREkew1RVtETRdWxrKchUJfeWvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
-        "events": "^3.3.0"
-      }
-    },
     "node_modules/@ledgerhq/hw-transport-node-hid": {
-      "version": "6.32.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.32.1.tgz",
-      "integrity": "sha512-P/X420k+OBbmE1p1fn8LMXL8/SeBA+IyqFxLhdtU2pExb6UBasRrrfpac70kFhoiWbq0LeiwMNJC0FPUvWiuwQ==",
+      "version": "6.33.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.33.1.tgz",
+      "integrity": "sha512-kHcbs1574aBE3yhi2sgQkcApDcArSwHlkJKaemCbsj//1VbEHs6jC9kfbfBSssQ6mSWl2ZSaBqjiCiNiXGqR7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/hw-transport": "6.34.1",
-        "@ledgerhq/hw-transport-node-hid-noevents": "^6.34.0",
-        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/devices": "8.14.1",
+        "@ledgerhq/errors": "^6.34.0",
+        "@ledgerhq/hw-transport": "6.35.1",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^6.35.1",
+        "@ledgerhq/logs": "^6.17.0",
         "lodash": "^4.17.21",
         "node-hid": "2.1.2",
         "usb": "2.9.0"
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.34.0.tgz",
-      "integrity": "sha512-aW8iGvpcxw02aaxRJ2IiAGhEvt82ouL08culAfaIGjO+xqvvN6x1D4K1CZAHG50i8feuaq+YF+asd4l8H1ufYA==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.35.1.tgz",
+      "integrity": "sha512-3NVgVYiACSXh1S1lgRjogNloF4Bewllv/nDydv8/Nc0DrnXJSGPNC+anl0ZR3cVo5Rg+iuZ1AvUKJFtmQZtt1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/hw-transport": "6.34.1",
-        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/devices": "8.14.1",
+        "@ledgerhq/errors": "^6.34.0",
+        "@ledgerhq/hw-transport": "6.35.1",
+        "@ledgerhq/logs": "^6.17.0",
         "node-hid": "2.1.2"
       }
     },
@@ -607,33 +565,6 @@
         "@solana/wallet-adapter-base": "^0.9.0",
         "@solana/web3.js": "^1.98.0",
         "viem": "^2.21.0"
-      }
-    },
-    "node_modules/@lifi/sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@lifi/sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@lifi/types": {
@@ -726,12 +657,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/borsh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
-      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
@@ -739,15 +664,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/superstruct": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@mrgnlabs/mrgn-common": {
@@ -766,65 +682,6 @@
         "decimal.js": "^10.4.3",
         "numeral": "^2.0.6",
         "superstruct": "^1.0.4"
-      }
-    },
-    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
-      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "@noble/curves": "^1.4.2",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.1",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^2.0.2"
-      }
-    },
-    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js/node_modules/superstruct": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
-      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@mrgnlabs/mrgn-common/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@mrgnlabs/mrgn-common/node_modules/superstruct": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@msgpack/msgpack": {
@@ -887,18 +744,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@mysten/sui/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@mysten/utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.2.0.tgz",
@@ -919,9 +764,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -950,12 +795,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
-      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.0"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -977,9 +822,9 @@
       "license": "MIT"
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
-      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -989,9 +834,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1306,9 +1151,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -1323,9 +1168,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -1340,9 +1185,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -1357,9 +1202,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -1374,9 +1219,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -1391,9 +1236,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1408,9 +1253,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -1425,9 +1270,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1442,9 +1287,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -1459,9 +1304,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -1476,9 +1321,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1493,9 +1338,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1510,9 +1355,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1520,18 +1365,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1546,9 +1391,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1563,9 +1408,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1592,33 +1437,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@scure/bip39": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
@@ -1627,18 +1445,6 @@
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1688,18 +1494,15 @@
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
-      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.3.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
+        "@solana/errors": "2.0.0-rc.1"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5"
       }
     },
     "node_modules/@solana/codecs-data-structures": {
@@ -1716,19 +1519,7 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-numbers": {
+    "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
       "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
@@ -1739,47 +1530,6 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-data-structures/node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-data-structures/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@solana/codecs-numbers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
-      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.3.0",
-        "@solana/errors": "2.3.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.3.3"
       }
     },
     "node_modules/@solana/codecs-strings": {
@@ -1797,123 +1547,20 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-strings/node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs-strings/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs/node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/codecs/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@solana/errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
-      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^14.0.0"
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
       },
-      "engines": {
-        "node": ">=20.18.0"
-      },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5"
       }
     },
     "node_modules/@solana/options": {
@@ -1930,56 +1577,6 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/options/node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/options/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -2085,6 +1682,56 @@
         "superstruct": "^2.0.2"
       }
     },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
     "node_modules/@solana/web3.js/node_modules/base-x": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -2094,6 +1741,17 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
     "node_modules/@solana/web3.js/node_modules/bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -2101,6 +1759,24 @@
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2177,36 +1853,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@switchboard-xyz/on-demand/node_modules/isomorphic-ws": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
-    "node_modules/@switchboard-xyz/on-demand/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2300,16 +1946,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2318,13 +1964,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2345,9 +1991,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2358,13 +2004,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2372,14 +2018,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2388,9 +2034,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2398,13 +2044,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2600,6 +2246,42 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@walletconnect/keyvaluestorage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
@@ -2649,6 +2331,33 @@
         "@walletconnect/safe-json": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
         "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@walletconnect/safe-json": {
@@ -2727,33 +2436,6 @@
         "uint8arrays": "3.1.1"
       }
     },
-    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
@@ -2790,9 +2472,9 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
-      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
@@ -3132,33 +2814,10 @@
       }
     },
     "node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/borsh/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/borsh/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
+      "license": "Apache-2.0"
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -3412,12 +3071,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -3840,9 +3499,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/events": {
@@ -3867,9 +3526,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3938,9 +3597,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
+      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -4335,9 +3994,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4533,9 +4192,9 @@
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -4594,6 +4253,51 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jito-ts": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jito-ts/-/jito-ts-3.0.1.tgz",
@@ -4608,108 +4312,6 @@
         "jayson": "^4.0.0",
         "node-fetch": "^2.6.7",
         "superstruct": "^1.0.3"
-      }
-    },
-    "node_modules/jito-ts/node_modules/@solana/web3.js": {
-      "version": "1.77.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.4.tgz",
-      "integrity": "sha512-XdN0Lh4jdY7J8FYMyucxCwzn6Ga2Sr1DHDWRbqVzk7ZPmmpSPOVWHzO67X1cVT+jNi1D6gZi2tgjHgDPuj6e9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.0",
-        "@solana/buffer-layout": "^4.0.0",
-        "agentkeepalive": "^4.2.1",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.0.0",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.0",
-        "node-fetch": "^2.6.7",
-        "rpc-websockets": "^7.5.1",
-        "superstruct": "^0.14.2"
-      }
-    },
-    "node_modules/jito-ts/node_modules/@solana/web3.js/node_modules/superstruct": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
-      "license": "MIT"
-    },
-    "node_modules/jito-ts/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jito-ts/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/jito-ts/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
-    "node_modules/jito-ts/node_modules/rpc-websockets": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "uuid": "^8.3.2",
-        "ws": "^8.5.0"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/kozjak"
-      },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      }
-    },
-    "node_modules/jito-ts/node_modules/superstruct": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/jito-ts/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/jose": {
@@ -5111,9 +4713,9 @@
       "license": "0BSD"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5529,17 +5131,11 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/pako": {
       "version": "2.1.0",
@@ -5701,9 +5297,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -5957,14 +5553,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5973,21 +5569,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -6036,41 +5632,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/utf-8-validate": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
-      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/rxjs": {
@@ -6426,9 +5987,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6492,9 +6053,9 @@
       }
     },
     "node_modules/superstruct": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
-      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6892,9 +6453,9 @@
       "license": "MIT"
     },
     "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6966,9 +6527,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.12",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.12.tgz",
-      "integrity": "sha512-tz3CBeGUMU357aZqzlHskgAiEoC3k0/PuEwBSOxh4EQ3uuNr4GJ2Gc67ArNYmdm4MVTVL+rsRdKYoqbloUva6g==",
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
+      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
       "funding": [
         {
           "type": "github",
@@ -6983,7 +6544,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.13",
+        "ox": "0.14.20",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -7010,22 +6571,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.14.13",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.13.tgz",
-      "integrity": "sha512-N3slDyEUq3qGw/53Xd8YZPZD7NUbbiOJDeWKvQ1ElNo2mFjjz6cV2TIbGenHw7k5ATcefDQh42dwUWoGtxU9Hg==",
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
       "funding": [
         {
           "type": "github",
@@ -7074,17 +6650,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7165,19 +6741,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -7205,12 +6781,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7339,16 +6915,16 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ledgerhq/hw-transport-node-hid": "^6.32.1",
         "@lifi/sdk": "^3.16.3",
         "@modelcontextprotocol/sdk": "^1.0.4",
+        "@mrgnlabs/marginfi-client-v2": "^6.4.1",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
         "@walletconnect/sign-client": "^2.17.0",
@@ -126,6 +127,179 @@
         "@noble/curves": "^1.7.0"
       }
     },
+    "node_modules/@coral-xyz/anchor": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.30.1.tgz",
+      "integrity": "sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/anchor-errors": "^0.30.1",
+        "@coral-xyz/borsh": "^0.30.1",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.68.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31": {
+      "name": "@coral-xyz/anchor",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.31.1.tgz",
+      "integrity": "sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/anchor-errors": "^0.31.1",
+        "@coral-xyz/borsh": "^0.31.1",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.69.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=17"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/@coral-xyz/anchor-errors": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz",
+      "integrity": "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/@coral-xyz/borsh": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.31.1.tgz",
+      "integrity": "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.69.0"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/anchor-31/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/anchor-errors": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz",
+      "integrity": "sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.30.1.tgz",
+      "integrity": "sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -232,6 +406,37 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -244,12 +449,31 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/@ledgerhq/devices": {
       "version": "8.13.0",
@@ -461,6 +685,148 @@
         }
       }
     },
+    "node_modules/@mrgnlabs/marginfi-client-v2": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mrgnlabs/marginfi-client-v2/-/marginfi-client-v2-6.4.1.tgz",
+      "integrity": "sha512-tLsdgntluUK4qUlwWNPMw35x23VUSmdMH9zT/i2/bs9+f8ai3JM3zUA1GiMoDW5EhkOi92IKBi9oDlL36k7Pwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.30.1",
+        "@coral-xyz/borsh": "^0.30.1",
+        "@mrgnlabs/mrgn-common": "2.0.7",
+        "@pythnetwork/pyth-solana-receiver": "^0.8.0",
+        "@solana/spl-token": "^0.1.8",
+        "@solana/wallet-adapter-base": "^0.9.23",
+        "@solana/web3.js": "^1.93.2",
+        "@switchboard-xyz/common": "^4.1.0",
+        "@switchboard-xyz/on-demand": "2.14.4",
+        "bignumber.js": "^9.1.2",
+        "bn.js": "^5.2.1",
+        "borsh": "^2.0.0",
+        "bs58": "^6.0.0",
+        "crypto-hash": "^3.1.0",
+        "decimal.js": "^10.4.3",
+        "superstruct": "^1.0.4"
+      }
+    },
+    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/@solana/spl-token": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
+      "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@solana/web3.js": "^1.21.0",
+        "bn.js": "^5.1.0",
+        "buffer": "6.0.3",
+        "buffer-layout": "^1.2.0",
+        "dotenv": "10.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mrgnlabs/marginfi-client-v2/node_modules/superstruct": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mrgnlabs/mrgn-common/-/mrgn-common-2.0.7.tgz",
+      "integrity": "sha512-sSB9jGgRJISBKG5Fh2SL7Ltn85FCnp74Hxoo8TrMq2FYsrh+mZQfEQW82CVVy939EDL8EHNpxqoDb/nlD0VGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.30.1",
+        "@solana/buffer-layout": "4.0.1",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/wallet-adapter-base": "^0.9.23",
+        "@solana/web3.js": "1.98.0",
+        "bignumber.js": "^9.1.2",
+        "bs58": "^6.0.0",
+        "decimal.js": "^10.4.3",
+        "numeral": "^2.0.6",
+        "superstruct": "^1.0.4"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common/node_modules/@solana/web3.js/node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@mrgnlabs/mrgn-common/node_modules/superstruct": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
@@ -598,6 +964,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.5.tgz",
+      "integrity": "sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@noble/hashes": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
@@ -644,6 +1022,288 @@
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@pythnetwork/price-service-sdk": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/price-service-sdk/-/price-service-sdk-1.9.0.tgz",
+      "integrity": "sha512-DX8N4VUqllyervqnCx/Z6Tjz130EcoczYYa96F1YjlbZf0rFyU8VCzX1yAf60q+b8EVcVFVeSkdzJTZD3n6+jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-solana-receiver/-/pyth-solana-receiver-0.8.2.tgz",
+      "integrity": "sha512-WrrdwwhSYvvB5vJEL+SfPnfuxgkRKMeKdZvGFFwe6ENrMhrQCM05oDkvNNYfXATLcpQGRAyBu9l1xIxUxixpqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.29.0",
+        "@noble/hashes": "^1.4.0",
+        "@pythnetwork/price-service-sdk": ">=1.6.0",
+        "@pythnetwork/solana-utils": "0.4.2",
+        "@solana/web3.js": "^1.90.0"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/@coral-xyz/anchor": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
+      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.29.0",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.68.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/@coral-xyz/borsh": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@pythnetwork/pyth-solana-receiver/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pythnetwork/solana-utils": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/solana-utils/-/solana-utils-0.4.2.tgz",
+      "integrity": "sha512-hKo7Bcs/kDWA5Fnqhg9zJSB94NMoUDIDjHjSi/uvZOzwizISUQI6oY3LWd2CXzNh4f8djjY2BS5iNHaM4cm8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.29.0",
+        "@solana/web3.js": "^1.90.0",
+        "bs58": "^5.0.0",
+        "jito-ts": "^3.0.1"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/@coral-xyz/anchor": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
+      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.29.0",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.68.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/@coral-xyz/anchor/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/@coral-xyz/anchor/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/@coral-xyz/borsh": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@pythnetwork/solana-utils/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -1465,6 +2125,90 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@switchboard-xyz/common": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-4.1.11.tgz",
+      "integrity": "sha512-zNclN+7Be28qL5dFlScL4qGCPAe/kLUQ7umNsT9+V9WC3jB3uUdYVlzsQzJc3WVYAGn0xc6gKJ0S/XW7NAxhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/web3.js": "^1.98.2",
+        "axios": "^1.9.0",
+        "big.js": "^6.2.2",
+        "bn.js": "^5.2.1",
+        "bs58": "^6.0.0",
+        "buffer": "^6.0.3",
+        "decimal.js": "^10.4.3",
+        "js-sha256": "^0.11.0",
+        "protobufjs": "^7.4.0",
+        "yaml": "^2.6.1",
+        "zod": "4.0.0-beta.20250505T195954"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@switchboard-xyz/common/node_modules/zod": {
+      "version": "4.0.0-beta.20250505T195954",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.0-beta.20250505T195954.tgz",
+      "integrity": "sha512-iB8WvxkobVIXMARvQu20fKvbS7mUTiYRpcD8OQV1xjRhxO0EEpYIRJBk6yfBzHAHEdOSDh3SxDITr5Eajr2vtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zod/core": "0.11.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@switchboard-xyz/on-demand": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-2.14.4.tgz",
+      "integrity": "sha512-+YL0+BUlJXEtX4MHS+1+0CpzS2z5z7moM58FqXixBu8Zm6L/KVZ4K29LHhRUW8sLZ4Lmet/JOLNMVCYDI+F8HQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1",
+        "@isaacs/ttlcache": "^1.4.1",
+        "@switchboard-xyz/common": "^4.0.0",
+        "axios": "^1.9",
+        "bs58": "^6.0.0",
+        "buffer": "^6.0.3",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@switchboard-xyz/on-demand/node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/@switchboard-xyz/on-demand/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2036,6 +2780,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/@zod/core": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.11.6.tgz",
+      "integrity": "sha512-03Bv82fFSfjDAvMfdHHdGSS6SOJs0iCcJlWJv1kJHRtoTT02hZpyip/2Lk6oo4l4FtjuwTrsEQTwg/LD8I7dJA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/abitype": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
@@ -2115,11 +2868,19 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2144,6 +2905,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2154,6 +2921,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2161,6 +2934,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base-x": {
@@ -2194,6 +2978,19 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
       "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
@@ -2419,6 +3216,15 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-layout": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
     "node_modules/bufferutil": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
@@ -2490,6 +3296,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2549,11 +3367,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2566,8 +3397,19 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -2648,6 +3490,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2671,6 +3522,18 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/crypto-hash": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-3.1.0.tgz",
+      "integrity": "sha512-HR8JlZ+Dn54Lc5gGWZJxJitWbOCUzWb9/AlyONGecBnYZ+n/ONvt0gQnEzDNpJMYeRrYO7KogQ4qwyTPKnWKEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2687,6 +3550,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2748,6 +3617,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2778,6 +3656,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2796,6 +3702,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2853,6 +3765,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
@@ -2876,6 +3803,15 @@
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3112,6 +4048,63 @@
         "micromatch": "^4.0.2"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3173,6 +4166,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3310,6 +4312,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3464,6 +4481,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3568,6 +4594,124 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jito-ts": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jito-ts/-/jito-ts-3.0.1.tgz",
+      "integrity": "sha512-TSofF7KqcwyaWGjPaSYC8RDoNBY1TPRNBHdrw24bdIi7mQ5bFEDdYK3D//llw/ml8YDvcZlgd644WxhjLTS9yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.8.13",
+        "@noble/ed25519": "^1.7.1",
+        "@solana/web3.js": "~1.77.3",
+        "agentkeepalive": "^4.3.0",
+        "dotenv": "^16.0.3",
+        "jayson": "^4.0.0",
+        "node-fetch": "^2.6.7",
+        "superstruct": "^1.0.3"
+      }
+    },
+    "node_modules/jito-ts/node_modules/@solana/web3.js": {
+      "version": "1.77.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.4.tgz",
+      "integrity": "sha512-XdN0Lh4jdY7J8FYMyucxCwzn6Ga2Sr1DHDWRbqVzk7ZPmmpSPOVWHzO67X1cVT+jNi1D6gZi2tgjHgDPuj6e9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@noble/curves": "^1.0.0",
+        "@noble/hashes": "^1.3.0",
+        "@solana/buffer-layout": "^4.0.0",
+        "agentkeepalive": "^4.2.1",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.0.0",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.6.7",
+        "rpc-websockets": "^7.5.1",
+        "superstruct": "^0.14.2"
+      }
+    },
+    "node_modules/jito-ts/node_modules/@solana/web3.js/node_modules/superstruct": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
+      "license": "MIT"
+    },
+    "node_modules/jito-ts/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jito-ts/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/jito-ts/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/jito-ts/node_modules/rpc-websockets": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
+      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "eventemitter3": "^4.0.7",
+        "uuid": "^8.3.2",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      }
+    },
+    "node_modules/jito-ts/node_modules/superstruct": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/jito-ts/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -3575,6 +4719,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -3921,6 +5083,33 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/lru-cache": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
@@ -4082,6 +5271,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
@@ -4168,6 +5373,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -4326,6 +5540,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -4552,6 +5772,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4563,6 +5807,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pump": {
@@ -4683,6 +5936,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -5103,6 +6365,22 @@
       "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
       "license": "MIT"
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -5176,6 +6454,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5357,6 +6661,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -5588,7 +6898,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -6006,6 +7315,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6033,11 +7359,19 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -6047,6 +7381,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
   },
   "overrides": {
     "uuid": "^14.0.0",
-    "hono": "^4.12.14"
+    "hono": "^4.12.14",
+    "@solana/web3.js": "$@solana/web3.js"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.32.1",
     "@lifi/sdk": "^3.16.3",
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "@mrgnlabs/marginfi-client-v2": "^6.4.1",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@walletconnect/sign-client": "^2.17.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ import {
   prepareMarginfiBorrow,
   prepareMarginfiRepay,
   getMarginfiPositions,
+  getSolanaSetupStatus,
   prepareAaveSupply,
   prepareAaveWithdraw,
   prepareAaveBorrow,
@@ -103,6 +104,7 @@ import {
   prepareMarginfiBorrowInput,
   prepareMarginfiRepayInput,
   getMarginfiPositionsInput,
+  getSolanaSetupStatusInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -1262,6 +1264,11 @@ async function main() {
         "Ledger-compatible. PDA seeds are [\"marginfi_account\", group, wallet, accountIndex, 0], " +
         "with `accountIndex` defaulting to 0. After broadcast, `prepare_marginfi_supply / " +
         "withdraw / borrow / repay` for this wallet will use this MarginfiAccount automatically. " +
+        "COST: ~0.01698 SOL rent-exempt minimum (for the 2312-byte PDA) + ~0.000005 SOL tx fee. " +
+        "The rent is PAID FROM THE USER WALLET DIRECTLY (not via an ephemeral keypair) and is " +
+        "reclaimable when the MarginfiAccount is closed. Surface this cost to the user before " +
+        "they approve on Ledger — the blind-sign screen only shows a Message Hash, so the user " +
+        "has no on-device check of the balance delta. " +
         "DURABLE NONCE REQUIRED: this tx carries ix[0] = nonceAdvance (same pattern as every " +
         "other Solana send in this server), so the wallet must have run `prepare_solana_nonce_init` " +
         "first; otherwise this tool errors with a clear pointer. BLIND-SIGN on Ledger (MarginFi's " +
@@ -1330,6 +1337,23 @@ async function main() {
       inputSchema: prepareMarginfiRepayInput.shape,
     },
     handler(prepareMarginfiRepay)
+  );
+
+  server.registerTool(
+    "get_solana_setup_status",
+    {
+      description:
+        "READ-ONLY — probe which one-time setup pieces are already in place for a Solana " +
+        "wallet: the durable-nonce account (exists / address / current nonce value / authority) " +
+        "and the set of MarginfiAccount PDAs (index + address). Call this BEFORE planning a " +
+        "multi-step Solana flow (nonce init → MarginFi init → supply) so agents can skip " +
+        "redundant prepare_* calls instead of re-proposing them and letting the user correct " +
+        "you. Mirrors the get_ledger_status pattern of cheap chain-read setup introspection. " +
+        "One getAccountInfo per probed PDA; no SDK load, no oracle fetch. Returns empty " +
+        "arrays / exists:false when nothing's set up — never throws for an empty wallet.",
+      inputSchema: getSolanaSetupStatusInput.shape,
+    },
+    handler(getSolanaSetupStatus)
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ import {
   prepareSolanaNonceClose,
   getSolanaSwapQuote,
   prepareSolanaSwap,
+  prepareMarginfiInit,
+  prepareMarginfiSupply,
+  prepareMarginfiWithdraw,
+  prepareMarginfiBorrow,
+  prepareMarginfiRepay,
+  getMarginfiPositions,
   prepareAaveSupply,
   prepareAaveWithdraw,
   prepareAaveBorrow,
@@ -91,6 +97,12 @@ import {
   prepareSolanaNonceCloseInput,
   getSolanaSwapQuoteInput,
   prepareSolanaSwapInput,
+  prepareMarginfiInitInput,
+  prepareMarginfiSupplyInput,
+  prepareMarginfiWithdrawInput,
+  prepareMarginfiBorrowInput,
+  prepareMarginfiRepayInput,
+  getMarginfiPositionsInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -1238,6 +1250,102 @@ async function main() {
       inputSchema: prepareSolanaSwapInput.shape,
     },
     handler(prepareSolanaSwap)
+  );
+
+  server.registerTool(
+    "prepare_marginfi_init",
+    {
+      description:
+        "One-time setup: build a tx that creates a deterministic MarginfiAccount PDA " +
+        "under the user's wallet on MarginFi mainnet. Uses `marginfi_account_initialize_pda` " +
+        "so only the wallet (authority + fee_payer) signs — no ephemeral keypair required, " +
+        "Ledger-compatible. PDA seeds are [\"marginfi_account\", group, wallet, accountIndex, 0], " +
+        "with `accountIndex` defaulting to 0. After broadcast, `prepare_marginfi_supply / " +
+        "withdraw / borrow / repay` for this wallet will use this MarginfiAccount automatically. " +
+        "DURABLE NONCE REQUIRED: this tx carries ix[0] = nonceAdvance (same pattern as every " +
+        "other Solana send in this server), so the wallet must have run `prepare_solana_nonce_init` " +
+        "first; otherwise this tool errors with a clear pointer. BLIND-SIGN on Ledger (MarginFi's " +
+        "program ID is not in the Solana app's clear-sign registry) — the user matches the Message " +
+        "Hash on-device after `preview_solana_send`. Refuses if a MarginfiAccount already exists at " +
+        "the derived PDA.",
+      inputSchema: prepareMarginfiInitInput.shape,
+    },
+    handler(prepareMarginfiInit)
+  );
+
+  server.registerTool(
+    "prepare_marginfi_supply",
+    {
+      description:
+        "Build an unsigned MarginFi SUPPLY tx for a given bank (by symbol or mint). " +
+        "Supplies the specified amount of the underlying token into the user's MarginfiAccount " +
+        "position in that bank, earning the bank's supply APY. DURABLE NONCE REQUIRED + " +
+        "prepare_marginfi_init must have run first; otherwise this tool errors. Pre-flight: " +
+        "bank-pause check; invalid-mint check (MarginFi only lists a subset of SPL tokens). " +
+        "Uses v0 VersionedTransaction + MarginFi group ALTs for compact wire size. BLIND-SIGN " +
+        "on Ledger — match the Message Hash on-device after `preview_solana_send`.",
+      inputSchema: prepareMarginfiSupplyInput.shape,
+    },
+    handler(prepareMarginfiSupply)
+  );
+
+  server.registerTool(
+    "prepare_marginfi_withdraw",
+    {
+      description:
+        "Build an unsigned MarginFi WITHDRAW tx. Withdraws the specified amount (or ALL, via " +
+        "`withdrawAll: true`) from the user's supplied position in the named bank. Pre-flight " +
+        "refuses if the account has zero free collateral (the withdraw would push the health " +
+        "factor below the maintenance threshold — the on-chain tx would revert). DURABLE NONCE + " +
+        "prepare_marginfi_init prerequisites identical to prepare_marginfi_supply. BLIND-SIGN on " +
+        "Ledger.",
+      inputSchema: prepareMarginfiWithdrawInput.shape,
+    },
+    handler(prepareMarginfiWithdraw)
+  );
+
+  server.registerTool(
+    "prepare_marginfi_borrow",
+    {
+      description:
+        "Build an unsigned MarginFi BORROW tx against the user's supplied collateral. " +
+        "Pre-flight refuses if the account has zero free collateral. The SDK computes the " +
+        "required oracle-refresh instructions and the health-factor gate is enforced on-chain " +
+        "— but this tool is the right place to surface a clear error rather than burning SOL " +
+        "on a reverting tx. DURABLE NONCE + prepare_marginfi_init prerequisites identical to " +
+        "prepare_marginfi_supply. BLIND-SIGN on Ledger.",
+      inputSchema: prepareMarginfiBorrowInput.shape,
+    },
+    handler(prepareMarginfiBorrow)
+  );
+
+  server.registerTool(
+    "prepare_marginfi_repay",
+    {
+      description:
+        "Build an unsigned MarginFi REPAY tx against outstanding debt in the named bank. " +
+        "Pass `repayAll: true` to repay the full outstanding debt (also clears the balance " +
+        "slot). DURABLE NONCE + prepare_marginfi_init prerequisites identical to " +
+        "prepare_marginfi_supply. BLIND-SIGN on Ledger.",
+      inputSchema: prepareMarginfiRepayInput.shape,
+    },
+    handler(prepareMarginfiRepay)
+  );
+
+  server.registerTool(
+    "get_marginfi_positions",
+    {
+      description:
+        "READ-ONLY — enumerate a Solana wallet's MarginFi lending positions. Probes the first 4 " +
+        "MarginfiAccount PDAs under the wallet (accountIndex 0..3) and returns one entry per " +
+        "existing account. Each entry reports the supplied and borrowed balances per bank " +
+        "(human amount + USD value), aggregate totals, and the health factor " +
+        "(assets/liabilities, >1 safe, <1 liquidatable, Infinity when no debt). Bank-level " +
+        "pause warnings surface in the `warnings` field. Parallel to EVM's `get_compound_positions` " +
+        "/ `get_morpho_positions`. Returns an empty array when the wallet has no MarginfiAccount.",
+      inputSchema: getMarginfiPositionsInput.shape,
+    },
+    handler(getMarginfiPositions)
   );
 
   server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ import {
   prepareMarginfiBorrow,
   prepareMarginfiRepay,
   getMarginfiPositions,
+  getMarginfiDiagnostics,
   getSolanaSetupStatus,
   prepareAaveSupply,
   prepareAaveWithdraw,
@@ -104,6 +105,7 @@ import {
   prepareMarginfiBorrowInput,
   prepareMarginfiRepayInput,
   getMarginfiPositionsInput,
+  getMarginfiDiagnosticsInput,
   getSolanaSetupStatusInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
@@ -1370,6 +1372,24 @@ async function main() {
       inputSchema: getMarginfiPositionsInput.shape,
     },
     handler(getMarginfiPositions)
+  );
+
+  server.registerTool(
+    "get_marginfi_diagnostics",
+    {
+      description:
+        "READ-ONLY — diagnostic surface for the hardened MarginFi client load. Returns the list " +
+        "of banks the bundled SDK (v6.4.1, IDL 0.1.7) had to skip while fetching the production " +
+        "group, with each record carrying the bank address, best-effort mint + symbol (recovered " +
+        "from raw bytes even when Borsh decode fails), the step where the skip happened " +
+        "(`decode` / `hydrate` / `tokenData` / `priceInfo`), and the raw error reason. Call this " +
+        "when `prepare_marginfi_*` reports that a mint you know is listed on mainnet (e.g. USDC) " +
+        "was missed — it will either name the bank explicitly as skipped with the root cause, or " +
+        "confirm the mint truly isn't in the current group. The snapshot reflects the most recent " +
+        "`fetchGroupData` pass in this process; an empty cache is warmed on demand. No input args.",
+      inputSchema: getMarginfiDiagnosticsInput.shape,
+    },
+    handler(getMarginfiDiagnostics)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -92,6 +92,12 @@ import type {
   PrepareSolanaNonceCloseArgs,
   GetSolanaSwapQuoteArgs,
   PrepareSolanaSwapArgs,
+  PrepareMarginfiInitArgs,
+  PrepareMarginfiSupplyArgs,
+  PrepareMarginfiWithdrawArgs,
+  PrepareMarginfiBorrowArgs,
+  PrepareMarginfiRepayArgs,
+  GetMarginfiPositionsArgs,
   PreviewSendArgs,
   SendTransactionArgs,
   GetTransactionStatusArgs,
@@ -260,6 +266,83 @@ export async function getSolanaSwapQuote(args: GetSolanaSwapQuoteArgs) {
     slippageBps: args.slippageBps,
     swapMode: args.swapMode,
   });
+}
+
+export async function prepareMarginfiInit(
+  args: PrepareMarginfiInitArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarginfiInit } = await import("../solana/marginfi.js");
+  const prepared = await buildMarginfiInit({
+    wallet: args.wallet,
+    ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarginfiSupply(
+  args: PrepareMarginfiSupplyArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarginfiSupply } = await import("../solana/marginfi.js");
+  const prepared = await buildMarginfiSupply({
+    wallet: args.wallet,
+    ...(args.symbol !== undefined ? { symbol: args.symbol } : {}),
+    ...(args.mint !== undefined ? { mint: args.mint } : {}),
+    amount: args.amount,
+    ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarginfiWithdraw(
+  args: PrepareMarginfiWithdrawArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarginfiWithdraw } = await import("../solana/marginfi.js");
+  const prepared = await buildMarginfiWithdraw({
+    wallet: args.wallet,
+    ...(args.symbol !== undefined ? { symbol: args.symbol } : {}),
+    ...(args.mint !== undefined ? { mint: args.mint } : {}),
+    amount: args.amount,
+    ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
+    ...(args.withdrawAll !== undefined ? { withdrawAll: args.withdrawAll } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarginfiBorrow(
+  args: PrepareMarginfiBorrowArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarginfiBorrow } = await import("../solana/marginfi.js");
+  const prepared = await buildMarginfiBorrow({
+    wallet: args.wallet,
+    ...(args.symbol !== undefined ? { symbol: args.symbol } : {}),
+    ...(args.mint !== undefined ? { mint: args.mint } : {}),
+    amount: args.amount,
+    ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarginfiRepay(
+  args: PrepareMarginfiRepayArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarginfiRepay } = await import("../solana/marginfi.js");
+  const prepared = await buildMarginfiRepay({
+    wallet: args.wallet,
+    ...(args.symbol !== undefined ? { symbol: args.symbol } : {}),
+    ...(args.mint !== undefined ? { mint: args.mint } : {}),
+    amount: args.amount,
+    ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
+    ...(args.repayAll !== undefined ? { repayAll: args.repayAll } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {
+  const { getMarginfiPositions: reader } = await import(
+    "../positions/marginfi.js"
+  );
+  const conn = getSolanaConnection();
+  return { positions: await reader(conn, args.wallet) };
 }
 
 export async function prepareSolanaSwap(
@@ -1289,7 +1372,17 @@ export interface SolanaVerificationArtifact {
   artifactVersion: "v1";
   handle: string;
   chain: "solana";
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
+  action:
+    | "native_send"
+    | "spl_send"
+    | "nonce_init"
+    | "nonce_close"
+    | "jupiter_swap"
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
   from: string;
   messageBase64: string;
   recentBlockhash: string;
@@ -1390,8 +1483,23 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
     if (!tx.verification) {
       throw new Error(`Internal: Solana tx for handle '${args.handle}' missing verification metadata.`);
     }
-    const ledgerMessageHash =
-      tx.action === "spl_send" ? solanaLedgerMessageHash(tx.messageBase64) : undefined;
+    // Blind-sign actions need the server-computed Ledger Message Hash in the
+    // artifact payload so the second LLM can tell the user which value to
+    // match against the on-device screen. Clear-sign actions (native_send,
+    // nonce_init, nonce_close) omit it — the device shows decoded fields
+    // and there is no hash to match.
+    const blindSignActions = new Set([
+      "spl_send",
+      "jupiter_swap",
+      "marginfi_init",
+      "marginfi_supply",
+      "marginfi_withdraw",
+      "marginfi_borrow",
+      "marginfi_repay",
+    ]);
+    const ledgerMessageHash = blindSignActions.has(tx.action)
+      ? solanaLedgerMessageHash(tx.messageBase64)
+      : undefined;
     // `description` and `decoded` are the human/structured summary the FIRST
     // agent showed the user. The second LLM uses them as a comparison target
     // (step 3 of SECOND_AGENT_INSTRUCTIONS) AFTER it independently decodes

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -345,6 +345,89 @@ export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {
   return { positions: await reader(conn, args.wallet) };
 }
 
+/**
+ * Read-only setup probe for a Solana wallet. Returns which one-time-setup
+ * prerequisites are already in place (durable-nonce account + MarginFi
+ * PDAs) so agents planning a supply/borrow/etc. don't re-propose a
+ * redundant prepare_solana_nonce_init or prepare_marginfi_init step.
+ *
+ * Mirrors `get_ledger_status` in spirit: a cheap inspection tool that
+ * turns "ask the user what's set up" into "read the chain". Issue #101.
+ */
+export async function getSolanaSetupStatus(args: {
+  wallet: string;
+}): Promise<{
+  wallet: string;
+  nonce: {
+    exists: boolean;
+    address: string;
+    lamports?: number;
+    currentNonce?: string;
+    authority?: string;
+  };
+  marginfi: {
+    accounts: Array<{ index: number; address: string }>;
+  };
+}> {
+  const { assertSolanaAddress } = await import("../solana/address.js");
+  const { deriveNonceAccountAddress, getNonceAccountValue } = await import(
+    "../solana/nonce.js"
+  );
+  const { deriveMarginfiAccountPda } = await import("../solana/marginfi.js");
+
+  const authority = assertSolanaAddress(args.wallet);
+  const conn = getSolanaConnection();
+
+  // Nonce lookup — one RPC + one decode.
+  const noncePubkey = await deriveNonceAccountAddress(authority);
+  const nonceInfo = await conn.getAccountInfo(noncePubkey, "confirmed");
+  let nonceState: { nonce: string; authority: string } | undefined;
+  let nonceLamports: number | undefined;
+  if (nonceInfo) {
+    nonceLamports = nonceInfo.lamports;
+    try {
+      const v = await getNonceAccountValue(conn, noncePubkey);
+      if (v) {
+        nonceState = { nonce: v.nonce, authority: v.authority.toBase58() };
+      }
+    } catch {
+      // Account exists but isn't a System-owned nonce — surface as
+      // exists:true without the nonce value. Caller should inspect the
+      // lamports + our own nonce tool's refusal to explain.
+    }
+  }
+
+  // MarginFi PDA probe — same 4-slot pattern as getMarginfiPositions, but
+  // stops at the existence check. No SDK load, no oracle fetch — cheap.
+  const marginfiAccounts: Array<{ index: number; address: string }> = [];
+  const MAX_SLOTS = 4;
+  for (let idx = 0; idx < MAX_SLOTS; idx++) {
+    const pda = deriveMarginfiAccountPda(authority, idx);
+    const info = await conn.getAccountInfo(pda, "confirmed");
+    if (!info) {
+      if (marginfiAccounts.length === 0 && idx === 0) break; // common: none
+      break; // gap in the slot sequence
+    }
+    marginfiAccounts.push({ index: idx, address: pda.toBase58() });
+  }
+
+  return {
+    wallet: args.wallet,
+    nonce: {
+      exists: nonceInfo !== null,
+      address: noncePubkey.toBase58(),
+      ...(nonceLamports !== undefined ? { lamports: nonceLamports } : {}),
+      ...(nonceState
+        ? {
+            currentNonce: nonceState.nonce,
+            authority: nonceState.authority,
+          }
+        : {}),
+    },
+    marginfi: { accounts: marginfiAccounts },
+  };
+}
+
 export async function prepareSolanaSwap(
   args: PrepareSolanaSwapArgs,
 ): Promise<PreparedSolanaTx> {

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -346,6 +346,73 @@ export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {
 }
 
 /**
+ * Read-only diagnostic surface for the hardened MarginFi client load.
+ * Returns per-bank skip records (address, best-effort mint, step, reason)
+ * from the last `fetchGroupData` pass in this process — the data that
+ * powers `findBankForMint`'s "bank listed but skipped" branch (issue #107).
+ *
+ * Triggers a fresh load if the cache is cold so the snapshot is always
+ * recent on demand.
+ */
+export async function getMarginfiDiagnostics(
+  _args?: Record<string, never>,
+): Promise<{
+  group: string;
+  fetchedAt: number | null;
+  addressesFetched: number;
+  banksHydrated: number;
+  skippedIntegrator: number;
+  skipped: Array<{
+    address: string;
+    mint: string | null;
+    symbol: string;
+    step: "decode" | "hydrate" | "tokenData" | "priceInfo";
+    reason: string;
+  }>;
+}> {
+  const marginfi = await import("../solana/marginfi.js");
+  const conn = getSolanaConnection();
+  let snap = marginfi.getLastMarginfiGroupDiagnostics();
+  if (!snap) {
+    // Warm the cache — picks a valid pubkey as the stub authority since
+    // the hardened fetch doesn't actually use it, only the SDK's wallet
+    // type-check does.
+    const { PublicKey } = await import("@solana/web3.js");
+    await marginfi.getHardenedMarginfiClient(
+      conn,
+      new PublicKey("11111111111111111111111111111111"),
+    );
+    snap = marginfi.getLastMarginfiGroupDiagnostics();
+  }
+  if (!snap) {
+    return {
+      group: marginfi.__internals.MAINNET_GROUP.toBase58(),
+      fetchedAt: null,
+      addressesFetched: 0,
+      banksHydrated: 0,
+      skippedIntegrator: 0,
+      skipped: [],
+    };
+  }
+  return {
+    group: marginfi.__internals.MAINNET_GROUP.toBase58(),
+    fetchedAt: snap.fetchedAt,
+    addressesFetched: snap.addressesFetched,
+    banksHydrated: snap.banksHydrated,
+    skippedIntegrator: snap.skippedIntegrator,
+    skipped: snap.records.map((r) => ({
+      address: r.address,
+      mint: r.mint,
+      symbol: r.mint
+        ? marginfi.__internals.resolveMintSymbol(r.mint)
+        : "UNKNOWN",
+      step: r.step,
+      reason: r.reason,
+    })),
+  };
+}
+
+/**
  * Read-only setup probe for a Solana wallet. Returns which one-time-setup
  * prerequisites are already in place (durable-nonce account + MarginFi
  * PDAs) so agents planning a supply/borrow/etc. don't re-propose a

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -257,6 +257,15 @@ export const prepareMarginfiRepayInput = z.object({
     ),
 });
 
+export const getSolanaSetupStatusInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet to probe. Returns the state of the durable-nonce account " +
+      "(exists / address / lamports / currentNonce / authority) and the list of " +
+      "existing MarginfiAccount PDAs (accountIndex + address) for the wallet. " +
+      "Read-only, no RPC fan-out — one getAccountInfo per probed PDA."
+  ),
+});
+
 export const getMarginfiPositionsInput = z.object({
   wallet: solanaAddressSchema.describe(
     "Solana wallet to enumerate MarginFi positions for. Probes the first 4 MarginfiAccount " +
@@ -517,3 +526,4 @@ export type PrepareMarginfiWithdrawArgs = z.infer<typeof prepareMarginfiWithdraw
 export type PrepareMarginfiBorrowArgs = z.infer<typeof prepareMarginfiBorrowInput>;
 export type PrepareMarginfiRepayArgs = z.infer<typeof prepareMarginfiRepayInput>;
 export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;
+export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -273,6 +273,8 @@ export const getMarginfiPositionsInput = z.object({
   ),
 });
 
+export const getMarginfiDiagnosticsInput = z.object({});
+
 export const getLedgerStatusInput = z.object({});
 
 const baseAaveAction = z.object({

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -144,6 +144,126 @@ export const prepareSolanaSwapInput = z.object({
     ),
 });
 
+/**
+ * MarginFi action schemas. `symbol` OR `mint` identifies the bank — pass
+ * either, not both. The builder resolves the symbol via the canonical
+ * SOLANA_TOKENS table; pass `mint` explicitly when the token isn't in that
+ * (small) allowlist but MarginFi does list it.
+ */
+const marginfiBankTarget = {
+  symbol: z
+    .string()
+    .optional()
+    .describe(
+      "Canonical token symbol (USDC, SOL, USDT, JUP, BONK, JTO, mSOL, jitoSOL). " +
+        "The builder resolves this to the underlying mint; MarginFi treats SOL as wSOL internally " +
+        "with auto-wrap/unwrap. Pass `mint` instead if your token isn't in the canonical list."
+    ),
+  mint: solanaAddressSchema
+    .optional()
+    .describe(
+      "Base58 SPL mint address. Used as an override or when the token isn't in the canonical " +
+        "SOLANA_TOKENS table. Exactly one of `symbol` or `mint` must be passed."
+    ),
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "MarginfiAccount slot (0 = first, 1 = second, ...). Most users stay on 0. " +
+        "Use a different index to segregate positions across multiple MarginfiAccounts " +
+        "owned by the same wallet."
+    ),
+};
+
+export const prepareMarginfiInitInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet that will own the MarginfiAccount PDA. The account is deterministic — " +
+      "seeds (marginfi_account, group, authority, accountIndex, third_party_id=0) produce " +
+      "the same PDA every time. Only the user (authority + fee_payer) signs; no rent-exempt " +
+      "seed is moved (this is a PDA, not a fresh account)."
+  ),
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "Account slot (default 0). Pass a different index to init a second MarginfiAccount " +
+        "under the same wallet."
+    ),
+});
+
+export const prepareMarginfiSupplyInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet executing the supply. Must have an initialized MarginfiAccount (run " +
+      "prepare_marginfi_init first) AND a durable-nonce account (prepare_solana_nonce_init)."
+  ),
+  ...marginfiBankTarget,
+  amount: z
+    .string()
+    .describe(
+      'Human-readable decimal amount to supply (e.g. "1.5" for 1.5 USDC). Decimals resolved ' +
+        'from the bank\'s mint — do NOT pass raw base units.'
+    ),
+});
+
+export const prepareMarginfiWithdrawInput = z.object({
+  wallet: solanaAddressSchema,
+  ...marginfiBankTarget,
+  amount: z
+    .string()
+    .describe(
+      'Human-readable decimal amount to withdraw. Pre-flight refuses if the withdraw would ' +
+        'push the health factor below the maintenance threshold.'
+    ),
+  withdrawAll: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set true to close the entire supplied position in this bank (lets the SDK pass the " +
+        "`withdraw_all` on-chain flag so the bank clears the balance slot). Omit for partial."
+    ),
+});
+
+export const prepareMarginfiBorrowInput = z.object({
+  wallet: solanaAddressSchema,
+  ...marginfiBankTarget,
+  amount: z
+    .string()
+    .describe(
+      'Human-readable decimal amount to borrow. Pre-flight refuses if the account has zero ' +
+        'free collateral.'
+    ),
+});
+
+export const prepareMarginfiRepayInput = z.object({
+  wallet: solanaAddressSchema,
+  ...marginfiBankTarget,
+  amount: z
+    .string()
+    .describe(
+      'Human-readable decimal amount to repay against outstanding debt in this bank.'
+    ),
+  repayAll: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set true to repay the full outstanding debt in this bank (SDK also clears the balance " +
+        "slot — cheaper for the user if they're closing out). Omit for partial."
+    ),
+});
+
+export const getMarginfiPositionsInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet to enumerate MarginFi positions for. Probes the first 4 MarginfiAccount " +
+      "PDAs under this wallet (accountIndex 0..3) and returns one entry per existing account."
+  ),
+});
+
 export const getLedgerStatusInput = z.object({});
 
 const baseAaveAction = z.object({
@@ -391,3 +511,9 @@ export type SendTransactionArgs = z.infer<typeof sendTransactionInput>;
 export type GetTransactionStatusArgs = z.infer<typeof getTransactionStatusInput>;
 export type GetTxVerificationArgs = z.infer<typeof getTxVerificationInput>;
 export type GetVerificationArtifactArgs = z.infer<typeof getVerificationArtifactInput>;
+export type PrepareMarginfiInitArgs = z.infer<typeof prepareMarginfiInitInput>;
+export type PrepareMarginfiSupplyArgs = z.infer<typeof prepareMarginfiSupplyInput>;
+export type PrepareMarginfiWithdrawArgs = z.infer<typeof prepareMarginfiWithdrawInput>;
+export type PrepareMarginfiBorrowArgs = z.infer<typeof prepareMarginfiBorrowInput>;
+export type PrepareMarginfiRepayArgs = z.infer<typeof prepareMarginfiRepayInput>;
+export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;

--- a/src/modules/feedback/index.ts
+++ b/src/modules/feedback/index.ts
@@ -7,9 +7,19 @@ const ISSUE_LABEL = "agent-request";
 const USER_AGENT = "vaultpilot-mcp/0.1.0 capability-request";
 const POST_TIMEOUT_MS = 8_000;
 const MAX_POST_BODY_BYTES = 16_384;
-const MAX_PREFILLED_URL_BYTES = 7168;
-const TRUNCATION_MARKER =
-  "\n\n_...(body truncated to fit in GitHub's prefilled-URL length limit — paste the full context into the issue after opening)_";
+/**
+ * OSC-8 hyperlink payloads are typically capped around 1–2 KB in terminal
+ * chat clients (iTerm2, Alacritty, tmux passthrough). Oversized URLs render
+ * as plain text — unreadable wrapped walls that force copy/paste (issue #98).
+ * If the full-body URL would exceed this budget, we emit a short URL that
+ * prefills only the title + labels and point the agent at the full `body`
+ * field / `ghCommand` snippet for the actual issue body.
+ */
+const CLICKABLE_URL_BUDGET_BYTES = 2048;
+const SHORT_URL_PLACEHOLDER_BODY =
+  "_Body provided separately by the MCP tool. Paste the full text from the " +
+  "`body` field of the `request_capability` tool result, or run the returned " +
+  "`ghCommand` shell snippet to submit via `gh` without copy-paste._";
 /**
  * HEREDOC terminator for the `ghCommand` shell snippet. Must be an unusual
  * string that agent-supplied body content is vanishingly unlikely to contain.
@@ -72,7 +82,7 @@ export async function requestCapability(args: RequestCapabilityArgs) {
     return await postToEndpoint(endpoint, payload);
   }
 
-  const { url: issueUrl, truncated } = buildPrefilledIssueUrl(payload);
+  const { url: issueUrl, bodyOmittedFromUrl } = buildPrefilledIssueUrl(payload);
   const ghCommand = buildGhCommand(payload);
   return {
     status: "prefilled_url" as const,
@@ -86,10 +96,10 @@ export async function requestCapability(args: RequestCapabilityArgs) {
       "escaping. Returns the created issue URL on success. " +
       "(b) `issueUrl` — a prefilled GitHub issue URL to render as a Markdown link; " +
       "the user opens it in a browser and clicks 'Submit new issue'. No gh CLI " +
-      "required. Note: URLs over a few KB may not render as clickable in terminal " +
-      "chat clients, forcing copy/paste." +
-      (truncated
-        ? " Only the URL body was truncated to fit GitHub's prefilled-URL length limit; ghCommand carries the full body and is preferred when available. Tell the user to paste the full context into the issue manually if they go with the URL path."
+      "required. The URL is kept short enough to stay clickable in terminal chat " +
+      "clients (OSC-8 hyperlink payloads are capped around 1–2 KB)." +
+      (bodyOmittedFromUrl
+        ? " Body is NOT prefilled — the full body wouldn't fit in the clickable URL budget. Render the full `body` field in a code block so the user can paste it into the GitHub form after opening the URL, or prefer `ghCommand` which ships the body via HEREDOC."
         : ""),
     issueUrl,
     ghCommand,
@@ -97,7 +107,7 @@ export async function requestCapability(args: RequestCapabilityArgs) {
     title,
     body,
     labels,
-    bodyTruncated: truncated,
+    bodyOmittedFromUrl,
     rateLimit: RATE_LIMITS,
   };
 }
@@ -190,7 +200,9 @@ function buildGhCommand(payload: IssuePayload): string {
   return `${cmdHead}\n${payload.body}\n${cmdTail}`;
 }
 
-function buildPrefilledIssueUrl(payload: IssuePayload): { url: string; truncated: boolean } {
+function buildPrefilledIssueUrl(
+  payload: IssuePayload,
+): { url: string; bodyOmittedFromUrl: boolean } {
   const base = `https://github.com/${REPO_OWNER}/${REPO_NAME}/issues/new`;
   const build = (body: string): string => {
     const params = new URLSearchParams({
@@ -202,26 +214,15 @@ function buildPrefilledIssueUrl(payload: IssuePayload): { url: string; truncated
   };
 
   const fullUrl = build(payload.body);
-  if (Buffer.byteLength(fullUrl, "utf8") <= MAX_PREFILLED_URL_BYTES) {
-    return { url: fullUrl, truncated: false };
+  if (Buffer.byteLength(fullUrl, "utf8") <= CLICKABLE_URL_BUDGET_BYTES) {
+    return { url: fullUrl, bodyOmittedFromUrl: false };
   }
 
-  // Binary-search the largest body length whose resulting URL still fits. The
-  // relationship body-length → encoded-URL-length isn't strictly linear
-  // (high-byte chars encode as %XX%XX), so we don't guess a ratio.
-  let lo = 0;
-  let hi = payload.body.length;
-  while (lo < hi) {
-    const mid = Math.floor((lo + hi + 1) / 2);
-    const candidate = payload.body.slice(0, mid) + TRUNCATION_MARKER;
-    if (Buffer.byteLength(build(candidate), "utf8") <= MAX_PREFILLED_URL_BYTES) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  const trimmedBody = payload.body.slice(0, lo) + TRUNCATION_MARKER;
-  return { url: build(trimmedBody), truncated: true };
+  // Full body would push the URL past the clickable budget for terminal chat
+  // clients. Swap the body for a short placeholder pointing at the agent's
+  // `body` field / `ghCommand`. The title (≤120 chars after the prefix) plus
+  // labels keeps this URL well under 1 KB even with worst-case URL encoding.
+  return { url: build(SHORT_URL_PLACEHOLDER_BODY), bodyOmittedFromUrl: true };
 }
 
 async function postToEndpoint(url: string, payload: IssuePayload) {

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -12,12 +12,15 @@ import { getMorphoPositions } from "../morpho/index.js";
 import { getTronBalances } from "../tron/balances.js";
 import { getTronStaking } from "../tron/staking.js";
 import { getSolanaBalances } from "../solana/balances.js";
+import { getMarginfiPositions as readMarginfiPositions } from "../positions/marginfi.js";
+import { getSolanaConnection } from "../solana/rpc.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
   LendingPositionUnion,
   MultiWalletPortfolioSummary,
   PortfolioCoverage,
   PortfolioSummary,
+  SolanaMarginfiPositionSlice,
   SolanaPortfolioSlice,
   SupportedChain,
   TokenAmount,
@@ -304,6 +307,7 @@ async function buildWalletSummary(
     tron: false,
     tronStaking: false,
     solana: false,
+    marginfi: false,
   };
   // Per-market Compound V3 failure detail, populated when at least one market
   // read errored. Surfaced in coverage.compound.note so the agent can tell
@@ -341,6 +345,7 @@ async function buildWalletSummary(
     tronSlice,
     tronStakingSlice,
     solanaSlice,
+    marginfiPositionsRaw,
   ] = await Promise.all([
       Promise.all(
         chains.map((c) =>
@@ -465,6 +470,18 @@ async function buildWalletSummary(
             return null as SolanaPortfolioSlice | null;
           })
         : (Promise.resolve(null) as Promise<SolanaPortfolioSlice | null>),
+      // MarginFi positions ride the same "solanaAddress was passed" gate as
+      // Solana balances. The reader deliberately short-circuits when the
+      // wallet has no MarginfiAccount (1 RPC lookup, then return []) so the
+      // cost of the idle case is essentially free.
+      solanaAddress
+        ? readMarginfiPositions(getSolanaConnection(), solanaAddress).catch(() => {
+            errors.marginfi = true;
+            return [] as Awaited<ReturnType<typeof readMarginfiPositions>>;
+          })
+        : (Promise.resolve([]) as Promise<
+            Awaited<ReturnType<typeof readMarginfiPositions>>
+          >),
     ]);
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -483,6 +500,36 @@ async function buildWalletSummary(
   const tronBalancesUsd = tronSlice?.walletBalancesUsd ?? 0;
   const tronStakingUsd = tronStakingSlice?.totalStakedUsd ?? 0;
   const solanaBalancesUsd = solanaSlice?.walletBalancesUsd ?? 0;
+  // Project the reader's full MarginfiPosition into the thin slice the
+  // types module exposes. Dropping bank/mint keeps the portfolio JSON
+  // compact — callers who want the full per-bank detail call
+  // get_marginfi_positions directly.
+  const marginfiSlices: SolanaMarginfiPositionSlice[] = marginfiPositionsRaw.map(
+    (pos) => ({
+      protocol: "marginfi",
+      chain: "solana",
+      marginfiAccount: pos.marginfiAccount,
+      supplied: pos.supplied.map((b) => ({
+        symbol: b.symbol,
+        amount: b.amount,
+        valueUsd: b.valueUsd,
+      })),
+      borrowed: pos.borrowed.map((b) => ({
+        symbol: b.symbol,
+        amount: b.amount,
+        valueUsd: b.valueUsd,
+      })),
+      totalSuppliedUsd: pos.totalSuppliedUsd,
+      totalBorrowedUsd: pos.totalBorrowedUsd,
+      netValueUsd: pos.netValueUsd,
+      healthFactor: pos.healthFactor,
+      warnings: pos.warnings,
+    }),
+  );
+  const solanaLendingUsd = marginfiSlices.reduce(
+    (s, p) => s + p.netValueUsd,
+    0,
+  );
   const walletBalancesUsd = round(
     [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) +
       tronBalancesUsd +
@@ -503,7 +550,12 @@ async function buildWalletSummary(
   // is surfaced separately (Phase 2 for Solana staking). EVM-only slices
   // (lending/LP/staking) are added here.
   const totalUsd = round(
-    walletBalancesUsd + lendingNetUsd + lpUsd + stakingUsd + tronStakingUsd,
+    walletBalancesUsd +
+      lendingNetUsd +
+      lpUsd +
+      stakingUsd +
+      tronStakingUsd +
+      solanaLendingUsd,
     2
   );
 
@@ -612,6 +664,13 @@ async function buildWalletSummary(
           solana: errors.solana
             ? { covered: false, errored: true, note: "Solana balance fetch failed — SOL/SPL not included in totals. Check SOLANA_RPC_URL or the solanaRpcUrl config." }
             : { covered: true },
+          marginfi: errors.marginfi
+            ? {
+                covered: false,
+                errored: true,
+                note: "MarginFi position fetch failed — lending positions not included in totals. SDK or oracle RPC error; balances still loaded if coverage.solana is covered.",
+              }
+            : { covered: true },
         }
       : {}),
     unpricedAssets,
@@ -650,6 +709,9 @@ async function buildWalletSummary(
     ...(tronBreakdown ? { tronUsd: tronUsdTotal } : {}),
     ...(tronStakingSlice ? { tronStakingUsd: round(tronStakingUsd, 2) } : {}),
     ...(solanaSlice ? { solanaUsd: round(solanaBalancesUsd, 2) } : {}),
+    ...(marginfiSlices.length > 0
+      ? { solanaLendingUsd: round(solanaLendingUsd, 2) }
+      : {}),
     breakdown: {
       native,
       erc20,
@@ -657,7 +719,19 @@ async function buildWalletSummary(
       lp: lp.positions,
       staking: staking.positions,
       ...(tronBreakdown ? { tron: tronBreakdown } : {}),
-      ...(solanaSlice ? { solana: solanaSlice } : {}),
+      ...(solanaSlice
+        ? {
+            solana: {
+              ...solanaSlice,
+              ...(marginfiSlices.length > 0
+                ? {
+                    marginfi: marginfiSlices,
+                    marginfiNetUsd: round(solanaLendingUsd, 2),
+                  }
+                : {}),
+            },
+          }
+        : {}),
     },
     coverage,
   };

--- a/src/modules/positions/marginfi.ts
+++ b/src/modules/positions/marginfi.ts
@@ -1,0 +1,226 @@
+import type { Connection, PublicKey } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { assertSolanaAddress } from "../solana/address.js";
+import { __internals, deriveMarginfiAccountPda } from "../solana/marginfi.js";
+
+/**
+ * Read-only MarginFi position reader. Parallels `getAaveLendingPosition` —
+ * enumerates one wallet's MarginfiAccount balances across all banks,
+ * computes the (USD-denominated) supplied + borrowed totals, and derives a
+ * health factor.
+ *
+ * Health factor convention: MarginFi's on-chain health components are
+ * `{assets, liabilities}` in USD. We publish `assets / liabilities` as the
+ * health factor (Infinity when liabilities === 0), same convention as Aave
+ * — user-facing semantics: >1 safe, <1 liquidatable.
+ */
+
+export interface MarginfiBalanceEntry {
+  bank: string;
+  mint: string;
+  symbol: string;
+  /** Human-readable decimal balance (already-decimals-applied). */
+  amount: string;
+  valueUsd: number;
+}
+
+export interface MarginfiPosition {
+  protocol: "marginfi";
+  chain: "solana";
+  wallet: string;
+  /** Base58 PDA of the MarginfiAccount this reader surfaced. */
+  marginfiAccount: string;
+  supplied: MarginfiBalanceEntry[];
+  borrowed: MarginfiBalanceEntry[];
+  totalSuppliedUsd: number;
+  totalBorrowedUsd: number;
+  netValueUsd: number;
+  /** assets/liabilities from `computeHealthComponents`. Infinity when no debt. */
+  healthFactor: number;
+  /** Optional bank-level pause flags — empty array when all banks healthy. */
+  warnings: string[];
+}
+
+interface MinimalBalance {
+  active: boolean;
+  bankPk: PublicKey;
+  computeQuantityUi(bank: unknown): { assets: BigNumber; liabilities: BigNumber };
+  computeUsdValue(
+    bank: unknown,
+    price: unknown,
+  ): { assets: BigNumber; liabilities: BigNumber };
+}
+
+interface MinimalWrapper {
+  address: PublicKey;
+  activeBalances: MinimalBalance[];
+  computeHealthComponents(req: unknown): {
+    assets: BigNumber;
+    liabilities: BigNumber;
+  };
+}
+
+interface MinimalBank {
+  address: PublicKey;
+  mint: PublicKey;
+  tokenSymbol?: string;
+  isPaused?: boolean;
+}
+
+interface MinimalClient {
+  banks: Map<string, MinimalBank>;
+  oraclePrices: Map<string, unknown>;
+  getOraclePriceByBank?(bankAddr: PublicKey): unknown;
+}
+
+/**
+ * Resolve the first `limit` MarginfiAccounts for a wallet. Most users have
+ * exactly one (accountIndex=0); we read up to 4 slots before giving up. The
+ * aggregate position is surfaced as PER-ACCOUNT entries — MarginFi treats
+ * separate MarginfiAccounts as independent borrowing containers, so mixing
+ * their totals would mask a per-account liquidation risk.
+ */
+export async function getMarginfiPositions(
+  conn: Connection,
+  wallet: string,
+): Promise<MarginfiPosition[]> {
+  const authority = assertSolanaAddress(wallet);
+
+  // The client fetch is idempotent & cached at the `solana/marginfi.ts`
+  // layer; calling its getter here rides the same cache.
+  const { MarginfiClient, getConfig, MarginfiAccountWrapper } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  const stubWallet = {
+    publicKey: authority,
+    signTransaction: async <T,>(_tx: T): Promise<T> => {
+      throw new Error("read-only path must not sign");
+    },
+    signAllTransactions: async <T,>(_txs: T[]): Promise<T[]> => {
+      throw new Error("read-only path must not sign");
+    },
+  };
+  const client = await MarginfiClient.fetch(getConfig("production"), stubWallet, conn, {
+    readOnly: true,
+  });
+
+  // Probe the first 4 account slots. The PDA is deterministic, so we can
+  // batch-fetch without scanning getProgramAccounts.
+  const results: MarginfiPosition[] = [];
+  const MAX_SLOTS = 4;
+  for (let idx = 0; idx < MAX_SLOTS; idx++) {
+    const pda = deriveMarginfiAccountPda(authority, idx);
+    const info = await conn.getAccountInfo(pda, "confirmed");
+    if (!info) {
+      // Once we hit a gap, subsequent slots are almost certainly also
+      // empty (users don't skip slots). Early-break keeps the common case
+      // (one account at slot 0) fast — 1 RPC lookup, not 4.
+      if (idx === 0) return []; // common: user has no MarginfiAccount at all
+      break;
+    }
+    let wrapper: MinimalWrapper;
+    try {
+      wrapper = (await MarginfiAccountWrapper.fetch(
+        pda,
+        client,
+      )) as unknown as MinimalWrapper;
+    } catch {
+      // Hydration failure on one slot shouldn't kill the whole enumeration.
+      continue;
+    }
+    results.push(buildPositionFromWrapper(client as unknown as MinimalClient, wrapper, wallet));
+  }
+  return results;
+}
+
+function buildPositionFromWrapper(
+  client: MinimalClient,
+  wrapper: MinimalWrapper,
+  wallet: string,
+): MarginfiPosition {
+  const supplied: MarginfiBalanceEntry[] = [];
+  const borrowed: MarginfiBalanceEntry[] = [];
+  const warnings: string[] = [];
+
+  let totalSuppliedUsd = 0;
+  let totalBorrowedUsd = 0;
+
+  for (const balance of wrapper.activeBalances) {
+    const bank = client.banks.get(balance.bankPk.toBase58());
+    if (!bank) continue;
+    const price = resolveOraclePrice(client, bank.address);
+    if (!price) continue;
+
+    const { assets: assetsUi, liabilities: liabilitiesUi } = balance.computeQuantityUi(
+      bank as unknown,
+    );
+    const usd = balance.computeUsdValue(bank as unknown, price);
+    const mint = bank.mint.toBase58();
+    const symbol = bank.tokenSymbol ?? __internals.resolveMintSymbol(mint);
+
+    if (assetsUi.gt(0)) {
+      const usdValue = usd.assets.toNumber();
+      supplied.push({
+        bank: bank.address.toBase58(),
+        mint,
+        symbol,
+        amount: assetsUi.toFixed(6).replace(/\.?0+$/, ""),
+        valueUsd: round2(usdValue),
+      });
+      totalSuppliedUsd += usdValue;
+    }
+    if (liabilitiesUi.gt(0)) {
+      const usdValue = usd.liabilities.toNumber();
+      borrowed.push({
+        bank: bank.address.toBase58(),
+        mint,
+        symbol,
+        amount: liabilitiesUi.toFixed(6).replace(/\.?0+$/, ""),
+        valueUsd: round2(usdValue),
+      });
+      totalBorrowedUsd += usdValue;
+    }
+    if (bank.isPaused) {
+      warnings.push(`${symbol} bank is governance-paused (all actions blocked).`);
+    }
+  }
+
+  // Maintenance margin type is the one users map to "can I be liquidated right now?".
+  // MarginRequirementType.Maintenance === 1 in the SDK's enum; we use the numeric
+  // literal to avoid importing the enum just for the one call.
+  const health = wrapper.computeHealthComponents(1);
+  const assetsUsd = health.assets.toNumber();
+  const liabsUsd = health.liabilities.toNumber();
+  const healthFactor =
+    liabsUsd <= 0 ? Number.POSITIVE_INFINITY : assetsUsd / liabsUsd;
+
+  return {
+    protocol: "marginfi",
+    chain: "solana",
+    wallet,
+    marginfiAccount: wrapper.address.toBase58(),
+    supplied,
+    borrowed,
+    totalSuppliedUsd: round2(totalSuppliedUsd),
+    totalBorrowedUsd: round2(totalBorrowedUsd),
+    netValueUsd: round2(totalSuppliedUsd - totalBorrowedUsd),
+    healthFactor,
+    warnings,
+  };
+}
+
+/**
+ * Resolve a bank's oracle price from the MarginFi client's `oraclePrices`
+ * map. The SDK exposes both a getter (when available) and a raw Map; we
+ * prefer the getter so per-bank price-age handling stays with the SDK.
+ */
+function resolveOraclePrice(client: MinimalClient, bank: PublicKey): unknown {
+  if (typeof client.getOraclePriceByBank === "function") {
+    return client.getOraclePriceByBank(bank);
+  }
+  return client.oraclePrices.get(bank.toBase58());
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}

--- a/src/modules/positions/marginfi.ts
+++ b/src/modules/positions/marginfi.ts
@@ -86,49 +86,119 @@ export async function getMarginfiPositions(
 ): Promise<MarginfiPosition[]> {
   const authority = assertSolanaAddress(wallet);
 
-  // The client fetch is idempotent & cached at the `solana/marginfi.ts`
-  // layer; calling its getter here rides the same cache.
-  const { MarginfiClient, getConfig, MarginfiAccountWrapper } = await import(
-    "@mrgnlabs/marginfi-client-v2"
-  );
-  const stubWallet = {
-    publicKey: authority,
-    signTransaction: async <T,>(_tx: T): Promise<T> => {
-      throw new Error("read-only path must not sign");
-    },
-    signAllTransactions: async <T,>(_txs: T[]): Promise<T[]> => {
-      throw new Error("read-only path must not sign");
-    },
-  };
-  const client = await MarginfiClient.fetch(getConfig("production"), stubWallet, conn, {
-    readOnly: true,
-  });
-
-  // Probe the first 4 account slots. The PDA is deterministic, so we can
-  // batch-fetch without scanning getProgramAccounts.
-  const results: MarginfiPosition[] = [];
+  // Short-circuit BEFORE loading the heavy MarginfiClient. The PDA is
+  // deterministic; a single getAccountInfo is cheap, and the common case
+  // (wallet has no MarginfiAccount at all) should not pay the SDK-load
+  // cost — nor expose users to the SDK's deep internals failing on an
+  // empty wallet (issue #102: `MarginfiClient.fetch` + related hydration
+  // paths have produced opaque `Cannot read properties of null (reading
+  // 'property')` errors when the MarginfiAccount was freshly initialized
+  // or missing). Probe the first 4 slots to find what's there.
   const MAX_SLOTS = 4;
+  const existingSlots: { idx: number; pda: PublicKey }[] = [];
   for (let idx = 0; idx < MAX_SLOTS; idx++) {
     const pda = deriveMarginfiAccountPda(authority, idx);
     const info = await conn.getAccountInfo(pda, "confirmed");
     if (!info) {
-      // Once we hit a gap, subsequent slots are almost certainly also
-      // empty (users don't skip slots). Early-break keeps the common case
-      // (one account at slot 0) fast — 1 RPC lookup, not 4.
-      if (idx === 0) return []; // common: user has no MarginfiAccount at all
+      // Gap in the slot sequence means no further accounts. Users don't
+      // skip slots in practice (UIs allocate 0, 1, 2 sequentially).
       break;
     }
+    existingSlots.push({ idx, pda });
+  }
+  if (existingSlots.length === 0) {
+    // Strict empty-array contract — this path replaces the prior code
+    // where a wallet without a MarginfiAccount triggered the SDK's null-
+    // property error before we ever reached the slot check (issue #101).
+    return [];
+  }
+
+  // At least one PDA exists — now load the SDK client. Wrap in a defensive
+  // try/catch so an SDK-internal failure (oracle decode, IDL mismatch,
+  // staked-bank layout drift, etc.) surfaces as an actionable error
+  // naming the failing step rather than a raw `null.property` trace.
+  let client: unknown;
+  try {
+    const { MarginfiClient, getConfig } = await import(
+      "@mrgnlabs/marginfi-client-v2"
+    );
+    const stubWallet = {
+      publicKey: authority,
+      signTransaction: async <T,>(_tx: T): Promise<T> => {
+        throw new Error("read-only path must not sign");
+      },
+      signAllTransactions: async <T,>(_txs: T[]): Promise<T[]> => {
+        throw new Error("read-only path must not sign");
+      },
+    };
+    client = await MarginfiClient.fetch(
+      getConfig("production"),
+      stubWallet,
+      conn,
+      { readOnly: true },
+    );
+  } catch (e) {
+    const raw = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `Failed to load MarginfiClient for wallet ${wallet} — this usually means the ` +
+        `bundled SDK (v6.4.1, IDL 0.1.7) couldn't decode one of the banks or oracle ` +
+        `prices fetched from the production group. Raw error: ${raw}. ` +
+        `As a workaround, the PDA ${existingSlots[0]?.pda.toBase58()} exists on chain ` +
+        `at accountIndex=${existingSlots[0]?.idx} — you can inspect it directly via ` +
+        `Solana Explorer.`,
+    );
+  }
+
+  // Hydrate each existing slot's wrapper. One failing slot shouldn't kill
+  // the whole enumeration — we continue and report what we can.
+  const { MarginfiAccountWrapper } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  const results: MarginfiPosition[] = [];
+  for (const { pda } of existingSlots) {
     let wrapper: MinimalWrapper;
     try {
       wrapper = (await MarginfiAccountWrapper.fetch(
         pda,
-        client,
+        client as never,
       )) as unknown as MinimalWrapper;
     } catch {
-      // Hydration failure on one slot shouldn't kill the whole enumeration.
+      // Hydration failure on one slot — skip it silently. The caller
+      // sees this as an empty array or fewer entries than slots; not
+      // a blocker.
       continue;
     }
-    results.push(buildPositionFromWrapper(client as unknown as MinimalClient, wrapper, wallet));
+    try {
+      results.push(
+        buildPositionFromWrapper(
+          client as unknown as MinimalClient,
+          wrapper,
+          wallet,
+        ),
+      );
+    } catch (e) {
+      // Health-compute / balance-decode failures on a freshly-inited
+      // account with no balances can trip the SDK's internal math
+      // (issue #102). Surface a placeholder position with health=Infinity
+      // so callers see the account exists rather than get a raw throw.
+      const raw = e instanceof Error ? e.message : String(e);
+      results.push({
+        protocol: "marginfi",
+        chain: "solana",
+        wallet,
+        marginfiAccount: pda.toBase58(),
+        supplied: [],
+        borrowed: [],
+        totalSuppliedUsd: 0,
+        totalBorrowedUsd: 0,
+        netValueUsd: 0,
+        healthFactor: Number.POSITIVE_INFINITY,
+        warnings: [
+          `MarginFi position compute failed (likely a fresh account with no balances, or an SDK decode issue). ` +
+            `The account itself exists on chain. Raw error: ${raw}`,
+        ],
+      });
+    }
   }
   return results;
 }
@@ -188,11 +258,25 @@ function buildPositionFromWrapper(
   // Maintenance margin type is the one users map to "can I be liquidated right now?".
   // MarginRequirementType.Maintenance === 1 in the SDK's enum; we use the numeric
   // literal to avoid importing the enum just for the one call.
-  const health = wrapper.computeHealthComponents(1);
-  const assetsUsd = health.assets.toNumber();
-  const liabsUsd = health.liabilities.toNumber();
-  const healthFactor =
-    liabsUsd <= 0 ? Number.POSITIVE_INFINITY : assetsUsd / liabsUsd;
+  //
+  // Guarded: a fresh account with no active balances has a healthCache the
+  // SDK hasn't written to yet, and `marginfiAccount.healthCache.*Maint` can
+  // be null → `null.toNumber()` throws (issue #102). Fall back to Infinity
+  // (conceptually: no debt, can't be liquidated) so the reader returns a
+  // usable entry instead of failing the whole call.
+  let healthFactor = Number.POSITIVE_INFINITY;
+  try {
+    const health = wrapper.computeHealthComponents(1);
+    const assetsUsd = health.assets.toNumber();
+    const liabsUsd = health.liabilities.toNumber();
+    healthFactor =
+      liabsUsd <= 0 ? Number.POSITIVE_INFINITY : assetsUsd / liabsUsd;
+  } catch {
+    healthFactor = Number.POSITIVE_INFINITY;
+    warnings.push(
+      "Health factor unavailable — SDK couldn't read healthCache (likely a freshly-initialized account with no balances).",
+    );
+  }
 
   return {
     protocol: "marginfi",

--- a/src/modules/positions/marginfi.ts
+++ b/src/modules/positions/marginfi.ts
@@ -1,7 +1,11 @@
 import type { Connection, PublicKey } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
 import { assertSolanaAddress } from "../solana/address.js";
-import { __internals, deriveMarginfiAccountPda } from "../solana/marginfi.js";
+import {
+  __internals,
+  deriveMarginfiAccountPda,
+  getHardenedMarginfiClient,
+} from "../solana/marginfi.js";
 
 /**
  * Read-only MarginFi position reader. Parallels `getAaveLendingPosition` —
@@ -113,30 +117,13 @@ export async function getMarginfiPositions(
     return [];
   }
 
-  // At least one PDA exists — now load the SDK client. Wrap in a defensive
-  // try/catch so an SDK-internal failure (oracle decode, IDL mismatch,
-  // staked-bank layout drift, etc.) surfaces as an actionable error
-  // naming the failing step rather than a raw `null.property` trace.
+  // At least one PDA exists — now load the SDK client through the shared
+  // hardened entry point so per-bank/per-oracle decode failures don't blow
+  // up the whole load (issue #105). Wrap in a defensive try/catch for the
+  // residual error surface (e.g. upstream RPC down, group account gone).
   let client: unknown;
   try {
-    const { MarginfiClient, getConfig } = await import(
-      "@mrgnlabs/marginfi-client-v2"
-    );
-    const stubWallet = {
-      publicKey: authority,
-      signTransaction: async <T,>(_tx: T): Promise<T> => {
-        throw new Error("read-only path must not sign");
-      },
-      signAllTransactions: async <T,>(_txs: T[]): Promise<T[]> => {
-        throw new Error("read-only path must not sign");
-      },
-    };
-    client = await MarginfiClient.fetch(
-      getConfig("production"),
-      stubWallet,
-      conn,
-      { readOnly: true },
-    );
+    client = await getHardenedMarginfiClient(conn, authority);
   } catch (e) {
     const raw = e instanceof Error ? e.message : String(e);
     throw new Error(

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -109,7 +109,17 @@ export interface SolanaNativeSendParams {
  */
 export interface PreparedSolanaTx {
   handle: string;
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
+  action:
+    | "native_send"
+    | "spl_send"
+    | "nonce_init"
+    | "nonce_close"
+    | "jupiter_swap"
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
   chain: "solana";
   from: string;
   description: string;

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -324,6 +324,13 @@ export interface PreparedMarginfiTx {
   decoded: { functionName: string; args: Record<string, string> };
   nonceAccount: string;
   marginfiAccount: string;
+  /**
+   * Rent-exempt minimum in lamports. Populated on `marginfi_init` — the
+   * PDA's 2312-byte account needs ~0.01698 SOL sent from the user's wallet
+   * (reclaimable on close). Surfaced so the agent's bullet summary shows
+   * the real cost to the user BEFORE they blind-sign (issue #103).
+   */
+  rentLamports?: number;
 }
 
 export interface MarginfiInitParams {
@@ -351,8 +358,18 @@ export async function buildMarginfiInit(
 
   const marginfiAccount = deriveMarginfiAccountPda(fromPubkey, accountIndex);
 
+  // Rent-exempt minimum for the 2312-byte MarginfiAccount PDA. The user's
+  // wallet funds this directly — no ephemeral keypair involved, but the
+  // SOL still leaves the wallet (reclaimable when the account is closed).
+  // Surfaced on the prepared tx so the agent's bullet summary can show
+  // real cost to the user before they blind-sign (issue #103).
+  const MARGINFI_ACCOUNT_SIZE_BYTES = 2312;
+  const rentLamports = await conn.getMinimumBalanceForRentExemption(
+    MARGINFI_ACCOUNT_SIZE_BYTES,
+  );
+
   // Refuse re-init — the on-chain ix reverts, but we get a clearer error by
-  // short-circuiting here. 0.00XX SOL would otherwise burn on the failed send.
+  // short-circuiting here. ~0.017 SOL would otherwise burn on the failed send.
   const existing = await conn.getAccountInfo(marginfiAccount, "confirmed");
   if (existing) {
     throw new Error(
@@ -403,7 +420,10 @@ export async function buildMarginfiInit(
       from: p.wallet,
       description:
         `Initialize MarginfiAccount ${marginfiAccountStr} for ${p.wallet} ` +
-        `(accountIndex=${accountIndex}, third_party_id=0; one-time setup — this is a PDA, no rent-exempt seed is moved)`,
+        `(accountIndex=${accountIndex}, third_party_id=0). One-time setup — rent-exempt ` +
+        `minimum ~${(rentLamports / 1e9).toFixed(6)} SOL is moved from your wallet to ` +
+        `fund the PDA (2312-byte account), reclaimable when the account is closed. ` +
+        `No separate keypair required.`,
       decoded: {
         functionName: "marginfi.account_initialize_pda",
         args: {
@@ -414,8 +434,11 @@ export async function buildMarginfiInit(
           accountIndex: String(accountIndex),
           thirdPartyId: "0",
           nonceAccount: nonceAccountStr,
+          rentLamports: String(rentLamports),
+          rentSol: (rentLamports / 1e9).toFixed(9).replace(/\.?0+$/, ""),
         },
       },
+      rentLamports,
       nonce: {
         account: nonceAccountStr,
         authority: fromPubkey.toBase58(),
@@ -433,6 +456,7 @@ export async function buildMarginfiInit(
     decoded: draft.meta.decoded,
     nonceAccount: nonceAccountStr,
     marginfiAccount: marginfiAccountStr,
+    rentLamports,
   };
 }
 
@@ -518,10 +542,39 @@ async function resolveActionContext(
   }
   const symbol = resolveMintSymbol(mint);
 
-  const client = await getMarginfiClient(conn, fromPubkey);
+  // The SDK-heavy paths below have produced opaque `null.property` errors
+  // in live testing when the MarginfiAccount is freshly-initialized or
+  // when one of the production group's banks has a layout the bundled IDL
+  // doesn't understand (issue #102). Wrap each heavy call so the user
+  // gets an actionable message naming the step + PDA + wallet instead of
+  // a raw runtime trace.
+  let client: unknown;
+  try {
+    client = await getMarginfiClient(conn, fromPubkey);
+  } catch (e) {
+    const raw = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `MarginfiClient load failed for wallet ${p.wallet} — the bundled SDK (v6.4.1) ` +
+        `couldn't decode one of the production group's banks or oracle prices. ` +
+        `Raw error: ${raw}. Retry in a minute; if it persists, MarginFi may have ` +
+        `shipped an on-chain upgrade the SDK version doesn't support yet.`,
+    );
+  }
   const bank = findBankForMint(client, mint);
 
-  const wrapper = await fetchMarginfiAccountWrapper(client, marginfiAccount);
+  let wrapper: MinimalWrapper | null;
+  try {
+    wrapper = await fetchMarginfiAccountWrapper(client, marginfiAccount);
+  } catch (e) {
+    const raw = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `MarginfiAccount hydration failed for ${marginfiAccount.toBase58()} ` +
+        `(wallet ${p.wallet}, accountIndex=${accountIndex}). Raw error: ${raw}. ` +
+        `The account exists on chain (verified earlier in this call) but the ` +
+        `SDK can't parse it. If you just ran prepare_marginfi_init, wait one ` +
+        `confirmation and retry.`,
+    );
+  }
   if (!wrapper) {
     throw new Error(
       `MarginfiAccount at ${marginfiAccount.toBase58()} exists on chain but the SDK could ` +
@@ -532,10 +585,21 @@ async function resolveActionContext(
   }
 
   // Action-specific pre-flight beyond the bank pause check that
-  // findBankForMint already enforced.
+  // findBankForMint already enforced. `computeFreeCollateral` internally
+  // reads `marginfiAccount.healthCache.*` which can be null on a freshly-
+  // initialized account; wrap it so the preflight fails SOFT (we skip
+  // the guard instead of blowing up), letting the on-chain program
+  // enforce the real check. For a wallet with no active balances, borrow
+  // will revert on-chain anyway — cost is one tx fee, same as any other
+  // pre-flight we skip.
   if (kind === "borrow" || kind === "withdraw") {
-    const free = wrapper.computeFreeCollateral();
-    if (free.lte(0)) {
+    let free: BigNumber | null = null;
+    try {
+      free = wrapper.computeFreeCollateral();
+    } catch {
+      free = null;
+    }
+    if (free && free.lte(0)) {
       throw new Error(
         `MarginfiAccount has zero free collateral — ${kind === "borrow" ? "cannot take on new debt" : "withdrawing would push health factor below the required ratio"}. ` +
           `Supply more collateral or repay existing debt first.`,

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -291,7 +291,13 @@ async function hardenedFetchGroupData(
 
   const p = program as {
     provider: { connection: Connection };
-    coder: { accounts: { decode(name: string, data: Buffer): unknown } };
+    // Anchor 0.30.1's coder exposes decode/encode directly — there is NO
+    // `coder.accounts` namespace (unlike the `program.account` namespace
+    // off a Program instance, which is a different object). Verified via
+    // empirical probe against `@coral-xyz/anchor@0.30.1`
+    // (`dist/cjs/coder/borsh/accounts.js` — the class is
+    // `BorshAccountsCoder` with top-level `decode`/`encode` methods).
+    coder: { decode(name: string, data: Buffer): unknown };
     programId: PublicKey;
     idl: unknown;
   };
@@ -338,11 +344,8 @@ async function hardenedFetchGroupData(
       // in marginfi_0.1.7.json). Anchor's BorshAccountsCoder keys its
       // `accountLayouts` map on that exact name, so the decode call must
       // use "Bank", not the camelCase `program.account.bank` accessor
-      // form.
-      const decoded = p.coder.accounts.decode(
-        "Bank",
-        ai.data,
-      ) as BankDecodedLike;
+      // form used elsewhere in the SDK.
+      const decoded = p.coder.decode("Bank", ai.data) as BankDecodedLike;
       // Skip integrator banks (KAMINO = 3, DRIFT = 4, SOLEND = 5). These
       // ride a different layout and aren't relevant to core lending.
       const tag = decoded.config?.assetTag;
@@ -462,6 +465,9 @@ export async function getHardenedMarginfiClient(
 ): Promise<unknown> {
   return getMarginfiClient(conn, authority);
 }
+
+/** Test-only: expose the hardened fetchGroupData for direct-path testing. */
+export const __hardenedFetchGroupDataForTest = hardenedFetchGroupData;
 
 /** Test-only hook so unit tests don't pay the cost of a live fetch. */
 export function __setMarginfiClientCacheEntry(client: unknown): void {

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -1,0 +1,702 @@
+import {
+  AddressLookupTableAccount,
+  PublicKey,
+  TransactionInstruction,
+  type Connection,
+} from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import { resolveAddressLookupTables } from "./alt.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+import { SOLANA_TOKEN_DECIMALS, SOLANA_TOKENS } from "../../config/solana.js";
+
+/**
+ * MarginFi lending — supply / withdraw / borrow / repay + one-time PDA
+ * MarginfiAccount init.
+ *
+ * Integration notes (scope-probed 2026-04-24 against SDK v6.4.1 — see
+ * project_marginfi_sdk_scope.md):
+ *
+ * - Every action is durable-nonce-protected: ix[0] = SystemProgram.nonceAdvance,
+ *   consistent with every other Solana send in this server. The wallet must
+ *   have run prepare_solana_nonce_init before any prepare_marginfi_* call.
+ *
+ * - Init uses the PDA variant `marginfi_account_initialize_pda`. Plan's note
+ *   3 claimed the SDK didn't wrap this; the scope-probe showed it does — via
+ *   `instructions.makeInitMarginfiAccountPdaIx` — so we use the SDK wrapper
+ *   instead of dropping to @coral-xyz/anchor codegen. Only `authority` and
+ *   `fee_payer` sign; the MarginfiAccount PDA is writable but not a signer
+ *   (Ledger-compatible).
+ *
+ * - Supply / Withdraw / Borrow / Repay go through
+ *   `MarginfiAccountWrapper.make{Deposit,Repay,Withdraw,Borrow}Ix`. These
+ *   return `InstructionsWrapper { instructions, keys: [] }`. `keys: []` is
+ *   the Ledger-compatibility signal — no ephemeral Keypair signers in the
+ *   lending happy path (scope-probed).
+ *
+ * - Transactions are always v0 VersionedMessages with the MarginFi group's
+ *   Address Lookup Tables. MarginFi's group-wide ALTs (shipped in the SDK's
+ *   ADDRESS_LOOKUP_TABLE_FOR_GROUP constant — 2 tables for the production
+ *   group) compress account lists; without them a borrow/withdraw can blow
+ *   past the 35-account legacy limit on banks with oracle cranks.
+ */
+
+const MAINNET_PROGRAM_ID = new PublicKey(
+  "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
+);
+
+const MAINNET_GROUP = new PublicKey(
+  "4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8",
+);
+
+/** ASCII bytes for `"marginfi_account"` — PDA seed 0 (16 bytes). */
+const MARGINFI_ACCOUNT_SEED = Buffer.from("marginfi_account", "utf-8");
+
+/**
+ * Canonical MarginFi symbol → mint resolver. Piggybacks on the existing
+ * SOLANA_TOKENS config so we don't duplicate the mint table. Extends with
+ * "SOL" → wSOL mint (MarginFi's SOL bank uses wSOL under the hood — the SDK
+ * auto-wraps/unwraps native SOL when `wrapAndUnwrapSol: true` is set, which
+ * is our default).
+ */
+const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+function resolveSymbolToMint(symbol: string): string {
+  if (symbol === "SOL") return WSOL_MINT;
+  const upper = symbol.toUpperCase();
+  const sol = SOLANA_TOKENS[upper as keyof typeof SOLANA_TOKENS];
+  if (!sol) {
+    throw new Error(
+      `Unknown token symbol "${symbol}". Supported: SOL, ${Object.keys(SOLANA_TOKENS).join(", ")}. ` +
+        `Pass a canonical mint address in the \`mint\` field instead if you need a non-canonical token.`,
+    );
+  }
+  return sol;
+}
+
+function resolveMintSymbol(mint: string): string {
+  if (mint === WSOL_MINT) return "SOL";
+  for (const [sym, addr] of Object.entries(SOLANA_TOKENS) as [
+    keyof typeof SOLANA_TOKENS,
+    string,
+  ][]) {
+    if (addr === mint) return sym;
+  }
+  return "UNKNOWN";
+}
+
+function resolveMintDecimals(mint: string): number | null {
+  if (mint === WSOL_MINT) return 9;
+  for (const [sym, addr] of Object.entries(SOLANA_TOKENS) as [
+    keyof typeof SOLANA_TOKENS,
+    string,
+  ][]) {
+    if (addr === mint) return SOLANA_TOKEN_DECIMALS[sym];
+  }
+  return null;
+}
+
+/**
+ * Derive a wallet's deterministic MarginfiAccount PDA. Seeds per IDL 0.1.7:
+ * ["marginfi_account", group, authority, account_index (u16 LE), third_party_id (u16 LE)].
+ *
+ * `accountIndex` lets one wallet own multiple MarginfiAccounts (most users
+ * stay on 0). `thirdPartyId` is reserved for protocol integrators; we pass 0.
+ */
+export function deriveMarginfiAccountPda(
+  authority: PublicKey,
+  accountIndex = 0,
+  thirdPartyId = 0,
+  group: PublicKey = MAINNET_GROUP,
+  programId: PublicKey = MAINNET_PROGRAM_ID,
+): PublicKey {
+  const indexBuf = Buffer.alloc(2);
+  indexBuf.writeUInt16LE(accountIndex);
+  const tpidBuf = Buffer.alloc(2);
+  tpidBuf.writeUInt16LE(thirdPartyId);
+  const [pda] = PublicKey.findProgramAddressSync(
+    [MARGINFI_ACCOUNT_SEED, group.toBuffer(), authority.toBuffer(), indexBuf, tpidBuf],
+    programId,
+  );
+  return pda;
+}
+
+/**
+ * Minimum SDK-facing `Wallet` shape (from @mrgnlabs/mrgn-common `types.d.ts`).
+ * The SDK never *calls* `signTransaction` / `signAllTransactions` during ix
+ * construction — only during the high-level `deposit()` flow, which we never
+ * use. But the type shape is required to construct `MarginfiClient.fetch()`.
+ * We stub the signers to throw on accidental call (defense in depth: if the
+ * SDK ever starts invoking them in the ix path, tests will surface it with
+ * a clear error rather than silently producing a tx with a zero signature).
+ */
+interface StubWallet {
+  publicKey: PublicKey;
+  signTransaction: <T>(tx: T) => Promise<T>;
+  signAllTransactions: <T>(txs: T[]) => Promise<T[]>;
+  signMessage?: (message: Uint8Array) => Promise<Uint8Array>;
+}
+
+function makeStubWallet(authority: PublicKey): StubWallet {
+  const fail = (): never => {
+    throw new Error(
+      "MarginFi SDK attempted to sign through the stub wallet — this is a bug. " +
+        "Ix construction should never invoke signTransaction / signAllTransactions. " +
+        "Signing happens later via Ledger USB HID in send_transaction.",
+    );
+  };
+  return {
+    publicKey: authority,
+    signTransaction: fail,
+    signAllTransactions: fail,
+  };
+}
+
+/**
+ * Per-process cache for the (heavy) `MarginfiClient.fetch()` call. Keyed on
+ * `group.toBase58()` — the client doesn't depend on the particular wallet
+ * asking, only on group state (banks, oracle prices, bank metadatas). A
+ * wallet-keyed cache would just multiply identical fetches.
+ *
+ * TTL of 60s balances two concerns: (1) MarginFi bank state (oracle prices,
+ * reserve configs) shifts within minutes under normal conditions; (2) a
+ * prepare_marginfi_* call cluster (init + supply + withdraw in one session)
+ * shouldn't re-fetch 3 times.
+ */
+const CLIENT_CACHE_TTL_MS = 60_000;
+interface CachedClient {
+  // Typed as unknown so we don't export the heavy SDK types through our
+  // module surface — callers interact via the module's public functions.
+  client: unknown;
+  expiresAt: number;
+}
+const clientCache = new Map<string, CachedClient>();
+
+async function getMarginfiClient(
+  conn: Connection,
+  authority: PublicKey,
+): Promise<unknown> {
+  const key = MAINNET_GROUP.toBase58();
+  const existing = clientCache.get(key);
+  if (existing && existing.expiresAt > Date.now()) return existing.client;
+
+  const { MarginfiClient, getConfig } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  const config = getConfig("production");
+  const wallet = makeStubWallet(authority);
+  const client = await MarginfiClient.fetch(config, wallet, conn, {
+    readOnly: true,
+  });
+  clientCache.set(key, {
+    client,
+    expiresAt: Date.now() + CLIENT_CACHE_TTL_MS,
+  });
+  return client;
+}
+
+/** Test-only hook so unit tests don't pay the cost of a live fetch. */
+export function __setMarginfiClientCacheEntry(client: unknown): void {
+  clientCache.set(MAINNET_GROUP.toBase58(), {
+    client,
+    expiresAt: Date.now() + CLIENT_CACHE_TTL_MS,
+  });
+}
+
+/** Test-only clear hook for vitest's beforeEach. */
+export function __clearMarginfiClientCache(): void {
+  clientCache.clear();
+}
+
+/**
+ * Minimal shape of the SDK objects we touch — deliberately narrow so the
+ * concrete SDK types don't leak across the boundary. Any widening here
+ * requires a matching widening of the SDK call in a builder function (the
+ * TypeScript compiler will surface the mismatch).
+ */
+interface MinimalBank {
+  address: PublicKey;
+  mint: PublicKey;
+  config: { assetWeightInit: BigNumber; liabilityWeightInit: BigNumber };
+  tokenSymbol?: string;
+  isPaused?: boolean;
+}
+interface MinimalClient {
+  getBankByMint(mint: PublicKey): MinimalBank | null;
+  banks: Map<string, MinimalBank>;
+  program: unknown;
+  wallet: StubWallet;
+  group: unknown;
+}
+interface MinimalWrapper {
+  address: PublicKey;
+  makeDepositIx(
+    amount: number | string | BigNumber,
+    bankAddress: PublicKey,
+    opts?: Record<string, unknown>,
+  ): Promise<{ instructions: TransactionInstruction[]; keys: unknown[] }>;
+  makeRepayIx(
+    amount: number | string | BigNumber,
+    bankAddress: PublicKey,
+    repayAll?: boolean,
+    opts?: Record<string, unknown>,
+  ): Promise<{ instructions: TransactionInstruction[]; keys: unknown[] }>;
+  makeWithdrawIx(
+    amount: number | string | BigNumber,
+    bankAddress: PublicKey,
+    withdrawAll?: boolean,
+    opts?: Record<string, unknown>,
+  ): Promise<{ instructions: TransactionInstruction[]; keys: unknown[] }>;
+  makeBorrowIx(
+    amount: number | string | BigNumber,
+    bankAddress: PublicKey,
+    opts?: Record<string, unknown>,
+  ): Promise<{ instructions: TransactionInstruction[]; keys: unknown[] }>;
+  computeHealthComponents(req: unknown): {
+    assets: BigNumber;
+    liabilities: BigNumber;
+  };
+  computeFreeCollateral(): BigNumber;
+}
+
+async function fetchMarginfiAccountWrapper(
+  client: unknown,
+  pda: PublicKey,
+): Promise<MinimalWrapper | null> {
+  const { MarginfiAccountWrapper } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  try {
+    const wrapper = await MarginfiAccountWrapper.fetch(pda, client as never);
+    return wrapper as unknown as MinimalWrapper;
+  } catch (e) {
+    // The SDK throws on missing account; fold into a null so the caller can
+    // distinguish "account exists but fetch errored" from "user hasn't init'd".
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/account.*does not exist|not found|Account does not exist/i.test(msg)) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+function findBankForMint(client: unknown, mint: string): MinimalBank {
+  const c = client as MinimalClient;
+  const bank = c.getBankByMint(new PublicKey(mint));
+  if (!bank) {
+    throw new Error(
+      `No MarginFi bank found for mint ${mint} (${resolveMintSymbol(mint)}). ` +
+        `MarginFi lists a subset of SPL tokens; not every mainnet SPL is supported. ` +
+        `Check https://app.marginfi.com for the current bank list.`,
+    );
+  }
+  if (bank.isPaused) {
+    throw new Error(
+      `MarginFi bank for ${resolveMintSymbol(mint)} is paused by governance. ` +
+        `Supply / withdraw / borrow / repay are all blocked until an unpause proposal passes. ` +
+        `Refusing to prepare the tx.`,
+    );
+  }
+  return bank;
+}
+
+export interface PreparedMarginfiTx {
+  handle: string;
+  action:
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  nonceAccount: string;
+  marginfiAccount: string;
+}
+
+export interface MarginfiInitParams {
+  wallet: string;
+  /** Account slot (0 = first, 1 = second, ...) — lets one wallet own multiple MarginfiAccounts. */
+  accountIndex?: number;
+}
+
+/**
+ * Build the one-time `marginfi_account_initialize_pda` tx. Deterministic PDA,
+ * only the user signs as authority + fee_payer. Runs under durable-nonce
+ * protection so the user has unbounded Ledger review time.
+ */
+export async function buildMarginfiInit(
+  p: MarginfiInitParams,
+): Promise<PreparedMarginfiTx> {
+  const fromPubkey = assertSolanaAddress(p.wallet);
+  const accountIndex = p.accountIndex ?? 0;
+  const conn = getSolanaConnection();
+
+  // Durable-nonce preflight.
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(p.wallet);
+
+  const marginfiAccount = deriveMarginfiAccountPda(fromPubkey, accountIndex);
+
+  // Refuse re-init — the on-chain ix reverts, but we get a clearer error by
+  // short-circuiting here. 0.00XX SOL would otherwise burn on the failed send.
+  const existing = await conn.getAccountInfo(marginfiAccount, "confirmed");
+  if (existing) {
+    throw new Error(
+      `MarginfiAccount already exists at PDA ${marginfiAccount.toBase58()} ` +
+        `for wallet ${p.wallet} (account_index=${accountIndex}). ` +
+        `If you want a second MarginfiAccount, call prepare_marginfi_init with a different ` +
+        `accountIndex (1, 2, ...). If you want to keep using this one, call ` +
+        `prepare_marginfi_supply / withdraw / borrow / repay directly.`,
+    );
+  }
+
+  const { instructions: mfnInstructions } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  const initIx = await mfnInstructions.makeInitMarginfiAccountPdaIx(
+    // The SDK's helper takes a `Program<Marginfi>` for `mfProgram`. We don't
+    // need a full client for the init path — just a Program bound to the
+    // program ID + a dummy provider. Construct it minimally.
+    (await buildMarginfiProgram(conn, fromPubkey)) as never,
+    {
+      marginfiGroup: MAINNET_GROUP,
+      marginfiAccount,
+      authority: fromPubkey,
+      feePayer: fromPubkey,
+    },
+    { accountIndex, thirdPartyId: 0 },
+  );
+
+  const instructions: TransactionInstruction[] = [
+    buildAdvanceNonceIx(noncePubkey, fromPubkey),
+    initIx,
+  ];
+
+  // Use v0 even for init — the ALT set is empty here (no complex account
+  // list yet), but v0 keeps the draft store branching uniform across all
+  // MarginFi actions.
+  const alts: AddressLookupTableAccount[] = [];
+
+  const nonceAccountStr = noncePubkey.toBase58();
+  const marginfiAccountStr = marginfiAccount.toBase58();
+  const draft: SolanaTxDraft = {
+    kind: "v0",
+    payerKey: fromPubkey,
+    instructions,
+    addressLookupTableAccounts: alts,
+    meta: {
+      action: "marginfi_init",
+      from: p.wallet,
+      description:
+        `Initialize MarginfiAccount ${marginfiAccountStr} for ${p.wallet} ` +
+        `(accountIndex=${accountIndex}, third_party_id=0; one-time setup — this is a PDA, no rent-exempt seed is moved)`,
+      decoded: {
+        functionName: "marginfi.account_initialize_pda",
+        args: {
+          wallet: p.wallet,
+          marginfiAccount: marginfiAccountStr,
+          authority: p.wallet,
+          marginfiGroup: MAINNET_GROUP.toBase58(),
+          accountIndex: String(accountIndex),
+          thirdPartyId: "0",
+          nonceAccount: nonceAccountStr,
+        },
+      },
+      nonce: {
+        account: nonceAccountStr,
+        authority: fromPubkey.toBase58(),
+        value: nonceState.nonce,
+      },
+    },
+  };
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "marginfi_init",
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: nonceAccountStr,
+    marginfiAccount: marginfiAccountStr,
+  };
+}
+
+/**
+ * Construct an Anchor `Program<Marginfi>` instance pointed at mainnet MarginFi
+ * with a stub provider. Only the init path needs this directly — supply/
+ * withdraw/borrow/repay go through the higher-level MarginfiAccountWrapper
+ * which already has a `_program` internal.
+ *
+ * Deliberately inlined here rather than shared with `getMarginfiClient`'s
+ * internal Program to keep the init path's dependency surface minimal
+ * (anchor, idl, program — nothing else).
+ */
+async function buildMarginfiProgram(
+  conn: Connection,
+  authority: PublicKey,
+): Promise<unknown> {
+  const { AnchorProvider, Program } = await import("@coral-xyz/anchor");
+  const { MARGINFI_IDL } = await import("@mrgnlabs/marginfi-client-v2");
+  const wallet = makeStubWallet(authority);
+  const provider = new AnchorProvider(conn, wallet as never, {
+    commitment: "confirmed",
+  });
+  // `MARGINFI_IDL` is typed as v0.1.7 IDL; spreading overrides .address to
+  // the deployed program id. Same pattern the SDK's `MarginfiClient.fetch`
+  // uses internally.
+  const idl = { ...MARGINFI_IDL, address: MAINNET_PROGRAM_ID.toBase58() };
+  return new Program(idl, provider);
+}
+
+export interface MarginfiActionParams {
+  wallet: string;
+  /** Canonical symbol ("USDC", "SOL", "USDT", ...) — resolved via SOLANA_TOKENS. */
+  symbol?: string;
+  /** OR pass an explicit mint address to override the symbol lookup. */
+  mint?: string;
+  /** Human-readable amount (e.g., "1.5" for 1.5 USDC). Decimals resolved from the bank. */
+  amount: string;
+  accountIndex?: number;
+}
+
+type ActionKind = "supply" | "withdraw" | "borrow" | "repay";
+
+interface ResolvedActionContext {
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+  marginfiAccount: PublicKey;
+  wrapper: MinimalWrapper;
+  bank: MinimalBank;
+  mint: string;
+  symbol: string;
+  amountUi: BigNumber;
+}
+
+async function resolveActionContext(
+  p: MarginfiActionParams,
+  kind: ActionKind,
+): Promise<ResolvedActionContext> {
+  const fromPubkey = assertSolanaAddress(p.wallet);
+  const conn = getSolanaConnection();
+
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(p.wallet);
+
+  const accountIndex = p.accountIndex ?? 0;
+  const marginfiAccount = deriveMarginfiAccountPda(fromPubkey, accountIndex);
+  const info = await conn.getAccountInfo(marginfiAccount, "confirmed");
+  if (!info) {
+    throw new Error(
+      `No MarginfiAccount exists for ${p.wallet} (accountIndex=${accountIndex}). ` +
+        `Run prepare_marginfi_init first — it's a one-time setup (no rent-exempt seed moved; ` +
+        `only ~0.000005 SOL tx fee) that creates your MarginFi lending state account.`,
+    );
+  }
+
+  const mint = p.mint ?? resolveSymbolToMint(p.symbol ?? "");
+  if (!mint) {
+    throw new Error(
+      `Specify either \`symbol\` (USDC / SOL / USDT / ...) or \`mint\` (base58 SPL mint). Neither supplied.`,
+    );
+  }
+  const symbol = resolveMintSymbol(mint);
+
+  const client = await getMarginfiClient(conn, fromPubkey);
+  const bank = findBankForMint(client, mint);
+
+  const wrapper = await fetchMarginfiAccountWrapper(client, marginfiAccount);
+  if (!wrapper) {
+    throw new Error(
+      `MarginfiAccount at ${marginfiAccount.toBase58()} exists on chain but the SDK could ` +
+        `not hydrate it as a MarginfiAccountWrapper — this is unexpected. Retry; if it ` +
+        `persists, the account data may be in a new schema this SDK version (v6.4.1) ` +
+        `doesn't understand.`,
+    );
+  }
+
+  // Action-specific pre-flight beyond the bank pause check that
+  // findBankForMint already enforced.
+  if (kind === "borrow" || kind === "withdraw") {
+    const free = wrapper.computeFreeCollateral();
+    if (free.lte(0)) {
+      throw new Error(
+        `MarginfiAccount has zero free collateral — ${kind === "borrow" ? "cannot take on new debt" : "withdrawing would push health factor below the required ratio"}. ` +
+          `Supply more collateral or repay existing debt first.`,
+      );
+    }
+  }
+
+  const amountUi = new BigNumber(p.amount);
+  if (!amountUi.isFinite() || amountUi.lte(0)) {
+    throw new Error(
+      `Invalid amount "${p.amount}" — expected a positive decimal (e.g. "1.5").`,
+    );
+  }
+
+  return {
+    fromPubkey,
+    noncePubkey,
+    nonceValue: nonceState.nonce,
+    marginfiAccount,
+    wrapper,
+    bank,
+    mint,
+    symbol,
+    amountUi,
+  };
+}
+
+async function wrapWithNonce(
+  ctx: ResolvedActionContext,
+  actionLabel: string,
+  actionAction:
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay",
+  bankIxs: TransactionInstruction[],
+  p: MarginfiActionParams,
+): Promise<PreparedMarginfiTx> {
+  const conn = getSolanaConnection();
+
+  // MarginFi publishes group-wide ALTs (2 tables for the production group).
+  // Pull them into the v0 draft so borrow/withdraw flows with oracle cranks
+  // fit inside the 1232-byte packet ceiling.
+  const altPubkeys = await getMarginfiGroupAltAddresses();
+  const alts = await resolveAddressLookupTables(conn, altPubkeys);
+
+  const instructions: TransactionInstruction[] = [
+    buildAdvanceNonceIx(ctx.noncePubkey, ctx.fromPubkey),
+    ...bankIxs,
+  ];
+
+  const accountIndex = p.accountIndex ?? 0;
+  const nonceAccountStr = ctx.noncePubkey.toBase58();
+  const marginfiAccountStr = ctx.marginfiAccount.toBase58();
+
+  const draft: SolanaTxDraft = {
+    kind: "v0",
+    payerKey: ctx.fromPubkey,
+    instructions,
+    addressLookupTableAccounts: alts,
+    meta: {
+      action: actionAction,
+      from: p.wallet,
+      description:
+        `MarginFi ${actionLabel}: ${ctx.amountUi.toFixed()} ${ctx.symbol} ` +
+        `(account ${marginfiAccountStr.slice(0, 8)}…, bank ${ctx.bank.address.toBase58().slice(0, 8)}…)`,
+      decoded: {
+        functionName: `marginfi.${actionAction.replace("marginfi_", "lending_account_")}`,
+        args: {
+          wallet: p.wallet,
+          marginfiAccount: marginfiAccountStr,
+          accountIndex: String(accountIndex),
+          bank: ctx.bank.address.toBase58(),
+          mint: ctx.mint,
+          symbol: ctx.symbol,
+          amount: ctx.amountUi.toFixed() + " " + ctx.symbol,
+          nonceAccount: nonceAccountStr,
+        },
+      },
+      nonce: {
+        account: nonceAccountStr,
+        authority: ctx.fromPubkey.toBase58(),
+        value: ctx.nonceValue,
+      },
+    },
+  };
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: actionAction,
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: nonceAccountStr,
+    marginfiAccount: marginfiAccountStr,
+  };
+}
+
+async function getMarginfiGroupAltAddresses(): Promise<PublicKey[]> {
+  const { ADDRESS_LOOKUP_TABLE_FOR_GROUP } = await import(
+    "@mrgnlabs/marginfi-client-v2"
+  );
+  return (
+    ADDRESS_LOOKUP_TABLE_FOR_GROUP[MAINNET_GROUP.toBase58()] ?? []
+  ) as PublicKey[];
+}
+
+export async function buildMarginfiSupply(
+  p: MarginfiActionParams,
+): Promise<PreparedMarginfiTx> {
+  const ctx = await resolveActionContext(p, "supply");
+  const { instructions } = await ctx.wrapper.makeDepositIx(
+    ctx.amountUi,
+    ctx.bank.address,
+  );
+  return wrapWithNonce(ctx, "supply", "marginfi_supply", instructions, p);
+}
+
+export async function buildMarginfiWithdraw(
+  p: MarginfiActionParams & { withdrawAll?: boolean },
+): Promise<PreparedMarginfiTx> {
+  const ctx = await resolveActionContext(p, "withdraw");
+  const { instructions } = await ctx.wrapper.makeWithdrawIx(
+    ctx.amountUi,
+    ctx.bank.address,
+    p.withdrawAll ?? false,
+  );
+  return wrapWithNonce(ctx, "withdraw", "marginfi_withdraw", instructions, p);
+}
+
+export async function buildMarginfiBorrow(
+  p: MarginfiActionParams,
+): Promise<PreparedMarginfiTx> {
+  const ctx = await resolveActionContext(p, "borrow");
+  const { instructions } = await ctx.wrapper.makeBorrowIx(
+    ctx.amountUi,
+    ctx.bank.address,
+  );
+  return wrapWithNonce(ctx, "borrow", "marginfi_borrow", instructions, p);
+}
+
+export async function buildMarginfiRepay(
+  p: MarginfiActionParams & { repayAll?: boolean },
+): Promise<PreparedMarginfiTx> {
+  const ctx = await resolveActionContext(p, "repay");
+  const { instructions } = await ctx.wrapper.makeRepayIx(
+    ctx.amountUi,
+    ctx.bank.address,
+    p.repayAll ?? false,
+  );
+  return wrapWithNonce(ctx, "repay", "marginfi_repay", instructions, p);
+}
+
+export const __internals = {
+  resolveSymbolToMint,
+  resolveMintSymbol,
+  resolveMintDecimals,
+  MAINNET_PROGRAM_ID,
+  MAINNET_GROUP,
+  fetchMarginfiAccountWrapper,
+  findBankForMint,
+};

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -183,6 +183,64 @@ interface CachedClient {
 }
 const clientCache = new Map<string, CachedClient>();
 
+/**
+ * Diagnostic record for a bank the hardened fetch path had to skip. Surfaced
+ * so `findBankForMint` can tell "bank not listed on MarginFi" apart from
+ * "bank IS listed but we failed to load it" (issue #107).
+ *
+ * `mint` is best-effort: on a step-2 Borsh decode failure we recover it from
+ * the raw 32 bytes at offset 8 (the Bank account's first field), so even a
+ * fully-undecodable bank gets an attributable mint.
+ */
+export type MarginfiBankSkipStep =
+  | "decode"
+  | "hydrate"
+  | "tokenData"
+  | "priceInfo";
+export interface MarginfiBankSkipRecord {
+  address: string;
+  mint: string | null;
+  step: MarginfiBankSkipStep;
+  reason: string;
+}
+interface DiagnosticSnapshot {
+  fetchedAt: number;
+  addressesFetched: number;
+  banksHydrated: number;
+  skippedIntegrator: number;
+  records: MarginfiBankSkipRecord[];
+}
+const lastGroupDiagnostics = new Map<string, DiagnosticSnapshot>();
+
+function recordSkip(
+  records: MarginfiBankSkipRecord[],
+  address: PublicKey,
+  mint: string | null,
+  step: MarginfiBankSkipStep,
+  err: unknown,
+): void {
+  const reason = err instanceof Error ? err.message : String(err);
+  records.push({ address: address.toBase58(), mint, step, reason });
+}
+
+/**
+ * Recover a bank's mint from the raw account data at IDL 0.1.7's known
+ * offset (8-byte discriminator + 32-byte mint pubkey). Lets us attribute a
+ * `decode`-step skip to a mint even when the Borsh layout is blind.
+ *
+ * Returns `null` if the data is too short or the bytes don't form a valid
+ * base58 key — `findBankForMint`'s diagnostic then falls back to reporting
+ * the bank address without the mint.
+ */
+function tryReadMintFromRawBankData(data: Buffer): string | null {
+  if (data.length < 8 + 32) return null;
+  try {
+    return new PublicKey(data.subarray(8, 8 + 32)).toBase58();
+  } catch {
+    return null;
+  }
+}
+
 async function getMarginfiClient(
   conn: Connection,
   authority: PublicKey,
@@ -354,11 +412,12 @@ async function hardenedFetchGroupData(
     emissionsMint: PublicKey;
   }
   const bankDatasKeyed: BankDatum[] = [];
-  let skippedDecode = 0;
+  const skipRecords: MarginfiBankSkipRecord[] = [];
   let skippedIntegrator = 0;
   for (let i = 0; i < addresses.length; i++) {
     const ai = bankAis[i];
     if (!ai) continue;
+    const address = addresses[i]!;
     try {
       // IDL 0.1.7 names the account "Bank" (PascalCase — see accounts[].name
       // in marginfi_0.1.7.json). Anchor's BorshAccountsCoder keys its
@@ -373,19 +432,21 @@ async function hardenedFetchGroupData(
         skippedIntegrator++;
         continue;
       }
-      bankDatasKeyed.push({ address: addresses[i]!, data: decoded });
-    } catch {
-      skippedDecode++;
+      bankDatasKeyed.push({ address, data: decoded });
+    } catch (err) {
+      // Recover the mint from raw bytes so the diagnostic can still
+      // attribute this skip to (e.g.) USDC even when the full layout is
+      // opaque — enables the distinct "bank listed but skipped" error
+      // in findBankForMint instead of the misleading "not listed" one
+      // (issue #107).
+      recordSkip(
+        skipRecords,
+        address,
+        tryReadMintFromRawBankData(ai.data),
+        "decode",
+        err,
+      );
     }
-  }
-  if (skippedDecode > 0) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[vaultpilot/marginfi] fetchGroupData: skipped ${skippedDecode} bank account(s) that the bundled ` +
-        `SDK (v6.4.1, IDL 0.1.7) couldn't decode. This is expected when MarginFi has shipped an ` +
-        `on-chain layout change ahead of a matching SDK release — the client still comes up with the ` +
-        `banks it understands. Skipped (integrator, expected): ${skippedIntegrator}.`,
-    );
   }
 
   // Step 3: fetch group account + oracles + mints + emission mints (plain
@@ -428,8 +489,11 @@ async function hardenedFetchGroupData(
         : undefined;
       const bank = Bank.fromAccountParsed(address, data, undefined, bankMeta);
       banks.set(address.toBase58(), bank);
-    } catch {
-      // Drop silently — we already warned above if the count is non-zero.
+    } catch (err) {
+      // Decode succeeded so we know the mint — diagnostic attributes the
+      // hydration failure to the specific token (e.g. "USDC bank skipped
+      // at hydrate: Invalid risk tier") rather than dropping silently.
+      recordSkip(skipRecords, address, data.mint.toBase58(), "hydrate", err);
     }
   }
 
@@ -439,7 +503,16 @@ async function hardenedFetchGroupData(
   for (let i = 0; i < bankDatasKeyed.length; i++) {
     const entry = bankDatasKeyed[i]!;
     const mintAi = mintAis[i];
-    if (!mintAi) continue;
+    if (!mintAi) {
+      recordSkip(
+        skipRecords,
+        entry.address,
+        entry.data.mint.toBase58(),
+        "tokenData",
+        new Error("mint account fetch returned null"),
+      );
+      continue;
+    }
     tokenDatas.set(entry.address.toBase58(), {
       mint: mintKeys[i],
       tokenProgram: mintAi.owner,
@@ -455,15 +528,51 @@ async function hardenedFetchGroupData(
   for (let i = 0; i < bankDatasKeyed.length; i++) {
     const entry = bankDatasKeyed[i]!;
     const priceAi = oracleAis[i];
-    if (!priceAi) continue;
+    if (!priceAi) {
+      recordSkip(
+        skipRecords,
+        entry.address,
+        entry.data.mint.toBase58(),
+        "priceInfo",
+        new Error("oracle account fetch returned null"),
+      );
+      continue;
+    }
     try {
       const oracleSetup = parseOracleSetup(entry.data.config.oracleSetup);
       const fixedPrice = wrappedI80F48toBigNumber(entry.data.config.fixedPrice);
       const parsed = parsePriceInfo(oracleSetup, priceAi.data, fixedPrice);
       priceInfos.set(entry.address.toBase58(), parsed);
-    } catch {
-      // drop silently
+    } catch (err) {
+      recordSkip(
+        skipRecords,
+        entry.address,
+        entry.data.mint.toBase58(),
+        "priceInfo",
+        err,
+      );
     }
+  }
+
+  // Publish the diagnostic snapshot BEFORE returning so callers (most
+  // importantly `findBankForMint`) can consult it on the next step.
+  lastGroupDiagnostics.set(groupAddress.toBase58(), {
+    fetchedAt: Date.now(),
+    addressesFetched: addresses.length,
+    banksHydrated: banks.size,
+    skippedIntegrator,
+    records: skipRecords,
+  });
+
+  // One consolidated warning keeps log volume sane but gives ops a hook.
+  // Integrator (KAMINO/DRIFT/SOLEND) skips are expected, not noise.
+  if (skipRecords.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[vaultpilot/marginfi] fetchGroupData: skipped ${skipRecords.length} bank(s). ` +
+        `Breakdown: ${summarizeSkipsByStep(skipRecords)}. Expected integrator skips: ${skippedIntegrator}. ` +
+        `Call get_marginfi_diagnostics for per-bank detail.`,
+    );
   }
 
   return {
@@ -473,6 +582,46 @@ async function hardenedFetchGroupData(
     tokenDatas,
     feedIdMap: new Map(),
   };
+}
+
+function summarizeSkipsByStep(records: MarginfiBankSkipRecord[]): string {
+  const counts: Record<MarginfiBankSkipStep, number> = {
+    decode: 0,
+    hydrate: 0,
+    tokenData: 0,
+    priceInfo: 0,
+  };
+  for (const r of records) counts[r.step]++;
+  return (Object.keys(counts) as MarginfiBankSkipStep[])
+    .filter((k) => counts[k] > 0)
+    .map((k) => `${k}=${counts[k]}`)
+    .join(", ");
+}
+
+/**
+ * Public accessor for the last hardened-fetch diagnostic snapshot for the
+ * mainnet group. Returns `null` when no fetch has happened yet in this
+ * process. Consumed by the `get_marginfi_diagnostics` MCP tool AND by
+ * `findBankForMint` to distinguish "bank not listed" from "bank listed
+ * but skipped by hardened decode" (issue #107).
+ */
+export function getLastMarginfiGroupDiagnostics(
+  group: PublicKey = MAINNET_GROUP,
+): DiagnosticSnapshot | null {
+  return lastGroupDiagnostics.get(group.toBase58()) ?? null;
+}
+
+/** Test-only hook: reset the diagnostic store between tests. */
+export function __clearMarginfiGroupDiagnostics(): void {
+  lastGroupDiagnostics.clear();
+}
+
+/** Test-only hook: preload a diagnostic snapshot (used by unit tests). */
+export function __setMarginfiGroupDiagnosticsForTest(
+  snapshot: DiagnosticSnapshot,
+  group: PublicKey = MAINNET_GROUP,
+): void {
+  lastGroupDiagnostics.set(group.toBase58(), snapshot);
 }
 
 /**
@@ -579,6 +728,23 @@ function findBankForMint(client: unknown, mint: string): MinimalBank {
   const c = client as MinimalClient;
   const bank = c.getBankByMint(new PublicKey(mint));
   if (!bank) {
+    // Issue #107 — before reporting "not listed", check the hardened
+    // fetch's skip log: a bank CAN be live on-chain yet absent from
+    // `client.banks` because we hit a decode/hydrate/oracle failure
+    // while loading it. Collapsing that into the generic message misled
+    // users into thinking MarginFi had de-listed the token.
+    const diag = getLastMarginfiGroupDiagnostics();
+    const skipped = diag?.records.find((r) => r.mint === mint);
+    if (skipped) {
+      throw new Error(
+        `MarginFi bank for ${resolveMintSymbol(mint)} (mint ${mint}) IS listed on-chain but was ` +
+          `skipped by the hardened client load at step "${skipped.step}" (bank ${skipped.address}). ` +
+          `Reason: ${skipped.reason}. This usually means MarginFi shipped an on-chain ` +
+          `change (new risk tier, operational state, oracle setup, or asset tag) that the ` +
+          `bundled SDK v6.4.1 / IDL 0.1.7 doesn't yet understand. Workaround: bump @mrgnlabs/marginfi-client-v2 ` +
+          `to a release that recognizes the new layout. Full skip log: call get_marginfi_diagnostics.`,
+      );
+    }
     throw new Error(
       `No MarginFi bank found for mint ${mint} (${resolveMintSymbol(mint)}). ` +
         `MarginFi lists a subset of SPL tokens; not every mainnet SPL is supported. ` +

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -2,6 +2,7 @@ import {
   AddressLookupTableAccount,
   PublicKey,
   TransactionInstruction,
+  type AccountInfo,
   type Connection,
 } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
@@ -222,15 +223,17 @@ async function getMarginfiClient(
  *
  * This version:
  *   1. Lists bank addresses via `getProgramAccounts` (same memcmp filter).
- *   2. Batch-fetches raw account data via
- *      `chunkedGetRawMultipleAccountInfoOrdered`.
+ *   2. Fetches raw account data via chunked plain `getMultipleAccountsInfo`
+ *      (one HTTP call per ≤100-key chunk). NOT the SDK's batch-RPC path
+ *      (`_rpcBatchRequest`), which rejects on many Solana RPC providers
+ *      and surfaces as `"Failed to fetch account infos after 3 retries"`
+ *      (issue #106).
  *   3. Decodes each bank in its own try/catch. Failures are skipped (with
  *      a console.warn tallying the count) — the client comes up with the
  *      set of banks it CAN understand.
  *   4. Skips integrator banks (KAMINO/DRIFT/SOLEND — AssetTag ≥ 3) same
  *      as the SDK does.
- *   5. Batch-fetches oracles + mints + emission mints in one call
- *      (identical to the SDK's batching).
+ *   5. Fetches oracles + mints + emission mints in one call (plain RPC).
  *   6. Per-bank wraps the price-info parse so a single unsupported oracle
  *      setup doesn't kill the whole client load either.
  *
@@ -239,6 +242,32 @@ async function getMarginfiClient(
  * `prepare_marginfi_*`. The user sees a clear warning count, not a
  * broken client. Bump the SDK whenever a new release ships.
  */
+/**
+ * Fetch account infos for a list of pubkeys via plain
+ * `connection.getMultipleAccountsInfo` (one HTTP call per ≤100-key chunk),
+ * preserving input order + nulls.
+ *
+ * Replaces mrgn-common's `chunkedGetRawMultipleAccountInfoOrdered`, which
+ * uses `connection._rpcBatchRequest` — JSON-RPC 2.0 batch requests are not
+ * universally supported by Solana RPC providers. Rejecting providers make
+ * the SDK's retry loop swallow the real error and surface a generic
+ * `"Failed to fetch account infos after 3 retries"` (issue #106). The
+ * plain `getMultipleAccounts` RPC is supported everywhere.
+ */
+async function chunkedGetAccountInfosWithNulls(
+  conn: Connection,
+  pubkeys: PublicKey[],
+): Promise<Array<AccountInfo<Buffer> | null>> {
+  const CHUNK_SIZE = 100;
+  const out: Array<AccountInfo<Buffer> | null> = [];
+  for (let i = 0; i < pubkeys.length; i += CHUNK_SIZE) {
+    const chunk = pubkeys.slice(i, i + CHUNK_SIZE);
+    const infos = await conn.getMultipleAccountsInfo(chunk, "confirmed");
+    out.push(...infos);
+  }
+  return out;
+}
+
 async function hardenedFetchGroupData(
   program: unknown,
   groupAddress: PublicKey,
@@ -278,14 +307,7 @@ async function hardenedFetchGroupData(
     ) => unknown;
     findOracleKey: (cfg: unknown) => { oracleKey: PublicKey };
   };
-  const {
-    chunkedGetRawMultipleAccountInfoOrdered,
-    wrappedI80F48toBigNumber,
-  } = common as unknown as {
-    chunkedGetRawMultipleAccountInfoOrdered: (
-      conn: Connection,
-      addrs: string[],
-    ) => Promise<Array<{ data: Buffer; owner: PublicKey } | null>>;
+  const { wrappedI80F48toBigNumber } = common as unknown as {
     wrappedI80F48toBigNumber: (w: unknown) => unknown;
   };
 
@@ -318,11 +340,9 @@ async function hardenedFetchGroupData(
     addresses = raw.map((r) => r.pubkey);
   }
 
-  // Step 2: batch-fetch bank raw data + decode with per-bank try/catch.
-  const bankAis = await chunkedGetRawMultipleAccountInfoOrdered(
-    conn,
-    addresses.map((a) => a.toBase58()),
-  );
+  // Step 2: fetch bank raw data (plain RPC, no batch) + decode with
+  // per-bank try/catch.
+  const bankAis = await chunkedGetAccountInfosWithNulls(conn, addresses);
   type BankDatum = { address: PublicKey; data: BankDecodedLike };
   interface BankDecodedLike {
     config: {
@@ -368,7 +388,8 @@ async function hardenedFetchGroupData(
     );
   }
 
-  // Step 3: batch-fetch group account + oracles + mints + emission mints.
+  // Step 3: fetch group account + oracles + mints + emission mints (plain
+  // RPC, no batch).
   const oracleKeys = bankDatasKeyed.map(
     (b) => findOracleKey(BankConfig.fromAccountParsed(b.data.config)).oracleKey,
   );
@@ -376,11 +397,11 @@ async function hardenedFetchGroupData(
   const emissionMintKeys = bankDatasKeyed
     .map((b) => b.data.emissionsMint)
     .filter((pk) => !pk.equals(PublicKey.default));
-  const allAis = await chunkedGetRawMultipleAccountInfoOrdered(conn, [
-    groupAddress.toBase58(),
-    ...oracleKeys.map((pk) => pk.toBase58()),
-    ...mintKeys.map((pk) => pk.toBase58()),
-    ...emissionMintKeys.map((pk) => pk.toBase58()),
+  const allAis = await chunkedGetAccountInfosWithNulls(conn, [
+    groupAddress,
+    ...oracleKeys,
+    ...mintKeys,
+    ...emissionMintKeys,
   ]);
   const groupAi = allAis.shift();
   const oracleAis = allAis.splice(0, oracleKeys.length);

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -195,14 +195,272 @@ async function getMarginfiClient(
   );
   const config = getConfig("production");
   const wallet = makeStubWallet(authority);
+  // Pass our hardened fetchGroupData so a single bank with a layout the
+  // bundled IDL 0.1.7 can't decode doesn't blow up the whole client load
+  // (issue #105 — `program.account.bank.all()` inside the SDK's default
+  // path throws `Cannot read properties of null (reading 'property')`
+  // when any on-chain Bank has a new field the IDL is blind to).
   const client = await MarginfiClient.fetch(config, wallet, conn, {
     readOnly: true,
-  });
+    fetchGroupDataOverride: hardenedFetchGroupData,
+  } as never);
   clientCache.set(key, {
     client,
     expiresAt: Date.now() + CLIENT_CACHE_TTL_MS,
   });
   return client;
+}
+
+/**
+ * Hardened replacement for `MarginfiClient.fetchGroupData` that survives
+ * per-bank / per-oracle decode failures. The default path calls
+ * `program.account.bank.all([filter])`, which internally runs
+ * `coder.accounts.decode` on every Bank account in one go — if even one
+ * has a layout the bundled IDL (0.1.7) doesn't understand (MarginFi has
+ * shipped on-chain changes faster than the SDK versions), the entire
+ * client load fails with the opaque `null.property` runtime error.
+ *
+ * This version:
+ *   1. Lists bank addresses via `getProgramAccounts` (same memcmp filter).
+ *   2. Batch-fetches raw account data via
+ *      `chunkedGetRawMultipleAccountInfoOrdered`.
+ *   3. Decodes each bank in its own try/catch. Failures are skipped (with
+ *      a console.warn tallying the count) — the client comes up with the
+ *      set of banks it CAN understand.
+ *   4. Skips integrator banks (KAMINO/DRIFT/SOLEND — AssetTag ≥ 3) same
+ *      as the SDK does.
+ *   5. Batch-fetches oracles + mints + emission mints in one call
+ *      (identical to the SDK's batching).
+ *   6. Per-bank wraps the price-info parse so a single unsupported oracle
+ *      setup doesn't kill the whole client load either.
+ *
+ * Trade-off: banks we skip won't have positions surfaced via
+ * `get_marginfi_positions` and can't be used as the target bank in
+ * `prepare_marginfi_*`. The user sees a clear warning count, not a
+ * broken client. Bump the SDK whenever a new release ships.
+ */
+async function hardenedFetchGroupData(
+  program: unknown,
+  groupAddress: PublicKey,
+  commitment: string | undefined,
+  bankAddresses: PublicKey[] | undefined,
+  bankMetadataMap: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const mfn = await import("@mrgnlabs/marginfi-client-v2");
+  const common = await import("@mrgnlabs/mrgn-common");
+  const {
+    MarginfiGroup,
+    Bank,
+    BankConfig,
+    AssetTag,
+    parseOracleSetup,
+    parsePriceInfo,
+    findOracleKey,
+  } = mfn as unknown as {
+    MarginfiGroup: {
+      fromBuffer(addr: PublicKey, data: Buffer, idl: unknown): unknown;
+    };
+    Bank: {
+      fromAccountParsed(
+        addr: PublicKey,
+        data: unknown,
+        feedIdMap: unknown,
+        bankMetadata: unknown,
+      ): unknown;
+    };
+    BankConfig: { fromAccountParsed(data: unknown): unknown };
+    AssetTag: { KAMINO: number };
+    parseOracleSetup: (raw: unknown) => unknown;
+    parsePriceInfo: (
+      setup: unknown,
+      data: Buffer,
+      fixedPrice: unknown,
+    ) => unknown;
+    findOracleKey: (cfg: unknown) => { oracleKey: PublicKey };
+  };
+  const {
+    chunkedGetRawMultipleAccountInfoOrdered,
+    wrappedI80F48toBigNumber,
+  } = common as unknown as {
+    chunkedGetRawMultipleAccountInfoOrdered: (
+      conn: Connection,
+      addrs: string[],
+    ) => Promise<Array<{ data: Buffer; owner: PublicKey } | null>>;
+    wrappedI80F48toBigNumber: (w: unknown) => unknown;
+  };
+
+  const p = program as {
+    provider: { connection: Connection };
+    coder: { accounts: { decode(name: string, data: Buffer): unknown } };
+    programId: PublicKey;
+    idl: unknown;
+  };
+  const conn = p.provider.connection;
+
+  // Step 1: enumerate bank addresses. If the caller preloaded a set, honor
+  // it; otherwise run the same memcmp filter the SDK uses to find all
+  // banks tied to this group.
+  let addresses: PublicKey[];
+  if (bankAddresses && bankAddresses.length > 0) {
+    addresses = bankAddresses;
+  } else {
+    const raw = await conn.getProgramAccounts(p.programId, {
+      filters: [
+        { memcmp: { offset: 8 + 32 + 1, bytes: groupAddress.toBase58() } },
+      ],
+    });
+    addresses = raw.map((r) => r.pubkey);
+  }
+
+  // Step 2: batch-fetch bank raw data + decode with per-bank try/catch.
+  const bankAis = await chunkedGetRawMultipleAccountInfoOrdered(
+    conn,
+    addresses.map((a) => a.toBase58()),
+  );
+  type BankDatum = { address: PublicKey; data: BankDecodedLike };
+  interface BankDecodedLike {
+    config: {
+      assetTag?: number | null;
+      oracleSetup: unknown;
+      fixedPrice: unknown;
+    };
+    mint: PublicKey;
+    emissionsMint: PublicKey;
+  }
+  const bankDatasKeyed: BankDatum[] = [];
+  let skippedDecode = 0;
+  let skippedIntegrator = 0;
+  for (let i = 0; i < addresses.length; i++) {
+    const ai = bankAis[i];
+    if (!ai) continue;
+    try {
+      // IDL 0.1.7 names the account "Bank" (PascalCase — see accounts[].name
+      // in marginfi_0.1.7.json). Anchor's BorshAccountsCoder keys its
+      // `accountLayouts` map on that exact name, so the decode call must
+      // use "Bank", not the camelCase `program.account.bank` accessor
+      // form.
+      const decoded = p.coder.accounts.decode(
+        "Bank",
+        ai.data,
+      ) as BankDecodedLike;
+      // Skip integrator banks (KAMINO = 3, DRIFT = 4, SOLEND = 5). These
+      // ride a different layout and aren't relevant to core lending.
+      const tag = decoded.config?.assetTag;
+      if (tag != null && tag >= AssetTag.KAMINO) {
+        skippedIntegrator++;
+        continue;
+      }
+      bankDatasKeyed.push({ address: addresses[i]!, data: decoded });
+    } catch {
+      skippedDecode++;
+    }
+  }
+  if (skippedDecode > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[vaultpilot/marginfi] fetchGroupData: skipped ${skippedDecode} bank account(s) that the bundled ` +
+        `SDK (v6.4.1, IDL 0.1.7) couldn't decode. This is expected when MarginFi has shipped an ` +
+        `on-chain layout change ahead of a matching SDK release — the client still comes up with the ` +
+        `banks it understands. Skipped (integrator, expected): ${skippedIntegrator}.`,
+    );
+  }
+
+  // Step 3: batch-fetch group account + oracles + mints + emission mints.
+  const oracleKeys = bankDatasKeyed.map(
+    (b) => findOracleKey(BankConfig.fromAccountParsed(b.data.config)).oracleKey,
+  );
+  const mintKeys = bankDatasKeyed.map((b) => b.data.mint);
+  const emissionMintKeys = bankDatasKeyed
+    .map((b) => b.data.emissionsMint)
+    .filter((pk) => !pk.equals(PublicKey.default));
+  const allAis = await chunkedGetRawMultipleAccountInfoOrdered(conn, [
+    groupAddress.toBase58(),
+    ...oracleKeys.map((pk) => pk.toBase58()),
+    ...mintKeys.map((pk) => pk.toBase58()),
+    ...emissionMintKeys.map((pk) => pk.toBase58()),
+  ]);
+  const groupAi = allAis.shift();
+  const oracleAis = allAis.splice(0, oracleKeys.length);
+  const mintAis = allAis.splice(0, mintKeys.length);
+
+  if (!groupAi) {
+    throw new Error(
+      `Failed to fetch the on-chain MarginfiGroup at ${groupAddress.toBase58()} — RPC returned null.`,
+    );
+  }
+  const marginfiGroup = MarginfiGroup.fromBuffer(
+    groupAddress,
+    groupAi.data,
+    p.idl,
+  );
+
+  // Step 4: build the `banks` map with per-bank try/catch (hydration of
+  // the Bank model could still trip if one mint metadata is surprising).
+  const banks = new Map<string, unknown>();
+  for (const { address, data } of bankDatasKeyed) {
+    try {
+      const bankMeta = bankMetadataMap
+        ? bankMetadataMap[address.toBase58()]
+        : undefined;
+      const bank = Bank.fromAccountParsed(address, data, undefined, bankMeta);
+      banks.set(address.toBase58(), bank);
+    } catch {
+      // Drop silently — we already warned above if the count is non-zero.
+    }
+  }
+
+  // Step 5: tokenDatas (mint + tokenProgram per bank). Per-bank try/catch
+  // so a missing mint account doesn't kill the whole load.
+  const tokenDatas = new Map<string, unknown>();
+  for (let i = 0; i < bankDatasKeyed.length; i++) {
+    const entry = bankDatasKeyed[i]!;
+    const mintAi = mintAis[i];
+    if (!mintAi) continue;
+    tokenDatas.set(entry.address.toBase58(), {
+      mint: mintKeys[i],
+      tokenProgram: mintAi.owner,
+      feeBps: 0,
+      emissionTokenProgram: null,
+    });
+  }
+
+  // Step 6: priceInfos (oracle parse per bank). Per-bank try/catch — new
+  // oracle setups that the SDK doesn't know how to parse become "no price"
+  // rather than "client load fails".
+  const priceInfos = new Map<string, unknown>();
+  for (let i = 0; i < bankDatasKeyed.length; i++) {
+    const entry = bankDatasKeyed[i]!;
+    const priceAi = oracleAis[i];
+    if (!priceAi) continue;
+    try {
+      const oracleSetup = parseOracleSetup(entry.data.config.oracleSetup);
+      const fixedPrice = wrappedI80F48toBigNumber(entry.data.config.fixedPrice);
+      const parsed = parsePriceInfo(oracleSetup, priceAi.data, fixedPrice);
+      priceInfos.set(entry.address.toBase58(), parsed);
+    } catch {
+      // drop silently
+    }
+  }
+
+  return {
+    marginfiGroup,
+    banks,
+    priceInfos,
+    tokenDatas,
+    feedIdMap: new Map(),
+  };
+}
+
+/**
+ * Public entry point for reader-side callers (`positions/marginfi.ts`) to
+ * ride the same cache + hardened decode override the builder path uses.
+ * Keeps the two paths from duplicating the stub-wallet + override wiring.
+ */
+export async function getHardenedMarginfiClient(
+  conn: Connection,
+  authority: PublicKey,
+): Promise<unknown> {
+  return getMarginfiClient(conn, authority);
 }
 
 /** Test-only hook so unit tests don't pay the cost of a live fetch. */

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -371,13 +371,23 @@ async function hardenedFetchGroupData(
 
   const p = program as {
     provider: { connection: Connection };
-    // Anchor 0.30.1's coder exposes decode/encode directly — there is NO
-    // `coder.accounts` namespace (unlike the `program.account` namespace
-    // off a Program instance, which is a different object). Verified via
-    // empirical probe against `@coral-xyz/anchor@0.30.1`
-    // (`dist/cjs/coder/borsh/accounts.js` — the class is
-    // `BorshAccountsCoder` with top-level `decode`/`encode` methods).
-    coder: { decode(name: string, data: Buffer): unknown };
+    // `program.coder` is a BorshCoder (top-level facade). Account decoding
+    // goes through the namespaced accounts coder: `coder.accounts.decode`.
+    //
+    // History: issue #105 fixed a coder.accounts.decode → coder.accounts
+    // nil-deref in a now-superseded SDK; commit 44408ed then "verified"
+    // the API by probing BorshAccountsCoder in isolation (which DOES have
+    // a top-level .decode), concluded program.coder had the same shape,
+    // and flattened the call to `coder.decode("Bank", data)`. That probe
+    // was checking the wrong object: `new Program(idl, provider).coder`
+    // is a `BorshCoder` (with .accounts / .instruction / .events / .types
+    // — no top-level .decode), whereas a free-standing `BorshAccountsCoder`
+    // exposes .decode because IT IS the accounts coder. The flattened
+    // call produced "p.coder.decode is not a function" for every bank
+    // (issue #108 — 188/188 banks skipped at step=decode). The guard test
+    // in `solana-marginfi.test.ts` now instantiates a real Anchor
+    // Program so the shape check can't drift again.
+    coder: { accounts: { decode(name: string, data: Buffer): unknown } };
     programId: PublicKey;
     idl: unknown;
   };
@@ -420,11 +430,16 @@ async function hardenedFetchGroupData(
     const address = addresses[i]!;
     try {
       // IDL 0.1.7 names the account "Bank" (PascalCase — see accounts[].name
-      // in marginfi_0.1.7.json). Anchor's BorshAccountsCoder keys its
-      // `accountLayouts` map on that exact name, so the decode call must
-      // use "Bank", not the camelCase `program.account.bank` accessor
-      // form used elsewhere in the SDK.
-      const decoded = p.coder.decode("Bank", ai.data) as BankDecodedLike;
+      // in marginfi_0.1.7.json), but Anchor camelCases account-layout keys
+      // when constructing the `BorshAccountsCoder` (live-probed against
+      // `@coral-xyz/anchor@0.30.1`: `program.coder.accounts.accountLayouts`
+      // contains `"bank"`, not `"Bank"`). So the key here matches
+      // `program.account.bank` — the same shape the SDK's default path
+      // uses internally.
+      const decoded = p.coder.accounts.decode(
+        "bank",
+        ai.data,
+      ) as BankDecodedLike;
       // Skip integrator banks (KAMINO = 3, DRIFT = 4, SOLEND = 5). These
       // ride a different layout and aren't relevant to core lending.
       const tag = decoded.config?.assetTag;

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -849,7 +849,17 @@ export function renderTronVerificationBlock(tx: UnsignedTronTx & { verification:
  */
 export interface RenderableSolanaPrepareResult {
   handle: string;
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
+  action:
+    | "native_send"
+    | "spl_send"
+    | "nonce_init"
+    | "nonce_close"
+    | "jupiter_swap"
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -877,6 +887,16 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "durable-nonce close (reclaim rent-exempt seed)";
     case "jupiter_swap":
       return "Jupiter swap";
+    case "marginfi_init":
+      return "MarginFi account init (one-time setup)";
+    case "marginfi_supply":
+      return "MarginFi supply";
+    case "marginfi_withdraw":
+      return "MarginFi withdraw";
+    case "marginfi_borrow":
+      return "MarginFi borrow";
+    case "marginfi_repay":
+      return "MarginFi repay";
   }
 }
 
@@ -1123,6 +1143,24 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   const isNonceInit = tx.action === "nonce_init";
   const isNonceClose = tx.action === "nonce_close";
   const isJupiterSwap = tx.action === "jupiter_swap";
+  const isMarginfi =
+    tx.action === "marginfi_init" ||
+    tx.action === "marginfi_supply" ||
+    tx.action === "marginfi_withdraw" ||
+    tx.action === "marginfi_borrow" ||
+    tx.action === "marginfi_repay";
+  const marginfiActionLabel =
+    tx.action === "marginfi_init"
+      ? "account init"
+      : tx.action === "marginfi_supply"
+        ? "supply"
+        : tx.action === "marginfi_withdraw"
+          ? "withdraw"
+          : tx.action === "marginfi_borrow"
+            ? "borrow"
+            : tx.action === "marginfi_repay"
+              ? "repay"
+              : null;
 
   // SPECIAL CASE — nonce_init is the one Solana action where ALL the
   // standard checks are pure ceremony. Why:
@@ -1190,14 +1228,14 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // as ix[0] — this flag drives the "DURABLE-NONCE MODE" explainer text +
   // the Nonce bullet in the summary + the expected-shape text for CHECK 1.
   const hasAdvanceNonceIx =
-    isNativeSend || isSpl || isNonceClose || isJupiterSwap;
+    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi;
   // The Ledger Solana app only clear-signs a small allowlist of programs
   // (System Program's transfer/advance/initialize/withdraw, and a few
   // others). Everything else falls to blind-sign, which shows only the
   // Message Hash on-device and requires the user to match it against the
   // hash the server displayed. SPL TransferChecked AND Jupiter swaps both
   // fall in that bucket.
-  const isBlindSign = isSpl || isJupiterSwap;
+  const isBlindSign = isSpl || isJupiterSwap || isMarginfi;
   const ledgerHash = isBlindSign ? solanaLedgerMessageHash(tx.messageBase64) : null;
 
   const checksPayload = {
@@ -1206,7 +1244,7 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
       threat: "MCP-side Solana message tampering",
       keywords: ["Solana", "tampering"],
     },
-    ...(isSpl
+    ...(isBlindSign
       ? {
           pairConsistencyLedgerHash: {
             autoRun: true,
@@ -1264,18 +1302,39 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
               ...(nonceBullet ? [nonceBullet] : []),
               "  - Fee: <fee in SOL>",
             ]
-          : [
-              // jupiter_swap
-              "  - Headline: \"Prepared Solana swap — <inputAmount> <inputSymbol> → <outputAmount> <outputSymbol> via Jupiter\"",
-              "  - From: <from address>",
-              "  - Input mint: <inputMint> (<inputSymbol if known>)",
-              "  - Output mint: <outputMint> (<outputSymbol if known>)",
-              "  - Expected output: <outputAmount> <outputSymbol> (min <minOutput> @ <slippageBps> bps)",
-              "  - Route: <route labels joined with →, from decoded.args.route>",
-              "  - Price impact: <priceImpactPct>%",
-              ...(nonceBullet ? [nonceBullet] : []),
-              "  - Fee: <fee in SOL (priority + base)>",
-            ];
+          : isJupiterSwap
+            ? [
+                "  - Headline: \"Prepared Solana swap — <inputAmount> <inputSymbol> → <outputAmount> <outputSymbol> via Jupiter\"",
+                "  - From: <from address>",
+                "  - Input mint: <inputMint> (<inputSymbol if known>)",
+                "  - Output mint: <outputMint> (<outputSymbol if known>)",
+                "  - Expected output: <outputAmount> <outputSymbol> (min <minOutput> @ <slippageBps> bps)",
+                "  - Route: <route labels joined with →, from decoded.args.route>",
+                "  - Price impact: <priceImpactPct>%",
+                ...(nonceBullet ? [nonceBullet] : []),
+                "  - Fee: <fee in SOL (priority + base)>",
+              ]
+            : tx.action === "marginfi_init"
+              ? [
+                  "  - Headline: \"Prepared MarginFi account init — <short PDA>\"",
+                  "  - Wallet: <from address>",
+                  "  - MarginfiAccount PDA: <marginfiAccount from decoded.args>",
+                  "  - Account index: <accountIndex from decoded.args, default 0>",
+                  ...(nonceBullet ? [nonceBullet] : []),
+                  "  - Fee: <est. fee in SOL>",
+                  "  - Note: one-time deterministic PDA — no rent-exempt seed moved",
+                ]
+              : [
+                  // marginfi_supply / withdraw / borrow / repay — same shape,
+                  // only the "Action" bullet text differs; keep one template.
+                  `  - Headline: \"Prepared MarginFi ${marginfiActionLabel} — <amount> <symbol>\"`,
+                  "  - Wallet: <from address>",
+                  "  - MarginfiAccount: <marginfiAccount from decoded.args>",
+                  "  - Bank: <bank from decoded.args> (<symbol>)",
+                  "  - Amount: <human amount + symbol>",
+                  ...(nonceBullet ? [nonceBullet] : []),
+                  "  - Fee: <est. fee in SOL>",
+                ];
 
   const inspectorUrl = solanaInspectorUrl(tx.messageBase64);
 
@@ -1499,9 +1558,15 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     "        (protects against a coordinated agent compromise)",
     "    ────────────────────────────────",
     "    NEXT ON-DEVICE — final check happens on your Ledger screen:",
-    ...(isSpl || isJupiterSwap
+    ...(isBlindSign
       ? [
-          `      • BLIND-SIGN (this tx — ${isJupiterSwap ? "Jupiter routing" : "SPL TransferChecked"} is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):`,
+          `      • BLIND-SIGN (this tx — ${
+            isJupiterSwap
+              ? "Jupiter routing"
+              : isMarginfi
+                ? `MarginFi ${marginfiActionLabel}`
+                : "SPL TransferChecked"
+          } is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):`,
           `          check the value on-device is exactly **\`${ledgerHash}\`**.`,
           "          Any difference → REJECT.",
           "          Prerequisite: Allow blind signing must be ON in Solana app Settings.",

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -954,6 +954,19 @@ export function renderSolanaPrepareSummaryBlock(
 export function renderSolanaPrepareAgentTaskBlock(
   r: RenderableSolanaPrepareResult,
 ): string {
+  const isMarginfi = r.action.startsWith("marginfi_");
+  const marginfiActionWord =
+    r.action === "marginfi_init"
+      ? "MarginFi account init"
+      : r.action === "marginfi_supply"
+        ? "MarginFi supply"
+        : r.action === "marginfi_withdraw"
+          ? "MarginFi withdraw"
+          : r.action === "marginfi_borrow"
+            ? "MarginFi borrow"
+            : r.action === "marginfi_repay"
+              ? "MarginFi repay"
+              : null;
   const actionWord =
     r.action === "native_send"
       ? "native SOL send"
@@ -961,7 +974,11 @@ export function renderSolanaPrepareAgentTaskBlock(
         ? "SPL send"
         : r.action === "nonce_init"
           ? "durable-nonce init"
-          : "durable-nonce close";
+          : r.action === "nonce_close"
+            ? "durable-nonce close"
+            : r.action === "jupiter_swap"
+              ? "Jupiter swap"
+              : marginfiActionWord ?? "Solana tx";
   const nonceBullet =
     r.nonceAccount && r.action !== "nonce_init"
       ? ["  - Nonce: <short nonce-account addr>"]
@@ -996,16 +1013,60 @@ export function renderSolanaPrepareAgentTaskBlock(
               "  - Fee: <est. fee in SOL>",
               "  - Note: one-time setup; reclaimable via prepare_solana_nonce_close",
             ]
-          : [
-              // nonce_close
-              "  - Headline: \"Prepared durable-nonce close — returning <balance> SOL to main wallet\"",
-              "  - Wallet: <from address>",
-              "  - Nonce account: <will be destroyed after this tx>",
-              "  - Destination: <from address (returns to the same wallet)>",
-              "  - Withdraw amount: <balance in SOL>",
-              ...nonceBullet,
-              "  - Fee: <est. fee in SOL>",
-            ];
+          : r.action === "nonce_close"
+            ? [
+                "  - Headline: \"Prepared durable-nonce close — returning <balance> SOL to main wallet\"",
+                "  - Wallet: <from address>",
+                "  - Nonce account: <will be destroyed after this tx>",
+                "  - Destination: <from address (returns to the same wallet)>",
+                "  - Withdraw amount: <balance in SOL>",
+                ...nonceBullet,
+                "  - Fee: <est. fee in SOL>",
+              ]
+            : r.action === "jupiter_swap"
+              ? [
+                  "  - Headline: \"Prepared Solana swap — <inputAmount> <inputSymbol> → <outputAmount> <outputSymbol> via Jupiter\"",
+                  "  - From: <from address>",
+                  "  - Input mint: <inputMint from decoded.args> (<inputSymbol if known>)",
+                  "  - Output mint: <outputMint from decoded.args> (<outputSymbol if known>)",
+                  "  - Expected output: <outputAmount> <outputSymbol> (min <minOutput> @ <slippageBps> bps)",
+                  "  - Route: <route labels joined with →, from decoded.args.route>",
+                  "  - Price impact: <priceImpactPct>%",
+                  ...nonceBullet,
+                  "  - Fee: <est. fee in SOL (priority + base)>",
+                ]
+              : r.action === "marginfi_init"
+                ? [
+                    "  - Headline: \"Prepared MarginFi account init — <short PDA>\"",
+                    "  - Wallet: <from address>",
+                    "  - MarginfiAccount PDA: <marginfiAccount from decoded.args>",
+                    "  - Account index: <accountIndex from decoded.args, default 0>",
+                    ...nonceBullet,
+                    "  - Rent: ~0.017 SOL (rent-exempt minimum for the MarginfiAccount PDA; reclaimable when the account is closed)",
+                    "  - Fee: <est. fee in SOL>",
+                  ]
+                : isMarginfi
+                  ? [
+                      // marginfi_supply / withdraw / borrow / repay — same
+                      // shape; the action word differentiates the headline.
+                      `  - Headline: \"Prepared ${marginfiActionWord} — <amount> <symbol>\"`,
+                      "  - Wallet: <from address>",
+                      "  - MarginfiAccount: <marginfiAccount from decoded.args>",
+                      "  - Bank: <bank from decoded.args> (<symbol>)",
+                      "  - Amount: <human amount + symbol>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : [
+                      // Fallback for any newly-added Solana action that
+                      // hasn't been wired up here yet — surface a generic
+                      // shape rather than reusing the nonce_close template
+                      // (which was #97's silent-mismatch bug).
+                      `  - Headline: \"Prepared ${actionWord}\"`,
+                      "  - From: <from address>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ];
   const closingLine =
     r.action === "nonce_init"
       ? '  "Reply \'send\' to continue — I\'ll pin a fresh blockhash (this init tx is the one exception that uses legacy-blockhash mode), run the mandatory integrity checks, and surface the Ledger Message Hash for you to match on-device."'

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -39,7 +39,17 @@ const TX_TTL_MS = 15 * 60_000;
  * cost, etc. Mirrors the non-message fields of `UnsignedSolanaTx`.
  */
 export interface SolanaDraftMeta {
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
+  action:
+    | "native_send"
+    | "spl_send"
+    | "nonce_init"
+    | "nonce_close"
+    | "jupiter_swap"
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
   from: string;
   description: string;
   decoded: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,10 +121,15 @@ export interface PortfolioCoverage {
   /**
    * Solana balance fetch coverage (SOL + SPL). `covered:false, errored:false`
    * means no Solana address was queried; errored:true means the Solana RPC
-   * call failed and SOL/SPL are missing from totals. Staking coverage is
-   * deferred to Phase 2.
+   * call failed and SOL/SPL are missing from totals.
    */
   solana?: CoverageStatus;
+  /**
+   * MarginFi position fetch coverage. Tracked separately from `solana` so a
+   * MarginFi-reader failure doesn't mask a successful balance read (mirror of
+   * `tronStaking` / `tron` split). Absent when no Solana address was queried.
+   */
+  marginfi?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
   /**
@@ -332,7 +337,8 @@ export interface SolanaBalance {
 
 /**
  * Solana slice of a portfolio summary. Parallel to TronPortfolioSlice.
- * Phase 1 does not enumerate native validator staking; defer to Phase 2.
+ * Phase 1 did not enumerate native validator staking; Phase 3 adds
+ * MarginFi lending.
  */
 export interface SolanaPortfolioSlice {
   /** Base58 Solana address the balances were resolved for. */
@@ -340,6 +346,36 @@ export interface SolanaPortfolioSlice {
   native: SolanaBalance[];
   spl: SolanaBalance[];
   walletBalancesUsd: number;
+  /**
+   * MarginFi lending positions (Phase 3). Present only when the wallet has
+   * at least one MarginfiAccount with non-zero balances — probed via the
+   * deterministic PDA at accountIndex 0..3. An empty/missing field means
+   * no MarginFi position, not "reader errored" (errored case is surfaced
+   * through PortfolioCoverage.marginfi).
+   */
+  marginfi?: SolanaMarginfiPositionSlice[];
+  /** MarginFi aggregate net USD (sum of netValueUsd across positions). */
+  marginfiNetUsd?: number;
+}
+
+/**
+ * Thin projection of the full `MarginfiPosition` type exposed by
+ * `src/modules/positions/marginfi.ts`. Kept here so the portfolio types
+ * module doesn't pull in the reader module's internals, matching how
+ * CompoundLendingPosition / MorphoLendingPosition are projections of their
+ * reader modules.
+ */
+export interface SolanaMarginfiPositionSlice {
+  protocol: "marginfi";
+  chain: "solana";
+  marginfiAccount: string;
+  supplied: Array<{ symbol: string; amount: string; valueUsd: number }>;
+  borrowed: Array<{ symbol: string; amount: string; valueUsd: number }>;
+  totalSuppliedUsd: number;
+  totalBorrowedUsd: number;
+  netValueUsd: number;
+  healthFactor: number;
+  warnings: string[];
 }
 
 /**
@@ -543,10 +579,17 @@ export interface PortfolioSummary {
   tronStakingUsd?: number;
   /**
    * Solana totals folded into the same aggregate as EVM/TRON. Present when
-   * the caller passed a `solanaAddress`. Phase 1 covers balances only
-   * (SOL native + SPL via ATAs); staking lands in Phase 2.
+   * the caller passed a `solanaAddress`. Phase 1 covers balances; Phase 3
+   * adds MarginFi lending (surfaced separately via `solanaLendingUsd`).
    */
   solanaUsd?: number;
+  /**
+   * Solana lending net USD — MarginFi (Phase 3). Parallels `tronStakingUsd`
+   * as a carve-out that's separately surfaced in UIs but also folded into
+   * `totalUsd`. Present only when at least one MarginfiAccount was found
+   * for the wallet.
+   */
+  solanaLendingUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];
@@ -667,7 +710,17 @@ export interface UnsignedSolanaTx {
    * - `nonce_close` — teardown: nonceAdvance + nonceWithdraw. Drains the
    *   rent-exempt balance back to the user's main wallet.
    */
-  action: "native_send" | "spl_send" | "nonce_init" | "nonce_close" | "jupiter_swap";
+  action:
+    | "native_send"
+    | "spl_send"
+    | "nonce_init"
+    | "nonce_close"
+    | "jupiter_swap"
+    | "marginfi_init"
+    | "marginfi_supply"
+    | "marginfi_withdraw"
+    | "marginfi_borrow"
+    | "marginfi_repay";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -178,28 +178,42 @@ describe("requestCapability (prefilled URL mode)", () => {
     expect(body).toContain("`\u200B``");
   });
 
-  it("truncates the body and flags it when the URL would exceed the GitHub limit (B1)", async () => {
+  // Issue #98 — full-body prefilled URLs blow past OSC-8 hyperlink limits
+  // (~1–2 KB) in terminal chat clients and stop rendering as clickable. When
+  // the body is too long, swap to a title-only URL with a placeholder body
+  // pointing the agent at the full `body` / `ghCommand` fields.
+  it("omits the body from the URL when the full-body URL would exceed the clickable budget (#98)", async () => {
     // Each `我` is 3 UTF-8 bytes and URL-encodes to `%E6%88%91` (9 bytes), so
-    // a max-length (4000-char) description of these blows past the 7168-byte
-    // cap and forces the truncation path.
+    // a max-length (4000-char) description of these blows well past the 2 KB
+    // clickable budget and forces the short-URL path.
     const huge = "我".repeat(4000);
     const res = (await requestCapability({
       summary: "Very long feedback payload with multi-byte characters",
       description: huge,
-    })) as { issueUrl: string; bodyTruncated: boolean; message: string };
-    expect(res.bodyTruncated).toBe(true);
-    expect(Buffer.byteLength(res.issueUrl, "utf8")).toBeLessThanOrEqual(7168);
+    })) as {
+      issueUrl: string;
+      bodyOmittedFromUrl: boolean;
+      message: string;
+      body: string;
+    };
+    expect(res.bodyOmittedFromUrl).toBe(true);
+    // Short URL stays well inside the clickable budget.
+    expect(Buffer.byteLength(res.issueUrl, "utf8")).toBeLessThanOrEqual(2048);
     const body = new URL(res.issueUrl).searchParams.get("body") ?? "";
-    expect(body).toMatch(/body truncated to fit/i);
-    expect(res.message).toMatch(/truncated/i);
+    expect(body).toMatch(/Body provided separately/i);
+    // Full body is still available to the agent via the `body` field.
+    expect(res.body).toContain("我");
+    expect(res.message).toMatch(/not prefilled|body provided separately/i);
   });
 
-  it("does not truncate when the body fits well within the limit", async () => {
+  it("keeps the full body in the URL when it fits inside the clickable budget (#98)", async () => {
     const res = (await requestCapability({
       summary: "Small request",
       description: "Please support X. This is short.",
-    })) as { bodyTruncated: boolean };
-    expect(res.bodyTruncated).toBe(false);
+    })) as { bodyOmittedFromUrl: boolean; issueUrl: string };
+    expect(res.bodyOmittedFromUrl).toBe(false);
+    const body = new URL(res.issueUrl).searchParams.get("body") ?? "";
+    expect(body).toContain("Please support X");
   });
 
   // Issue #89 — the prefilled URL blew past terminal URL-length limits on

--- a/test/solana-ledger-hash.test.ts
+++ b/test/solana-ledger-hash.test.ts
@@ -155,6 +155,68 @@ describe("renderSolanaPrepareAgentTaskBlock", () => {
     // Don't pre-decode or fabricate a hash at prepare time.
     expect(block).toContain("Do NOT fabricate a hash");
   });
+
+  // Issue #97 regression: jupiter_swap used to fall through to the
+  // nonce_close template, misleading agents into rendering "returning X
+  // SOL to main wallet" for an actual token swap.
+  it("jupiter_swap: emits the Jupiter-shaped summary, not the nonce_close fallback", () => {
+    const block = renderSolanaPrepareAgentTaskBlock({
+      handle: "jup-1",
+      action: "jupiter_swap",
+      from: "4FLpszPQR1Cno8TDnEwYHzxhQSJQAWvb7mMzynArAQGf",
+      description: "Swap 1 USDC → 0.011 SOL via Jupiter",
+      decoded: {
+        functionName: "solana.jupiter.swap",
+        args: { route: "HumidiFi", slippageBps: "50" },
+      },
+      nonceAccount: "NoncE11111111111111111111111111111111111111",
+    });
+    expect(block).toContain("Prepared Solana swap");
+    expect(block).toContain("Jupiter");
+    expect(block).toContain("Route: <route labels");
+    expect(block).toContain("Price impact");
+    // The bug shape — nonce_close template leaking into swap UX.
+    expect(block).not.toContain("Prepared durable-nonce close");
+    expect(block).not.toContain("returning <balance> SOL to main wallet");
+  });
+
+  it("marginfi_supply: emits MarginFi-shaped summary, not nonce_close fallback", () => {
+    const block = renderSolanaPrepareAgentTaskBlock({
+      handle: "mfn-1",
+      action: "marginfi_supply",
+      from: "4FLpszPQR1Cno8TDnEwYHzxhQSJQAWvb7mMzynArAQGf",
+      description: "MarginFi supply 1 USDC",
+      decoded: {
+        functionName: "marginfi.lending_account_deposit",
+        args: { symbol: "USDC", amount: "1 USDC" },
+      },
+      nonceAccount: "NoncE11111111111111111111111111111111111111",
+    });
+    expect(block).toContain("Prepared MarginFi supply");
+    expect(block).toContain("MarginfiAccount");
+    expect(block).toContain("Bank:");
+    expect(block).not.toContain("Prepared durable-nonce close");
+  });
+
+  it("marginfi_init: surfaces the real ~0.017 SOL rent (issue #103)", () => {
+    const block = renderSolanaPrepareAgentTaskBlock({
+      handle: "mfn-init-1",
+      action: "marginfi_init",
+      from: "4FLpszPQR1Cno8TDnEwYHzxhQSJQAWvb7mMzynArAQGf",
+      description: "Initialize MarginfiAccount",
+      decoded: {
+        functionName: "marginfi.account_initialize_pda",
+        args: { accountIndex: "0" },
+      },
+      nonceAccount: "NoncE11111111111111111111111111111111111111",
+    });
+    expect(block).toContain("Prepared MarginFi account init");
+    // The rent line must be present — prior wording implied "no rent
+    // moved", which misled the agent into quoting a 5 µSOL tx-fee-only
+    // cost (actual is ~0.017 SOL).
+    expect(block).toContain("Rent:");
+    expect(block).toMatch(/0\.017|rent-exempt/);
+  });
 });
 
 describe("renderSolanaAgentTaskBlock", () => {

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -403,6 +403,50 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
 });
 
 /**
+ * Issue #105 — `getMarginfiClient` must pass `fetchGroupDataOverride` to
+ * `MarginfiClient.fetch` so the SDK's default per-bank decode (which
+ * throws on the first layout mismatch between on-chain state and the
+ * bundled IDL 0.1.7) is replaced with our resilient variant. We assert
+ * behaviourally: construct a real call to `MarginfiClient.fetch` (mocked
+ * at the module boundary) and verify the override is present.
+ */
+describe("hardened MarginfiClient.fetch (issue #105)", () => {
+  it("passes fetchGroupDataOverride to MarginfiClient.fetch", async () => {
+    // Re-mock MarginfiClient.fetch for this test to capture the options.
+    const captured: { clientOptions?: Record<string, unknown> } = {};
+    const mfn = await import("@mrgnlabs/marginfi-client-v2");
+    (mfn.MarginfiClient.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_cfg: unknown, _wallet: unknown, _conn: unknown, opts: unknown) => {
+        captured.clientOptions = opts as Record<string, unknown>;
+        // Return a minimal object that passes through to the reader.
+        return {
+          getBankByMint: () => null,
+          banks: new Map(),
+          oraclePrices: new Map(),
+        };
+      },
+    );
+
+    // Clear our module cache so getHardenedMarginfiClient actually calls fetch.
+    const marginfi = await import("../src/modules/solana/marginfi.js");
+    marginfi.__clearMarginfiClientCache();
+
+    await marginfi.getHardenedMarginfiClient(
+      connectionStub as never,
+      WALLET_KEYPAIR.publicKey,
+    );
+    expect(captured.clientOptions).toBeDefined();
+    expect(typeof captured.clientOptions?.fetchGroupDataOverride).toBe(
+      "function",
+    );
+    // Also sanity-check readOnly carries through (we never sign via the
+    // position reader, and sending read-only mode to the SDK disables a
+    // handful of sign-related checks upstream).
+    expect(captured.clientOptions?.readOnly).toBe(true);
+  });
+});
+
+/**
  * Issue #102 — getMarginfiPositions must short-circuit BEFORE loading the
  * SDK client when no MarginfiAccount exists. Prior behaviour threw an
  * opaque `Cannot read properties of null (reading 'property')` because

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -176,6 +176,11 @@ function installFakeWrapperFor(kind: "healthy" | "noCollateral"): void {
 
 beforeEach(async () => {
   connectionStub.getAccountInfo.mockReset();
+  connectionStub.getMinimumBalanceForRentExemption.mockReset();
+  // Rent-exempt minimum for the 2312-byte MarginfiAccount PDA (live mainnet
+  // value 2026-04-24). Tests rely on the exact value to assert the surfaced
+  // rent cost (issue #103).
+  connectionStub.getMinimumBalanceForRentExemption.mockResolvedValue(16_982_400);
   resolveAltMock.mockReset();
   resolveAltMock.mockResolvedValue([]);
   wrapperFetchMock.mockReset();
@@ -250,6 +255,12 @@ describe("buildMarginfiInit", () => {
     expect(res.chain).toBe("solana");
     expect(res.handle).toMatch(/^[0-9a-f-]+$/);
     expect(res.nonceAccount).toBeTruthy();
+    // Issue #103 — rent MUST be surfaced so the agent can tell the user
+    // their wallet is funding ~0.017 SOL (not "only a fee" as the prior
+    // wording claimed).
+    expect(res.rentLamports).toBe(16_982_400);
+    expect(res.description).toContain("rent-exempt minimum");
+    expect(res.decoded.args.rentLamports).toBe("16982400");
     const draft = getSolanaDraft(res.handle);
     expect(draft.kind).toBe("v0");
     if (draft.kind !== "v0") throw new Error("unreachable");
@@ -388,5 +399,25 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
     await expect(
       buildMarginfiSupply({ wallet: WALLET, symbol: "USDC", amount: "1" }),
     ).rejects.toThrow(/No MarginfiAccount exists|prepare_marginfi_init/i);
+  });
+});
+
+/**
+ * Issue #102 — getMarginfiPositions must short-circuit BEFORE loading the
+ * SDK client when no MarginfiAccount exists. Prior behaviour threw an
+ * opaque `Cannot read properties of null (reading 'property')` because
+ * MarginfiClient.fetch was called unconditionally.
+ */
+describe("getMarginfiPositions short-circuit (issues #102, #101)", () => {
+  it("returns [] without invoking the MarginFi SDK when no PDA exists", async () => {
+    connectionStub.getAccountInfo.mockResolvedValue(null); // no PDA at any slot
+    const { getMarginfiPositions } = await import(
+      "../src/modules/positions/marginfi.js"
+    );
+    const results = await getMarginfiPositions(
+      connectionStub as never,
+      WALLET,
+    );
+    expect(results).toEqual([]);
   });
 });

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+
+/**
+ * MarginFi builder tests. Strategy mirrors solana-jupiter.test.ts: mock the
+ * RPC (getAccountInfo for nonce + MarginfiAccount existence), mock the
+ * MarginfiClient + wrapper via a fake we install into the module's cache
+ * with `__setMarginfiClientCacheEntry`. No live network, no SDK import of
+ * heavy transitive deps at test time.
+ *
+ * The fake surfaces the same `getBankByMint` shape the real client exposes,
+ * plus a MarginfiAccountWrapper.fetch hook (via vi.mock on the SDK module).
+ * Each builder test asserts: (1) ix[0] is SystemProgram.nonceAdvance,
+ * (2) the bank ix list is appended, (3) the draft meta carries the right
+ * action/bank/mint, (4) pre-flight failures produce clear errors.
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const BANK_USDC = new PublicKey("2s37akK2eyBbp8DZgCm7RtsaEz8eJP3Nxd4urLHQv7yB");
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+
+// Single shared connectionStub object — `getAccountInfo` is the main method
+// both the nonce preflight AND the marginfi-account existence check call.
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+  getMinimumBalanceForRentExemption: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+  getBalance: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+// Mock ALT resolution — MarginFi's group-wide ALTs are pulled via
+// `resolveAddressLookupTables`. We don't care about the real lookup here;
+// asserting we pass the right pubkeys is enough.
+const resolveAltMock = vi.fn();
+vi.mock("../src/modules/solana/alt.js", () => ({
+  resolveAddressLookupTables: (...args: unknown[]) => resolveAltMock(...args),
+  clearAltCache: () => {},
+  invalidateAlt: () => {},
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+// Fake MarginfiAccountWrapper + SDK surface. The real SDK module is heavy
+// (it pulls in Pyth + Switchboard transitively); mocking lets us run the
+// suite without the 147MB transitive footprint on each test.
+const wrapperFetchMock = vi.fn();
+const makeInitIxMock = vi.fn();
+vi.mock("@mrgnlabs/marginfi-client-v2", () => ({
+  MarginfiClient: {
+    fetch: vi.fn(),
+  },
+  MarginfiAccountWrapper: {
+    fetch: (...args: unknown[]) => wrapperFetchMock(...args),
+  },
+  instructions: {
+    makeInitMarginfiAccountPdaIx: (...args: unknown[]) => makeInitIxMock(...args),
+  },
+  getConfig: () => ({
+    programId: new PublicKey("MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA"),
+    groupPk: new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8"),
+    environment: "production",
+    cluster: "mainnet",
+  }),
+  ADDRESS_LOOKUP_TABLE_FOR_GROUP: {
+    "4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8": [
+      new PublicKey("BrWF8J3CEuHaXsWk3kqGZ6VHvRp4SJuG9AzvB6ei2kbV"),
+    ],
+  },
+  MARGINFI_IDL: { address: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA" },
+}));
+
+// Minimal mock of @coral-xyz/anchor — only `buildMarginfiProgram` uses it,
+// and only for the init path. AnchorProvider + Program don't need to be
+// real since `makeInitIxMock` intercepts the SDK call.
+vi.mock("@coral-xyz/anchor", () => ({
+  AnchorProvider: class {},
+  Program: class {},
+}));
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    authority: WALLET_KEYPAIR.publicKey,
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+function buildFakeBank(mint: string, address = BANK_USDC): unknown {
+  return {
+    address,
+    mint: new PublicKey(mint),
+    config: {
+      assetWeightInit: new BigNumber(0.9),
+      liabilityWeightInit: new BigNumber(1.1),
+    },
+    tokenSymbol: "USDC",
+    isPaused: false,
+  };
+}
+
+async function installFakeClient(
+  bankLookup: (mint: PublicKey) => unknown | null,
+): Promise<void> {
+  // The module's cache is keyed on the mainnet group; we poke the fake in
+  // via the test-only hook so `getMarginfiClient` returns this without
+  // ever calling the real `MarginfiClient.fetch`.
+  const mfn = await import("../src/modules/solana/marginfi.js");
+  mfn.__setMarginfiClientCacheEntry({
+    getBankByMint: bankLookup,
+    banks: new Map(),
+    oraclePrices: new Map(),
+  });
+}
+
+function dummyIx(label: string): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(
+      "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
+    ),
+    keys: [],
+    data: Buffer.from(label, "utf-8"),
+  });
+}
+
+function installFakeWrapperFor(kind: "healthy" | "noCollateral"): void {
+  const free = kind === "noCollateral" ? new BigNumber(0) : new BigNumber(1000);
+  wrapperFetchMock.mockResolvedValue({
+    address: new PublicKey(
+      // Any valid base58 pubkey works here — the builder just passes it
+      // through to the draft meta as marginfiAccount.
+      "11111111111111111111111111111111",
+    ),
+    makeDepositIx: vi
+      .fn()
+      .mockResolvedValue({ instructions: [dummyIx("deposit")], keys: [] }),
+    makeWithdrawIx: vi
+      .fn()
+      .mockResolvedValue({ instructions: [dummyIx("withdraw")], keys: [] }),
+    makeBorrowIx: vi
+      .fn()
+      .mockResolvedValue({ instructions: [dummyIx("borrow")], keys: [] }),
+    makeRepayIx: vi
+      .fn()
+      .mockResolvedValue({ instructions: [dummyIx("repay")], keys: [] }),
+    computeHealthComponents: () => ({
+      assets: new BigNumber(1100),
+      liabilities: new BigNumber(100),
+    }),
+    computeFreeCollateral: () => free,
+  });
+}
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  resolveAltMock.mockReset();
+  resolveAltMock.mockResolvedValue([]);
+  wrapperFetchMock.mockReset();
+  makeInitIxMock.mockReset();
+  makeInitIxMock.mockResolvedValue(dummyIx("init"));
+
+  const mfn = await import("../src/modules/solana/marginfi.js");
+  mfn.__clearMarginfiClientCache();
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("deriveMarginfiAccountPda", () => {
+  it("is deterministic — same inputs always yield the same PDA", async () => {
+    const { deriveMarginfiAccountPda } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const pda1 = deriveMarginfiAccountPda(WALLET_KEYPAIR.publicKey, 0);
+    const pda2 = deriveMarginfiAccountPda(WALLET_KEYPAIR.publicKey, 0);
+    expect(pda1.toBase58()).toBe(pda2.toBase58());
+  });
+
+  it("different accountIndex yields different PDA", async () => {
+    const { deriveMarginfiAccountPda } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const pda0 = deriveMarginfiAccountPda(WALLET_KEYPAIR.publicKey, 0);
+    const pda1 = deriveMarginfiAccountPda(WALLET_KEYPAIR.publicKey, 1);
+    expect(pda0.toBase58()).not.toBe(pda1.toBase58());
+  });
+});
+
+describe("buildMarginfiInit", () => {
+  it("refuses when nonce account is missing (clear error pointing to init)", async () => {
+    await setNonceMissing();
+    const { buildMarginfiInit } = await import("../src/modules/solana/marginfi.js");
+    await expect(buildMarginfiInit({ wallet: WALLET })).rejects.toThrow(
+      /nonce account not initialized/i,
+    );
+  });
+
+  it("refuses if a MarginfiAccount already exists at the derived PDA", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    const { buildMarginfiInit } = await import("../src/modules/solana/marginfi.js");
+    await expect(buildMarginfiInit({ wallet: WALLET })).rejects.toThrow(
+      /already exists at PDA/i,
+    );
+  });
+
+  it("builds a v0 draft with ix[0]=nonceAdvance, ix[1]=init, action=marginfi_init", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue(null); // PDA doesn't exist yet
+    const { buildMarginfiInit } = await import("../src/modules/solana/marginfi.js");
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const res = await buildMarginfiInit({ wallet: WALLET });
+    expect(res.action).toBe("marginfi_init");
+    expect(res.chain).toBe("solana");
+    expect(res.handle).toMatch(/^[0-9a-f-]+$/);
+    expect(res.nonceAccount).toBeTruthy();
+    const draft = getSolanaDraft(res.handle);
+    expect(draft.kind).toBe("v0");
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    expect(draft.instructions).toHaveLength(2);
+    // ix[0] is nonceAdvance (System Program, 32-byte programId of all-1s)
+    expect(draft.instructions[0]!.programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.meta.action).toBe("marginfi_init");
+  });
+});
+
+describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
+  async function setupHappyPath(): Promise<void> {
+    await setNoncePresent();
+    // PDA exists (user has run init). Simulate account info so both the
+    // nonce preflight and MarginfiAccount existence check pass.
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    await installFakeClient((mint) =>
+      mint.toBase58() === USDC_MINT ? buildFakeBank(USDC_MINT) : null,
+    );
+    installFakeWrapperFor("healthy");
+  }
+
+  it("supply: ix[0]=nonceAdvance, ix[1]=deposit (from SDK), action=marginfi_supply", async () => {
+    await setupHappyPath();
+    const { buildMarginfiSupply } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const res = await buildMarginfiSupply({
+      wallet: WALLET,
+      symbol: "USDC",
+      amount: "1.5",
+    });
+    expect(res.action).toBe("marginfi_supply");
+    const draft = getSolanaDraft(res.handle);
+    if (draft.kind !== "v0") throw new Error("expected v0 draft");
+    expect(draft.instructions[0]!.programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions).toHaveLength(2);
+    expect(draft.meta.decoded.args.symbol).toBe("USDC");
+    expect(draft.meta.decoded.args.amount).toContain("1.5 USDC");
+    expect(draft.meta.action).toBe("marginfi_supply");
+  });
+
+  it("withdraw with zero free collateral → refuses with health-factor error", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    await installFakeClient((mint) =>
+      mint.toBase58() === USDC_MINT ? buildFakeBank(USDC_MINT) : null,
+    );
+    installFakeWrapperFor("noCollateral");
+    const { buildMarginfiWithdraw } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    await expect(
+      buildMarginfiWithdraw({ wallet: WALLET, symbol: "USDC", amount: "1" }),
+    ).rejects.toThrow(/free collateral/i);
+  });
+
+  it("borrow: passes the amount through to makeBorrowIx and prepends nonceAdvance", async () => {
+    await setupHappyPath();
+    const { buildMarginfiBorrow } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const res = await buildMarginfiBorrow({
+      wallet: WALLET,
+      symbol: "USDC",
+      amount: "5",
+    });
+    expect(res.action).toBe("marginfi_borrow");
+    const draft = getSolanaDraft(res.handle);
+    if (draft.kind !== "v0") throw new Error("expected v0 draft");
+    expect(draft.meta.action).toBe("marginfi_borrow");
+    expect(draft.instructions[0]!.programId.toBase58()).toBe(SYSTEM_PROGRAM);
+  });
+
+  it("repay: action=marginfi_repay + decoded.args.amount carries symbol", async () => {
+    await setupHappyPath();
+    const { buildMarginfiRepay } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const res = await buildMarginfiRepay({
+      wallet: WALLET,
+      symbol: "USDC",
+      amount: "2",
+    });
+    expect(res.action).toBe("marginfi_repay");
+    expect(res.decoded.args.symbol).toBe("USDC");
+    expect(res.decoded.args.amount).toContain("USDC");
+  });
+
+  it("refuses when the bank is not listed on MarginFi (actionable error)", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    // getBankByMint always returns null → "not in any bank" path.
+    await installFakeClient(() => null);
+    installFakeWrapperFor("healthy");
+    const { buildMarginfiSupply } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    await expect(
+      buildMarginfiSupply({ wallet: WALLET, symbol: "USDC", amount: "1" }),
+    ).rejects.toThrow(/No MarginFi bank found/i);
+  });
+
+  it("refuses when the MarginfiAccount hasn't been initialized yet", async () => {
+    await setNoncePresent();
+    // First getAccountInfo call returns null → MarginfiAccount doesn't exist.
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+    await installFakeClient((mint) =>
+      mint.toBase58() === USDC_MINT ? buildFakeBank(USDC_MINT) : null,
+    );
+    installFakeWrapperFor("healthy");
+    const { buildMarginfiSupply } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    await expect(
+      buildMarginfiSupply({ wallet: WALLET, symbol: "USDC", amount: "1" }),
+    ).rejects.toThrow(/No MarginfiAccount exists|prepare_marginfi_init/i);
+  });
+});

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -82,6 +82,16 @@ vi.mock("@mrgnlabs/marginfi-client-v2", () => ({
     ],
   },
   MARGINFI_IDL: { address: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA" },
+  // Stubs the hardened fetchGroupData destructures from the SDK. Only used
+  // by the issue-#106 fetch-path test; every other test mocks the whole
+  // MarginfiClient and never reaches hardenedFetchGroupData.
+  MarginfiGroup: { fromBuffer: vi.fn() },
+  Bank: { fromAccountParsed: vi.fn() },
+  BankConfig: { fromAccountParsed: vi.fn() },
+  AssetTag: { KAMINO: 3 },
+  parseOracleSetup: vi.fn(),
+  parsePriceInfo: vi.fn(),
+  findOracleKey: vi.fn(),
 }));
 
 // Minimal mock of @coral-xyz/anchor — only `buildMarginfiProgram` uses it,
@@ -480,6 +490,55 @@ describe("hardened MarginfiClient.fetch (issue #105)", () => {
     // position reader, and sending read-only mode to the SDK disables a
     // handful of sign-related checks upstream).
     expect(captured.clientOptions?.readOnly).toBe(true);
+  });
+});
+
+/**
+ * Issue #106 — the hardened `fetchGroupData` must fetch account infos via
+ * plain `connection.getMultipleAccountsInfo` (one non-batched JSON-RPC
+ * call per ≤100-key chunk), NOT via mrgn-common's
+ * `chunkedGetRawMultipleAccountInfoOrdered` which internally calls
+ * `connection._rpcBatchRequest`. JSON-RPC 2.0 batch requests are rejected
+ * by many Solana RPC providers; the SDK's retry loop swallows the real
+ * error and surfaces the opaque `"Failed to fetch account infos after 3
+ * retries"`. Regression guard: the stub Connection deliberately does NOT
+ * define `_rpcBatchRequest`, so any reach for it throws with a clear
+ * message instead of silently regressing.
+ */
+describe("hardenedFetchGroupData fetch path (issue #106)", () => {
+  it("uses plain getMultipleAccountsInfo, does NOT reach for _rpcBatchRequest", async () => {
+    const getMultipleAccountsInfo = vi.fn().mockResolvedValue([null]);
+    // _rpcBatchRequest deliberately absent — if the code reaches for it, the
+    // stub throws "not a function" and the test fails with a clear signal.
+    const conn = { getMultipleAccountsInfo };
+
+    const program = {
+      provider: { connection: conn },
+      coder: { decode: () => ({}) },
+      programId: new PublicKey(SYSTEM_PROGRAM),
+      idl: {},
+    };
+
+    const { __hardenedFetchGroupDataForTest } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+
+    const groupAddress = new PublicKey(SYSTEM_PROGRAM);
+    const bankAddresses = [new PublicKey(SYSTEM_PROGRAM)];
+
+    // With no bank data (null) and no group data (null on the 2nd fetch),
+    // the function throws on the MarginfiGroup fetch check. Fine — the
+    // assertion is about fetch-method selection, not end-to-end success.
+    await expect(
+      __hardenedFetchGroupDataForTest(
+        program as never,
+        groupAddress,
+        undefined,
+        bankAddresses,
+        undefined,
+      ),
+    ).rejects.toThrow(/MarginfiGroup/i);
+    expect(getMultipleAccountsInfo).toHaveBeenCalled();
   });
 });
 

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -561,3 +561,191 @@ describe("getMarginfiPositions short-circuit (issues #102, #101)", () => {
     expect(results).toEqual([]);
   });
 });
+
+/**
+ * Issue #107 — when a bank IS listed on-chain but the hardened fetch path
+ * had to skip it (Borsh decode failure, oracle parse failure, etc.),
+ * `findBankForMint` must distinguish that case from "mint truly not listed",
+ * so the user isn't told MarginFi dropped a token that's actually live.
+ * Exercised via the test-only diagnostic-store setter + the real
+ * `findBankForMint` path on the `__internals` export.
+ */
+describe("findBankForMint diagnostic branch (issue #107)", () => {
+  const BANK_USDC_ADDR = BANK_USDC.toBase58();
+
+  beforeEach(async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__clearMarginfiGroupDiagnostics();
+  });
+
+  it("points at the skipped bank + reason when decode-phase drop is recorded", async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiGroupDiagnosticsForTest({
+      fetchedAt: Date.now(),
+      addressesFetched: 1,
+      banksHydrated: 0,
+      skippedIntegrator: 0,
+      records: [
+        {
+          address: BANK_USDC_ADDR,
+          mint: USDC_MINT,
+          step: "hydrate",
+          reason: "Invalid risk tier \"{ uncharted: {} }\"",
+        },
+      ],
+    });
+    // Empty client — no bank in the map for USDC. findBankForMint should
+    // consult the diagnostic store and fall into the distinct branch.
+    const client = {
+      getBankByMint: () => null,
+      banks: new Map(),
+      oraclePrices: new Map(),
+    };
+    expect(() =>
+      mfn.__internals.findBankForMint(client, USDC_MINT),
+    ).toThrow(/IS listed on-chain but was skipped.*hydrate.*Invalid risk tier/s);
+  });
+
+  it("falls through to the generic 'not listed' message when diagnostic has no record for the mint", async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiGroupDiagnosticsForTest({
+      fetchedAt: Date.now(),
+      addressesFetched: 5,
+      banksHydrated: 5,
+      skippedIntegrator: 0,
+      records: [], // nothing skipped
+    });
+    const client = {
+      getBankByMint: () => null,
+      banks: new Map(),
+      oraclePrices: new Map(),
+    };
+    expect(() =>
+      mfn.__internals.findBankForMint(client, USDC_MINT),
+    ).toThrow(/No MarginFi bank found.*not every mainnet SPL is supported/s);
+  });
+
+  it("prepare_marginfi_supply surfaces the skip reason when USDC was dropped at decode", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    // Client comes up with no USDC bank (simulating the post-#106 live
+    // failure mode) but the diagnostic flags that USDC was the mint of
+    // the skipped bank.
+    await installFakeClient(() => null);
+    installFakeWrapperFor("healthy");
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiGroupDiagnosticsForTest({
+      fetchedAt: Date.now(),
+      addressesFetched: 1,
+      banksHydrated: 0,
+      skippedIntegrator: 0,
+      records: [
+        {
+          address: BANK_USDC_ADDR,
+          mint: USDC_MINT,
+          step: "decode",
+          reason: "Unexpected discriminant value",
+        },
+      ],
+    });
+    await expect(
+      mfn.buildMarginfiSupply({ wallet: WALLET, symbol: "USDC", amount: "1" }),
+    ).rejects.toThrow(/USDC.*skipped by the hardened client load.*decode/s);
+  });
+});
+
+/**
+ * Issue #107 — the hardened fetch populates the diagnostic store with the
+ * address, mint (even when decode fails — recovered from raw bytes), step,
+ * and reason for each skipped bank. Tested against the direct hardened
+ * path with crafted AccountInfo buffers so we don't pay for a live fetch.
+ */
+describe("hardenedFetchGroupData diagnostic recording (issue #107)", () => {
+  it("records a decode-phase skip with mint recovered from raw bytes", async () => {
+    // Build a buffer with the right shape for mint recovery: 8 bytes
+    // discriminator (junk) + 32 bytes = the USDC mint pubkey, then
+    // arbitrary extra bytes so the decoder has something to chew on.
+    const mintBytes = new PublicKey(USDC_MINT).toBuffer();
+    const fakeBankData = Buffer.concat([
+      Buffer.alloc(8, 0xff),
+      mintBytes,
+      Buffer.alloc(64, 0),
+    ]);
+
+    const getMultipleAccountsInfo = vi
+      .fn()
+      // First call: bank account data.
+      .mockResolvedValueOnce([
+        {
+          data: fakeBankData,
+          owner: new PublicKey(SYSTEM_PROGRAM),
+          lamports: 1,
+          executable: false,
+        },
+      ])
+      // Second call: group + oracles + mints. With zero hydrated banks
+      // the oracle/mint lists are empty so we only need one element —
+      // the group account — which we return as a dummy buffer; the
+      // parse will fail downstream but our try/catch on MarginfiGroup
+      // is the only place the error propagates out of the function.
+      .mockResolvedValueOnce([
+        {
+          data: Buffer.alloc(128, 0),
+          owner: new PublicKey(SYSTEM_PROGRAM),
+          lamports: 1,
+          executable: false,
+        },
+      ]);
+
+    const conn = { getMultipleAccountsInfo };
+    const program = {
+      provider: { connection: conn },
+      // Force a decode failure to exercise the skip path.
+      coder: {
+        decode: () => {
+          throw new Error("probe-induced decode failure");
+        },
+      },
+      programId: new PublicKey(SYSTEM_PROGRAM),
+      idl: {},
+    };
+
+    const marginfi = await import("../src/modules/solana/marginfi.js");
+    marginfi.__clearMarginfiGroupDiagnostics();
+
+    // MarginfiGroup.fromBuffer gets called; return anything — we don't
+    // assert on the return value, only on the diagnostic side-effect.
+    const mfnMod = await import("@mrgnlabs/marginfi-client-v2");
+    (mfnMod.MarginfiGroup.fromBuffer as ReturnType<typeof vi.fn>).mockReturnValue(
+      {},
+    );
+
+    const bankAddresses = [BANK_USDC];
+    const groupAddress = new PublicKey(
+      "4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8",
+    );
+    await marginfi.__hardenedFetchGroupDataForTest(
+      program as never,
+      groupAddress,
+      undefined,
+      bankAddresses,
+      undefined,
+    );
+
+    const snap = marginfi.getLastMarginfiGroupDiagnostics();
+    expect(snap).not.toBeNull();
+    expect(snap!.addressesFetched).toBe(1);
+    expect(snap!.banksHydrated).toBe(0);
+    expect(snap!.records).toHaveLength(1);
+    const rec = snap!.records[0]!;
+    expect(rec.address).toBe(BANK_USDC.toBase58());
+    expect(rec.mint).toBe(USDC_MINT);
+    expect(rec.step).toBe("decode");
+    expect(rec.reason).toMatch(/probe-induced decode failure/);
+  });
+});

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -411,6 +411,43 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
  * at the module boundary) and verify the override is present.
  */
 describe("hardened MarginfiClient.fetch (issue #105)", () => {
+  // Issue #105 — documentation test for the Anchor 0.30.1 coder API that
+  // our hardened override depends on. A real BorshAccountsCoder:
+  //   • exposes .decode(name, data) — the flat API we USE
+  //   • has NO .accounts namespace (coder.accounts === undefined)
+  // If Anchor ever changes the shape (e.g. reintroduces .accounts.decode)
+  // or we accidentally reach for the wrong method, this test forces the
+  // decision to be made consciously. Guards against the exact regression
+  // we caught in live probing where coder.accounts.decode silently failed
+  // every bank (issue #105, 2026-04-24).
+  it("BorshAccountsCoder exposes .decode(name, data) but not .accounts", async () => {
+    const { BorshAccountsCoder } = await vi.importActual<
+      typeof import("@coral-xyz/anchor")
+    >("@coral-xyz/anchor");
+    // Minimum valid IDL — one empty-struct account is enough.
+    const minimalIdl = {
+      version: "0.1.0",
+      name: "probe",
+      instructions: [],
+      accounts: [
+        {
+          name: "Thing",
+          discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+        },
+      ],
+      types: [
+        {
+          name: "Thing",
+          type: { kind: "struct", fields: [] },
+        },
+      ],
+    };
+    const coder = new BorshAccountsCoder(minimalIdl as never);
+    expect(typeof coder.decode).toBe("function");
+    // The key invariant: no .accounts namespace on the accounts-coder.
+    expect((coder as unknown as { accounts?: unknown }).accounts).toBeUndefined();
+  });
+
   it("passes fetchGroupDataOverride to MarginfiClient.fetch", async () => {
     // Re-mock MarginfiClient.fetch for this test to capture the options.
     const captured: { clientOptions?: Record<string, unknown> } = {};

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -421,41 +421,53 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
  * at the module boundary) and verify the override is present.
  */
 describe("hardened MarginfiClient.fetch (issue #105)", () => {
-  // Issue #105 — documentation test for the Anchor 0.30.1 coder API that
-  // our hardened override depends on. A real BorshAccountsCoder:
-  //   • exposes .decode(name, data) — the flat API we USE
-  //   • has NO .accounts namespace (coder.accounts === undefined)
-  // If Anchor ever changes the shape (e.g. reintroduces .accounts.decode)
-  // or we accidentally reach for the wrong method, this test forces the
-  // decision to be made consciously. Guards against the exact regression
-  // we caught in live probing where coder.accounts.decode silently failed
-  // every bank (issue #105, 2026-04-24).
-  it("BorshAccountsCoder exposes .decode(name, data) but not .accounts", async () => {
-    const { BorshAccountsCoder } = await vi.importActual<
+  // Issue #108 — guard the exact shape the hardened override touches on
+  // a real Anchor `Program` instance. `program.coder` is a `BorshCoder`
+  // (top-level facade) whose account decoding lives at
+  // `coder.accounts.decode(name, data)`, NOT at a flat `coder.decode`.
+  //
+  // The prior version of this test constructed a `BorshAccountsCoder`
+  // directly (which IS the accounts coder and DOES have a top-level
+  // `.decode`) and concluded the same was true of `program.coder`. It
+  // wasn't — #108 caught 188/188 banks failing with
+  // `p.coder.decode is not a function` because we'd flattened the call
+  // based on that wrong premise. This version instantiates a real
+  // Program so the shape that matters (program.coder) is the one
+  // under assertion.
+  it("program.coder decodes accounts through .accounts.decode (not a flat .decode)", async () => {
+    const { Program, AnchorProvider, BorshAccountsCoder } = await vi.importActual<
       typeof import("@coral-xyz/anchor")
     >("@coral-xyz/anchor");
-    // Minimum valid IDL — one empty-struct account is enough.
+    // Real Anchor Program needs a valid IDL + provider. Minimal struct
+    // account is enough; we never actually decode anything here.
     const minimalIdl = {
-      version: "0.1.0",
-      name: "probe",
+      address: "11111111111111111111111111111111",
+      metadata: { name: "probe", version: "0.1.0", spec: "0.1.0" },
       instructions: [],
-      accounts: [
-        {
-          name: "Thing",
-          discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
-        },
-      ],
-      types: [
-        {
-          name: "Thing",
-          type: { kind: "struct", fields: [] },
-        },
-      ],
+      accounts: [{ name: "Thing", discriminator: [1, 2, 3, 4, 5, 6, 7, 8] }],
+      types: [{ name: "Thing", type: { kind: "struct", fields: [] } }],
     };
-    const coder = new BorshAccountsCoder(minimalIdl as never);
-    expect(typeof coder.decode).toBe("function");
-    // The key invariant: no .accounts namespace on the accounts-coder.
-    expect((coder as unknown as { accounts?: unknown }).accounts).toBeUndefined();
+    const provider = {
+      connection: {},
+      publicKey: undefined,
+    } as unknown as InstanceType<typeof AnchorProvider>;
+    const program = new Program(minimalIdl as never, provider);
+    // The invariant that drove #108: flat .decode does NOT exist on
+    // program.coder — any call site reaching for it regresses to the
+    // 188/188-banks-skipped failure.
+    expect(
+      (program.coder as unknown as { decode?: unknown }).decode,
+    ).toBeUndefined();
+    // And the correct path IS a function.
+    expect(typeof program.coder.accounts.decode).toBe("function");
+    // Cross-check: a free-standing BorshAccountsCoder (what 44408ed's
+    // "verification" probe actually inspected) does expose a flat
+    // .decode — that's why the probe was misleading. Keep this line
+    // so future readers see why it was easy to get wrong.
+    const standaloneAccountsCoder = new BorshAccountsCoder(
+      minimalIdl as never,
+    );
+    expect(typeof standaloneAccountsCoder.decode).toBe("function");
   });
 
   it("passes fetchGroupDataOverride to MarginfiClient.fetch", async () => {
@@ -514,7 +526,7 @@ describe("hardenedFetchGroupData fetch path (issue #106)", () => {
 
     const program = {
       provider: { connection: conn },
-      coder: { decode: () => ({}) },
+      coder: { accounts: { decode: () => ({}) } },
       programId: new PublicKey(SYSTEM_PROGRAM),
       idl: {},
     };
@@ -707,8 +719,10 @@ describe("hardenedFetchGroupData diagnostic recording (issue #107)", () => {
       provider: { connection: conn },
       // Force a decode failure to exercise the skip path.
       coder: {
-        decode: () => {
-          throw new Error("probe-induced decode failure");
+        accounts: {
+          decode: () => {
+            throw new Error("probe-induced decode failure");
+          },
         },
       },
       programId: new PublicKey(SYSTEM_PROGRAM),

--- a/test/solana-setup-status.test.ts
+++ b/test/solana-setup-status.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+/**
+ * get_solana_setup_status (issue #101) — read-only probe that tells agents
+ * which one-time setup pieces are already in place. Mocks the RPC at the
+ * getAccountInfo boundary; no SDK load required.
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const SYSTEM_PROGRAM = new PublicKey("11111111111111111111111111111111");
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+// Mock nonce module — we only care about the deterministic PDA derivation
+// and the getNonceAccountValue contract. Using the real derivation is fine;
+// we stub getNonceAccountValue via its own module hook.
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+// MarginFi SDK not needed for the setup-status path (it only derives the
+// PDA + runs getAccountInfo). Stub out the whole module so Node doesn't
+// try to load Pyth/Switchboard transitive deps.
+vi.mock("@mrgnlabs/marginfi-client-v2", () => ({}));
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function nonOwnedAccountInfo(lamports: number) {
+  return {
+    data: Buffer.alloc(0),
+    owner: SYSTEM_PROGRAM,
+    lamports,
+    executable: false,
+  };
+}
+
+describe("getSolanaSetupStatus", () => {
+  it("reports nonce:false and marginfi:[] for an empty wallet", async () => {
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+    const { getSolanaSetupStatus } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const res = await getSolanaSetupStatus({ wallet: WALLET });
+    expect(res.wallet).toBe(WALLET);
+    expect(res.nonce.exists).toBe(false);
+    expect(res.nonce.address).toMatch(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/);
+    expect(res.nonce.currentNonce).toBeUndefined();
+    expect(res.marginfi.accounts).toEqual([]);
+  });
+
+  it("reports nonce details when a nonce account exists", async () => {
+    // First lookup is the nonce PDA → exists. Subsequent MarginFi PDAs
+    // return null for a minimal "just the nonce" setup.
+    const nonceLamports = 1_447_680;
+    let call = 0;
+    connectionStub.getAccountInfo.mockImplementation(async () => {
+      call++;
+      if (call === 1) return nonOwnedAccountInfo(nonceLamports);
+      return null;
+    });
+    const { getNonceAccountValue } = await import(
+      "../src/modules/solana/nonce.js"
+    );
+    (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+      nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      authority: WALLET_KEYPAIR.publicKey,
+    });
+
+    const { getSolanaSetupStatus } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const res = await getSolanaSetupStatus({ wallet: WALLET });
+    expect(res.nonce.exists).toBe(true);
+    expect(res.nonce.lamports).toBe(nonceLamports);
+    expect(res.nonce.currentNonce).toBe(
+      "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    );
+    expect(res.nonce.authority).toBe(WALLET);
+    expect(res.marginfi.accounts).toEqual([]);
+  });
+
+  it("lists existing MarginfiAccount PDAs (first slot present, second missing)", async () => {
+    // First getAccountInfo = nonce (null here: user has no nonce). Next 4
+    // calls are MarginFi PDA probes. Slot 0 exists; slot 1 missing →
+    // enumeration stops.
+    let call = 0;
+    connectionStub.getAccountInfo.mockImplementation(async () => {
+      call++;
+      if (call === 1) return null; // no nonce
+      if (call === 2) return nonOwnedAccountInfo(16_982_400); // slot 0 exists
+      return null; // slot 1 missing → break
+    });
+    const { getSolanaSetupStatus } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const res = await getSolanaSetupStatus({ wallet: WALLET });
+    expect(res.nonce.exists).toBe(false);
+    expect(res.marginfi.accounts).toHaveLength(1);
+    expect(res.marginfi.accounts[0]!.index).toBe(0);
+    expect(res.marginfi.accounts[0]!.address).toMatch(
+      /^[1-9A-HJ-NP-Za-km-z]{43,44}$/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Solana Phase 3, second half: MarginFi lending (all four actions + PDA init + position reader) on top of the v0/ALT foundation shipped in PR #99. Kamino deferred per plan.

- **Milestone C** — 5 `prepare_marginfi_*` tools (init / supply / withdraw / borrow / repay) + `get_marginfi_positions` reader. Uses `@mrgnlabs/marginfi-client-v2@6.4.1` via the SDK's high-level `MarginfiAccountWrapper`; init uses the publicly-exported `instructions.makeInitMarginfiAccountPdaIx` so only the user signs (Ledger-compatible). Every action prepends `SystemProgram.nonceAdvance` as `ix[0]`, produces a v0 VersionedMessage with MarginFi's group-wide ALTs, and goes through the BLIND-SIGN Ledger path. Pre-flights: bank pause, zero-free-collateral refusal for borrow/withdraw, init-required error for subsequent actions.
- **Milestone D** — `get_portfolio_summary` folds MarginFi into the per-wallet total. New carve-out `solanaLendingUsd` parallels `tronStakingUsd`. `breakdown.solana.marginfi[]` carries per-MarginfiAccount detail; `coverage.marginfi` tracked separately so a lending-read failure can't mask a successful balance read.

## Issues addressed

Fixes #97 — prepare_solana_swap emitted the wrong agent-task summary template.
Fixes #98 — prefilled request_capability URL now stays inside the OSC-8 clickable budget.
Fixes #101 — added `get_solana_setup_status` (nonce + MarginfiAccount read-only check).
Fixes #102 — MarginFi `null.property` crash now surfaces a structured error.
Fixes #103 — `prepare_marginfi_init` description now accurately describes the ~0.017 SOL rent cost.
Fixes #104 — CVE-2024-30253 patched via transitive `@solana/web3.js` override.
Fixes #105 — hardened `fetchGroupData` override + corrected Anchor coder API path; mainnet OracleSetup variant 16 drift no longer breaks client load.
Fixes #106 — replaced mrgn-common's JSON-RPC batch fetch with plain `getMultipleAccountsInfo` so the hardened path works on RPC providers that reject batch requests.

## Scope-probe finding → plan correction

The plan's note 3 said the SDK doesn't wrap `marginfi_account_initialize_pda` and we'd need `@coral-xyz/anchor` codegen. Scope-probing v6.4.1 (on 2026-04-24, before coding) showed that's wrong: `instructions.makeInitMarginfiAccountPdaIx` IS publicly exported and all four lending-action wrappers return `InstructionsWrapper { keys: [] }` (no ephemeral signers in the happy path). Corrected in `project_marginfi_sdk_scope.md`.

## Test plan

- [x] `test/solana-marginfi.test.ts` — 11 tests. Mocks the SDK at the module boundary (`vi.mock @mrgnlabs/marginfi-client-v2`) + a fake MarginfiClient planted via `__setMarginfiClientCacheEntry`. Covers PDA determinism, init preflight + re-init refusal, supply/withdraw/borrow/repay ix composition with `nonceAdvance` at `ix[0]`, zero-free-collateral refusal on withdraw, bank-not-listed error, uninitialized-account error.
- [x] Full vitest — 742 passed.
- [x] `npx tsc --noEmit` + `npm run build` green.
- [ ] Live end-to-end on mainnet: supply 1 USDC into MarginFi → `get_marginfi_positions` shows it → withdraw → borrow 0.1 USDC → repay. Confirm BLIND-SIGN Message Hash matches on-device for each.
- [ ] `get_portfolio_summary` with a real Solana wallet holding a MarginFi position shows `solanaLendingUsd` and `breakdown.solana.marginfi[]`.

## Out of scope — still deferred

- **Kamino lending** — still its own plan cycle (kit vs web3.js v1 bridge + multi-tx send pipeline + Scope oracle refresh + elevation groups + obligation lifecycle). Plan's Roadmap captures the future shape.
- **Solana staking (Marinade / Jito / native validator)** — Phase 4 candidate.
- **Nonce-aware dropped-tx polling** — separate small plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
