### PR TITLE
feat(solana): pre-sign simulation gate in preview_solana_send (#115)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -539,6 +539,7 @@ export async function previewSolanaSend(args: {
   const draft = getSolanaDraft(args.handle);
   const conn = getSolanaConnection();
 
+  let pinned: UnsignedSolanaTx;
   if (draft.meta.nonce) {
     // Durable-nonce path: refresh the nonce value in case someone else
     // advanced it between prepare and preview (edge case — another tx
@@ -556,13 +557,65 @@ export async function previewSolanaSend(args: {
     }
     // Update meta so pinSolanaHandle's consistency check passes.
     draft.meta.nonce.value = fresh.nonce;
-    return pinSolanaHandle(args.handle, fresh.nonce);
+    pinned = pinSolanaHandle(args.handle, fresh.nonce);
+  } else {
+    // Legacy recent-blockhash path — only reachable for `nonce_init` now,
+    // since every send/close is durable-nonce-protected.
+    const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash(
+      "confirmed",
+    );
+    pinned = pinSolanaHandle(args.handle, blockhash, lastValidBlockHeight);
   }
 
-  // Legacy recent-blockhash path — only reachable for `nonce_init` now,
-  // since every send/close is durable-nonce-protected.
-  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
-  return pinSolanaHandle(args.handle, blockhash, lastValidBlockHeight);
+  // Pre-sign simulation gate (issue #115). Run `simulateTransaction` on the
+  // pinned versioned tx so program-level reverts (MarginFi OperationBorrowOnly,
+  // stale-oracle rejects, bank-paused asserts, etc.) surface BEFORE the user
+  // is asked to blind-sign on Ledger. Mirrors the EVM enrichTx path which
+  // runs eth_call at prepare_* time.
+  //
+  // Skip for `nonce_init`: that's a legacy-message one-time setup (createAccount
+  // + nonceInitialize) with no interesting revert surface worth a pre-sign
+  // RPC. Every other Solana action here is v0.
+  if (pinned.action !== "nonce_init") {
+    const { simulatePinnedSolanaTx } = await import("../solana/simulate.js");
+    try {
+      const sim = await simulatePinnedSolanaTx(conn, pinned.messageBase64);
+      if (!sim.ok) {
+        const header = sim.anchorError
+          ? `Pre-sign simulation REJECTED the ${pinned.action} tx — ` +
+            `${sim.anchorError.name} (${sim.anchorError.code}): ${sim.anchorError.message}.`
+          : `Pre-sign simulation REJECTED the ${pinned.action} tx. Raw err: ${sim.err ?? "(unknown)"}.`;
+        const logTail = sim.logs && sim.logs.length
+          ? `\nLast program logs:\n  ${sim.logs.slice(-8).join("\n  ")}`
+          : "";
+        throw new Error(
+          header +
+            logTail +
+            `\nRefusing to surface the Ledger hash — the tx would revert on broadcast. ` +
+            `Resolve the underlying issue (e.g. withdraw conflicting collateral, wait for oracle freshness, ` +
+            `pick a different bank) and call prepare_* again.`,
+        );
+      }
+      pinned.simulation = sim;
+    } catch (e) {
+      // Distinguish our own throw (preview-level rejection — re-raise) from
+      // an RPC-level error (transient — swallow and proceed without the
+      // simulation field; broadcast-side preflight is the backstop).
+      if (
+        e instanceof Error &&
+        /Pre-sign simulation REJECTED/.test(e.message)
+      ) {
+        throw e;
+      }
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[vaultpilot/solana] pre-sign simulate RPC failed: ${e instanceof Error ? e.message : String(e)}. ` +
+          `Proceeding without simulation — broadcast-side preflight will still catch reverts.`,
+      );
+    }
+  }
+
+  return pinned;
 }
 
 /**

--- a/src/modules/solana/simulate.ts
+++ b/src/modules/solana/simulate.ts
@@ -1,0 +1,124 @@
+import {
+  VersionedMessage,
+  VersionedTransaction,
+  type Connection,
+} from "@solana/web3.js";
+
+/**
+ * Pre-sign simulation result for a pinned Solana VersionedTransaction. Mirrors
+ * the shape of EVM's `SimulationResult` in spirit — `ok: false` means the
+ * network WOULD reject this tx if broadcast as-is, and the preview step
+ * should abort before the user's Ledger prompts.
+ *
+ * `anchorError` is best-effort: when the logs carry an Anchor-style error
+ * frame ("AnchorError thrown in … Error Code: X. Error Number: Y. Error
+ * Message: Z."), we extract it so agents can relay a structured code +
+ * human message instead of asking users to read raw logs. Falls back to
+ * `err` (the raw RPC err object stringified) when no Anchor frame is
+ * present.
+ */
+export interface SolanaSimulationResult {
+  ok: boolean;
+  unitsConsumed?: number;
+  /** Program logs from the simulation (full array when present). */
+  logs?: string[];
+  /** Raw stringified err object when ok === false. */
+  err?: string;
+  /** Parsed Anchor error from the logs, if any. */
+  anchorError?: {
+    code: number;
+    name: string;
+    message: string;
+  };
+}
+
+/**
+ * Simulate a pinned Solana message via `Connection.simulateTransaction` —
+ * NO signature needed because we pass `sigVerify: false`. Also
+ * `replaceRecentBlockhash: false` so the pinned nonce / blockhash stays
+ * exactly what the Ledger will see at sign time; otherwise the RPC would
+ * substitute a fresh blockhash and the simulated tx wouldn't reflect the
+ * durable-nonce branch Agave takes on-chain.
+ *
+ * Caller is responsible for deciding what to do with `ok: false` — this
+ * function just reports. The wiring in `previewSolanaSend` turns a
+ * failed simulation into a preview-level throw so the agent never
+ * surfaces a Ledger hash for a guaranteed-revert tx (issue #115).
+ *
+ * Handles both legacy and v0 messages — `VersionedMessage.deserialize`
+ * dispatches on the high bit of the first byte (0x80 = v0, 0x00 = legacy)
+ * and returns the right concrete message type. Native/SPL sends are
+ * legacy; MarginFi / Jupiter txs are v0. Both shapes wrap into a
+ * `VersionedTransaction` which is what `Connection.simulateTransaction`
+ * expects as its first arg under the `sigVerify: false` config overload.
+ */
+export async function simulatePinnedSolanaTx(
+  conn: Connection,
+  messageBase64: string,
+): Promise<SolanaSimulationResult> {
+  const msgBytes = Buffer.from(messageBase64, "base64");
+  const message = VersionedMessage.deserialize(msgBytes);
+  const tx = new VersionedTransaction(message);
+  const { value } = await conn.simulateTransaction(tx, {
+    sigVerify: false,
+    replaceRecentBlockhash: false,
+    commitment: "confirmed",
+  });
+  const logs = value.logs ?? undefined;
+  if (value.err === null) {
+    return {
+      ok: true,
+      ...(value.unitsConsumed !== undefined
+        ? { unitsConsumed: value.unitsConsumed }
+        : {}),
+      ...(logs ? { logs } : {}),
+    };
+  }
+  const anchorError = extractAnchorError(logs);
+  return {
+    ok: false,
+    ...(value.unitsConsumed !== undefined
+      ? { unitsConsumed: value.unitsConsumed }
+      : {}),
+    ...(logs ? { logs } : {}),
+    err: JSON.stringify(value.err),
+    ...(anchorError ? { anchorError } : {}),
+  };
+}
+
+/**
+ * Scrape an Anchor error frame from the last matching log line. Anchor
+ * programs emit a line like:
+ *   "Program log: AnchorError thrown in programs/marginfi/src/…:1142. Error
+ *    Code: RiskEngineInitRejected. Error Number: 6009. Error Message:
+ *    RiskEngine rejected due to either bad health or stale oracles."
+ *
+ * Scanning from the end catches the deepest (most specific) error when
+ * multiple programs log errors in the same sim.
+ */
+function extractAnchorError(
+  logs: string[] | undefined,
+): { code: number; name: string; message: string } | undefined {
+  if (!logs || logs.length === 0) return undefined;
+  // Match "Error Code: X. Error Number: Y. Error Message: Z" anywhere in the
+  // line. An earlier version anchored at `AnchorError` and used `[^.]*` up to
+  // the first dot — but the source-file path in the real log (".../marginfi_account.rs:1142.")
+  // contains dots that broke the match. Scanning for the triple labels alone
+  // is robust and matches how Anchor's runtime formats every thrown error.
+  const re =
+    /Error Code:\s*(\w+)\.\s*Error Number:\s*(\d+)\.\s*Error Message:\s*(.+?)\.?\s*$/;
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const m = logs[i]!.match(re);
+    if (m) {
+      return {
+        name: m[1]!,
+        code: Number(m[2]),
+        message: m[3]!.trim(),
+      };
+    }
+  }
+  return undefined;
+}
+
+/** Test-only export so unit tests can cover the log-scraping independently. */
+export const __extractAnchorErrorForTest = extractAnchorError;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -783,6 +783,28 @@ export interface UnsignedSolanaTx {
    */
   verification?: TxVerification;
   /**
+   * Pre-sign simulation result. Populated by `preview_solana_send` via
+   * `connection.simulateTransaction(sigVerify: false, replaceRecentBlockhash:
+   * false)` against the pinned message. Absent only when the caller
+   * explicitly skipped simulation (currently `nonce_init`, which is legacy
+   * and has no interesting revert surface) OR when the simulation RPC
+   * itself errored transiently — in both cases `preview_solana_send`
+   * proceeds so a momentary network hiccup can't block a user's flow.
+   *
+   * When present with `ok: false` the preview handler throws BEFORE
+   * returning, so this field effectively always carries `ok: true` on the
+   * wire — but the shape keeps `ok: boolean` so downstream callers that
+   * might loosen the throw policy (e.g. a future "force" flag) stay
+   * type-correct.
+   */
+  simulation?: {
+    ok: boolean;
+    unitsConsumed?: number;
+    logs?: string[];
+    err?: string;
+    anchorError?: { code: number; name: string; message: string };
+  };
+  /**
    * Durable-nonce metadata — present when ix[0] = SystemProgram.nonceAdvance.
    * For `native_send` / `spl_send` / `nonce_close` this is always set; for
    * `nonce_init` it's absent (that's the tx that CREATES the nonce account;

--- a/test/solana-sign-dispatch.test.ts
+++ b/test/solana-sign-dispatch.test.ts
@@ -37,6 +37,8 @@ const connectionStub = {
   getLatestBlockhash: vi.fn(),
   getRecentPrioritizationFees: vi.fn(),
   sendRawTransaction: vi.fn(),
+  simulateTransaction: vi.fn(),
+  getMinimumBalanceForRentExemption: vi.fn(),
 };
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
@@ -65,6 +67,15 @@ beforeEach(async () => {
     lastValidBlockHeight: 123_456_789,
   });
   connectionStub.getRecentPrioritizationFees.mockResolvedValue([]);
+  // Default pre-sign simulation to success so existing tests stay focused on
+  // the sign/broadcast path. Tests that exercise the simulation gate (issue
+  // #115) override this with a failure envelope.
+  connectionStub.simulateTransaction.mockResolvedValue({
+    context: { slot: 1 },
+    value: { err: null, logs: ["Program 11111111111111111111111111111111 success"], unitsConsumed: 300 },
+  });
+  // Rent-exempt minimum used by buildSolanaNonceInit — live-on-mainnet value.
+  connectionStub.getMinimumBalanceForRentExemption.mockResolvedValue(1_447_680);
   getAppConfigurationMock.mockResolvedValue({ version: "1.10.0" });
 
   // Durable-nonce protection is required for every send. Mock a present
@@ -219,6 +230,122 @@ describe("sendTransaction dispatch — Solana", () => {
     });
     expect(result.chain).toBe("solana");
     expect(result.lastValidBlockHeight).toBeUndefined();
+  });
+
+  /**
+   * Issue #115 — pre-sign simulation must gate the preview so guaranteed-
+   * revert txs are caught BEFORE the user blind-signs on Ledger. Without
+   * this, a borrow-while-supplied (MarginFi OperationBorrowOnly) or stale-
+   * oracle revert reaches the device, the user approves, and only then
+   * does broadcast-side preflight surface the error — a wasted Ledger
+   * review cycle.
+   */
+  it("#115 preview throws with decoded Anchor error when simulation rejects the pinned tx", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    const { buildSolanaNativeSend } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "0.1",
+    });
+    // Simulate the exact revert class that bit #115 in production: an
+    // AnchorError thrown by MarginFi's risk engine.
+    connectionStub.simulateTransaction.mockResolvedValue({
+      context: { slot: 1 },
+      value: {
+        err: { InstructionError: [2, { Custom: 6021 }] },
+        unitsConsumed: 42000,
+        logs: [
+          "Program MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA invoke [1]",
+          "Program log: Instruction: LendingAccountBorrow",
+          "Program log: AnchorError thrown in programs/marginfi/src/state/marginfi_account.rs:1902. Error Code: OperationBorrowOnly. Error Number: 6021. Error Message: Operation is borrow-only.",
+          "Program MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA failed: custom program error: 0x1785",
+        ],
+      },
+    });
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.toThrow(
+      /Pre-sign simulation REJECTED.*OperationBorrowOnly.*6021.*Operation is borrow-only/s,
+    );
+    // And never surface a ledger prompt — USB must stay untouched.
+    expect(signTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("#115 preview attaches simulation metadata on success", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    const { buildSolanaNativeSend } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "0.1",
+    });
+    connectionStub.simulateTransaction.mockResolvedValue({
+      context: { slot: 1 },
+      value: {
+        err: null,
+        unitsConsumed: 1234,
+        logs: [
+          "Program 11111111111111111111111111111111 invoke [1]",
+          "Program 11111111111111111111111111111111 success",
+        ],
+      },
+    });
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const pinned = await previewSolanaSend({ handle: draft.handle });
+    expect(pinned.simulation).toBeDefined();
+    expect(pinned.simulation!.ok).toBe(true);
+    expect(pinned.simulation!.unitsConsumed).toBe(1234);
+    expect(pinned.simulation!.logs).toHaveLength(2);
+  });
+
+  it("#115 preview proceeds (no simulation field) when the simulate RPC itself throws", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    const { buildSolanaNativeSend } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "0.1",
+    });
+    // Transient RPC failure — preview should not block the flow. The
+    // broadcast-side preflight is the backstop.
+    connectionStub.simulateTransaction.mockRejectedValue(
+      new Error("fetch failed: ECONNRESET"),
+    );
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const pinned = await previewSolanaSend({ handle: draft.handle });
+    expect(pinned.simulation).toBeUndefined();
+    // Preview still pinned the blockhash, so send_transaction can proceed.
+    expect(pinned.messageBase64).toBeDefined();
+  });
+
+  it("#115 preview skips simulation for nonce_init (one-time legacy setup)", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    // nonce_init runs in legacy recent-blockhash mode — no durable nonce yet.
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+    // simulateTransaction MUST NOT be called.
+    const { buildSolanaNonceInit } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNonceInit({ wallet: WALLET });
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await previewSolanaSend({ handle: draft.handle });
+    expect(connectionStub.simulateTransaction).not.toHaveBeenCalled();
   });
 
   it("re-calling preview_solana_send on the same handle re-pins with a refreshed nonce value", async () => {


### PR DESCRIPTION
Fixes #115.

## Problem

`broadcastSolanaTx` uses `skipPreflight: false`, but that simulation runs **inside** `sendRawTransaction` — *after* the user has already blind-signed on Ledger. Program-level reverts (MarginFi `OperationBorrowOnly`, stale-oracle rejects, bank-paused asserts) burned a Ledger review cycle before surfacing.

EVM has parity via \`enrichTx\`'s \`eth_call\` at prepare-time; Solana didn't.

## Approach

Add \`simulatePinnedSolanaTx\` (\`src/modules/solana/simulate.ts\`) that wraps the pinned versioned message in a \`VersionedTransaction\` and calls \`connection.simulateTransaction(tx, { sigVerify: false, replaceRecentBlockhash: false, commitment: 'confirmed' })\`. \`VersionedMessage.deserialize\` handles both legacy (native / SPL / nonce_close) and v0 (MarginFi / Jupiter) draft kinds.

\`preview_solana_send\` runs it after pinning:
- \`sim.ok === false\` → throw with an Anchor-decoded header + log tail. Preview never surfaces the Ledger hash; agents see the rejection immediately.
- \`sim.ok === true\` → attach \`simulation\` to the returned \`UnsignedSolanaTx\` (mirrors EVM's \`simulation\` field shape).
- Simulate RPC itself throws → \`console.warn\` and proceed; broadcast-side preflight remains the backstop.
- \`action === 'nonce_init'\` → skipped (legacy one-time setup, no interesting revert surface).

## Live-verified against #115 repro

Same wallet (\`4FLpsz…\`), attempt 1 USDC borrow against same-bank supply:

\`\`\`
Pre-sign simulation REJECTED the marginfi_borrow tx — RiskEngineInitRejected (6009): RiskEngine rejected due to either bad health or stale oracles.
Last program logs:
  Program log: Instruction: LendingAccountBorrow
  ...
  Program log: AnchorError thrown in programs/marginfi/src/state/marginfi_account.rs:1142. Error Code: RiskEngineInitRejected. Error Number: 6009. …
  Program MFv2… failed: custom program error: 0x1779
Refusing to surface the Ledger hash — the tx would revert on broadcast.
\`\`\`

No USB HID open; no Ledger prompt.

## Test plan

- [x] Unit — sim.err with Anchor log → preview throws with extracted message
- [x] Unit — sim.ok → preview returns with \`simulation\` field attached
- [x] Unit — simulate RPC throws → preview proceeds without \`simulation\` field
- [x] Unit — \`action === 'nonce_init'\` → \`simulateTransaction\` NOT called
- [x] Live — reporter's exact repro wallet on fix branch → preview rejects before Ledger USB opens
- [x] 751/751 tests pass; type-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)