### PR TITLE
fix(marginfi): request 3 oracle samples + reframe NotEnoughSamples (#120)

### DIFF
--- a/src/modules/solana/broadcast.ts
+++ b/src/modules/solana/broadcast.ts
@@ -44,7 +44,32 @@ export async function broadcastSolanaTx(signedTxBytes: Buffer): Promise<string> 
       name?: string;
     };
     const base = err?.message ?? String(e);
-    const logs = Array.isArray(err?.logs) ? `\nProgram logs:\n  ${err.logs.join("\n  ")}` : "";
+    const logsArr = Array.isArray(err?.logs) ? err.logs : [];
+    const logs = logsArr.length ? `\nProgram logs:\n  ${logsArr.join("\n  ")}` : "";
+
+    // Switchboard `NotEnoughSamples` (Anchor 6030 / 0x178e) on the crank ix
+    // means the oracle samples we fetched at preview time aged past their
+    // `max_staleness` window during Ledger review (issue #120). With
+    // numSignatures=3 the headroom is ~3× but not unbounded; a slow
+    // review (>20s) or a feed with a tight max_staleness can still trip
+    // this. Reframe so the user gets an actionable message instead of
+    // a raw program error — the remediation is always "re-prepare" and
+    // the pre-sign simulation will re-fetch fresh samples.
+    const notEnoughSamples =
+      /custom program error: 0x178e/i.test(base) ||
+      /custom program error: 0x178e/i.test(logs) ||
+      /NotEnoughSamples/.test(logs);
+    if (notEnoughSamples) {
+      throw new Error(
+        `Switchboard oracle samples aged out during Ledger review — the tx's ` +
+          `embedded oracle attestations were fresh at preview time but too old ` +
+          `by the time broadcast tried to land (issue #120). Re-prepare the ` +
+          `action (call prepare_marginfi_* again) to fetch a fresh crank and ` +
+          `retry. No on-chain effect — the durable nonce was not advanced. ` +
+          `Raw: ${base}${logs}`,
+      );
+    }
+
     throw new Error(`Solana broadcast failed: ${base}${logs}`);
   }
 }

