### PR TITLE
chore: ignore claude-work/ for local planning + audit scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,12 @@ dist/
 coverage/
 .vitest-cache/
 
-# Internal planning docs — not published to git.
+# Internal planning doc — not published to git.
 recon-mcp-requirements.md
-solana-roadmap.md
+
+# Local scratch for Claude Code working files (plans, audits, one-off notes
+# that outlive a single plan-mode session). Not published to git.
+claude-work/
 
 # crypto-audit skill output — local-only audit scratch.
 .context/

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,9 @@ dist/
 coverage/
 .vitest-cache/
 
-# Internal planning doc — not published to git.
-recon-mcp-requirements.md
-
-# Local scratch for Claude Code working files (plans, audits, one-off notes
-# that outlive a single plan-mode session). Not published to git.
+# Local scratch for Claude Code working files (plans, audits, requirements
+# docs, one-off notes that outlive a single plan-mode session). Not
+# published to git.
 claude-work/
 
 # crypto-audit skill output — local-only audit scratch.


### PR DESCRIPTION
## Summary

- New local convention: `claude-work/` (gitignored) holds Claude Code planning + audit scratch that outlives a single plan-mode session but isn't public-facing. Mirrors how `.context/` already works for crypto-audit skill output.
- Drops the explicit `solana-roadmap.md` entry from `.gitignore`; the file now lives at `claude-work/solana-roadmap.md` and is covered by the directory rule.
- Locally moved (not part of this commit — lives under the ignore):
  - `solana-roadmap.md` → `claude-work/solana-roadmap.md` (the Solana post-phase-3 plan from PR #122)
  - New: `claude-work/security-checks-audit.md` (inventory of current verification checks across EVM / Solana / TRON, categorised as essential / defense-in-depth / low-value; written up from the plan-mode audit run earlier today)

## Why

We keep accumulating local `.md` scratch files from plan-mode sessions — each one ended up with its own `.gitignore` line. A single directory rule is cleaner, and parks these files at a stable path instead of `~/.claude/plans/*` names that get overwritten by the next plan-mode session.

## Test plan

- [x] `git check-ignore -v claude-work/{solana-roadmap.md,security-checks-audit.md}` — both resolve to the new rule
- [x] `git status` — shows only `.gitignore` modified; the `claude-work/` contents don't leak as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)