### PR TITLE
chore(release): skill pin v0.1.3 + version 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -971,7 +971,7 @@ async function main() {
         "",
         "PIN DATA:",
         "  Expected SHA-256 of SKILL.md:",
-        "    c8bffbf172436ed40b28622819ed757010c101d65f2ae0148cd1d64f59a65344",
+        "    10db66ad5fcfa250b4a5a753fd745eac4dc358b41ccfc1a1258f67040b7eddea",
         "  Expected in-file sentinel — NOTE: assembled from fragments below so the",
         "  full literal does not appear in these instructions (if it did, searching",
         "  context for it would always succeed and defeat the check). Concatenate:",


### PR DESCRIPTION
## Summary

Coordinated release with [vaultpilot-skill v0.1.3](https://github.com/szhygulin/vaultpilot-skill/releases/tag/v0.1.3) (already released). Removes the dormant "Fast-retry mode" section from the skill and aligns the MCP's pinned SHA-256 accordingly.

## Changes

- **`src/index.ts:969`** — bump pinned SHA-256 from `c8bffbf1…65344` (skill v0.1.2) to `10db66ad…7eddea` (skill v0.1.3).
- **`package.json` / `server.json`** — 0.6.0 → 0.6.1.
- **`package-lock.json`** — regenerated.

## Why

Skill v0.1.2 added a "Fast-retry mode" section documenting the agent's buy-in rules for the `FAST-RETRY MODE` agent-task block. That block was reverted upstream in [PR #136](https://github.com/szhygulin/vaultpilot-mcp/pull/136) — the abridged-checks path didn't measurably reduce wall time and added UX divergence. Skill v0.1.3 removes the section (now dormant). This PR updates the pin to match.

## SHA-256 note

v0.1.3 SKILL.md is byte-identical to v0.1.1 — the Fast-retry mode section was the only substantive v0.1.2 delta. Users on skill v0.1.1 pass the pin check on MCP 0.6.1 without upgrading the skill. Users on skill v0.1.2 fail the pin check on MCP 0.6.1 until they `git pull` (to v0.1.3) or downgrade (to v0.1.1).

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 792/792 pass.
- [x] Skill v0.1.3 released before merging this PR (required ordering).

## What's next (not this PR)

- Merge → tag MCP `v0.6.1` → publish to npm if that's part of your release flow.
- Your locally-installed skill is already at `10db66ad…7eddea` (was v0.1.1, byte-identical to v0.1.3). `git pull` in `~/.claude/skills/vaultpilot-preflight` brings the tag/head up to v0.1.3 without touching the file.