--- a/src/modules/solana/swb-crank.ts
+++ b/src/modules/solana/swb-crank.ts
@@ -21,23 +21,24 @@ import {
 //   uses it for guardian-set signatures.
 //
 // Data layout (per Agave `sdk/secp256k1-program/src/lib.rs`):
-//   [0]        num_signatures             (u8)       — patch assumes ==1
-//   [1..=2]    signature_offset           (u16 LE)
-//   [3]        signature_instruction_index (u8)      ← position-ABSOLUTE
-//   [4..=5]    eth_address_offset         (u16 LE)
-//   [6]        eth_address_instruction_index (u8)    ← position-ABSOLUTE
-//   [7..=8]    message_data_offset        (u16 LE)
-//   [9..=10]   message_data_size          (u16 LE)
-//   [11]       message_instruction_index  (u8)       ← position-ABSOLUTE
-//   [12..]     the actual signature / eth-address / message bytes
+//   [0]                           num_signatures  (u8, call it N)
+//   [1 + 11·k ..= 2 + 11·k]       signature_offset            (u16 LE)  k in [0..N)
+//   [3 + 11·k]                    signature_instruction_index (u8)      ← position-ABSOLUTE
+//   [4 + 11·k ..= 5 + 11·k]       eth_address_offset          (u16 LE)
+//   [6 + 11·k]                    eth_address_instruction_index (u8)    ← position-ABSOLUTE
+//   [7 + 11·k ..= 8 + 11·k]       message_data_offset         (u16 LE)
+//   [9 + 11·k ..= 10 + 11·k]      message_data_size           (u16 LE)
+//   [11 + 11·k]                   message_instruction_index   (u8)      ← position-ABSOLUTE
+//   [1 + 11·N ..]                 N × (signature || recoveryId || ethAddress) blocks
+//   [trailing]                    common message bytes (shared across all N sigs)
 //
 // The subtle bit:
-//   The three `_instruction_index` fields are ABSOLUTE tx-relative indices,
-//   NOT self-relative. `0` does NOT mean "this instruction" — it means
-//   literally ix[0] of the outer tx. SDKs that build these ixs (Switchboard
-//   `PullFeed.fetchUpdateManyIx`, Wormhole's guardian verifier) hardcode all
-//   three to `0` because they expect to own the whole tx and sit at position
-//   0 themselves.
+//   The three `_instruction_index` fields (three per signature) are ABSOLUTE
+//   tx-relative indices, NOT self-relative. `0` does NOT mean "this instruction"
+//   — it means literally ix[0] of the outer tx. SDKs that build these ixs
+//   (Switchboard `PullFeed.fetchUpdateManyIx`, Wormhole's guardian verifier)
+//   hardcode all three to `0` because they expect to own the whole tx and sit
+//   at position 0 themselves.
 //
 // The 0xff sentinel is NOT valid here:
 //   Some Solana pre-compiles interpret 0xff as "same instruction". Secp256k1
@@ -53,15 +54,17 @@ import {
 //   offsets.
 //
 // The fix:
-//   Rewrite bytes 3, 6, and 11 to the ix's final tx-relative position before
-//   including it. `patchSecp256k1CrankIxPosition` below does exactly that.
-//   Single-signature payloads only — multi-sig would need additional writes
-//   at +11-byte strides, and we guard against that case.
+//   Rewrite the three instruction-index bytes in every offset block to the
+//   ix's final tx-relative position before including it. For k in [0..N):
+//   bytes (3 + 11·k), (6 + 11·k), (11 + 11·k).
+//   `patchSecp256k1CrankIxPosition` below does exactly that.
 //
 // Provenance:
-//   Issue #116 ask C; live-probed against Switchboard's Crossbar gateway
-//   2026-04-24 via `createUpdateFeedIx` from @mrgnlabs/marginfi-client-v2
-//   v6.4.1. The specific Agave runtime version: mainnet slot 2026-04-24.
+//   Issue #116 ask C (single-sig implementation, 2026-04-24) and issue #120
+//   (multi-sig — the NUM_SIGNATURES=3 default tunes for 5–15s Ledger review
+//   windows, and the patch loop handles N offset blocks). Live-probed against
+//   Switchboard's Crossbar gateway + Agave mainnet 2026-04-24 via
+//   `@switchboard-xyz/on-demand`'s `PullFeed.fetchUpdateManyIx`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** `KeccakSecp256k11111111111111111111111111111` — the pre-compile program. */
@@ -123,6 +126,38 @@ export interface SwbCrankResult {
 const EMPTY: SwbCrankResult = { instructions: [], luts: [], oracles: [] };
 
 /**
+ * Number of Switchboard oracle samples to request per crank.
+ *
+ * Why not 1 (MarginFi's `createUpdateFeedIx` hardcodes that): each sample
+ * has a `max_staleness` window measured in slots, and the on-chain SWB
+ * program rejects any sample older than that at the slot the tx lands at.
+ * With 1 sample, a Ledger blind-sign review of 5–15s (12–40 slots at
+ * ~400ms) can age the sample past `max_staleness` and yield
+ * `NotEnoughSamples` (Anchor 6030 / 0x178e) even though the crank
+ * simulated fine at preview time — issue #120.
+ *
+ * Three samples give ~3× the staleness headroom with minimal tx-size
+ * cost (each extra sample adds 96 bytes to the secp256k1 ix: 11 offset
+ * bytes + 85 signature/eth-address bytes). Single-oracle crank at N=3
+ * is ~650 bytes, leaving ~580 bytes inside the 1232-byte wire ceiling
+ * for the MarginFi borrow ixs.
+ *
+ * Matches Switchboard's own default for `fetchUpdateManyIx` when
+ * `numSignatures` is omitted (`minSampleSize + 33%`, typically 2–3).
+ */
+const NUM_SIGNATURES = 3;
+
+/**
+ * Switchboard uses this sentinel oracle pubkey to mark an "empty" slot
+ * in a bank's 5-slot oracle-key array (most banks only use slot 0).
+ * MarginFi's own `createUpdateFeedIx` filters this same address; we
+ * iterate the raw config so mirror the filter.
+ */
+const SWB_EMPTY_SLOT_SENTINEL = new PublicKey(
+  "DMhGWtLAKE5d56WdyHQxqeFncwUeqMEnuC2RvvZfbuur",
+);
+
+/**
  * Minimum bank shape we need: oracle setup + primary oracle key.
  * `oracleSetup` comes back as the enum variant string (e.g. "SwitchboardPull")
  * — matches `OracleSetup.SwitchboardPull` in the SDK.
@@ -145,10 +180,26 @@ interface ClientLike {
 }
 
 /**
- * Rewrite a Secp256k1 verify ix's three `_instruction_index` fields so they
- * point to the ix's actual position in the final tx. Required whenever the
- * crank isn't the first instruction (which is always, in our flow — see the
- * file-header reference block for why and what breaks if you skip this).
+ * Size of one Secp256k1 offset block. See the file-header reference for the
+ * exact layout. There are N of these starting at byte 1 (after the u8
+ * num_signatures count).
+ */
+const SIGNATURE_OFFSETS_SERIALIZED_SIZE = 11;
+
+/**
+ * Rewrite a Secp256k1 verify ix's `_instruction_index` fields (three per
+ * signature) so they point to the ix's actual position in the final tx.
+ * Required whenever the crank isn't the first instruction (which is always,
+ * in our flow — see the file-header reference block for why and what breaks
+ * if you skip this).
+ *
+ * Handles N signatures: Switchboard requests `numSignatures` oracle samples
+ * per crank (default 3, issue #120 NUM_SIGNATURES) and packs them into a
+ * single Secp256k1 ix. For each signature k in [0..N), the three
+ * `instruction_index` bytes sit at absolute positions (3 + 11·k,
+ * 6 + 11·k, 11 + 11·k) — one `num_signatures` count byte at offset 0
+ * plus k complete 11-byte offset blocks before the k-th block's internal
+ * triplet at relative positions 2/5/10.
  *
  * Returns a NEW `TransactionInstruction` with a patched data buffer; the
  * input is left untouched so callers can still hold references to the
@@ -165,23 +216,29 @@ export function patchSecp256k1CrankIxPosition(
         `That would mean more than 255 instructions in the tx — nowhere near reachable.`,
     );
   }
-  // Only the single-signature layout is supported (num_signatures === 1).
-  // The Switchboard crank emits exactly one signature per feed and
-  // `createUpdateFeedIx` batches multi-oracle cranks into a single SWB
-  // submit ix, keeping the signature count at 1. Bail loudly if a future
-  // SDK release changes that assumption so the silent-bad-offsets failure
-  // mode can't regress.
   const numSigs = ix.data.readUInt8(0);
-  if (numSigs !== 1) {
+  if (numSigs === 0) {
     throw new Error(
-      `patchSecp256k1CrankIxPosition: expected 1 signature, got ${numSigs}. ` +
-        `The pre-compile data layout assumes single-sig; multi-sig needs a different patch loop.`,
+      `patchSecp256k1CrankIxPosition: num_signatures=0; no offset blocks to patch.`,
+    );
+  }
+  // Sanity-check the buffer carries the declared number of offset blocks.
+  // A short buffer means the SDK emitted malformed data OR a new format —
+  // better to fail loudly than to write past the intended offsets.
+  const requiredLen = 1 + numSigs * SIGNATURE_OFFSETS_SERIALIZED_SIZE;
+  if (ix.data.length < requiredLen) {
+    throw new Error(
+      `patchSecp256k1CrankIxPosition: ix.data too short for declared ` +
+        `num_signatures=${numSigs} (need ≥${requiredLen} bytes, got ${ix.data.length}).`,
     );
   }
   const patched = Buffer.from(ix.data);
-  patched.writeUInt8(position, 3);
-  patched.writeUInt8(position, 6);
-  patched.writeUInt8(position, 11);
+  for (let k = 0; k < numSigs; k++) {
+    const blockStart = 1 + k * SIGNATURE_OFFSETS_SERIALIZED_SIZE;
+    patched.writeUInt8(position, blockStart + 2); // signature_instruction_index
+    patched.writeUInt8(position, blockStart + 5); // eth_address_instruction_index
+    patched.writeUInt8(position, blockStart + 10); // message_instruction_index
+  }
   return new TransactionInstruction({
     programId: ix.programId,
     keys: ix.keys,
@@ -223,6 +280,7 @@ export async function buildSwitchboardCrankIxs(
       (bank.config.oracleKeys && bank.config.oracleKeys[0]) ??
       undefined;
     if (!oracleKey) continue;
+    if (oracleKey.equals(SWB_EMPTY_SLOT_SENTINEL)) continue;
     const b58 = oracleKey.toBase58();
     if (swbOracleBase58.includes(b58)) continue; // dedupe shared feeds
     swbOracles.push(oracleKey);
@@ -230,15 +288,23 @@ export async function buildSwitchboardCrankIxs(
   }
   if (swbOracles.length === 0) return EMPTY;
 
-  // Dynamic import so the Anchor + Switchboard + CrossbarClient footprint
-  // stays off the cold-start path for wallets that never touch a
-  // SwitchboardPull bank.
+  // Dynamic import so the Switchboard + CrossbarClient footprint stays off
+  // the cold-start path for wallets that never touch a SwitchboardPull bank.
+  //
+  // Call `PullFeed.fetchUpdateManyIx` DIRECTLY rather than going through
+  // MarginFi's `createUpdateFeedIx` wrapper — that wrapper hardcodes
+  // `numSignatures: 1`, which is exactly the root cause of issue #120's
+  // `NotEnoughSamples` race. The setup mirrors what the wrapper does
+  // internally: load the Switchboard program, wrap each oracle key in a
+  // PullFeed, get a CrossbarClient + gateway URL. Just with our own
+  // tuned sample count.
   const { AnchorProvider } = await import("@coral-xyz/anchor");
-  const { createUpdateFeedIx } = await import(
-    "@mrgnlabs/marginfi-client-v2"
+  const { PullFeed, AnchorUtils } = await import(
+    "@switchboard-xyz/on-demand"
   );
+  const { CrossbarClient } = await import("@switchboard-xyz/common");
 
-  // Stub wallet — `createUpdateFeedIx` only reads `provider.publicKey` as
+  // Stub wallet — `fetchUpdateManyIx` only reads `provider.publicKey` as
   // the payer; it never calls `signTransaction` / `signAllTransactions`.
   // The fail-throwing stubs double as a tripwire: if the SDK ever starts
   // invoking them in this path, the stale-tx-assembly bug will surface
@@ -250,7 +316,7 @@ export async function buildSwitchboardCrankIxs(
     signTransaction: async () => {
       throw new Error(
         "SWB crank stub wallet: unexpected signTransaction call. " +
-          "createUpdateFeedIx should only read publicKey; signing happens later via Ledger.",
+          "fetchUpdateManyIx should only read publicKey; signing happens later via Ledger.",
       );
     },
     signAllTransactions: async () => {
@@ -263,9 +329,21 @@ export async function buildSwitchboardCrankIxs(
     commitment: "confirmed",
   });
 
-  const { instructions, luts } = await createUpdateFeedIx({
-    swbPullOracles: swbOracles,
-    provider,
+  const swbProgram = await AnchorUtils.loadProgramFromConnection(
+    provider.connection,
+  );
+  const pullFeeds = swbOracles.map(
+    (pubkey) => new PullFeed(swbProgram, pubkey),
+  );
+  const crossbarClient = CrossbarClient.default();
+  const gateway = await pullFeeds[0]!.fetchGatewayUrl(crossbarClient);
+
+  const [instructions, luts] = await PullFeed.fetchUpdateManyIx(swbProgram, {
+    feeds: pullFeeds,
+    gateway,
+    numSignatures: NUM_SIGNATURES,
+    payer,
+    crossbarClient,
   });
   return { instructions, luts, oracles: swbOracleBase58 };
 }

--- a/test/solana-broadcast.test.ts
+++ b/test/solana-broadcast.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * broadcastSolanaTx tests. Keeps the RPC path fake so we can exercise the
+ * error-reframing branches without burning live network calls.
+ */
+
+const sendRawTransactionMock = vi.fn();
+const connectionStub = { sendRawTransaction: sendRawTransactionMock };
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+beforeEach(() => {
+  sendRawTransactionMock.mockReset();
+});
+
+describe("broadcastSolanaTx", () => {
+  it("returns the signature on success", async () => {
+    sendRawTransactionMock.mockResolvedValue("sig123");
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    const sig = await broadcastSolanaTx(Buffer.alloc(0));
+    expect(sig).toBe("sig123");
+  });
+
+  it("wraps generic errors with a 'Solana broadcast failed' prefix + logs", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message: "Transaction simulation failed",
+      logs: [
+        "Program Foo invoke [1]",
+        "Program Foo failed: custom program error: 0x1",
+      ],
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Solana broadcast failed: Transaction simulation failed/,
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Program Foo failed: custom program error: 0x1/,
+    );
+  });
+
+  /**
+   * Issue #120 — Switchboard `NotEnoughSamples` (Anchor 6030 / 0x178e)
+   * means the oracle samples embedded in the tx aged past their
+   * `max_staleness` during Ledger blind-sign review. The raw RPC error
+   * is useless to end-users; reframe it as "re-prepare" guidance.
+   */
+  it("reframes Switchboard NotEnoughSamples (0x178e) as a re-prepare-needed message", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message: "Transaction simulation failed",
+      logs: [
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+        "Program log: AnchorError thrown in programs/sb_on_demand/src/impls/pull_feed_impl.rs:328. Error Code: NotEnoughSamples. Error Number: 6030.",
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x178e",
+      ],
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Switchboard oracle samples aged out during Ledger review/,
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /prepare_marginfi_\* again/,
+    );
+    // Still includes the raw logs for debuggability.
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /0x178e/,
+    );
+  });
+
+  it("reframes even when 0x178e appears only in the outer message (no logs array)", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message:
+        "Transaction simulation failed: Error processing Instruction 2: custom program error: 0x178e",
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Switchboard oracle samples aged out/,
+    );
+  });
+
+  it("does NOT reframe other Switchboard errors (only NotEnoughSamples is timing-specific)", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message: "Transaction simulation failed",
+      logs: [
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x12",
+      ],
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Solana broadcast failed/,
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.not.toThrow(
+      /Switchboard oracle samples aged out/,
+    );
+  });
+});

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -60,7 +60,41 @@ vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
 // suite without the 147MB transitive footprint on each test.
 const wrapperFetchMock = vi.fn();
 const makeInitIxMock = vi.fn();
