### PR TITLE
feat(portfolio): fold Solana staking into get_portfolio_summary (roadmap #2)

### DIFF
--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -13,6 +13,7 @@ import { getTronBalances } from "../tron/balances.js";
 import { getTronStaking } from "../tron/staking.js";
 import { getSolanaBalances } from "../solana/balances.js";
 import { getMarginfiPositions as readMarginfiPositions } from "../positions/marginfi.js";
+import { getSolanaStakingPositions as readSolanaStakingPositions } from "../positions/solana-staking.js";
 import { getSolanaConnection } from "../solana/rpc.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
@@ -22,6 +23,7 @@ import type {
   PortfolioSummary,
   SolanaMarginfiPositionSlice,
   SolanaPortfolioSlice,
+  SolanaStakingPositionSlice,
   SupportedChain,
   TokenAmount,
   TronPortfolioSlice,
@@ -308,6 +310,7 @@ async function buildWalletSummary(
     tronStaking: false,
     solana: false,
     marginfi: false,
+    solanaStaking: false,
   };
   // Per-market Compound V3 failure detail, populated when at least one market
   // read errored. Surfaced in coverage.compound.note so the agent can tell
@@ -346,6 +349,7 @@ async function buildWalletSummary(
     tronStakingSlice,
     solanaSlice,
     marginfiPositionsRaw,
+    solanaStakingRaw,
   ] = await Promise.all([
       Promise.all(
         chains.map((c) =>
@@ -482,6 +486,25 @@ async function buildWalletSummary(
         : (Promise.resolve([]) as Promise<
             Awaited<ReturnType<typeof readMarginfiPositions>>
           >),
+      // Solana staking rides the same gate. The consolidated reader fans
+      // out to three sub-readers (Marinade SDK, Jito stake pool, native
+      // stake-program enumeration) in parallel. A failure is independent
+      // of balance/MarginFi coverage (mirror of tronStaking / marginfi
+      // split). Returns null on failure so the aggregator can render a
+      // present-but-errored coverage entry.
+      solanaAddress
+        ? readSolanaStakingPositions(
+            getSolanaConnection(),
+            solanaAddress,
+          ).catch(() => {
+            errors.solanaStaking = true;
+            return null as Awaited<
+              ReturnType<typeof readSolanaStakingPositions>
+            > | null;
+          })
+        : (Promise.resolve(null) as Promise<Awaited<
+            ReturnType<typeof readSolanaStakingPositions>
+          > | null>),
     ]);
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -530,6 +553,54 @@ async function buildWalletSummary(
     (s, p) => s + p.netValueUsd,
     0,
   );
+
+  // Solana staking slice — shrink the consolidated reader's shape into the
+  // portfolio's thin projection. Dropping the wallet/protocol/chain fields
+  // on each sub-reader's output keeps the summary JSON compact; callers
+  // who want the full view call get_solana_staking_positions directly.
+  const solanaStakingSlice: SolanaStakingPositionSlice | undefined =
+    solanaStakingRaw
+      ? {
+          chain: "solana",
+          marinade: {
+            mSolBalance: solanaStakingRaw.marinade.mSolBalance,
+            solEquivalent: solanaStakingRaw.marinade.solEquivalent,
+            exchangeRate: solanaStakingRaw.marinade.exchangeRate,
+          },
+          jito: {
+            jitoSolBalance: solanaStakingRaw.jito.jitoSolBalance,
+            solEquivalent: solanaStakingRaw.jito.solEquivalent,
+            exchangeRate: solanaStakingRaw.jito.exchangeRate,
+          },
+          nativeStakes: solanaStakingRaw.nativeStakes.map((s) => ({
+            stakePubkey: s.stakePubkey,
+            ...(s.validator ? { validator: s.validator } : {}),
+            stakeSol: s.stakeSol,
+            status: s.status,
+            ...(s.activationEpoch !== undefined
+              ? { activationEpoch: s.activationEpoch }
+              : {}),
+            ...(s.deactivationEpoch !== undefined
+              ? { deactivationEpoch: s.deactivationEpoch }
+              : {}),
+          })),
+          totalSolEquivalent: solanaStakingRaw.totalSolEquivalent,
+        }
+      : undefined;
+
+  // Convert the Solana staking subtotal to USD using the same SOL price
+  // that valued the native-SOL line in solanaSlice. Reusing avoids a
+  // duplicate price fetch + guarantees the two USD numbers (SOL-in-wallet
+  // vs. staked-SOL) use the exact same SOL price. Falls back to 0 if the
+  // solanaSlice is absent or didn't manage to resolve a SOL price.
+  const solPriceUsd = solanaSlice?.native.find(
+    (b) => b.token === "native",
+  )?.priceUsd;
+  const solanaStakingUsd =
+    solanaStakingSlice && typeof solPriceUsd === "number"
+      ? solanaStakingSlice.totalSolEquivalent * solPriceUsd
+      : 0;
+
   const walletBalancesUsd = round(
     [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) +
       tronBalancesUsd +
@@ -547,7 +618,7 @@ async function buildWalletSummary(
   );
   // totalUsd folds every accounted-for slice: EVM balances + TRON balances +
   // Solana balances are already rolled into walletBalancesUsd; TRON staking
-  // is surfaced separately (Phase 2 for Solana staking). EVM-only slices
+  // and Solana staking are surfaced separately. EVM-only slices
   // (lending/LP/staking) are added here.
   const totalUsd = round(
     walletBalancesUsd +
@@ -555,7 +626,8 @@ async function buildWalletSummary(
       lpUsd +
       stakingUsd +
       tronStakingUsd +
-      solanaLendingUsd,
+      solanaLendingUsd +
+      solanaStakingUsd,
     2
   );
 
@@ -671,6 +743,13 @@ async function buildWalletSummary(
                 note: "MarginFi position fetch failed — lending positions not included in totals. SDK or oracle RPC error; balances still loaded if coverage.solana is covered.",
               }
             : { covered: true },
+          solanaStaking: errors.solanaStaking
+            ? {
+                covered: false,
+                errored: true,
+                note: "Solana staking fetch failed — Marinade / Jito / native stake positions not included in totals. Independent of coverage.solana; MarginFi + balances still loaded if those are covered.",
+              }
+            : { covered: true },
         }
       : {}),
     unpricedAssets,
@@ -712,6 +791,9 @@ async function buildWalletSummary(
     ...(marginfiSlices.length > 0
       ? { solanaLendingUsd: round(solanaLendingUsd, 2) }
       : {}),
+    ...(solanaStakingSlice && solanaStakingSlice.totalSolEquivalent > 0
+      ? { solanaStakingUsd: round(solanaStakingUsd, 2) }
+      : {}),
     breakdown: {
       native,
       erc20,
@@ -727,6 +809,13 @@ async function buildWalletSummary(
                 ? {
                     marginfi: marginfiSlices,
                     marginfiNetUsd: round(solanaLendingUsd, 2),
+                  }
+                : {}),
+              ...(solanaStakingSlice &&
+              solanaStakingSlice.totalSolEquivalent > 0
+                ? {
+                    staking: solanaStakingSlice,
+                    stakingNetUsd: round(solanaStakingUsd, 2),
                   }
                 : {}),
             },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,6 +130,13 @@ export interface PortfolioCoverage {
    * `tronStaking` / `tron` split). Absent when no Solana address was queried.
    */
   marginfi?: CoverageStatus;
+  /**
+   * Solana staking position fetch coverage (Marinade mSOL, Jito jitoSOL,
+   * native stake accounts). Mirrors the `marginfi` split so a staking-
+   * reader failure doesn't mask a successful balance read. Absent when no
+   * Solana address was queried.
+   */
+  solanaStaking?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
   /**
@@ -356,6 +363,49 @@ export interface SolanaPortfolioSlice {
   marginfi?: SolanaMarginfiPositionSlice[];
   /** MarginFi aggregate net USD (sum of netValueUsd across positions). */
   marginfiNetUsd?: number;
+  /**
+   * Solana staking positions — Marinade mSOL, Jito jitoSOL, native stake
+   * accounts. Present when any of the three sections is non-empty for
+   * this wallet. Missing means nothing found (errored case surfaces
+   * through PortfolioCoverage.solanaStaking).
+   */
+  staking?: SolanaStakingPositionSlice;
+  /** Solana staking aggregate net USD (SOL-equivalent × SOL price). */
+  stakingNetUsd?: number;
+}
+
+/**
+ * Thin projection of the three staking readers' output
+ * (`src/modules/positions/solana-staking.ts`). Kept in sync with
+ * `SolanaStakingPositions` but stripped down — the portfolio JSON doesn't
+ * need the per-reader wrapper metadata (wallet duplication, protocol
+ * tags on subtotals).
+ */
+export interface SolanaStakingPositionSlice {
+  chain: "solana";
+  /** mSOL balance + SOL-equivalent via Marinade's on-chain mSolPrice. */
+  marinade: {
+    mSolBalance: number;
+    solEquivalent: number;
+    exchangeRate: number;
+  };
+  /** jitoSOL balance + SOL-equivalent via stake-pool's totalLamports/supply. */
+  jito: {
+    jitoSolBalance: number;
+    solEquivalent: number;
+    exchangeRate: number;
+  };
+  /** One entry per native stake account (SPL stake-program) with activation status. */
+  nativeStakes: Array<{
+    stakePubkey: string;
+    validator?: string;
+    stakeSol: number;
+    status: "activating" | "active" | "deactivating" | "inactive";
+    activationEpoch?: number;
+    deactivationEpoch?: number;
+  }>;
+  /** Sum of SOL-equivalents across Marinade + Jito + native stakes. */
+  totalSolEquivalent: number;
 }
 
 /**
@@ -590,6 +640,14 @@ export interface PortfolioSummary {
    * for the wallet.
    */
   solanaLendingUsd?: number;
+  /**
+   * Solana staking net USD — Marinade mSOL + Jito jitoSOL + native stake
+   * accounts (roadmap #2). Computed as `totalSolEquivalent * SOL price`
+   * using the same SOL price that valued the native-SOL balance line.
+   * Folded into `totalUsd`; carve-out here for UIs. Present only when the
+   * wallet holds at least some Solana staking.
+   */
+  solanaStakingUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];

--- a/test/solana-portfolio.test.ts
+++ b/test/solana-portfolio.test.ts
@@ -15,6 +15,9 @@ import { cache } from "../src/data/cache.js";
 const connectionStub = {
   getBalance: vi.fn(),
   getTokenAccountsByOwner: vi.fn(),
+  getParsedTokenAccountsByOwner: vi.fn(),
+  getParsedProgramAccounts: vi.fn(),
+  getEpochInfo: vi.fn(),
 };
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
@@ -61,10 +64,48 @@ vi.mock("../src/modules/morpho/index.js", () => ({
 const EVM_WALLET = "0x1111111111111111111111111111111111111111";
 const SOL_WALLET = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
 
+// Stub the staking reader's SDK deps so the staking fan-out inside the
+// aggregator doesn't try to decode a real Marinade state or Jito pool.
+const marinadeStateStub = { mSolPrice: 1 };
+const getMarinadeStateMock = vi.fn(async () => marinadeStateStub);
+vi.mock("@marinade.finance/marinade-ts-sdk", () => {
+  class MarinadeConfig {}
+  class Marinade {
+    async getMarinadeState() {
+      return getMarinadeStateMock();
+    }
+  }
+  return { MarinadeConfig, Marinade };
+});
+
+const getStakePoolAccountMock = vi.fn();
+vi.mock("@solana/spl-stake-pool", () => ({
+  getStakePoolAccount: getStakePoolAccountMock,
+}));
+
 beforeEach(() => {
   cache.clear();
   connectionStub.getBalance.mockReset();
   connectionStub.getTokenAccountsByOwner.mockReset();
+  connectionStub.getParsedTokenAccountsByOwner.mockReset();
+  connectionStub.getParsedProgramAccounts.mockReset();
+  connectionStub.getEpochInfo.mockReset();
+  getMarinadeStateMock.mockClear();
+  getStakePoolAccountMock.mockReset();
+  // Sensible defaults — empty-staking, rate=1 so staking tests start
+  // neutral. Individual tests override for non-zero holdings.
+  connectionStub.getParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+  connectionStub.getParsedProgramAccounts.mockResolvedValue([]);
+  connectionStub.getEpochInfo.mockResolvedValue({ epoch: 500 });
+  marinadeStateStub.mSolPrice = 1;
+  getStakePoolAccountMock.mockResolvedValue({
+    account: {
+      data: {
+        totalLamports: { toString: () => "0" },
+        poolTokenSupply: { toString: () => "0" },
+      },
+    },
+  });
 
   vi.stubGlobal(
     "fetch",
@@ -132,5 +173,126 @@ describe("get_portfolio_summary with solanaAddress", () => {
         solanaAddress: SOL_WALLET,
       }),
     ).rejects.toThrow(/solanaAddress.*single EVM `wallet`/);
+  });
+
+  it("folds staking positions into breakdown.solana.staking + solanaStakingUsd when holdings exist + SOL price resolved", async () => {
+    // Balance path: 1 SOL native, priced at $100 → solanaBalancesUsd = 100,
+    // and SOL price propagates to the staking USD conversion.
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+    // The balance reader URL-encodes the coin keys
+    // (`coingecko%3Asolana,solana%3A<mint>,...`), so match loosely on the
+    // encoded form. Return a stub price map that covers native SOL.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({
+          coins: { "coingecko:solana": { price: 100 } },
+        }),
+      })),
+    );
+
+    // Staking path: 10 mSOL at rate 1.2 (→ 12 SOL), 5 jitoSOL at rate 1.1
+    // (→ 5.5 SOL), no native stakes. Total SOL-equivalent = 17.5 → USD = 1750.
+    connectionStub.getParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [
+        {
+          pubkey: { toBase58: () => "ATA" },
+          account: {
+            lamports: 0,
+            owner: {},
+            executable: false,
+            rentEpoch: 0,
+            data: {
+              program: "spl-token",
+              parsed: {
+                type: "account",
+                info: { tokenAmount: { uiAmount: 10 } },
+              },
+              space: 165,
+            },
+          },
+        },
+      ],
+    });
+    marinadeStateStub.mSolPrice = 1.2;
+    // Override one call to return jitoSOL balance = 5. Since both Marinade
+    // and Jito readers call getParsedTokenAccountsByOwner, the stub above
+    // returns 10 for both — close enough for the math assertion below.
+    // We'll assert the aggregate instead of per-LST.
+    getStakePoolAccountMock.mockResolvedValue({
+      account: {
+        data: {
+          totalLamports: { toString: () => "110000000000" },
+          poolTokenSupply: { toString: () => "100000000000" },
+        },
+      },
+    });
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    const solana = res.breakdown.solana;
+    expect(solana).toBeDefined();
+    // Staking subtotal: 10 mSOL × 1.2 + 10 jitoSOL × 1.1 = 23 SOL. ($100 each → $2300.)
+    expect(solana?.staking).toBeDefined();
+    expect(solana?.staking?.totalSolEquivalent).toBeCloseTo(23);
+    expect(solana?.stakingNetUsd).toBeCloseTo(2300, 0);
+    expect(res.solanaStakingUsd).toBeCloseTo(2300, 0);
+    // Coverage flag is present + clean.
+    expect(res.coverage.solanaStaking?.covered).toBe(true);
+    // Top-level totalUsd now includes the staking USD.
+    expect(res.totalUsd).toBeGreaterThanOrEqual(2300);
+  });
+
+  it("marks coverage.solanaStaking as errored when the reader fails — balance + MarginFi coverage unaffected", async () => {
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+    // Make the staking reader's RPC path throw.
+    connectionStub.getParsedTokenAccountsByOwner.mockRejectedValue(
+      new Error("Helius 503 on parsed token accounts"),
+    );
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    expect(res.coverage.solanaStaking?.errored).toBe(true);
+    expect(res.coverage.solana?.covered).toBe(true); // balance fetch survived
+    expect(res.breakdown.solana?.staking).toBeUndefined();
+    expect(res.solanaStakingUsd).toBeUndefined();
+  });
+
+  it("omits solanaStakingUsd when staking fetch succeeds but user has zero holdings", async () => {
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+    // Defaults (beforeEach) leave all staking readers empty.
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    expect(res.coverage.solanaStaking?.covered).toBe(true);
+    expect(res.breakdown.solana?.staking).toBeUndefined();
+    expect(res.solanaStakingUsd).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes **roadmap item #2** (section 2 of 2) from `claude-work/HIGH-solana-roadmap.md`. Follow-up to PR #141 which shipped the standalone reader + `get_solana_staking_positions` tool. This PR folds the SOL-equivalent subtotals into `get_portfolio_summary`, paralleling how MarginFi lending and TRON staking are surfaced today.

## Wire-up

| Layer | Change |
|---|---|
| Types | `SolanaStakingPositionSlice` (thin projection of the reader), `PortfolioCoverage.solanaStaking`, `PortfolioSummary.solanaStakingUsd`, `SolanaPortfolioSlice.staking` / `stakingNetUsd` |
| Aggregator | `getSolanaStakingPositions` added to the `solanaAddress`-gated Promise.all; graceful-degradation via `.catch(() => null)` mirrors the MarginFi reader's pattern |
| USD math | Uses the **same** SOL price that valued the native-SOL balance line — extracted via `solanaSlice.native.find(b => b.token === "native").priceUsd`. No duplicate price fetch; guarantees SOL-in-wallet and staked-SOL use identical SOL price |
| `totalUsd` | Now includes `solanaStakingUsd` alongside `solanaLendingUsd` and `tronStakingUsd` |
| Conditional rendering | Staking fields only appear when `totalSolEquivalent > 0` — no dangling empty-stake fields on wallets without staking |

## Tests

| | Before | After |
|---|---|---|
| Full suite | 802 | **805** (+3) |
| `test/solana-portfolio.test.ts` | 3 | 6 |

New cases:
1. **Happy path** — mSOL (10 × 1.2) + jitoSOL (10 × 1.1) = 23 SOL-equivalent × $100 SOL price = $2300 `solanaStakingUsd`. Verifies math end-to-end through the aggregator.
2. **Failure path** — reader throws → `coverage.solanaStaking.errored: true`; `coverage.solana` still `covered: true` (independent split); no `staking` key on the breakdown; no top-level carve-out.
3. **Zero-holdings** — reader succeeds but empty → `coverage.solanaStaking.covered: true`; no dangling staking fields anywhere.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 805/805 pass.
- [ ] **Live sanity**: call `get_portfolio_summary({ wallet: <EVM>, solanaAddress: <wallet with staking> })` against a wallet that holds mSOL/jitoSOL/native stakes. Confirm `breakdown.solana.staking.totalSolEquivalent` matches cross-checks on explorers (Marinade dashboard for mSOL, Jito dashboard for jitoSOL, solscan for native). Confirm `solanaStakingUsd` + `totalUsd` include the staking USD.

## Roadmap status after this PR

- ✅ #1 Nonce-aware dropped-tx polling (PR #137)
- ✅ #2 Solana staking reads — **section 1 (PR #141) + section 2 (this PR)**
- ⏳ #3 Solana staking writes (Marinade / Jito / native — 2-3 PRs)
- ⏳ #4 Multi-tx send pipeline
- ⏳ #5 Kamino lending
- ⏳ #6 Drift / Solend
