### PR TITLE
fix(marginfi): detect Switchboard feed rotation; split NotEnoughSamples error (#125)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -611,14 +611,34 @@ export async function previewSolanaSend(args: {
             // Swallow — diagnosis is additive, not gating.
           }
         }
-        throw new Error(
-          header +
-            logTail +
-            diagnosis +
-            `\nRefusing to surface the Ledger hash — the tx would revert on broadcast. ` +
-            `Resolve the underlying issue (e.g. withdraw conflicting collateral, wait for oracle freshness, ` +
-            `pick a different bank) and call prepare_* again.`,
+        // Issue #125 — split the two NotEnoughSamples failure modes. A
+        // "Rotating mega slot" log line immediately before the Anchor
+        // 6030 means the feed is mid oracle-set rotation: consensus can't
+        // be reached for ~60–120s regardless of how many samples we
+        // requested (#120's N=3 tuning doesn't help during rotation).
+        // The right user action is to WAIT, not loop-retry. The plain
+        // stale-samples branch still tells the user to re-prepare.
+        const isNotEnoughSamples = sim.anchorError?.code === 6030;
+        const { isSwitchboardRotation } = await import(
+          "../solana/simulate.js"
         );
+        const rotating =
+          isNotEnoughSamples && isSwitchboardRotation(sim.logs);
+        const remediation = rotating
+          ? `\nThis is a transient SWITCHBOARD ORACLE ROTATION ("Rotating mega slot" ` +
+            `in the logs) — the feed is between oracle sets and consensus is ` +
+            `temporarily unreachable. Wait 60–120s before retrying; tight retry ` +
+            `loops will fail identically until rotation completes. No code bug ` +
+            `on our side; no fix on retry. Durable nonce was not advanced.`
+          : isNotEnoughSamples
+            ? `\nOracle samples fetched at preview time are already past their ` +
+              `max-staleness window. This is unusual at preview time (the fetch ` +
+              `is seconds-old) and typically indicates extreme RPC lag or a ` +
+              `freshly-rotated feed. Call prepare_* again to fetch fresh samples.`
+            : `\nRefusing to surface the Ledger hash — the tx would revert on broadcast. ` +
+              `Resolve the underlying issue (e.g. withdraw conflicting collateral, wait for oracle freshness, ` +
+              `pick a different bank) and call prepare_* again.`;
+        throw new Error(header + logTail + diagnosis + remediation);
       }
       pinned.simulation = sim;
     } catch (e) {

--- a/src/modules/solana/broadcast.ts
+++ b/src/modules/solana/broadcast.ts
@@ -48,18 +48,38 @@ export async function broadcastSolanaTx(signedTxBytes: Buffer): Promise<string> 
     const logs = logsArr.length ? `\nProgram logs:\n  ${logsArr.join("\n  ")}` : "";
 
     // Switchboard `NotEnoughSamples` (Anchor 6030 / 0x178e) on the crank ix
-    // means the oracle samples we fetched at preview time aged past their
-    // `max_staleness` window during Ledger review (issue #120). With
-    // numSignatures=3 the headroom is ~3× but not unbounded; a slow
-    // review (>20s) or a feed with a tight max_staleness can still trip
-    // this. Reframe so the user gets an actionable message instead of
-    // a raw program error — the remediation is always "re-prepare" and
-    // the pre-sign simulation will re-fetch fresh samples.
+    // has two distinct causes, and the right user action differs:
+    //
+    //   1. Samples AGED OUT during Ledger review (issue #120). The tx's
+    //      embedded oracle attestations were fresh at preview time but
+    //      slipped past their max_staleness window by the time broadcast
+    //      tried to land. Re-preparing refetches samples at a newer slot
+    //      and usually succeeds.
+    //
+    //   2. Feed is ROTATING (issue #125). The Switchboard on-demand program
+    //      emits "Rotating mega slot" when the feed is mid oracle-set
+    //      transition; consensus is unreachable for ~60–120s regardless
+    //      of sample count. Tight retry loops fail identically — the
+    //      user needs to WAIT, not retry.
+    //
+    // Signal: "Rotating mega slot" in the logs. Without that line, treat
+    // it as aged-out.
     const notEnoughSamples =
       /custom program error: 0x178e/i.test(base) ||
       /custom program error: 0x178e/i.test(logs) ||
       /NotEnoughSamples/.test(logs);
     if (notEnoughSamples) {
+      const rotating = /Rotating mega slot/i.test(logs);
+      if (rotating) {
+        throw new Error(
+          `Switchboard feed is ROTATING oracles ("Rotating mega slot" in the logs) ` +
+            `— this is a transient ~60–120s state during which consensus cannot ` +
+            `be reached regardless of how many samples we fetch (issue #125). ` +
+            `Wait at least 60s before retrying — tight retry loops will fail ` +
+            `identically until rotation completes. No on-chain effect — the ` +
+            `durable nonce was not advanced. Raw: ${base}${logs}`,
+        );
+      }
       throw new Error(
         `Switchboard oracle samples aged out during Ledger review — the tx's ` +
           `embedded oracle attestations were fresh at preview time but too old ` +

--- a/src/modules/solana/simulate.ts
+++ b/src/modules/solana/simulate.ts
@@ -100,20 +100,24 @@ function extractAnchorError(
   logs: string[] | undefined,
 ): { code: number; name: string; message: string } | undefined {
   if (!logs || logs.length === 0) return undefined;
-  // Match "Error Code: X. Error Number: Y. Error Message: Z" anywhere in the
-  // line. An earlier version anchored at `AnchorError` and used `[^.]*` up to
-  // the first dot — but the source-file path in the real log (".../marginfi_account.rs:1142.")
-  // contains dots that broke the match. Scanning for the triple labels alone
-  // is robust and matches how Anchor's runtime formats every thrown error.
+  // Match "Error Code: X. Error Number: Y." with an OPTIONAL
+  // "Error Message: Z." trailing segment. MarginFi's Anchor errors always
+  // include the message; Switchboard's `NotEnoughSamples` and some others
+  // omit it entirely (issue #125 — the log ends right after "Error Number: 6030.").
+  // An earlier version required the message and used `[^.]*` up to the
+  // first dot — that broke on MarginFi because the source-file path
+  // ("marginfi_account.rs:1142.") contains dots, AND on Switchboard because
+  // the whole "Error Message:" suffix is absent. Both call sites care more
+  // about the code than the message text, so message is optional.
   const re =
-    /Error Code:\s*(\w+)\.\s*Error Number:\s*(\d+)\.\s*Error Message:\s*(.+?)\.?\s*$/;
+    /Error Code:\s*(\w+)\.\s*Error Number:\s*(\d+)\.(?:\s*Error Message:\s*(.+?)\.?)?\s*$/;
   for (let i = logs.length - 1; i >= 0; i--) {
     const m = logs[i]!.match(re);
     if (m) {
       return {
         name: m[1]!,
         code: Number(m[2]),
-        message: m[3]!.trim(),
+        message: m[3] ? m[3].trim() : "(no message provided by program)",
       };
     }
   }
@@ -122,3 +126,27 @@ function extractAnchorError(
 
 /** Test-only export so unit tests can cover the log-scraping independently. */
 export const __extractAnchorErrorForTest = extractAnchorError;
+
+/**
+ * Detect whether a Switchboard `NotEnoughSamples` (Anchor 6030 / 0x178e)
+ * failure is due to an active oracle-set rotation on the feed. The
+ * on-chain Switchboard program logs `Rotating mega slot` immediately
+ * before throwing `NotEnoughSamples` when the feed is between oracle
+ * sets — a transient state lasting seconds to ~2 minutes during which
+ * consensus can't be reached regardless of how many samples we
+ * requested from the gateway (issue #125).
+ *
+ * Distinguishing this from the plain-stale-samples case matters for
+ * user guidance: stale-samples → "re-prepare to retry" (re-fetching
+ * gateway samples gets fresh ones); rotating → "wait ~60–120s, don't
+ * loop-retry" (no amount of re-fetching produces a valid consensus
+ * payload until rotation completes).
+ *
+ * Pure log-string scan: no side effects, no RPC calls. The caller is
+ * responsible for confirming the AnchorError is actually 6030 before
+ * acting on this signal.
+ */
+export function isSwitchboardRotation(logs: string[] | undefined): boolean {
+  if (!logs || logs.length === 0) return false;
+  return logs.some((l) => /Rotating mega slot/.test(l));
+}

--- a/test/solana-broadcast.test.ts
+++ b/test/solana-broadcast.test.ts
@@ -107,4 +107,98 @@ describe("broadcastSolanaTx", () => {
       /Switchboard oracle samples aged out/,
     );
   });
+
+  /**
+   * Issue #125 — a NotEnoughSamples caused by an active feed rotation
+   * (logs contain "Rotating mega slot") must produce the "wait, don't
+   * retry" message, not the aged-out "re-prepare" message. The two
+   * failure modes carry the same Anchor error code (6030) but require
+   * opposite user actions.
+   */
+  it("reframes NotEnoughSamples WITH 'Rotating mega slot' as a wait-don't-retry message", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message: "Transaction simulation failed",
+      logs: [
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+        "Program log: Instruction: PullFeedSubmitResponseConsensus",
+        "Program log: Rotating mega slot",
+        "Program log: AnchorError thrown in programs/sb_on_demand/src/impls/pull_feed_impl.rs:328. Error Code: NotEnoughSamples. Error Number: 6030.",
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x178e",
+      ],
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /ROTATING oracles/,
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /Wait at least 60s/,
+    );
+    // Must NOT suggest re-prepare — that's the wrong action for rotation.
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.not.toThrow(
+      /aged out during Ledger review/,
+    );
+  });
+
+  it("keeps the aged-out framing for NotEnoughSamples WITHOUT rotation marker", async () => {
+    sendRawTransactionMock.mockRejectedValue({
+      message: "Transaction simulation failed",
+      logs: [
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+        "Program log: AnchorError thrown in ...:328. Error Code: NotEnoughSamples. Error Number: 6030.",
+        "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x178e",
+      ],
+    });
+    const { broadcastSolanaTx } = await import(
+      "../src/modules/solana/broadcast.js"
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.toThrow(
+      /aged out during Ledger review/,
+    );
+    await expect(broadcastSolanaTx(Buffer.alloc(0))).rejects.not.toThrow(
+      /ROTATING oracles/,
+    );
+  });
+});
+
+/**
+ * Issue #125 — the rotation-vs-aged-out detector is also used by the
+ * pre-sign simulation gate. Keep the pure-function behavior covered
+ * independently so both call sites (broadcast.ts and execution/index.ts)
+ * can trust the signal.
+ */
+describe("isSwitchboardRotation", () => {
+  it("returns true when 'Rotating mega slot' appears anywhere in the logs", async () => {
+    const { isSwitchboardRotation } = await import(
+      "../src/modules/solana/simulate.js"
+    );
+    expect(
+      isSwitchboardRotation([
+        "Program A invoke [1]",
+        "Program log: Rotating mega slot",
+        "Program log: AnchorError ...",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false for plain NotEnoughSamples logs without the rotation marker", async () => {
+    const { isSwitchboardRotation } = await import(
+      "../src/modules/solana/simulate.js"
+    );
+    expect(
+      isSwitchboardRotation([
+        "Program A invoke [1]",
+        "Program log: AnchorError ... Error Code: NotEnoughSamples. Error Number: 6030.",
+      ]),
+    ).toBe(false);
+  });
+
+  it("handles empty / undefined input defensively", async () => {
+    const { isSwitchboardRotation } = await import(
+      "../src/modules/solana/simulate.js"
+    );
+    expect(isSwitchboardRotation(undefined)).toBe(false);
+    expect(isSwitchboardRotation([])).toBe(false);
+  });
 });

--- a/test/solana-sign-dispatch.test.ts
+++ b/test/solana-sign-dispatch.test.ts
@@ -277,6 +277,91 @@ describe("sendTransaction dispatch — Solana", () => {
     expect(signTransactionMock).not.toHaveBeenCalled();
   });
 
+  /**
+   * Issue #125 — when pre-sign simulation fails with Switchboard
+   * NotEnoughSamples (6030) AND the logs carry "Rotating mega slot",
+   * the preview must tell the user to WAIT (~60-120s), not re-prepare.
+   * Tight retry loops during rotation fail identically; re-prepare is
+   * the wrong action.
+   */
+  it("#125 preview: rotation-caused NotEnoughSamples → 'wait, don't retry' message", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    const { buildSolanaNativeSend } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "0.1",
+    });
+    connectionStub.simulateTransaction.mockResolvedValue({
+      context: { slot: 1 },
+      value: {
+        err: { InstructionError: [2, { Custom: 6030 }] },
+        unitsConsumed: 45600,
+        logs: [
+          "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+          "Program log: Instruction: PullFeedSubmitResponseConsensus",
+          "Program log: Rotating mega slot",
+          "Program log: AnchorError thrown in programs/sb_on_demand/src/impls/pull_feed_impl.rs:328. Error Code: NotEnoughSamples. Error Number: 6030.",
+          "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x178e",
+        ],
+      },
+    });
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.toThrow(/SWITCHBOARD ORACLE ROTATION/);
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.toThrow(/Wait 60–120s/);
+    // Must NOT tell the user to re-prepare — that's the wrong guidance for
+    // rotation and would cause a tight retry loop.
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.not.toThrow(/Call prepare_\* again to fetch fresh samples/);
+    // Sanity: still the standard sim-reject envelope.
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.toThrow(/Pre-sign simulation REJECTED/);
+    expect(signTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("#125 preview: plain NotEnoughSamples (no rotation marker) → 'refetch fresh samples' message", async () => {
+    connectionStub.getBalance.mockResolvedValue(5_000_000_000);
+    const { buildSolanaNativeSend } = await import(
+      "../src/modules/solana/actions.js"
+    );
+    const draft = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "0.1",
+    });
+    connectionStub.simulateTransaction.mockResolvedValue({
+      context: { slot: 1 },
+      value: {
+        err: { InstructionError: [2, { Custom: 6030 }] },
+        unitsConsumed: 30000,
+        logs: [
+          "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv invoke [1]",
+          "Program log: AnchorError thrown in ...:328. Error Code: NotEnoughSamples. Error Number: 6030.",
+          "Program SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv failed: custom program error: 0x178e",
+        ],
+      },
+    });
+    const { previewSolanaSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.toThrow(/Call prepare_\* again to fetch fresh samples/);
+    await expect(
+      previewSolanaSend({ handle: draft.handle }),
+    ).rejects.not.toThrow(/ROTATION/);
+  });
+
   it("#115 preview attaches simulation metadata on success", async () => {
     connectionStub.getBalance.mockResolvedValue(5_000_000_000);
     const { buildSolanaNativeSend } = await import(


### PR DESCRIPTION
Fixes #125. Follow-up to #120 / #123.

## Problem

#123 shipped \`numSignatures=3\` + reframed \`NotEnoughSamples\` (Anchor 6030 / 0x178e) as "samples aged out during Ledger review, re-prepare to retry." That's one of TWO causes of the same error code.

\`#125\` documents the second: the Switchboard feed is mid oracle-set rotation. The gateway returns insufficient signatures for consensus, the program emits \`Program log: Rotating mega slot\` right before the 6030 throw, and the state lasts ~60–120s. Tight retry loops (exactly what the \`re-prepare\` message encourages) fail identically until rotation completes. **The remediations are opposite.**

Reporter hit this three times in seconds: once post-device-review, twice pre-sign sim. "Re-prepare" was the wrong guidance.

## Fix

**Detect the rotation marker.** Pure log scan in \`simulate.ts\`:

\`\`\`typescript
export function isSwitchboardRotation(logs: string[] | undefined): boolean {
  if (!logs || logs.length === 0) return false;
  return logs.some((l) => /Rotating mega slot/.test(l));
}
\`\`\`

**Split the error message** at both sites that surfaced NotEnoughSamples:

- \`previewSolanaSend\` (sim-reject branch, #115 codepath) — on 6030 + rotation: "Switchboard feed is ROTATING, wait 60–120s, don't loop-retry." On 6030 without rotation: "samples aged out, call prepare_* again."
- \`broadcastSolanaTx\` (existing 0x178e branch from #123) — same split. Rotation → wait; non-rotation → re-prepare.

**Fixed a latent bug in \`extractAnchorError\`** surfaced by this work. The regex required a trailing \`Error Message:\` segment — Anchor's default format includes it, but Switchboard's \`NotEnoughSamples\` (and presumably other programs with minimal error attrs) omits the message entirely. Result: \`anchorError\` was \`undefined\` for Switchboard failures, and the rotation-split logic had nothing to branch on. Made the message segment optional with a \`"(no message provided by program)"\` fallback. MarginFi case unchanged.

## What I didn't do (and why)

**Direction 1 — bump \`numSignatures\` to 5.** During rotation, N=5 fails identically to N=3 because consensus is the bottleneck, not sample count. Also: each extra sample adds 96 bytes to the secp256k1 ix; N=5 on a single-oracle crank would push the tx to ~1309 bytes, over the 1232-byte wire ceiling. Costs with no benefit.

**Direction 2 — server-side gateway retry on rotation.** Attempted mentally, rejected. Rotation can last 2 minutes; silently blocking \`preview_solana_send\` for that long would be a worse UX than surfacing the wait-and-retry signal explicitly. Plus the on-chain program is the authoritative oracle-rotation detector, not our client — best to let it tell us.

## Live repro (reporter's session)

Before: three "re-prepare and retry" attempts, all failing identically → user loops without understanding.

After (with this PR): preview would throw with

\`\`\`
Pre-sign simulation REJECTED the marginfi_borrow tx — NotEnoughSamples (6030): …
Last program logs:
  Program log: Rotating mega slot
  Program log: AnchorError thrown in …:328. Error Code: NotEnoughSamples. Error Number: 6030.
  Program SBondMD… failed: custom program error: 0x178e
This is a transient SWITCHBOARD ORACLE ROTATION ("Rotating mega slot" in the logs) — the feed is between oracle sets and consensus is temporarily unreachable. Wait 60–120s before retrying; tight retry loops will fail identically until rotation completes. No code bug on our side; no fix on retry. Durable nonce was not advanced.
\`\`\`

## Test plan

- [x] Unit — \`isSwitchboardRotation\` returns true when marker present, false otherwise + defensive empty/undefined input
- [x] Unit — broadcast: NotEnoughSamples + rotation marker → "ROTATING" / "Wait at least 60s", no "aged out"; plain NotEnoughSamples → "aged out", no "ROTATING"
- [x] Unit — preview: same split (two new #125 cases added alongside the existing #115 test)
- [x] Regression guard — replacing \`isSwitchboardRotation\` body with \`return false\` fails 2 targeted tests cleanly
- [x] 775/775 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)