-const createUpdateFeedIxMock = vi.fn();
+// Switchboard crank mocks (issue #116 ask C / #120). The production path
+// reaches @switchboard-xyz/on-demand directly (bypassing MarginFi's
+// createUpdateFeedIx wrapper so it can pass numSignatures=3 instead of
+// the wrapper's hardcoded 1). Tests intercept at the Switchboard module
+// boundary to exercise wrapWithNonce's branching without pulling in the
+// real Crossbar HTTP client.
+const fetchUpdateManyIxMock = vi.fn();
+vi.mock("@switchboard-xyz/on-demand", () => {
+  class PullFeedStub {
+    public program: unknown;
+    public pubkey: PublicKey;
+    constructor(program: unknown, pubkey: PublicKey) {
+      this.program = program;
+      this.pubkey = pubkey;
+    }
+    async fetchGatewayUrl(): Promise<string> {
+      return "https://gateway.test";
+    }
+    static fetchUpdateManyIx(...args: unknown[]): unknown {
+      return fetchUpdateManyIxMock(...args);
+    }
+  }
+  return {
+    PullFeed: PullFeedStub,
+    AnchorUtils: {
+      loadProgramFromConnection: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+vi.mock("@switchboard-xyz/common", () => ({
+  CrossbarClient: {
+    default: () => ({}),
+  },
+}));
+
 vi.mock("@mrgnlabs/marginfi-client-v2", () => ({
   MarginfiClient: {
     fetch: vi.fn(),
@@ -71,10 +105,6 @@ vi.mock("@mrgnlabs/marginfi-client-v2", () => ({
   instructions: {
     makeInitMarginfiAccountPdaIx: (...args: unknown[]) => makeInitIxMock(...args),
   },
-  // Switchboard crank prepend (issue #116 ask C) — mocked out so tests
-  // can exercise the wrapWithNonce branching without pulling in the
-  // real Switchboard Crossbar HTTP client.
-  createUpdateFeedIx: (...args: unknown[]) => createUpdateFeedIxMock(...args),
   getConfig: () => ({
     programId: new PublicKey("MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA"),
     groupPk: new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8"),
@@ -220,11 +250,12 @@ beforeEach(async () => {
   wrapperFetchMock.mockReset();
   makeInitIxMock.mockReset();
   makeInitIxMock.mockResolvedValue(dummyIx("init"));
-  createUpdateFeedIxMock.mockReset();
-  // Default: no SwitchboardPull oracle touched → crank helper returns
-  // empty ixs. Individual tests exercising the crank path override
-  // to return real-ish secp+submit ixs.
-  createUpdateFeedIxMock.mockResolvedValue({ instructions: [], luts: [] });
+  fetchUpdateManyIxMock.mockReset();
+  // Default: empty ixs + empty LUTs + empty report tuple. Matches
+  // PullFeed.fetchUpdateManyIx's `[ixns, luts, report]` return shape.
+  // Tests that exercise the crank path override with real-ish
+  // secp256k1 + submit ixs.
+  fetchUpdateManyIxMock.mockResolvedValue([[], [], {}]);
 
   const mfn = await import("../src/modules/solana/marginfi.js");
   mfn.__clearMarginfiClientCache();
@@ -1280,11 +1311,13 @@ describe("Switchboard crank prepend (issue #116 ask C)", () => {
   it("prepends secp256k1 + submit ixs, patches instruction_index to the new position", async () => {
     await setupWithActiveSolBalance();
     // Crank helper returns 2 ixs: fake secp256k1 (indices hardcoded to 0)
-    // + a fake submit ix.
-    createUpdateFeedIxMock.mockResolvedValue({
-      instructions: [fakeSecp256k1Ix(), fakeSwbSubmitIx()],
-      luts: [],
-    });
+    // + a fake submit ix. PullFeed.fetchUpdateManyIx's tuple return:
+    // [instructions, luts, report].
+    fetchUpdateManyIxMock.mockResolvedValue([
+      [fakeSecp256k1Ix(), fakeSwbSubmitIx()],
+      [],
+      {},
+    ]);
     const { buildMarginfiBorrow } = await import(
       "../src/modules/solana/marginfi.js"
     );
@@ -1402,16 +1435,17 @@ describe("Switchboard crank prepend (issue #116 ask C)", () => {
     // Bare: nonceAdvance + borrow, nothing else. No ComputeBudget bloat.
     expect(draft.instructions).toHaveLength(2);
     expect(draft.instructions[0]!.programId.toBase58()).toBe(SYSTEM_PROGRAM);
-    // Ensure createUpdateFeedIx was never called — not just that nothing
-    // came back. (Calls an HTTP gateway; must skip for Pyth-only flows.)
-    expect(createUpdateFeedIxMock).not.toHaveBeenCalled();
+    // Ensure PullFeed.fetchUpdateManyIx was never called — not just that
+    // nothing came back. (Calls an HTTP gateway; must skip for Pyth-only
+    // flows.)
+    expect(fetchUpdateManyIxMock).not.toHaveBeenCalled();
     expect(draft.meta.marginfiOracleCranks!.oracles).toEqual([]);
     expect(draft.meta.marginfiOracleCranks!.instructionCount).toBe(0);
   });
 
-  it("falls through without crank when createUpdateFeedIx throws (gateway failure)", async () => {
+  it("falls through without crank when the Switchboard gateway throws (gateway failure)", async () => {
     await setupWithActiveSolBalance();
-    createUpdateFeedIxMock.mockRejectedValue(
+    fetchUpdateManyIxMock.mockRejectedValue(
       new Error("crossbar gateway unreachable"),
     );
     const { buildMarginfiBorrow } = await import(
@@ -1473,14 +1507,65 @@ describe("Switchboard crank prepend (issue #116 ask C)", () => {
     expect(result.data.readUInt8(3)).toBe(0xaa);
   });
 
-  it("patchSecp256k1CrankIxPosition: throws if multi-signature payload shows up", async () => {
+  it("patchSecp256k1CrankIxPosition: patches ALL N offset blocks for multi-sig payloads (issue #120)", async () => {
     const { patchSecp256k1CrankIxPosition } = await import(
       "../src/modules/solana/swb-crank.js"
     );
-    const multi = fakeSecp256k1Ix();
-    multi.data.writeUInt8(2, 0); // num_sigs = 2
-    expect(() => patchSecp256k1CrankIxPosition(multi, 2)).toThrow(
-      /expected 1 signature.*got 2/,
+    // Build a plausible 3-signature payload. Count byte = 3, followed by
+    // 3 × 11-byte offset blocks (all instruction_index bytes initialized
+    // to 0, mirroring what the SDK emits), then a fake signatures area
+    // + common message. The patch function doesn't touch anything past
+    // the offset section, so the tail can stay zeroed.
+    const N = 3;
+    const offsetsAreaSize = 1 + N * 11;
+    const signatureBlockSize = 64 + 1 + 20; // sig + recoveryId + ethAddress
+    const messageSize = 32;
+    const data = Buffer.alloc(offsetsAreaSize + N * signatureBlockSize + messageSize, 0);
+    data.writeUInt8(N, 0);
+    // Populate the three index bytes in each offset block with SDK's
+    // default (0). The patch should rewrite every one of them.
+    for (let k = 0; k < N; k++) {
+      const base = 1 + k * 11;
+      data.writeUInt8(0, base + 2);
+      data.writeUInt8(0, base + 5);
+      data.writeUInt8(0, base + 10);
+    }
+    const multi = new TransactionInstruction({
+      programId: new PublicKey(SECP256K1_PROGRAM),
+      keys: [],
+      data,
+    });
+    const patched = patchSecp256k1CrankIxPosition(multi, 7);
+    for (let k = 0; k < N; k++) {
+      const base = 1 + k * 11;
+      expect(patched.data.readUInt8(base + 2)).toBe(7);
+      expect(patched.data.readUInt8(base + 5)).toBe(7);
+      expect(patched.data.readUInt8(base + 10)).toBe(7);
+    }
+    // Original is untouched.
+    for (let k = 0; k < N; k++) {
+      const base = 1 + k * 11;
+      expect(multi.data.readUInt8(base + 2)).toBe(0);
+    }
+  });
+
+  it("patchSecp256k1CrankIxPosition: throws on truncated buffer (declared N > actual size)", async () => {
+    const { patchSecp256k1CrankIxPosition } = await import(
+      "../src/modules/solana/swb-crank.js"
+    );
+    // Claim 3 signatures but only carry enough bytes for 1 offset block.
+    // A silently-wrong patch would stop at the buffer end and leave
+    // blocks 1..2 with the SDK default (0) — the exact regression we
+    // want this guard to catch.
+    const data = Buffer.alloc(12, 0);
+    data.writeUInt8(3, 0); // num_sigs=3 (needs 1 + 3*11 = 34 bytes)
+    const truncated = new TransactionInstruction({
+      programId: new PublicKey(SECP256K1_PROGRAM),
+      keys: [],
+      data,
+    });
+    expect(() => patchSecp256k1CrankIxPosition(truncated, 2)).toThrow(
+      /too short.*num_signatures=3/,
     );
   });
 });


### PR DESCRIPTION
Fixes #120.

## Problem

#119 shipped Switchboard auto-crank via MarginFi's \`createUpdateFeedIx\` wrapper, which hardcodes \`numSignatures: 1\`. Single-sample cranks are a ticking clock: each oracle sample has a \`max_staleness\` window in slots, and the on-chain SWB program rejects samples older than that at the slot the tx lands at.

Ledger blind-sign review runs 5–15s = 12–40 slots at 400ms. A sample that was 30 slots old at preview time can be 50 slots old at broadcast time — past the window for tighter feeds. Reporter observed this exactly: preview sim passed (crank ix consumed 39k CU, \`success\`); broadcast preflight failed with \`NotEnoughSamples\` (6030 / 0x178e) on the same bytes, consuming only 30k CU before short-circuiting.

## Root cause (live-verified)

\`@mrgnlabs/marginfi-client-v2\`'s \`createUpdateFeedIx\` wraps \`PullFeed.fetchUpdateManyIx\` with \`numSignatures: 1\`. Switchboard's own default (when omitted) is \`minSampleSize + 33%\`, typically 2–3. The MarginFi UI gets away with single-sample because its review window is ~0s (browser auto-approve) — ours can't.

## Fix

**Bypass the MarginFi wrapper.** Call \`PullFeed.fetchUpdateManyIx\` directly from \`@switchboard-xyz/on-demand\` with \`numSignatures=3\`. Duplicates ~12 lines of setup (load SWB program, wrap oracle keys in PullFeed, get CrossbarClient + gateway URL) — worth it for the tuning lever. Matches Switchboard's own default.

**Extend \`patchSecp256k1CrankIxPosition\` to handle N signatures.** The old version guarded with \`numSigs !== 1 → throw\` because the single-sig byte positions were hardcoded. Now loops over N offset blocks — for k in [0..N), patches bytes (3 + 11·k, 6 + 11·k, 11 + 11·k) to the ix's tx-relative position. Added a buffer-length sanity check so a malformed SDK payload fails loudly instead of silently leaving later blocks at the SDK default of \`0\`.

**Reframe the residual failure mode.** For very slow Ledger reviews or tighter-max-staleness feeds, even N=3 may not be enough. In \`broadcastSolanaTx\`, detect the Switchboard \`0x178e\` / NotEnoughSamples signature in the error message or logs and swap it for a clear \"oracle samples aged out during Ledger review; re-prepare to retry\" message instead of the raw program error.

## Cost

- Each extra sample adds 96 bytes to the secp256k1 ix (11 offset + 85 sig block). Live-verified: single-oracle crank at N=3 → 1117 bytes total serialized, well under the 1232-byte wire ceiling.
- ~16k extra CU consumed (149k → 165k). Miles under the 1.4M budget.
- No on-chain protocol change. Same integrity chain (nonce not advanced on failure).

## Live verification (reporter's wallet)

\`\`\`
prepare: 6.5s
secp256k1 num_signatures: 3 (data len: 321)
  sig[0] instruction_indices: sig=2 eth=2 msg=2
  sig[1] instruction_indices: sig=2 eth=2 msg=2
  sig[2] instruction_indices: sig=2 eth=2 msg=2
serialized tx size: 1117 bytes
preview: 181ms → sim.ok=true, CU=165038
\`\`\`

## Test plan

- [x] Unit — multi-sig patch rewrites ALL N offset blocks (replaces old throw-on-multi test)
- [x] Unit — truncated buffer (declared N > actual size) throws before writing past end
- [x] Unit — 5 cases for broadcast NotEnoughSamples reframing (success / generic / 0x178e in logs / 0x178e in message / unrelated Switchboard error not reframed)
- [x] Unit — cranked-borrow / no-crank-for-Pyth / gateway-throws integration paths re-wired to mock \`PullFeed.fetchUpdateManyIx\` directly
- [x] Live — reporter's repro wallet shows N=3 ix with all blocks patched, sim passes
- [x] Regression guard — limiting the patch loop to \`k<1\` fails the N=3 test cleanly
- [x] 768/768 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)