### PR TITLE
fix(verify-block): pull Solana blind-sign hash onto its own indented line

### DIFF
--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -1634,7 +1634,10 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
                 ? `MarginFi ${marginfiActionLabel}`
                 : "SPL TransferChecked"
           } is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):`,
-          `          check the value on-device is exactly **\`${ledgerHash}\`**.`,
+          "          The Message Hash on-device MUST equal:",
+          "",
+          `              **\`${ledgerHash}\`**`,
+          "",
           "          Any difference → REJECT.",
           "          Prerequisite: Allow blind signing must be ON in Solana app Settings.",
         ]
@@ -1664,13 +1667,19 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     "",
     ...(isBlindSign
       ? [
-          "Render the Message Hash with BOTH bold AND single-backtick inline",
-          "code — i.e. `**\\`<hash>\\`**` — exactly as shown in the template",
-          "above. Backticks alone render too subtly in some clients; bold+code",
-          "reads with clear contrast everywhere. Do NOT strip either marker.",
+          "Render the Message Hash on a LINE BY ITSELF — blank line above, the",
+          "hash indented with both bold AND single-backtick inline-code wrappers",
+          "(`**\\`<hash>\\`**`), blank line below — exactly as shown in the",
+          "template above. Keeping it inline at the end of a prose sentence",
+          "(even bold+code) has blended into surrounding text in live Claude",
+          "Code renderings where the CHECKS PERFORMED block gets treated as a",
+          "preformatted region and the Markdown emphasis markers leak through",
+          "as literal characters; the isolated indented line plus blank",
+          "separators forces a visual break that survives that rendering.",
+          "Do NOT strip the wrappers and do NOT collapse the blank lines.",
           "Whenever you reference the hash elsewhere (headline, post-broadcast",
-          "summary, etc.) use the same wrapper — inconsistent emphasis slows",
-          "the user's visual match.",
+          "summary, etc.) use the same `**\\`<hash>\\`**` wrapper — inconsistent",
+          "emphasis slows the user's visual match.",
           "",
         ]
       : [


### PR DESCRIPTION
## Summary

- The MarginFi / Jupiter / SPL blind-sign branch of `renderSolanaAgentTaskBlock` kept the Message Hash inline at the end of a prose sentence. In live Claude Code rendering, the CHECKS PERFORMED region gets treated as a preformatted block and the Markdown `**` / backtick emphasis markers leak through as literal characters — exactly the symptom commit `a7240b8` fixed for EVM but never carried over to the Solana path.
- Mirror the EVM fix: hash on its own indented line with blank lines above and below, bold + single-backtick wrappers preserved. The `Prerequisite: Allow blind signing` line stays below the `REJECT` line.
- Updated the agent-facing prose guidance in the same block to describe the new layout explicitly, so the agent doesn't drift back to the old inline shape when relaying.

## Before / after

Before:
```
      • BLIND-SIGN (this tx — MarginFi borrow is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):
          check the value on-device is exactly **` + "`" + `<hash>` + "`" + `**.
          Any difference → REJECT.
          Prerequisite: Allow blind signing must be ON in Solana app Settings.
```

After:
```
      • BLIND-SIGN (this tx — MarginFi borrow is not in the Solana app's clear-sign registry, so the device shows only 'Message Hash'):
          The Message Hash on-device MUST equal:

              **` + "`" + `<hash>` + "`" + `**

          Any difference → REJECT.
          Prerequisite: Allow blind signing must be ON in Solana app Settings.
```

## Test plan

- [x] `npm test` — 762/762 passing
- [x] `npm run build` — clean
- [ ] Live run: trigger a MarginFi borrow prepare → `preview_solana_send` and confirm the CHECKS PERFORMED block renders the Message Hash on its own line in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)