### PR TITLE
fix(registry): trim description to <= 100 chars for MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vaultpilot-mcp",
   "version": "0.5.3",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
-  "description": "Hardware-verified DeFi for AI agents. Agent proposes, you approve on your Ledger device.",
+  "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vaultpilot-mcp",
   "version": "0.5.3",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
-  "description": "Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.",
+  "description": "Hardware-verified DeFi for AI agents. Agent proposes, you approve on your Ledger device.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
-  "description": "Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.",
+  "description": "Hardware-verified DeFi for AI agents. Agent proposes, you approve on your Ledger device.",
   "version": "0.5.3",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
-  "description": "Hardware-verified DeFi for AI agents. Agent proposes, you approve on your Ledger device.",
+  "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "version": "0.5.3",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {


### PR DESCRIPTION
## Summary
- v0.5.3 publish workflow succeeded on npm but failed on MCP Registry with HTTP 422 — `body.description` was 133 chars, registry cap is 100.
- Trim `server.json` description (and sync `package.json`) to 93 chars, keeping the "designed for when the AI can be compromised" framing that conveys the product's security model.
- No version bump — npm 0.5.3 is already live; this unblocks a manual `mcp-publisher publish` run against the already-published version.

## Description change
- **Before** (133 chars): "Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised."
- **After** (93 chars): "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve."

## Visibility
- **MCP Registry**: new description visible for 0.5.3 (once \`mcp-publisher publish\` succeeds post-merge) and all future releases.
- **npm**: 0.5.3 is frozen on npm with the old 133-char copy — can't change that metadata without a version bump. \`package.json\` is synced here so 0.5.4+ will show the new text.

## Recovery plan (after merge)
\`\`\`bash
curl -L https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz -C /tmp mcp-publisher
chmod +x /tmp/mcp-publisher
/tmp/mcp-publisher login github   # interactive device-code
/tmp/mcp-publisher publish
\`\`\`

## Test plan
- [x] \`npm run build\` passes
- [ ] After merge: manual \`mcp-publisher publish\` succeeds against the updated server.json