### PR TITLE
feat(marginfi): diagnose RiskEngineInitRejected stale-oracle vs bad-health (#116)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -588,9 +588,33 @@ export async function previewSolanaSend(args: {
         const logTail = sim.logs && sim.logs.length
           ? `\nLast program logs:\n  ${sim.logs.slice(-8).join("\n  ")}`
           : "";
+        // Issue #116 — enrich with a targeted root-cause diagnosis for
+        // ambiguous MarginFi errors (currently just 6009 RiskEngineInitRejected,
+        // which collapses "stale oracle" and "bad health" into one message).
+        // Best-effort: diagnosis failure must NOT mask the real sim error.
+        let diagnosis = "";
+        if (
+          pinned.action.startsWith("marginfi_") &&
+          sim.anchorError &&
+          draft.meta.marginfiTouchedBanks
+        ) {
+          try {
+            const { diagnoseMarginfiSimRejection } = await import(
+              "../solana/marginfi.js"
+            );
+            const result = await diagnoseMarginfiSimRejection(
+              draft.meta.marginfiTouchedBanks,
+              sim.anchorError,
+            );
+            if (result) diagnosis = `\n${result}`;
+          } catch {
+            // Swallow — diagnosis is additive, not gating.
+          }
+        }
         throw new Error(
           header +
             logTail +
+            diagnosis +
             `\nRefusing to surface the Ledger hash — the tx would revert on broadcast. ` +
             `Resolve the underlying issue (e.g. withdraw conflicting collateral, wait for oracle freshness, ` +
             `pick a different bank) and call prepare_* again.`,

--- a/src/modules/solana/marginfi.ts
+++ b/src/modules/solana/marginfi.ts
@@ -687,8 +687,13 @@ interface MinimalClient {
   wallet: StubWallet;
   group: unknown;
 }
+interface MinimalBalance {
+  bankPk: PublicKey;
+  active: boolean;
+}
 interface MinimalWrapper {
   address: PublicKey;
+  activeBalances: MinimalBalance[];
   makeDepositIx(
     amount: number | string | BigNumber,
     bankAddress: PublicKey,
@@ -1144,6 +1149,16 @@ async function wrapWithNonce(
   const nonceAccountStr = ctx.noncePubkey.toBase58();
   const marginfiAccountStr = ctx.marginfiAccount.toBase58();
 
+  // Stamp the set of banks MarginFi's risk engine will cross-check — the
+  // target bank + every bank backing an active balance on this MarginfiAccount
+  // (including the one we just added via the target-bank path, deduped).
+  // Used by preview_solana_send to diagnose RiskEngineInitRejected by
+  // probing each bank's oracle age (issue #116).
+  const touchedBanks = new Set<string>([ctx.bank.address.toBase58()]);
+  for (const balance of ctx.wrapper.activeBalances) {
+    if (balance.active) touchedBanks.add(balance.bankPk.toBase58());
+  }
+
   const draft: SolanaTxDraft = {
     kind: "v0",
     payerKey: ctx.fromPubkey,
@@ -1173,6 +1188,7 @@ async function wrapWithNonce(
         authority: ctx.fromPubkey.toBase58(),
         value: ctx.nonceValue,
       },
+      marginfiTouchedBanks: [...touchedBanks],
     },
   };
 
@@ -1242,6 +1258,123 @@ export async function buildMarginfiRepay(
     p.repayAll ?? false,
   );
   return wrapWithNonce(ctx, "repay", "marginfi_repay", instructions, p);
+}
+
+/**
+ * Diagnose a MarginFi simulation rejection (issue #116). Currently handles
+ * Anchor error 6009 (RiskEngineInitRejected) — the most common + most
+ * ambiguous failure mode — by probing each touched bank's oracle age
+ * against its configured `oracleMaxAge` and telling the agent whether the
+ * rejection is "stale oracle" (transient, typically SwitchboardPull) or
+ * "bad health" (actually undercollateralized).
+ *
+ * The MarginFi UI sidesteps this by auto-prepending Switchboard/Pyth
+ * oracle update ixs to every risk-engine tx; this server doesn't do
+ * that yet (future follow-up — see #116 ask C), so the best we can do
+ * today is name the root cause clearly.
+ *
+ * Returns `null` when the diagnosis doesn't apply (different Anchor code,
+ * no banks stamped, client couldn't load). Callers should fall back to
+ * the generic simulation-rejection message in that case.
+ *
+ * Best-effort: errors thrown inside this function must NOT bubble —
+ * callers use the diagnosis purely to enrich an already-thrown preview
+ * error. The shape `string | null` makes that explicit.
+ */
+export async function diagnoseMarginfiSimRejection(
+  touchedBanks: string[],
+  anchorError: { code: number; name: string; message: string },
+): Promise<string | null> {
+  if (anchorError.code !== 6009) return null; // Only RiskEngineInitRejected for now
+  if (!touchedBanks || touchedBanks.length === 0) return null;
+
+  let client: MinimalClient;
+  try {
+    const conn = getSolanaConnection();
+    // Reuse the cached hardened client — authority doesn't matter for
+    // read-only bank + oracle state, so we pass the SystemProgram id as
+    // a throwaway pubkey. If the cache is cold, this will trigger a
+    // fetch but that's the same cost the prepare path paid earlier.
+    client = (await getHardenedMarginfiClient(
+      conn,
+      new PublicKey("11111111111111111111111111111111"),
+    )) as MinimalClient;
+  } catch {
+    return null;
+  }
+
+  interface PriceInfoLike {
+    timestamp?: { toNumber(): number };
+  }
+  interface BankWithOracleConfig extends MinimalBank {
+    config: MinimalBank["config"] & {
+      oracleMaxAge: number;
+      oracleSetup: string;
+    };
+  }
+  const clientWithPrices = client as MinimalClient & {
+    oraclePrices: Map<string, PriceInfoLike>;
+  };
+
+  const nowSeconds = Math.round(Date.now() / 1000);
+  const stale: Array<{
+    symbol: string;
+    bank: string;
+    ageSeconds: number;
+    maxAgeSeconds: number;
+    oracleSetup: string;
+  }> = [];
+  const checked: string[] = [];
+
+  for (const bankAddr of touchedBanks) {
+    const rawBank = client.banks.get(bankAddr) as BankWithOracleConfig | undefined;
+    const priceInfo = clientWithPrices.oraclePrices.get(bankAddr);
+    if (!rawBank || !priceInfo) continue;
+    const oracleTs = priceInfo.timestamp?.toNumber?.();
+    if (oracleTs === undefined) continue;
+    const age = nowSeconds - oracleTs;
+    const maxAge = rawBank.config.oracleMaxAge;
+    const symbol =
+      rawBank.tokenSymbol ?? resolveMintSymbol(rawBank.mint.toBase58());
+    checked.push(`${symbol} (${age}s old / ${maxAge}s max)`);
+    if (age > maxAge) {
+      stale.push({
+        symbol,
+        bank: bankAddr,
+        ageSeconds: age,
+        maxAgeSeconds: maxAge,
+        oracleSetup: String(rawBank.config.oracleSetup),
+      });
+    }
+  }
+
+  if (checked.length === 0) return null;
+
+  if (stale.length === 0) {
+    return (
+      `Diagnosis: stale oracle is RULED OUT — all ${checked.length} touched bank(s) ` +
+      `have oracle prices within their maxAge window. Likely cause: BAD HEALTH ` +
+      `(MarginFi's init-time asset weights are stricter than maintenance; re-check ` +
+      `weighted collateral vs. requested borrow). Checked: ${checked.join(", ")}.`
+    );
+  }
+
+  const staleLines = stale
+    .map(
+      (s) =>
+        `  - ${s.symbol} (${s.oracleSetup}) — oracle ${s.ageSeconds}s old, maxAge ${s.maxAgeSeconds}s`,
+    )
+    .join("\n");
+  return (
+    `Diagnosis: STALE ORACLE(S) — ${stale.length} of ${checked.length} touched banks ` +
+    `have oracle prices past their maxAge. The risk engine rejects the tx until these ` +
+    `are refreshed:\n${staleLines}\n` +
+    `Workaround: (a) retry in a few seconds if the oracle is push-style (PythPushOracle ` +
+    `updates continuously off-chain); (b) for SwitchboardPull-backed banks (common for ` +
+    `SOL), the MarginFi UI prepends a Switchboard crank ix — this server does not yet ` +
+    `auto-prepend (see issue #116 ask C). Use the MarginFi UI to refresh, or pick a ` +
+    `different collateral bank backed by a push-style oracle.`
+  );
 }
 
 export const __internals = {

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -77,6 +77,18 @@ export interface SolanaDraftMeta {
     authority: string;
     value: string;
   };
+  /**
+   * Bank addresses (base58) the MarginFi risk engine will cross-check on
+   * this tx — the target action bank PLUS every bank with an active balance
+   * on the user's MarginfiAccount. Stamped at prepare time so
+   * `preview_solana_send` can diagnose `RiskEngineInitRejected` (Anchor
+   * error 6009) without re-deriving the account's balance set (issue #116).
+   *
+   * Absent on non-MarginFi actions. A present-but-empty array means the
+   * builder saw zero active balances + target (shouldn't happen; treated
+   * as "diagnosis N/A").
+   */
+  marginfiTouchedBanks?: string[];
 }
 
 /**

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -174,6 +174,11 @@ function installFakeWrapperFor(kind: "healthy" | "noCollateral"): void {
       // through to the draft meta as marginfiAccount.
       "11111111111111111111111111111111",
     ),
+    // activeBalances drives the touched-banks stamp used by the #116
+    // diagnosis path. Empty array is the common fresh-account case;
+    // tests that need to assert on touched banks inject a non-empty
+    // list via a bespoke wrapper mock.
+    activeBalances: [],
     makeDepositIx: vi
       .fn()
       .mockResolvedValue({ instructions: [dummyIx("deposit")], keys: [] }),
@@ -383,6 +388,7 @@ describe("buildMarginfiSupply / Withdraw / Borrow / Repay", () => {
     // reports a real balance. The pre-flight should trust Legacy.
     wrapperFetchMock.mockResolvedValue({
       address: new PublicKey("11111111111111111111111111111111"),
+      activeBalances: [],
       makeDepositIx: vi
         .fn()
         .mockResolvedValue({ instructions: [dummyIx("deposit")], keys: [] }),
@@ -836,5 +842,294 @@ describe("hardenedFetchGroupData diagnostic recording (issue #107)", () => {
     expect(rec.mint).toBe(USDC_MINT);
     expect(rec.step).toBe("decode");
     expect(rec.reason).toMatch(/probe-induced decode failure/);
+  });
+});
+
+/**
+ * Issue #116 — when MarginFi's risk engine rejects a borrow/withdraw
+ * with `RiskEngineInitRejected` (Anchor error 6009), the raw message
+ * ("bad health or stale oracles") is ambiguous. `diagnoseMarginfiSimRejection`
+ * probes each touched bank's oracle age against its configured oracleMaxAge
+ * and reports which one is the actual culprit.
+ */
+describe("diagnoseMarginfiSimRejection (issue #116)", () => {
+  const SOL_BANK = "CCKtUs6Cgwo4aaQUmBPmyoApH2gUDErxNZCAntD6LYGh";
+  const USDC_BANK = "2s37akK2eyBbp8DZgCm7RtsaEz8eJP3Nxd4urLHQv7yB";
+
+  beforeEach(async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__clearMarginfiClientCache();
+  });
+
+  function installPricedClient(
+    priced: Array<{
+      bank: string;
+      symbol: string;
+      oracleMaxAge: number;
+      oracleSetup: string;
+      oracleAgeSeconds: number;
+    }>,
+  ): void {
+    const banks = new Map<string, unknown>();
+    const oraclePrices = new Map<string, unknown>();
+    const nowSec = Math.round(Date.now() / 1000);
+    for (const p of priced) {
+      banks.set(p.bank, {
+        address: new PublicKey(p.bank),
+        mint: new PublicKey(USDC_MINT),
+        tokenSymbol: p.symbol,
+        config: {
+          oracleMaxAge: p.oracleMaxAge,
+          oracleSetup: p.oracleSetup,
+        },
+        isPaused: false,
+      });
+      const ts = nowSec - p.oracleAgeSeconds;
+      oraclePrices.set(p.bank, { timestamp: { toNumber: () => ts } });
+    }
+    // Poke the fake client into the module cache so
+    // getHardenedMarginfiClient returns it — the diagnosis helper
+    // fetches lazily via that path.
+    (async () => {
+      const mfn = await import("../src/modules/solana/marginfi.js");
+      mfn.__setMarginfiClientCacheEntry({
+        getBankByMint: () => null,
+        banks,
+        oraclePrices,
+      });
+    })();
+    // installPricedClient is async-under-the-hood but awaited in tests
+    // via a separate statement; this pattern matches installFakeClient.
+  }
+
+  it("names a stale SwitchboardPull SOL oracle as the rejection cause", async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiClientCacheEntry({
+      getBankByMint: () => null,
+      banks: new Map([
+        [
+          SOL_BANK,
+          {
+            address: new PublicKey(SOL_BANK),
+            mint: new PublicKey(USDC_MINT),
+            tokenSymbol: "SOL",
+            config: {
+              oracleMaxAge: 70,
+              oracleSetup: "SwitchboardPull",
+            },
+            isPaused: false,
+          },
+        ],
+        [
+          USDC_BANK,
+          {
+            address: new PublicKey(USDC_BANK),
+            mint: new PublicKey(USDC_MINT),
+            tokenSymbol: "USDC",
+            config: {
+              oracleMaxAge: 300,
+              oracleSetup: "PythPushOracle",
+            },
+            isPaused: false,
+          },
+        ],
+      ]),
+      oraclePrices: new Map([
+        // SOL oracle 1696 seconds old — well past the 70-second window.
+        [
+          SOL_BANK,
+          {
+            timestamp: {
+              toNumber: () => Math.round(Date.now() / 1000) - 1696,
+            },
+          },
+        ],
+        // USDC oracle fresh (10 seconds old, within 300 max).
+        [
+          USDC_BANK,
+          {
+            timestamp: {
+              toNumber: () => Math.round(Date.now() / 1000) - 10,
+            },
+          },
+        ],
+      ]),
+    });
+    const diagnosis = await mfn.diagnoseMarginfiSimRejection(
+      [SOL_BANK, USDC_BANK],
+      { code: 6009, name: "RiskEngineInitRejected", message: "bad health or stale oracles" },
+    );
+    expect(diagnosis).not.toBeNull();
+    expect(diagnosis!).toMatch(/STALE ORACLE/);
+    expect(diagnosis!).toMatch(/SOL \(SwitchboardPull\)/);
+    expect(diagnosis!).toMatch(/1696s old, maxAge 70s/);
+    // USDC is fresh — should NOT appear as stale.
+    expect(diagnosis!).not.toMatch(/USDC \(PythPushOracle\) — oracle \d+s old, maxAge 300s/);
+  });
+
+  it("rules out staleness when all touched oracles are fresh — flags bad-health", async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiClientCacheEntry({
+      getBankByMint: () => null,
+      banks: new Map([
+        [
+          SOL_BANK,
+          {
+            address: new PublicKey(SOL_BANK),
+            mint: new PublicKey(USDC_MINT),
+            tokenSymbol: "SOL",
+            config: { oracleMaxAge: 70, oracleSetup: "SwitchboardV2" },
+            isPaused: false,
+          },
+        ],
+      ]),
+      oraclePrices: new Map([
+        [
+          SOL_BANK,
+          {
+            timestamp: {
+              toNumber: () => Math.round(Date.now() / 1000) - 5,
+            },
+          },
+        ],
+      ]),
+    });
+    const diagnosis = await mfn.diagnoseMarginfiSimRejection(
+      [SOL_BANK],
+      { code: 6009, name: "RiskEngineInitRejected", message: "x" },
+    );
+    expect(diagnosis).not.toBeNull();
+    expect(diagnosis!).toMatch(/stale oracle is RULED OUT/);
+    expect(diagnosis!).toMatch(/BAD HEALTH/);
+  });
+
+  it("returns null for unrelated Anchor codes EVEN when a priced client + stale oracle are present", async () => {
+    // Install a priced client with a stale SOL oracle — if the helper
+    // ever stopped gating on the Anchor code, it would produce a
+    // misleading diagnosis for unrelated failures like
+    // OperationBorrowOnly (which already has a self-explanatory name
+    // and nothing to do with oracle freshness).
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    mfn.__setMarginfiClientCacheEntry({
+      getBankByMint: () => null,
+      banks: new Map([
+        [
+          SOL_BANK,
+          {
+            address: new PublicKey(SOL_BANK),
+            mint: new PublicKey(USDC_MINT),
+            tokenSymbol: "SOL",
+            config: { oracleMaxAge: 70, oracleSetup: "SwitchboardPull" },
+            isPaused: false,
+          },
+        ],
+      ]),
+      oraclePrices: new Map([
+        [
+          SOL_BANK,
+          {
+            timestamp: {
+              toNumber: () => Math.round(Date.now() / 1000) - 9999,
+            },
+          },
+        ],
+      ]),
+    });
+    const diagnosis = await mfn.diagnoseMarginfiSimRejection(
+      [SOL_BANK],
+      { code: 6021, name: "OperationBorrowOnly", message: "x" },
+    );
+    expect(diagnosis).toBeNull();
+  });
+
+  it("returns null when no banks were stamped (empty touched set)", async () => {
+    const mfn = await import("../src/modules/solana/marginfi.js");
+    const diagnosis = await mfn.diagnoseMarginfiSimRejection(
+      [],
+      { code: 6009, name: "RiskEngineInitRejected", message: "x" },
+    );
+    expect(diagnosis).toBeNull();
+  });
+});
+
+/**
+ * Issue #116 — `wrapWithNonce` must stamp `marginfiTouchedBanks` on the
+ * draft meta so `preview_solana_send` knows which banks to probe for
+ * oracle freshness on simulation rejection.
+ */
+describe("marginfiTouchedBanks stamping on draft meta (issue #116)", () => {
+  async function setupHappyPath(): Promise<void> {
+    const { getNonceAccountValue } = await import(
+      "../src/modules/solana/nonce.js"
+    );
+    (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+      nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      authority: WALLET_KEYPAIR.publicKey,
+    });
+    connectionStub.getAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      owner: new PublicKey("11111111111111111111111111111111"),
+      lamports: 1,
+      executable: false,
+    });
+    await installFakeClient((mint) =>
+      mint.toBase58() === USDC_MINT ? buildFakeBank(USDC_MINT) : null,
+    );
+  }
+
+  it("includes both the target bank and every active-balance bank, deduped", async () => {
+    await setupHappyPath();
+    const OTHER_BANK = new PublicKey(
+      "CCKtUs6Cgwo4aaQUmBPmyoApH2gUDErxNZCAntD6LYGh",
+    );
+    // Wrapper reports two active balances — one matches the target USDC
+    // bank (should dedupe), the other is a different (SOL) bank.
+    wrapperFetchMock.mockResolvedValue({
+      address: new PublicKey("11111111111111111111111111111111"),
+      activeBalances: [
+        { active: true, bankPk: BANK_USDC },
+        { active: true, bankPk: OTHER_BANK },
+        { active: false, bankPk: new PublicKey("11111111111111111111111111111112") },
+      ],
+      makeDepositIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("deposit")], keys: [] }),
+      makeWithdrawIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("withdraw")], keys: [] }),
+      makeBorrowIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("borrow")], keys: [] }),
+      makeRepayIx: vi
+        .fn()
+        .mockResolvedValue({ instructions: [dummyIx("repay")], keys: [] }),
+      computeHealthComponents: () => ({
+        assets: new BigNumber(0),
+        liabilities: new BigNumber(0),
+      }),
+      computeHealthComponentsLegacy: () => ({
+        assets: new BigNumber(1000),
+        liabilities: new BigNumber(0),
+      }),
+      computeFreeCollateral: () => new BigNumber(1000),
+    });
+    const { buildMarginfiBorrow } = await import(
+      "../src/modules/solana/marginfi.js"
+    );
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const res = await buildMarginfiBorrow({
+      wallet: WALLET,
+      symbol: "USDC",
+      amount: "1",
+    });
+    const draft = getSolanaDraft(res.handle);
+    expect(draft.meta.marginfiTouchedBanks).toBeDefined();
+    // Target USDC bank + non-target SOL active bank; duplicate USDC +
+    // inactive entry excluded.
+    expect(draft.meta.marginfiTouchedBanks!.sort()).toEqual(
+      [BANK_USDC.toBase58(), OTHER_BANK.toBase58()].sort(),
+    );
   });
 });


