### PR TITLE
feat(onboarding): zero-config RPC defaults + Linux udev detector + deep-link API-key URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 ## Requirements
 
 - Node.js >= 18.17
-- RPC provider (Infura, Alchemy, or custom) for EVM chains; a Solana RPC (Helius / QuickNode / Triton — the default public endpoint is rate-limited)
-- Optional: Etherscan API key, 1inch API key (enables swap-quote comparison), WalletConnect project ID (required for EVM Ledger signing), TronGrid API key (required in practice for TRON reads — anonymous calls are capped at ~15 req/min)
-- For TRON/Solana signing: USB HID access to a Ledger with the **Tron** / **Solana** app installed. On Linux, install Ledger's [udev rules](https://github.com/LedgerHQ/udev-rules); `node-hid` compiles natively so Debian/Ubuntu needs `sudo apt install libudev-dev build-essential`. For SPL/MarginFi/Jupiter flows, enable **Allow blind signing** in the Solana app's on-device Settings. SOL native transfers clear-sign and do not need this.
+- **Zero-config path (portfolio reads):** no API keys needed. The server falls back to PublicNode (EVM) and Solana public mainnet when nothing is configured — rate-limited, but enough for first-contact and light use.
+- **For real use:** set your own RPC provider (Infura / Alchemy / custom) for EVM chains and a Solana RPC (Helius / QuickNode / Triton) when the public endpoints rate-limit you. One env var per chain (`ETHEREUM_RPC_URL`, `SOLANA_RPC_URL`, …) or `vaultpilot-mcp-setup`.
+- **Optional (prompted on demand):** Etherscan API key, 1inch API key (enables swap-quote comparison), WalletConnect project ID (required for EVM Ledger signing), TronGrid API key (raises the ~15 req/min anonymous cap).
+- **For TRON/Solana signing:** USB HID access to a Ledger with the **Tron** / **Solana** app installed. On Linux, install Ledger's [udev rules](https://github.com/LedgerHQ/udev-rules) — `vaultpilot-mcp-setup` prints the exact one-liner if they're missing. `node-hid` compiles natively so Debian/Ubuntu needs `sudo apt install libudev-dev build-essential`. For SPL/MarginFi/Jupiter flows, enable **Allow blind signing** in the Solana app's on-device Settings. SOL native transfers clear-sign and do not need this.
 
 ## Install
 

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -36,6 +36,41 @@ const ENV_URL_VAR: Record<SupportedChain, string> = {
   optimism: "OPTIMISM_RPC_URL",
 };
 
