### PR TITLE
fix(marginfi): recompute free collateral from raw balances (#110)

### DIFF
--- a/src/modules/positions/marginfi.ts
+++ b/src/modules/positions/marginfi.ts
@@ -58,7 +58,14 @@ interface MinimalBalance {
 interface MinimalWrapper {
   address: PublicKey;
   activeBalances: MinimalBalance[];
-  computeHealthComponents(req: unknown): {
+  /**
+   * Legacy (recompute-from-raw) health components. `computeHealthComponents`
+   * alone reads `marginfiAccount.healthCache.*`, which is all-zero on
+   * MarginfiAccounts where the program hasn't written a fresh cache yet
+   * (issue #110). We use the Legacy path so the surfaced healthFactor
+   * matches the supplied[] line emitted from the same reader.
+   */
+  computeHealthComponentsLegacy(req: unknown): {
     assets: BigNumber;
     liabilities: BigNumber;
   };
@@ -246,14 +253,22 @@ function buildPositionFromWrapper(
   // MarginRequirementType.Maintenance === 1 in the SDK's enum; we use the numeric
   // literal to avoid importing the enum just for the one call.
   //
-  // Guarded: a fresh account with no active balances has a healthCache the
-  // SDK hasn't written to yet, and `marginfiAccount.healthCache.*Maint` can
-  // be null → `null.toNumber()` throws (issue #102). Fall back to Infinity
-  // (conceptually: no debt, can't be liquidated) so the reader returns a
-  // usable entry instead of failing the whole call.
+  // Use the Legacy (recompute-from-raw) path. `computeHealthComponents`
+  // alone reads `marginfiAccount.healthCache.assetValueMaint` — a field
+  // that lives on-chain and is routinely all-zero on accounts where the
+  // MarginFi program hasn't written a fresh cache (issue #110). With a
+  // zeroed cache, the cache-based compute reports assets=0 liabilities=0
+  // → healthFactor collapses to Infinity even when the account has
+  // $87 actually supplied. Legacy weighs `balance × price × assetWeightMaint`
+  // live from the hydrated bank + oracle state.
+  //
+  // Guarded: a freshly-initialized account with no active balances can
+  // still trip the SDK's internal math (issue #102). Fall back to
+  // Infinity (conceptually: no debt, can't be liquidated) so the reader
+  // returns a usable entry instead of failing the whole call.
   let healthFactor = Number.POSITIVE_INFINITY;
   try {
-    const health = wrapper.computeHealthComponents(1);
+    const health = wrapper.computeHealthComponentsLegacy(1);
     const assetsUsd = health.assets.toNumber();
     const liabsUsd = health.liabilities.toNumber();
     healthFactor =
@@ -261,7 +276,7 @@ function buildPositionFromWrapper(
   } catch {
     healthFactor = Number.POSITIVE_INFINITY;
     warnings.push(
-      "Health factor unavailable — SDK couldn't read healthCache (likely a freshly-initialized account with no balances).",
+      "Health factor unavailable — SDK couldn't recompute health from balances (likely a freshly-initialized account with no balances).",
     );
   }
 

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -715,6 +715,18 @@ interface MinimalWrapper {
     assets: BigNumber;
     liabilities: BigNumber;
   };
+  /**
+   * Recompute health from active balances + raw bank state + oracle prices.
+   * Unlike `computeHealthComponents` (which reads the on-chain `healthCache`
+   * field — frequently all-zero on recently-supplied accounts in SDK v6.4.1
+   * — see issue #110), this path weights each balance by `assetWeightInit` /
+   * `assetWeightMaint` live and matches what the on-chain borrow/withdraw
+   * program computes at ix time.
+   */
+  computeHealthComponentsLegacy(req: unknown): {
+    assets: BigNumber;
+    liabilities: BigNumber;
+  };
   computeFreeCollateral(): BigNumber;
 }
 
@@ -1051,17 +1063,28 @@ async function resolveActionContext(
   }
 
   // Action-specific pre-flight beyond the bank pause check that
-  // findBankForMint already enforced. `computeFreeCollateral` internally
-  // reads `marginfiAccount.healthCache.*` which can be null on a freshly-
-  // initialized account; wrap it so the preflight fails SOFT (we skip
-  // the guard instead of blowing up), letting the on-chain program
-  // enforce the real check. For a wallet with no active balances, borrow
-  // will revert on-chain anyway — cost is one tx fee, same as any other
-  // pre-flight we skip.
+  // findBankForMint already enforced.
+  //
+  // Must use the Legacy (recompute-from-raw) compute path, NOT
+  // `computeFreeCollateral()`. The SDK's default `computeFreeCollateral`
+  // reads `marginfiAccount.healthCache.assetValue` — an on-chain field
+  // that is all-zero on MarginfiAccounts where the program hasn't yet
+  // written a fresh health cache. Live-probed a wallet with 1 SOL +
+  // 1 USDC supplied (issue #110, wallet 4FLpsz…): healthCache.assetValue
+  // = 0 across all three margin types, yet computeHealthComponentsLegacy
+  // correctly recomputes to ~$70 weighted collateral at Initial. The
+  // cache-based path was producing a false-negative refusal on every
+  // freshly-supplied account.
+  //
+  // Soft pre-flight: on throw we skip the guard and let the on-chain
+  // program enforce the real check (cost of failure is one tx fee).
   if (kind === "borrow" || kind === "withdraw") {
     let free: BigNumber | null = null;
     try {
-      free = wrapper.computeFreeCollateral();
+      const { assets, liabilities } = wrapper.computeHealthComponentsLegacy(
+        0, // MarginRequirementType.Initial — what the on-chain borrow check uses
+      );
+      free = BigNumber.max(new BigNumber(0), assets.minus(liabilities));
     } catch {
       free = null;
     }

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -157,7 +157,17 @@ function dummyIx(label: string): TransactionInstruction {
 }
 
 function installFakeWrapperFor(kind: "healthy" | "noCollateral"): void {
-  const free = kind === "noCollateral" ? new BigNumber(0) : new BigNumber(1000);
+  // Legacy recompute stub — this is the path the pre-flight (issue #110)
+  // reads from. `healthy` = supplied collateral with no debt; `noCollateral`
+  // = debt matches supply exactly (free = 0). The cache-reading
+  // `computeHealthComponents` / `computeFreeCollateral` stubs are kept so
+  // tests that pre-date the #110 fix still have a value to read, but the
+  // pre-flight no longer calls them.
+  const legacyAssets = new BigNumber(1000);
+  const legacyLiabs =
+    kind === "noCollateral" ? new BigNumber(1000) : new BigNumber(0);
+  const cacheFree =
+    kind === "noCollateral" ? new BigNumber(0) : new BigNumber(1000);
   wrapperFetchMock.mockResolvedValue({
     address: new PublicKey(
       // Any valid base58 pubkey works here — the builder just passes it
@@ -180,7 +190,11 @@ function installFakeWrapperFor(kind: "healthy" | "noCollateral"): void {
       assets: new BigNumber(1100),
       liabilities: new BigNumber(100),
     }),
-    computeFreeCollateral: () => free,
+    computeHealthComponentsLegacy: () => ({
+      assets: legacyAssets,
+      liabilities: legacyLiabs,
+    }),
+    computeFreeCollateral: () => cacheFree,
   });
 }
 
@@ -339,6 +353,67 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
     await expect(
       buildMarginfiWithdraw({ wallet: WALLET, symbol: "USDC", amount: "1" }),
     ).rejects.toThrow(/free collateral/i);
+  });
+
+  /**
+   * Issue #110 — the borrow/withdraw pre-flight used to read the
+   * `healthCache`-backed `computeFreeCollateral()`, which returns 0 on
+   * MarginfiAccounts where the on-chain health cache hasn't been written
+   * (common after a fresh supply in SDK v6.4.1). With the cache-reading
+   * path, a borrow against $87 of live collateral was refused with
+   * "zero free collateral". The fix switches the pre-flight to the
+   * Legacy recompute path. This test reproduces the exact scenario:
+   * cache reports zero, Legacy recomputes positive — pre-flight must
+   * pass and the borrow ix must build.
+   */
+  it("borrow against live collateral succeeds even when healthCache is all-zero", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    await installFakeClient((mint) =>
+      mint.toBase58() === USDC_MINT ? buildFakeBank(USDC_MINT) : null,
+    );
+    // Install a wrapper that simulates the #110 scenario exactly:
+    // healthCache-reading APIs return zeroes (as they would on-chain
+    // when the program hasn't refreshed), but the Legacy recompute
+    // reports a real balance. The pre-flight should trust Legacy.
+    wrapperFetchMock.mockResolvedValue({
+      address: new PublicKey("11111111111111111111111111111111"),
+      makeDepositIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("deposit")], keys: [] }),
+      makeWithdrawIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("withdraw")], keys: [] }),
+      makeBorrowIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("borrow")], keys: [] }),
+      makeRepayIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("repay")], keys: [] }),
+      computeHealthComponents: () => ({
+        assets: new BigNumber(0),
+        liabilities: new BigNumber(0),
+      }),
+      computeHealthComponentsLegacy: () => ({
+        assets: new BigNumber(70.11),
+        liabilities: new BigNumber(0),
+      }),
+      computeFreeCollateral: () => new BigNumber(0),
+    });
+    const { buildMarginfiBorrow } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const res = await buildMarginfiBorrow({
+      wallet: WALLET,
+      symbol: "USDC",
+      amount: "1",
+    });
+    expect(res.action).toBe("marginfi_borrow");
   });
 
   it("borrow: passes the amount through to makeBorrowIx and prepends nonceAdvance", async () => {


### PR DESCRIPTION
## Summary

Fixes #110 — `prepare_marginfi_borrow` was refusing with *"zero free collateral"* on accounts that `get_marginfi_positions` correctly reported as having \$87 supplied (1 SOL + 1 USDC, no debt).

## Root cause

SDK v6.4.1's `MarginfiAccount.computeFreeCollateral()` reads `marginfiAccount.healthCache.assetValue` — an on-chain field that's all-zero on accounts where the MarginFi program hasn't written a fresh health cache. Live-probed the reporter's wallet (`4FLpsz…`, MarginfiAccount `BHzJbH…`):

```
healthCache.assetValue          = 0
healthCache.assetValueMaint     = 0
healthCache.assetValueEquity    = 0
healthCache.flags               = 0
computeHealthComponents(Initial):       assets=0    liab=0    → free=0   ❌
computeHealthComponentsLegacy(Initial): assets=70.11 liab=0   → free=70  ✅
computeHealthComponentsLegacy(Maint):   assets=78.75 liab=0
```

The cache-based compute is a no-op on-chain-cache-backed read; Legacy recomputes from raw balances × oracle prices × `assetWeight{Init,Maint}` and matches what the on-chain borrow check enforces at tx time.

## Changes

- **`resolveActionContext`** (borrow/withdraw pre-flight): switch from `computeFreeCollateral()` to `computeHealthComponentsLegacy(Initial)` + manual `max(0, assets - liabilities)`.
- **`getMarginfiPositions`** (health factor): switch from `computeHealthComponents(Maintenance)` to `computeHealthComponentsLegacy(Maintenance)` so the surfaced HF agrees with the `supplied[]` line the same reader emits.
- **Test stubs** now provide `computeHealthComponentsLegacy` alongside the existing `computeFreeCollateral`.
- **New regression test** stubs the exact #110 scenario: cache reports zero, Legacy reports positive — borrow pre-flight must pass.

## Validation

- `npx vitest run` — 747/747 pass (1 new regression test)
- Temporarily regressed the pre-flight to `computeFreeCollateral()` — regression test fails with the exact #110 error message.
- Live-probed reporter's wallet against the fixed build: `borrow pre-flight passed AND tx built`.

## Test plan

- [x] Unit: cache=0 + Legacy=positive → pre-flight passes, borrow ix builds
- [x] Unit: Legacy=0 → pre-flight still refuses with clear error
- [x] Unit: all prior borrow/withdraw tests unchanged
- [x] Live: reporter's wallet `4FLpszPQR1Cno8TDnEwYHzxhQSJQAWvb7mMzynArAQGf` — pre-flight passes; `get_marginfi_positions` still returns \$87.39 supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)