### PR DESCRIPTION
Fixes #116 (ask A). Follow-up to #115 / #117.

## Problem

#115's pre-sign simulation gate catches MarginFi reverts before the Ledger prompt. But the most common revert — \`RiskEngineInitRejected\` (Anchor error 6009) — carries the verbatim message *\"RiskEngine rejected due to either bad health or stale oracles\"*. Those are two completely different root causes:

- **Stale oracle** → transient; retry or refresh the feed
- **Bad health** → actually undercollateralized; requires changing the tx

The agent had no way to tell which, so it either guessed (wrong in the reporter's case) or punted back to the user.

## Root cause (live-probed on reporter's wallet)

Probed the exact repro (\`4FLpszP…\`, MarginfiAccount \`BHzJbH…\`):

\`\`\`
SOL  bank CCKtUs6C… — oracleSetup: SwitchboardPull, oracleMaxAge: 70s,  oracle timestamp 1696s old  ← STALE
USDC bank 2s37akK2… — oracleSetup: PythPushOracle,  oracleMaxAge: 300s, oracle timestamp 10s old    ← fresh
\`\`\`

SwitchboardPull oracles don't get pushed on-chain — MarginFi's UI auto-prepends crank ixs before every risk-engine tx. We don't (yet). That leaves the feed stale whenever a cranker hasn't run recently, and the risk engine correctly refuses the borrow even though health is fine.

## Approach

**(A) Decode the ambiguous error.** Extend the #115 simulation path to call a diagnosis helper when the rejected anchor error is code 6009 + action is \`marginfi_*\`. Probe each touched bank's oracle age against its configured \`oracleMaxAge\` and report either:

- \"STALE ORACLE(S)\" — named by symbol + oracle setup + exact age vs. maxAge
- \"BAD HEALTH\" — when all touched oracles are within window, explicitly ruling out staleness

Wired into the preview's thrown error so the agent relays a concrete root cause instead of guessing.

**What I didn't do.** Reporter's ask (C) — auto-prepending Switchboard/Pyth crank ixs — is deliberately out of scope. The MarginFi SDK does expose \`getActiveStaleBanks\` + \`createUpdateFeedIx\`, so it's technically viable on Ledger (1 signer, no ephemeral keys), but it'd:
- Pull a new Switchboard-gateway dependency (https requests per prepare)
- Add ~4 ixs + external account list + LUT baggage to every risk-engine tx
- Risk blowing past the 1232-byte v0 packet ceiling

Better as a separate follow-up.

## Implementation

- **\`SolanaDraftMeta.marginfiTouchedBanks?: string[]\`** — stamped at prepare time from \`wrapper.activeBalances\` + target bank, deduped.
- **\`diagnoseMarginfiSimRejection\`** in \`solana/marginfi.ts\` — takes touched banks + Anchor error, returns \`string | null\`. Reuses the cached hardened client to read \`banks\` / \`oraclePrices\`. Best-effort: errors swallowed to null.
- **\`preview_solana_send\`** — on sim rejection with \`action.startsWith(\"marginfi_\")\` + \`anchorError\`, appends the diagnosis to the thrown message.

## Live-verified output

Preview now throws with:

\`\`\`
Pre-sign simulation REJECTED the marginfi_borrow tx — RiskEngineInitRejected (6009): …
Last program logs:
  …
Diagnosis: STALE ORACLE(S) — 1 of 2 touched banks have oracle prices past their maxAge. The risk engine rejects the tx until these are refreshed:
  - SOL (SwitchboardPull) — oracle 1974s old, maxAge 70s
Workaround: (a) retry in a few seconds if the oracle is push-style (PythPushOracle updates continuously off-chain); (b) for SwitchboardPull-backed banks (common for SOL), the MarginFi UI prepends a Switchboard crank ix — this server does not yet auto-prepend (see issue #116 ask C). Use the MarginFi UI to refresh, or pick a different collateral bank backed by a push-style oracle.
Refusing to surface the Ledger hash…
\`\`\`

## Test plan

- [x] Unit — RiskEngineInitRejected with stale SwitchboardPull SOL → names it + age vs. maxAge; fresh USDC NOT flagged
- [x] Unit — all oracles fresh → \"stale RULED OUT\" + \"BAD HEALTH\"
- [x] Unit — non-6009 Anchor code (6021 OperationBorrowOnly) with priced-client + stale-oracle fixture → returns \`null\`. This test catches regression if someone removes the code filter and starts misdiagnosing every failure as stale oracle.
- [x] Unit — \`marginfiTouchedBanks\` stamp includes target + active balances, dedupes, excludes inactive
- [x] Live — reporter's repro wallet shows exactly the diagnosis text above
- [x] 756/756 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)