+/**
+ * PublicNode free-tier fallbacks, used when the user has neither configured
+ * a provider nor set per-chain env vars. Lets the zero-config install work
+ * end-to-end for portfolio reads without the user signing up for any
+ * provider. Shared public endpoints are rate-limited — a user who plans to
+ * use the server heavily will want their own Infura / Alchemy key — but for
+ * first-contact + light use these are enough.
+ *
+ * PublicNode is maintained by Pokt Network (https://www.publicnode.com/),
+ * publicly documented, and exposes HTTPS (so our `validateRpcUrl` still
+ * accepts them). Optimism doesn't appear in the plan doc but is covered by
+ * the same template; include it so the zero-config path is uniform across
+ * all SUPPORTED_CHAINS.
+ */
+const PUBLIC_NODE_FALLBACK: Record<SupportedChain, string> = {
+  ethereum: "https://ethereum-rpc.publicnode.com",
+  arbitrum: "https://arbitrum-one-rpc.publicnode.com",
+  polygon: "https://polygon-bor-rpc.publicnode.com",
+  base: "https://base-rpc.publicnode.com",
+  optimism: "https://optimism-rpc.publicnode.com",
+};
+
+/**
+ * Public Solana mainnet endpoint. Aggressively rate-limited (429s under
+ * mild fan-out) but ships as the zero-config fallback so `get_portfolio_summary`
+ * with a `solanaAddress` works on first install. Upgrading to a Helius /
+ * QuickNode / Triton endpoint is one env var away (SOLANA_RPC_URL) when the
+ * user hits throttling.
+ */
+const SOLANA_PUBLIC_MAINNET = "https://api.mainnet-beta.solana.com";
+
+/** Whether `resolveRpcUrlRaw` has already warned about using the public fallback this process. */
+const warnedPublicFallback: Partial<Record<SupportedChain, boolean>> = {};
+let warnedSolanaPublicFallback = false;
+
 export class RpcConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -171,33 +206,41 @@ function resolveRpcUrlRaw(chain: SupportedChain, userConfig: UserConfig | null):
     if (provider === "custom") {
       const url = customUrls?.[chain];
       if (url) return url;
-      throw new RpcConfigError(
-        `No custom RPC URL configured for chain "${chain}". Re-run \`vaultpilot-mcp-setup\`.`
-      );
-    }
-    if (provider === "infura" || provider === "alchemy") {
-      if (!apiKey) {
-        throw new RpcConfigError(
-          `Missing API key for RPC provider "${provider}". Re-run \`vaultpilot-mcp-setup\`.`
-        );
-      }
-      return PROVIDER_URL_TEMPLATES[provider][chain](apiKey);
+      // Fall through to the public fallback rather than throwing — makes
+      // zero-config installs work and doesn't punish a user who configured
+      // one chain's custom URL but not another.
+    } else if (provider === "infura" || provider === "alchemy") {
+      if (apiKey) return PROVIDER_URL_TEMPLATES[provider][chain](apiKey);
+      // Missing apiKey — also fall through to public fallback.
     }
   }
 
-  throw new RpcConfigError(
-    `No RPC provider configured for chain "${chain}". ` +
-      `Run \`vaultpilot-mcp-setup\` to configure Infura, Alchemy, or a custom endpoint.`
-  );
+  // Zero-config / incomplete-config fallback: shared public endpoint.
+  // Emits a one-time per-chain warning to stderr so the user knows their
+  // reads are going through a rate-limited public RPC (explains any
+  // intermittent 429s) but doesn't fail the operation outright.
+  if (!warnedPublicFallback[chain]) {
+    warnedPublicFallback[chain] = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[vaultpilot] No RPC provider configured for ${chain} — using shared public ` +
+        `endpoint (${PUBLIC_NODE_FALLBACK[chain]}). Rate-limited; set ${ENV_URL_VAR[chain]} ` +
+        `or run \`vaultpilot-mcp-setup\` to upgrade.`,
+    );
+  }
+  return PUBLIC_NODE_FALLBACK[chain];
 }
 
 /**
  * Resolve the Solana mainnet RPC URL. Priority:
  *   1. SOLANA_RPC_URL env var (pastes cleanly from any provider's dashboard).
  *   2. `solanaRpcUrl` in user config (set by `vaultpilot-mcp-setup`).
- *   3. Throws. No silent fallback to public mainnet — Solana's public RPC
- *      is rate-limited hard enough that defaulting there would set the user
- *      up for intermittent failures they couldn't diagnose.
+ *   3. Public mainnet fallback (`api.mainnet-beta.solana.com`) with a
+ *      one-time stderr warning. Previously this layer threw; that hard-
+ *      gated the zero-config install for portfolio reads. Falling back
+ *      lets a first-time user see their Solana balance without signing up
+ *      for Helius first, at the cost of likely 429s under load — the
+ *      warning tells them exactly which env var to set when that bites.
  *
  * The returned URL passes through `validateRpcUrl` (https-only, no loopback)
  * before being handed to `Connection` — same safety bar as EVM RPCs.
@@ -213,10 +256,14 @@ export function resolveSolanaRpcUrl(userConfig: UserConfig | null): string {
     validateRpcUrl("solana", configUrl);
     return configUrl;
   }
-  throw new RpcConfigError(
-    `No Solana RPC configured. Set the SOLANA_RPC_URL env var to a provider URL ` +
-      `(Helius recommended — https://mainnet.helius-rpc.com/?api-key=YOUR_KEY) or run ` +
-      `\`vaultpilot-mcp-setup\` to stash it in ~/.vaultpilot-mcp/config.json. Solana's ` +
-      `public mainnet RPC is rate-limited and unreliable for production.`
-  );
+  if (!warnedSolanaPublicFallback) {
+    warnedSolanaPublicFallback = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[vaultpilot] No Solana RPC configured — using public mainnet ` +
+        `(${SOLANA_PUBLIC_MAINNET}). Rate-limited; set SOLANA_RPC_URL to a ` +
+        `Helius / QuickNode / Triton URL for real use.`,
+    );
+  }
+  return SOLANA_PUBLIC_MAINNET;
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,6 +22,7 @@ import {
   readUserConfig,
   getConfigPath,
 } from "./config/user-config.js";
+import { reportLedgerUdevStatus } from "./setup/linux-udev.js";
 import type { RpcProvider, SupportedChain, UserConfig } from "./types/index.js";
 
 /** Thin readline wrapper so each prompt is a single awaited call. */
