### PR TITLE
feat(solana): nonce-aware dropped-tx polling (roadmap #1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -626,6 +626,7 @@ function sendTransactionHandler(
     to?: `0x${string}`;
     valueWei?: string;
     lastValidBlockHeight?: number;
+    durableNonce?: { noncePubkey: string; nonceValue: string };
   }>,
 ) {
   return async (args: SendTransactionArgs) => {
@@ -653,6 +654,7 @@ function sendTransactionHandler(
           ...(result.lastValidBlockHeight !== undefined
             ? { lastValidBlockHeight: result.lastValidBlockHeight }
             : {}),
+          ...(result.durableNonce ? { durableNonce: result.durableNonce } : {}),
         }),
       });
       return { content };
@@ -781,9 +783,12 @@ async function main() {
         "   send_transaction refuses with a clear error. TRON and Solana handles ignore those two.",
         "7. After `send_transaction` returns a txHash, relay the TRANSACTION BROADCAST block",
         "   VERBATIM to the user (it carries the hash + explorer link — do NOT drop it), THEN",
-        "   poll `get_transaction_status` YOURSELF every ~5s until status is `success` or",
-        "   `failed` (budget ~2min). Do NOT stop and wait for the user to type \"next\" — the",
-        "   per-call AGENT TASK block emitted alongside the txHash prescribes the exact cadence.",
+        "   poll `get_transaction_status` YOURSELF every ~5s until status is `success` /",
+        "   `failed` / `dropped` (budget ~2min). Do NOT stop and wait for the user to type",
+        "   \"next\". On Solana, pass the `durableNonce` or `lastValidBlockHeight` field from",
+        "   send_transaction's return verbatim into get_transaction_status so it can detect",
+        "   dropped txs (without it, dropped reads as forever-pending). The per-call AGENT",
+        "   TASK block emitted alongside the txHash prescribes the exact cadence.",
         "",
         "TWO-STEP ALLOWANCE FLOWS: when a `prepare_*` tool returns an approval tx alongside",
         "the main tx (supply, repay, swap, etc.), submit the approval FIRST via preview_send",
@@ -1594,7 +1599,7 @@ async function main() {
     "get_transaction_status",
     {
       description:
-        "Poll a transaction's status via the chain's RPC (EVM / Solana) or TronGrid (TRON). Returns pending / success / failed, plus 'dropped' on Solana when the baked blockhash has expired past the supplied lastValidBlockHeight and the tx was never seen. Pass chain='tron' with the bare hex txID for TRON; chain='solana' with the base58 signature for Solana. For Solana, ALSO pass the `lastValidBlockHeight` value returned by `send_transaction` — without it the status tool cannot distinguish 'dropped' from 'still propagating' and reports 'pending' forever for txs that silently fell out of the mempool.",
+        "Poll a transaction's status via the chain's RPC (EVM / Solana) or TronGrid (TRON). Returns pending / success / failed, plus 'dropped' on Solana when the tx is mathematically unable to land. Pass chain='tron' with the bare hex txID for TRON; chain='solana' with the base58 signature for Solana. For Solana, ALSO pass whichever drop-detection field send_transaction returned: (a) `durableNonce` for nearly every send (native/SPL sends, nonce_close, jupiter_swap, all marginfi_* actions) — the tool reads the on-chain nonce account and reports 'dropped' if it rotated past the baked value; or (b) `lastValidBlockHeight` for legacy-blockhash txs (currently just nonce_init) — reports 'dropped' if current block height is past. Without either field the tool reports 'pending' forever for dropped txs.",
       inputSchema: getTransactionStatusInput.shape,
     },
     handler(getTransactionStatus)

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -672,6 +672,7 @@ async function sendSolanaTransaction(args: SendTransactionArgs): Promise<{
   txHash: string;
   chain: "solana";
   lastValidBlockHeight?: number;
+  durableNonce?: { noncePubkey: string; nonceValue: string };
 }> {
   const tx: UnsignedSolanaTx = consumeSolanaHandle(args.handle);
   // Proof-of-identity guard: same logic as the TRON sender. Recompute the
@@ -718,8 +719,21 @@ async function sendSolanaTransaction(args: SendTransactionArgs): Promise<{
   return {
     txHash: txSignature,
     chain: "solana",
+    // `lastValidBlockHeight` is for legacy-blockhash txs (nonce_init only);
+    // `durableNonce` is for every other send. The status poller uses one
+    // or the other to distinguish dropped from pending — always surface
+    // the applicable field so the agent can hand it back to
+    // `get_transaction_status` verbatim.
     ...(tx.lastValidBlockHeight !== undefined
       ? { lastValidBlockHeight: tx.lastValidBlockHeight }
+      : {}),
+    ...(tx.nonce
+      ? {
+          durableNonce: {
+            noncePubkey: tx.nonce.account,
+            nonceValue: tx.nonce.value,
+          },
+        }
       : {}),
   };
 }
@@ -1302,12 +1316,21 @@ export async function sendTransaction(args: SendTransactionArgs): Promise<{
   /** Decimal wei string, echoed alongside `preSignHash` for the post-broadcast block. */
   valueWei?: string;
   /**
-   * Solana only: the last block height at which the tx's baked blockhash
-   * remains valid. Surfaced so `get_transaction_status` can distinguish
-   * "dropped" (current slot past this) from "not-yet-propagated" when
-   * `getSignatureStatuses` returns null.
+   * Solana legacy-blockhash txs (currently just `nonce_init`). Surfaced so
+   * `get_transaction_status` can distinguish "dropped" (current slot past
+   * this) from "not-yet-propagated" when `getSignatureStatuses` returns
+   * null.
    */
   lastValidBlockHeight?: number;
+  /**
+   * Solana durable-nonce txs (native/SPL sends, nonce_close, jupiter_swap,
+   * all marginfi_* actions). Surfaced so `get_transaction_status` can
+   * authoritatively distinguish "dropped" (on-chain nonce rotated past
+   * `nonceValue`) from "not-yet-propagated". Authoritative because Agave
+   * itself gates durable-nonce tx validity on the nonce state, not block
+   * height.
+   */
+  durableNonce?: { noncePubkey: string; nonceValue: string };
 }> {
   if (hasTronHandle(args.handle)) {
     return sendTronTransaction(args);
@@ -1393,6 +1416,7 @@ export async function getTransactionStatus(args: GetTransactionStatusArgs) {
       ...(args.lastValidBlockHeight !== undefined
         ? { lastValidBlockHeight: args.lastValidBlockHeight }
         : {}),
+      ...(args.durableNonce ? { durableNonce: args.durableNonce } : {}),
     });
   }
   const client = getClient(args.chain as SupportedChain);

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -464,11 +464,29 @@ export const getTransactionStatusInput = z.object({
     .nonnegative()
     .optional()
     .describe(
-      "Solana only. Block-height ceiling for the tx's baked blockhash — returned by " +
-        "send_transaction for Solana txs. When supplied and `getSignatureStatuses` " +
-        "returns null (tx not visible), the poller compares against the current block " +
-        "height and reports `dropped` instead of forever `pending` if the window has " +
-        "passed. Omit for EVM / TRON; ignored on those chains."
+      "Solana only, legacy-blockhash txs (currently just `nonce_init`). Block-height " +
+        "ceiling for the tx's baked blockhash — returned by send_transaction for such " +
+        "txs. When supplied and `getSignatureStatuses` returns null, the poller " +
+        "compares against current block height and reports `dropped` if the window " +
+        "has passed. Omit for EVM / TRON; ignored on those chains. For durable-nonce " +
+        "Solana txs (every send this server builds except nonce_init), use " +
+        "`durableNonce` instead — it's authoritative."
+    ),
+  durableNonce: z
+    .object({
+      noncePubkey: z.string(),
+      nonceValue: z.string(),
+    })
+    .optional()
+    .describe(
+      "Solana only, durable-nonce txs (native_send, spl_send, nonce_close, " +
+        "jupiter_swap, all marginfi_* actions). Returned by send_transaction on these " +
+        "flows. When supplied and `getSignatureStatuses` returns null, the poller " +
+        "reads the on-chain nonce account: if the nonce rotated past `nonceValue` " +
+        "(or the account was closed), the tx can never land and is reported as " +
+        "`dropped` with diagnostic fields `nonceAccount` / `bakedNonce` / " +
+        "`currentNonce`. Without this field the poller reports `pending` forever " +
+        "for dropped durable-nonce txs — a known Phase 2 UX gap."
     ),
 });
 

--- a/src/modules/solana/status.ts
+++ b/src/modules/solana/status.ts
@@ -1,3 +1,5 @@
+import { PublicKey } from "@solana/web3.js";
+import { getNonceAccountValue } from "./nonce.js";
 import { getSolanaConnection } from "./rpc.js";
 
 export interface SolanaTransactionStatus {
@@ -6,10 +8,13 @@ export interface SolanaTransactionStatus {
   /**
    * `pending` — not yet visible on chain; might still land.
    * `success` / `failed` — landed (the latter with an error string).
-   * `dropped` — blockhash past its last-valid-block-height and tx was never
-   *   found; cannot possibly land from here. Only set when the caller
-   *   supplied `lastValidBlockHeight` AND the current block height is past
-   *   it AND `getSignatureStatuses` still returns null.
+   * `dropped` — one of two mathematical impossibilities:
+   *   - Legacy-blockhash tx: baked blockhash is past its
+   *     `lastValidBlockHeight` and `getSignatureStatuses` returns null.
+   *   - Durable-nonce tx: on-chain nonce no longer matches the baked
+   *     nonce value (rotated or account closed) and the tx was never
+   *     found. The on-chain nonce state is what Agave checks, so this
+   *     is authoritative.
    */
   status: "pending" | "success" | "failed" | "dropped";
   /**
@@ -24,14 +29,23 @@ export interface SolanaTransactionStatus {
   /** Human error string from the cluster when `status === "failed"`. */
   error?: string;
   /**
-   * Populated when status === "dropped" — the block height past which the
-   * tx's baked blockhash was no longer valid, and the current block height
-   * observed at the time of the poll. Useful for the agent to explain why
-   * it's reporting "dropped" and for the user to cross-check on an
-   * explorer.
+   * Populated when a legacy-blockhash tx is reported as dropped — the block
+   * height past which the tx's baked blockhash was no longer valid, and the
+   * current block height observed at the time of the poll.
    */
   lastValidBlockHeight?: number;
   currentBlockHeight?: number;
+  /**
+   * Populated when a durable-nonce tx is reported as dropped — the nonce
+   * account the tx referenced, the nonce value baked into the tx's
+   * `recentBlockhash` field, and the on-chain nonce value observed at the
+   * time of the poll (or `"closed"` if the account was destroyed). Lets
+   * the agent explain exactly why we report dropped: another tx against
+   * the same nonce advanced it before ours could land.
+   */
+  nonceAccount?: string;
+  bakedNonce?: string;
+  currentNonce?: string;
 }
 
 /**
@@ -40,21 +54,36 @@ export interface SolanaTransactionStatus {
  *
  * Solana RPC surfaces the status via `getSignatureStatuses` — returns
  * a `{confirmationStatus, err, slot}` tuple or null if the tx isn't
- * visible yet. When null is returned and the caller supplied
- * `lastValidBlockHeight` (populated by send_transaction from the pinned
- * tx), the poller cross-checks against current block height: if we're
- * past the validity window, the tx is mathematically unable to land and
- * we report `dropped`. This avoids the old behavior of reporting
- * `pending` forever for txs that silently fell out of the mempool.
+ * visible yet. When null is returned, the poller distinguishes dropped
+ * from still-pending based on tx type:
+ *
+ *   - Durable-nonce txs (nearly every send this server builds): check the
+ *     on-chain nonce account. If the nonce rotated past the baked value
+ *     (or the account was closed), the tx can never land — authoritative.
+ *   - Legacy-blockhash txs (`nonce_init` only): check current block height
+ *     against `lastValidBlockHeight`. If we're past, dropped.
+ *
+ * This avoids reporting `pending` forever for txs that silently fell out
+ * of the mempool — a known UX gap from Solana Phase 2.
  */
 export async function getSolanaTransactionStatus(args: {
   signature: string;
   /**
    * Optional. When supplied and `getSignatureStatuses` returns null, the
    * poller compares against `getBlockHeight()`; if we're past, the tx is
-   * reported as `dropped` rather than forever `pending`.
+   * reported as `dropped` rather than forever `pending`. Used for legacy-
+   * blockhash txs (currently just `nonce_init`).
    */
   lastValidBlockHeight?: number;
+  /**
+   * Optional. When supplied and `getSignatureStatuses` returns null, the
+   * poller compares the on-chain nonce to `nonceValue`; if the nonce
+   * rotated (or the account was closed), the tx is reported as `dropped`.
+   * Authoritative for durable-nonce-protected sends (native_send, spl_send,
+   * nonce_close, jupiter_swap, all `marginfi_*` actions). `send_transaction`
+   * surfaces both fields on its return value.
+   */
+  durableNonce?: { noncePubkey: string; nonceValue: string };
 }): Promise<SolanaTransactionStatus> {
   const conn = getSolanaConnection();
   const res = await conn.getSignatureStatuses([args.signature], {
@@ -62,9 +91,24 @@ export async function getSolanaTransactionStatus(args: {
   });
   const entry = res.value[0];
   if (!entry) {
-    // Tx not visible to this RPC. Two possibilities: (a) genuinely in
-    // flight and hasn't propagated yet, or (b) dropped and never will.
-    // If the caller supplied lastValidBlockHeight, we can distinguish.
+    // Tx not visible to this RPC. Distinguish dropped vs pending.
+    // Prefer the durable-nonce check when supplied — it's authoritative
+    // (Agave validates the nonce state, not block height, for nonce txs).
+    if (args.durableNonce) {
+      const noncePubkey = new PublicKey(args.durableNonce.noncePubkey);
+      const current = await getNonceAccountValue(conn, noncePubkey);
+      if (!current || current.nonce !== args.durableNonce.nonceValue) {
+        return {
+          chain: "solana",
+          signature: args.signature,
+          status: "dropped",
+          nonceAccount: args.durableNonce.noncePubkey,
+          bakedNonce: args.durableNonce.nonceValue,
+          currentNonce: current ? current.nonce : "closed",
+        };
+      }
+      return { chain: "solana", signature: args.signature, status: "pending" };
+    }
     if (args.lastValidBlockHeight !== undefined) {
       const currentBlockHeight = await conn.getBlockHeight("confirmed");
       if (currentBlockHeight > args.lastValidBlockHeight) {

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -769,27 +769,46 @@ export function renderPostSendPollBlock(args: {
   txHash: string;
   nextHandle?: string;
   /**
-   * Solana only. When supplied, the poll block tells the agent to pass it
-   * into `get_transaction_status` so the status tool can distinguish
-   * `dropped` (current slot past this) from `pending` (tx still propagating).
-   * Without it, a dropped Solana tx reads as `pending` forever.
+   * Solana legacy-blockhash txs only (currently just `nonce_init`). Lets
+   * the status poller distinguish `dropped` (current block past this) from
+   * `pending` for that specific tx kind.
    */
   lastValidBlockHeight?: number;
+  /**
+   * Solana durable-nonce txs (every send except nonce_init). Lets the
+   * status poller authoritatively distinguish `dropped` (on-chain nonce
+   * rotated past the baked value) from `pending`. Without it a dropped
+   * durable-nonce tx reads as `pending` forever — a known Phase 2 UX gap.
+   */
+  durableNonce?: { noncePubkey: string; nonceValue: string };
 }): string {
-  const { chain, txHash, nextHandle, lastValidBlockHeight } = args;
+  const { chain, txHash, nextHandle, lastValidBlockHeight, durableNonce } = args;
   const cadence = POLL_CADENCE[chain] ?? POLL_CADENCE.ethereum;
-  const statusCall =
-    chain === "solana" && lastValidBlockHeight !== undefined
-      ? `get_transaction_status({ chain: "solana", txHash: "${txHash}", lastValidBlockHeight: ${lastValidBlockHeight} })`
-      : `get_transaction_status({ chain: "${chain}", txHash: "${txHash}" })`;
-  const solanaDroppedBranch = chain === "solana" && lastValidBlockHeight !== undefined
+  const solanaHasDropDetect =
+    chain === "solana" &&
+    (durableNonce !== undefined || lastValidBlockHeight !== undefined);
+  let statusCall: string;
+  if (chain === "solana" && durableNonce !== undefined) {
+    statusCall =
+      `get_transaction_status({ chain: "solana", txHash: "${txHash}", durableNonce: ` +
+      `{ noncePubkey: "${durableNonce.noncePubkey}", nonceValue: "${durableNonce.nonceValue}" } })`;
+  } else if (chain === "solana" && lastValidBlockHeight !== undefined) {
+    statusCall = `get_transaction_status({ chain: "solana", txHash: "${txHash}", lastValidBlockHeight: ${lastValidBlockHeight} })`;
+  } else {
+    statusCall = `get_transaction_status({ chain: "${chain}", txHash: "${txHash}" })`;
+  }
+  const solanaDroppedBranch = solanaHasDropDetect
     ? [
-        `  5. SOLANA SPECIFIC — if status returns "dropped", the tx's blockhash`,
-        `     expired (current block height is past lastValidBlockHeight=${lastValidBlockHeight})`,
-        `     and the tx is permanently gone. Tell the user the broadcast did`,
-        `     not land and offer to re-run the prepare → preview → send flow`,
-        `     with a fresh blockhash. Do NOT keep polling — "dropped" is`,
-        `     terminal.`,
+        `  5. SOLANA SPECIFIC — if status returns "dropped", the tx is`,
+        durableNonce !== undefined
+          ? `     permanently gone (on-chain nonce rotated past bakedNonce=${durableNonce.nonceValue};`
+          : `     permanently gone (current block height is past`,
+        durableNonce !== undefined
+          ? `     see returned currentNonce for the post-rotation value). Tell the`
+          : `     lastValidBlockHeight=${lastValidBlockHeight}). Tell the`,
+        `     user the broadcast did not land and offer to re-run the`,
+        `     prepare → preview → send flow. Do NOT keep polling — "dropped"`,
+        `     is terminal.`,
       ]
     : [];
   const lines = [

--- a/test/solana-status.test.ts
+++ b/test/solana-status.test.ts
@@ -3,11 +3,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 /**
  * Tests for the Solana get_transaction_status "dropped" detection. The
  * RPC's `getSignatureStatuses` returns null both for "not yet propagated"
- * and "silently dropped" txs; without the blockhash expiry cross-check,
- * dropped txs report as "pending" forever. The caller supplies
- * `lastValidBlockHeight` (captured at preview-pin time, surfaced by
- * send_transaction), and the status tool compares against `getBlockHeight`
- * to distinguish the two cases.
+ * and "silently dropped" txs. Two distinguishing paths:
+ *
+ *   (1) Legacy-blockhash txs (nonce_init only): caller supplies
+ *       `lastValidBlockHeight`; status tool compares against getBlockHeight.
+ *   (2) Durable-nonce txs (every other send): caller supplies `durableNonce`;
+ *       status tool reads the on-chain nonce account and reports `dropped`
+ *       if the nonce rotated past the baked value or the account was closed.
+ *       Authoritative per Agave's own validity check.
  */
 
 const connectionStub = {
@@ -15,14 +18,21 @@ const connectionStub = {
   getBlockHeight: vi.fn(),
 };
 
+const getNonceAccountValueMock = vi.fn();
+
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
   resetSolanaConnection: () => {},
 }));
 
+vi.mock("../src/modules/solana/nonce.js", () => ({
+  getNonceAccountValue: getNonceAccountValueMock,
+}));
+
 beforeEach(() => {
   connectionStub.getSignatureStatuses.mockReset();
   connectionStub.getBlockHeight.mockReset();
+  getNonceAccountValueMock.mockReset();
 });
 
 afterEach(() => {
@@ -116,5 +126,92 @@ describe("getSolanaTransactionStatus — dropped detection", () => {
     });
     expect(status.status).toBe("failed");
     expect(status.error).toContain("InsufficientFunds");
+  });
+});
+
+describe("getSolanaTransactionStatus — durable-nonce drop detection", () => {
+  const NONCE_ACCOUNT = "11111111111111111111111111111111";
+  const BAKED_NONCE = "3pohVnAmNzrhJfH5pbPJMJuAw8NzfWMSsDn3snPUBmRp";
+  const ROTATED_NONCE = "5GZ4Gx1hAPf2vWGZyK6ZnfKGqN7hPs5R7oG6JrPNjSCG";
+
+  it("reports 'pending' when status is null AND on-chain nonce still matches baked value (tx may still land)", async () => {
+    connectionStub.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    getNonceAccountValueMock.mockResolvedValue({
+      nonce: BAKED_NONCE,
+      authority: { toBase58: () => "auth" },
+    });
+
+    const { getSolanaTransactionStatus } = await import(
+      "../src/modules/solana/status.js"
+    );
+    const status = await getSolanaTransactionStatus({
+      signature: "sig123",
+      durableNonce: { noncePubkey: NONCE_ACCOUNT, nonceValue: BAKED_NONCE },
+    });
+    expect(status.status).toBe("pending");
+    // Block-height check must NOT fire when durableNonce is supplied —
+    // the nonce state is authoritative.
+    expect(connectionStub.getBlockHeight).not.toHaveBeenCalled();
+    expect(getNonceAccountValueMock).toHaveBeenCalledOnce();
+  });
+
+  it("reports 'dropped' with diagnostic fields when on-chain nonce has rotated past the baked value", async () => {
+    connectionStub.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    getNonceAccountValueMock.mockResolvedValue({
+      nonce: ROTATED_NONCE,
+      authority: { toBase58: () => "auth" },
+    });
+
+    const { getSolanaTransactionStatus } = await import(
+      "../src/modules/solana/status.js"
+    );
+    const status = await getSolanaTransactionStatus({
+      signature: "sig123",
+      durableNonce: { noncePubkey: NONCE_ACCOUNT, nonceValue: BAKED_NONCE },
+    });
+    expect(status.status).toBe("dropped");
+    expect(status.nonceAccount).toBe(NONCE_ACCOUNT);
+    expect(status.bakedNonce).toBe(BAKED_NONCE);
+    expect(status.currentNonce).toBe(ROTATED_NONCE);
+  });
+
+  it("reports 'dropped' with currentNonce='closed' when the nonce account was destroyed", async () => {
+    connectionStub.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    // getNonceAccountValue returns null when the account doesn't exist.
+    getNonceAccountValueMock.mockResolvedValue(null);
+
+    const { getSolanaTransactionStatus } = await import(
+      "../src/modules/solana/status.js"
+    );
+    const status = await getSolanaTransactionStatus({
+      signature: "sig123",
+      durableNonce: { noncePubkey: NONCE_ACCOUNT, nonceValue: BAKED_NONCE },
+    });
+    expect(status.status).toBe("dropped");
+    expect(status.currentNonce).toBe("closed");
+  });
+
+  it("short-circuits nonce check when tx is already visible (success short-circuit)", async () => {
+    // The tx landed between poll intervals — status is no longer null.
+    // Nonce check must NOT fire because we already have authoritative info.
+    connectionStub.getSignatureStatuses.mockResolvedValue({
+      value: [
+        {
+          slot: 500,
+          confirmationStatus: "confirmed",
+          err: null,
+        },
+      ],
+    });
+
+    const { getSolanaTransactionStatus } = await import(
+      "../src/modules/solana/status.js"
+    );
+    const status = await getSolanaTransactionStatus({
+      signature: "sig123",
+      durableNonce: { noncePubkey: NONCE_ACCOUNT, nonceValue: BAKED_NONCE },
+    });
+    expect(status.status).toBe("success");
+    expect(getNonceAccountValueMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Roadmap item #1 from `claude-work/HIGH-solana-roadmap.md` section 1. Closes the Phase 2 UX gap where `get_transaction_status` reports `pending` forever for dropped durable-nonce txs (the `lastValidBlockHeight`-based drop detection is meaningless for nonce-protected txs, per memory `project_solana_phase2_live_findings.md`).

Affects every Solana send this server builds except `nonce_init`: `native_send`, `spl_send`, `nonce_close`, `jupiter_swap`, all four `marginfi_*` actions.

## How it works

Durable-nonce txs bake the current nonce value into `recentBlockhash`. On broadcast, Agave executes `ix[0] = nonceAdvance` which rotates the nonce. So:

- **On-chain nonce == baked nonce** → tx may still land → `pending`.
- **On-chain nonce != baked nonce** (or account closed) → nonce was rotated, our tx can never land → `dropped`.

This is Agave's own validity check — authoritative, not heuristic.

## API changes

**`send_transaction`** now returns `durableNonce: { noncePubkey, nonceValue }` on nonce-protected Solana sends, alongside existing `lastValidBlockHeight` for legacy-blockhash txs. Agents relay whichever field applies.

**`get_transaction_status`** accepts the new `durableNonce` field:

```ts
get_transaction_status({
  chain: "solana",
  txHash: "<signature>",
  durableNonce: { noncePubkey, nonceValue },  // from send_transaction
})
```

Returns new diagnostic fields on `dropped`:
```ts
{
  status: "dropped",
  nonceAccount: "<pubkey>",
  bakedNonce: "<nonce value at send>",
  currentNonce: "<on-chain value now>" | "closed",
}
```

**`renderPostSendPollBlock`** now generates the correct `get_transaction_status` call with `durableNonce` for nonce-protected sends; the dropped-branch explainer in the polling block references `bakedNonce` / `currentNonce` instead of block heights.

**Tool description + TYPICAL TX WORKFLOW step 7** in `src/index.ts` explain both drop-detection modes.

## Security posture

Unchanged. The nonce check is a READ against the user's own nonce account. No new attack surface — a compromised MCP could already lie about tx status.

## Tests

| | Before | After |
|---|---|---|
| Total | 787 | 791 |
| `solana-status.test.ts` | 5 | 9 (+4) |

New cases:
- pending when on-chain nonce still matches baked
- dropped with diagnostic fields when nonce rotated
- dropped with `currentNonce: "closed"` when account destroyed
- success short-circuit (nonce check doesn't fire when tx is visible)

Existing 5 `lastValidBlockHeight` cases unchanged — new field is purely additive and backwards compatible.

## What's NOT in this PR

- Memory annotation of `project_solana_phase2_live_findings.md` (waiting on merge).
- Next roadmap item (Solana staking reads) — separate PR per the roadmap's execution-order discipline.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 791/791 pass.
- [ ] **Live sanity** (per plan verification): send a nonce-protected tx → status returns `pending` → `success`. Then deliberately rotate the nonce with a second send (e.g. `prepare_solana_native_send` with tiny amount) while holding the first signature → status on the first returns `dropped` with `bakedNonce !== currentNonce`.