@@ -86,6 +87,15 @@ async function validateRpcUrl(url: string): Promise<number> {
 
 async function configureRpc(p: Prompt): Promise<UserConfig["rpc"]> {
   console.log("\n--- RPC Provider ---");
+  console.log(
+    "Optional for first-time portfolio reads — the zero-config path uses",
+  );
+  console.log(
+    "shared public endpoints (PublicNode). Heavy use / fan-out will rate-",
+  );
+  console.log(
+    "limit on the public path; set a provider below for real headroom.",
+  );
   // Default to the currently-configured provider if any, so re-running the
   // wizard doesn't force the user to re-pick every time. Index order matches
   // the `providerOrder` array below.
@@ -167,7 +177,9 @@ async function configureEtherscan(p: Prompt): Promise<string | undefined> {
 
 async function configureOneInch(p: Prompt): Promise<string | undefined> {
   console.log("\n--- 1inch (optional — enables swap-quote comparison vs LiFi) ---");
-  console.log("Create a free key at https://portal.1inch.dev. Skip with empty input.");
+  // Deep link to the new-key form; landing on the dashboard root makes users
+  // hunt through nav. Marketing pages are also click-wastage for this audience.
+  console.log("Create a free key at https://portal.1inch.dev/dashboard/api/keys. Skip with empty input.");
   const existing = readUserConfig()?.oneInchApiKey;
   const answer = await p.ask(
     existing
@@ -191,7 +203,7 @@ async function configureTron(p: Prompt): Promise<string | undefined> {
   console.log("\n--- TRON (optional — enables TRX + TRC-20 balance reads) ---");
   console.log("TRON is non-EVM: no Aave/Compound/Uniswap there, but TRC-20 USDT");
   console.log("dominates the chain and is worth folding into your portfolio total.");
-  console.log("Create a free key at https://www.trongrid.io (Dashboard → API Keys).");
+  console.log("Create a free key at https://www.trongrid.io/dashboard/apikeys (deep link to the API-Keys page).");
   console.log("Skip with empty input — TRON reads will be disabled.");
   const existing = readUserConfig()?.tronApiKey;
   const answer = await p.ask(
@@ -286,7 +298,7 @@ async function configureSolana(p: Prompt): Promise<string | undefined> {
 
   if (providerIdx === 0) {
     // Helius flow — mirrors the Infura/Alchemy key-based path for EVM RPC.
-    console.log("Create a free Helius API key at https://dashboard.helius.dev (Project → API Keys).");
+    console.log("Create a free Helius API key at https://dashboard.helius.dev/api-keys (deep link to the API-Keys page).");
     for (let attempt = 0; attempt < 3; attempt++) {
       const prompt = existingHeliusKey
         ? "Helius API key [press enter to keep existing]: "
@@ -330,7 +342,10 @@ async function configureSolana(p: Prompt): Promise<string | undefined> {
 
 async function configureWalletConnect(p: Prompt): Promise<string | undefined> {
   console.log("\n--- WalletConnect (optional — required for Ledger Live signing) ---");
-  console.log("Create a free project at https://cloud.walletconnect.com.");
+  // Reown is WalletConnect's rebranded dashboard. Deep link goes straight to
+  // the new-project form; the /app route below it would require navigating
+  // the main dashboard manually.
+  console.log("Create a free project at https://cloud.reown.com/app/new-project.");
   const existing = readUserConfig()?.walletConnect?.projectId;
   const answer = await p.ask(
     existing
@@ -549,6 +564,11 @@ async function runFullWizard(p: Prompt): Promise<void> {
   } else {
     console.log("\nSkipping Ledger Live pairing (no WalletConnect project ID set).");
   }
+
+  // Linux-only: surface Ledger udev-rules status at the end. No-op on
+  // macOS / Windows. If rules are missing on Linux, prints the install
+  // one-liner for the user to run separately (no sudo during the wizard).
+  reportLedgerUdevStatus();
 }
 
 async function main() {

--- a/src/setup/linux-udev.ts
+++ b/src/setup/linux-udev.ts
@@ -1,0 +1,98 @@
+/**
+ * Linux-only helper: detect whether Ledger's udev rules are installed and,
+ * if not, surface the exact install command for the user to run.
+ *
+ * Why not auto-run sudo:
+ *   - Adds supply-chain risk (one-shot curl | bash from a third-party repo).
+ *   - Requires stdin hand-off to the sudo password prompt mid-wizard, which
+ *     interacts badly with our own readline loop.
+ *   - User sees exactly what they're about to run and can opt out.
+ *
+ * The command we print pulls Ledger's officially-maintained install script
+ * via wget + pipes to sudo bash; users who prefer manual review can click
+ * through to the repo and apply the rules themselves.
+ *
+ * Called only when `process.platform === "linux"`. No-op on macOS / Windows
+ * (the former doesn't need udev; the latter uses WinUSB + Ledger's driver).
+ */
+import { existsSync } from "node:fs";
+
+/**
+ * Ledger's official rules file. Installed by their script at this path.
+ * Matches Ledger's documented location; checking it is the reliable
+ * "are rules installed?" signal.
+ */
+const LEDGER_UDEV_RULES_PATH = "/etc/udev/rules.d/20-hw1.rules";
+
+/**
+ * One-liner that fetches + installs + reloads. Matches Ledger's official
+ * README at github.com/LedgerHQ/udev-rules (verified 2026-04-25). Print as-is
+ * for the user to paste; do not eval.
+ */
+export const LEDGER_UDEV_INSTALL_COMMAND =
+  "wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash";
+
+export interface LedgerUdevStatus {
+  /** True on platforms that don't need udev rules (macOS / Windows). */
+  notApplicable: boolean;
+  /** Whether `/etc/udev/rules.d/20-hw1.rules` exists. */
+  rulesInstalled: boolean;
+}
+
+export function checkLedgerUdevStatus(): LedgerUdevStatus {
+  if (process.platform !== "linux") {
+    return { notApplicable: true, rulesInstalled: true };
+  }
+  return {
+    notApplicable: false,
+    rulesInstalled: existsSync(LEDGER_UDEV_RULES_PATH),
+  };
+}
+
+/**
+ * Emit setup-wizard output about udev state. Called from `src/setup.ts` on
+ * Linux only; no-op on other platforms.
+ *
+ * Design: always print a one-line status so the user sees it. If rules are
+ * missing, also print the install command with a short why + mitigation
+ * note. No interactive prompt — running sudo during the setup wizard
+ * conflicts with our readline loop and the user gets a cleaner experience
+ * running the command themselves in a separate terminal or after exiting
+ * setup.
+ */
+export function reportLedgerUdevStatus(): void {
+  const status = checkLedgerUdevStatus();
+  if (status.notApplicable) return;
+
+  console.log("\n--- Ledger udev rules (Linux only) ---");
+  if (status.rulesInstalled) {
+    console.log(`  OK: ${LEDGER_UDEV_RULES_PATH} exists.`);
+    return;
+  }
+  console.log(
+    "  MISSING: Ledger's udev rules are not installed, so USB HID access to",
+  );
+  console.log(
+    "  your Ledger device will fail with \"permission denied\" when pairing",
+  );
+  console.log(
+    "  for TRON or Solana signing. Install them now by running this one-liner",
+  );
+  console.log("  in a separate terminal (requires sudo):");
+  console.log("");
+  console.log(`      ${LEDGER_UDEV_INSTALL_COMMAND}`);
+  console.log("");
+  console.log(
+    "  Source: https://github.com/LedgerHQ/udev-rules — Ledger's officially",
+  );
+  console.log(
+    "  maintained rules file. After running, unplug + replug your Ledger",
+  );
+  console.log(
+    "  (the new rules only apply to new device connections). WalletConnect-",
+  );
+  console.log(
+    "  based EVM signing via Ledger Live isn't affected — this only matters",
+  );
+  console.log("  for the direct-USB TRON and Solana paths.");
+}

--- a/test/chains.test.ts
+++ b/test/chains.test.ts
@@ -94,19 +94,50 @@ describe("resolveRpcUrl", () => {
     expect(resolveRpcUrl("arbitrum", cfg)).toBe("https://my-node/arb");
   });
 
-  it("missing API key for Infura throws", () => {
+  // Incomplete / missing config falls back to the shared PublicNode endpoint
+  // rather than throwing — lets the zero-config install work for portfolio
+  // reads. The fallback emits a one-time stderr warning; a heavy user sees
+  // it, sets their own env var, moves on.
+
+  it("missing API key for Infura falls back to the public endpoint instead of throwing", () => {
     const cfg: UserConfig = { rpc: { provider: "infura" } };
-    expect(() => resolveRpcUrl("ethereum", cfg)).toThrow(RpcConfigError);
+    expect(resolveRpcUrl("ethereum", cfg)).toBe("https://ethereum-rpc.publicnode.com");
   });
 
-  it("custom provider without URL for a chain throws", () => {
+  it("custom provider without URL for a chain falls back to the public endpoint", () => {
     const cfg: UserConfig = {
       rpc: { provider: "custom", customUrls: { ethereum: "https://x" } },
     };
-    expect(() => resolveRpcUrl("arbitrum", cfg)).toThrow(RpcConfigError);
+    expect(resolveRpcUrl("arbitrum", cfg)).toBe("https://arbitrum-one-rpc.publicnode.com");
+    // The configured chain still wins over the fallback.
+    expect(resolveRpcUrl("ethereum", cfg)).toBe("https://x");
   });
 
-  it("no configuration at all throws", () => {
-    expect(() => resolveRpcUrl("ethereum", null)).toThrow(RpcConfigError);
+  it("no configuration at all falls back to the public endpoint per chain", () => {
+    expect(resolveRpcUrl("ethereum", null)).toBe("https://ethereum-rpc.publicnode.com");
+    expect(resolveRpcUrl("arbitrum", null)).toBe("https://arbitrum-one-rpc.publicnode.com");
+    expect(resolveRpcUrl("polygon", null)).toBe("https://polygon-bor-rpc.publicnode.com");
+    expect(resolveRpcUrl("base", null)).toBe("https://base-rpc.publicnode.com");
+    expect(resolveRpcUrl("optimism", null)).toBe("https://optimism-rpc.publicnode.com");
+  });
+
+  it("RpcConfigError still thrown for structurally bad config (unknown provider)", () => {
+    const cfg: UserConfig = {
+      // @ts-expect-error — intentional invalid provider to exercise the throw
+      rpc: { provider: "not-a-real-provider" },
+    };
+    // The unknown-provider path remains a hard error — it's a
+    // programming-error signal, not a missing-config signal.
+    // Via RPC_PROVIDER env var:
+    const prev = process.env.RPC_PROVIDER;
+    process.env.RPC_PROVIDER = "bogus";
+    process.env.RPC_API_KEY = "k";
+    try {
+      expect(() => resolveRpcUrl("ethereum", cfg)).toThrow(RpcConfigError);
+    } finally {
+      if (prev === undefined) delete process.env.RPC_PROVIDER;
+      else process.env.RPC_PROVIDER = prev;
+      delete process.env.RPC_API_KEY;
+    }
   });
 });


### PR DESCRIPTION
## Summary

First focused pass from `claude-work/HIGH-plan-broad-audience-onboarding.md`. Three of the lowest-risk Tier-1 + Tier-2 items bundled together; heavier pieces (bundled binary, client auto-register, agent-guided `/setup` skill, Ledger app-state probe) deferred to separate PRs.

## What shipped

### 1.3 — Default free-tier RPC endpoints (zero-config works)

Before: running the server without a configured provider threw `RpcConfigError` on every tool call. `get_portfolio_summary` — the common first-contact operation for non-dev users — hard-stopped before any network activity.

After: `src/config/chains.ts` falls back to PublicNode per EVM chain and `api.mainnet-beta.solana.com` for Solana when nothing is configured. One-time per-chain stderr warning names the exact env var to set when rate limits bite. `RpcConfigError` still thrown for structurally bad config (`RPC_PROVIDER=bogus` etc.) — that's a programming-error signal, not a missing-config one.

### 2.2 — Deep-link API-key URLs in the wizard

Replaced dashboard-root URLs with direct deep links to the new-key form:

| Provider | Old | New |
|---|---|---|
| 1inch | `portal.1inch.dev` | `/dashboard/api/keys` |
| Helius | dashboard root | `/api-keys` |
| TronGrid | `trongrid.io` root | `/dashboard/apikeys` |
| WalletConnect | `cloud.walletconnect.com` | `cloud.reown.com/app/new-project` |

Tiny change, disproportionate click-to-key time reduction for non-devs.

### 1.4 — Linux udev rules detector

New `src/setup/linux-udev.ts`. Detects `/etc/udev/rules.d/20-hw1.rules`; prints Ledger's official install one-liner if missing, "OK" if present. No-op on macOS / Windows. Called from `runFullWizard()`.

**Deliberately NOT auto-running sudo** during the wizard:
- Adds supply-chain risk (one-shot `curl | bash` fetch).
- Interleaves poorly with our readline loop + sudo's own password prompt.
- User sees exact command + source link and can vet / run separately.

### Wizard reframe

RPC-provider step now opens with: "Optional for first-time portfolio reads — the zero-config path uses shared public endpoints. Heavy use / fan-out will rate-limit on the public path; set a provider below for real headroom." Existing prompts kept for users who want immediate headroom.

### README Requirements rewrite

Split "what you need to get started" (nothing) from "what you'll want for real use" (provider keys) from "what's prompted on demand" (Etherscan / 1inch / WC / TronGrid).

## Explicitly deferred from the plan

- **1.1 bundled binary** (`pkg` config + GH release workflow) — needs CI matrix, separate PR.
- **1.2 auto-register MCP with agent clients** — moderate scope, separate PR.
- **2.1 agent-guided `/setup` skill** — needs new external `vaultpilot-setup-skill` repo.
- **2.3 Ledger app-state detection** — needs spike on `hw-transport-node-hid` device-info probe.
- **Tier 3** — explicitly "bigger bets" in the plan.

## Test plan

- [x] `npm test` — **795/795** pass. 3 existing `.toThrow(RpcConfigError)` tests flipped to positive fallback assertions; 1 new test pins the `RpcConfigError` hard-error path for structurally bad config.
- [x] `npm run build` — clean TS.
- [ ] Manual: `vaultpilot-mcp-setup` on Linux without udev rules prints the install one-liner; with them installed prints "OK".
- [ ] Manual: server starts with zero config + zero env vars; `get_portfolio_summary` on a known EVM wallet + Solana address returns real data + one-time stderr warning about the public fallback.

## Size

234 insertions / 37 deletions across 5 files (1 new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)