### PR TITLE
feat(onboarding): auto-register MCP entry into Claude Desktop / Claude Code / Cursor configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,19 @@ npm run setup
 
 Environment variables always override the config file.
 
-## Use with Claude Desktop
+## Use with Claude Desktop / Claude Code / Cursor
+
+`vaultpilot-mcp-setup` detects which agent clients you have installed and offers to add a `vaultpilot-mcp` entry to each one's MCP-server config automatically. Each existing config is backed up to `<file>.vaultpilot.bak` before any change. Detected client paths:
+
+- Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Claude Desktop (Windows): `%APPDATA%\Claude\claude_desktop_config.json`
+- Claude Desktop (Linux): `~/.config/Claude/claude_desktop_config.json`
+- Claude Code (user-level): `~/.claude.json`
+- Cursor (user-level): `~/.cursor/mcp.json`
+
+Per-project (`<project>/.claude/settings.json`) and per-workspace (`<workspace>/.cursor/mcp.json`) configs are deliberately skipped — the wizard runs from an arbitrary CWD and patching the wrong project is worse than skipping.
+
+If you'd rather edit configs by hand, the entry is:
 
 ```json
 {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -23,6 +23,12 @@ import {
   getConfigPath,
 } from "./config/user-config.js";
 import { reportLedgerUdevStatus } from "./setup/linux-udev.js";
+import {
+  detectClient,
+  getClientConfigPaths,
+  registerVaultPilotWithClients,
+  summarizePatchResults,
+} from "./setup/register-clients.js";
 import type { RpcProvider, SupportedChain, UserConfig } from "./types/index.js";
 
 /** Thin readline wrapper so each prompt is a single awaited call. */
@@ -569,6 +575,47 @@ async function runFullWizard(p: Prompt): Promise<void> {
   // macOS / Windows. If rules are missing on Linux, prints the install
   // one-liner for the user to run separately (no sudo during the wizard).
   reportLedgerUdevStatus();
+
+  // Auto-register the MCP entry into installed agent-client configs so
+  // the user doesn't have to find + edit the JSON file by hand. Asks
+  // permission first — even with backups, touching another app's config
+  // file should be opt-in.
+  await offerClientAutoRegister(p);
+}
+
+/**
+ * Detect which agent clients are installed on the host and offer to add
+ * the `vaultpilot-mcp` entry to each of their MCP-server configs. Only
+ * touches user-level configs (Claude Desktop's per-OS path, Claude Code's
+ * `~/.claude.json`, Cursor's `~/.cursor/mcp.json`) — per-project / per-
+ * workspace configs are skipped because the wizard runs from an arbitrary
+ * CWD and patching the wrong project's config is worse than skipping.
+ */
+async function offerClientAutoRegister(p: Prompt): Promise<void> {
+  console.log("\n--- Agent client registration ---");
+  const targets = getClientConfigPaths();
+  const detected = targets.filter(
+    ({ configPath }) => detectClient(configPath) !== "absent",
+  );
+  if (detected.length === 0) {
+    console.log("  No agent clients detected (Claude Desktop / Claude Code / Cursor).");
+    console.log("  Skipping auto-registration. If you install one later, re-run this");
+    console.log("  setup or add the snippet from the README manually.");
+    return;
+  }
+  console.log("  Detected: " + detected.map((d) => d.client).join(", "));
+  console.log("  We can add a `vaultpilot-mcp` entry to each detected client's");
+  console.log("  MCP-server config so the server starts automatically when you");
+  console.log("  open the client. Each existing config is backed up to");
+  console.log("  `<file>.vaultpilot.bak` before any change.");
+  const ans = (await p.ask("  Auto-register now? [Y/n]: ")).trim().toLowerCase();
+  if (ans === "n" || ans === "no") {
+    console.log("  Skipped. Re-run the wizard to register later.");
+    return;
+  }
+  const results = registerVaultPilotWithClients();
+  console.log("\n  Result:");
+  console.log(summarizePatchResults(results));
 }
 
 async function main() {

--- a/src/setup/register-clients.ts
+++ b/src/setup/register-clients.ts
@@ -1,0 +1,251 @@
+/**
+ * Detect installed agent clients (Claude Desktop, Claude Code, Cursor) and
+ * patch their MCP configs to add a `vaultpilot-mcp` entry. Eliminates the
+ * single biggest non-dev failure mode in `claude-work/HIGH-plan-broad-
+ * audience-onboarding.md` — manual JSON-config editing — for the audience
+ * we're trying to reach.
+ *
+ * Each patch is:
+ *   - Additive (merge into existing `mcpServers` block; don't touch other keys).
+ *   - Idempotent (re-running detects the existing entry and leaves it alone).
+ *   - Atomic (write tmp + rename so a crashed wizard never leaves a half-
+ *     written config).
+ *   - Reversible (backup to `<file>.vaultpilot.bak` before overwrite).
+ *
+ * Per-project Claude Code (`<project>/.claude/settings.json`) and per-
+ * workspace Cursor (`<workspace>/.cursor/mcp.json`) are deliberately NOT
+ * touched — the wizard runs from an arbitrary CWD and patching the wrong
+ * project's config is worse than leaving it alone. Only user-level configs.
+ */
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type PatchStatus = "added" | "already-present" | "not-detected" | "error";
+
+export interface ClientPatchResult {
+  client: string;
+  configPath: string;
+  status: PatchStatus;
+  /** Populated for `added` (path to backup) and `error` (message). */
+  detail?: string;
+}
+
+/**
+ * Build the MCP server entry to inject. Resolves the absolute path to
+ * `dist/index.js` from this file's own location — works whether the user
+ * `npm i -g`'d (this file lives in the global node_modules tree) or
+ * cloned from source (this file is in the repo's `dist/setup/`). Using an
+ * absolute `node` invocation rather than the `vaultpilot-mcp` bin is
+ * deliberate: it doesn't depend on PATH and won't break if the user
+ * uninstalls / reinstalls under a different prefix.
+ */
+function buildServerEntry(): { command: string; args: string[] } {
+  // import.meta.url → file URL of this module → absolute path → dirname
+  // (= dist/setup) → "../index.js" (= dist/index.js).
+  const here = fileURLToPath(import.meta.url);
+  const serverPath = resolve(dirname(here), "..", "index.js");
+  return { command: "node", args: [serverPath] };
+}
+
+/**
+ * Per-client config file paths. Returned in detection order — earlier
+ * entries are surfaced first in the user-facing summary, so list the
+ * common-case clients first.
+ */
+export function getClientConfigPaths(): { client: string; configPath: string }[] {
+  const home = homedir();
+  const plat = platform();
+  const targets: { client: string; configPath: string }[] = [];
+
+  if (plat === "darwin") {
+    targets.push({
+      client: "Claude Desktop",
+      configPath: join(
+        home,
+        "Library",
+        "Application Support",
+        "Claude",
+        "claude_desktop_config.json",
+      ),
+    });
+  } else if (plat === "win32") {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      targets.push({
+        client: "Claude Desktop",
+        configPath: join(appData, "Claude", "claude_desktop_config.json"),
+      });
+    }
+  } else {
+    targets.push({
+      client: "Claude Desktop",
+      configPath: join(home, ".config", "Claude", "claude_desktop_config.json"),
+    });
+  }
+
+  // Claude Code keeps its user-level config at ~/.claude.json. Per-project
+  // configs live at <project>/.claude/settings.json — see module doc-comment
+  // for why we skip those.
+  targets.push({ client: "Claude Code", configPath: join(home, ".claude.json") });
+
+  // Cursor user-level MCP registry. Per-workspace alt is <workspace>/.cursor/
+  // mcp.json — also skipped for the same reason.
+  targets.push({ client: "Cursor", configPath: join(home, ".cursor", "mcp.json") });
+
+  return targets;
+}
+
+/** Detect whether a client is even installed by checking for either the
+ * config file or its parent dir. Either signal is sufficient — Claude
+ * Desktop creates the parent dir on install whether or not the user has
+ * configured any MCP servers yet. */
+export function detectClient(configPath: string): "configured" | "installed" | "absent" {
+  if (existsSync(configPath)) return "configured";
+  if (existsSync(dirname(configPath))) return "installed";
+  return "absent";
+}
+
+/** Read + parse the existing config, or return an empty object if missing.
+ * Throws on parse failure — the caller decides whether to abort or skip
+ * this particular client. */
+function readExistingConfig(configPath: string): Record<string, unknown> {
+  if (!existsSync(configPath)) return {};
+  const raw = readFileSync(configPath, "utf8");
+  if (raw.trim() === "") return {};
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Atomic write — tmp + rename — preserving 0o600 mode (configs may carry
+ * API keys). On Windows, rename across same-volume overwrite is atomic;
+ * on POSIX it's atomic by definition. */
+function atomicWriteJson(configPath: string, value: unknown): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  const tmp = `${configPath}.vaultpilot.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", { mode: 0o600 });
+  renameSync(tmp, configPath);
+}
+
+interface PatchOptions {
+  /** Override for tests — substitute the server entry. */
+  serverEntry?: { command: string; args?: string[] };
+}
+
+/** Patch a single client config. Pure function — no console output, no
+ * prompts. Returns a structured result the caller can summarise. */
+export function patchClientConfig(
+  client: string,
+  configPath: string,
+  opts: PatchOptions = {},
+): ClientPatchResult {
+  const state = detectClient(configPath);
+  if (state === "absent") {
+    return { client, configPath, status: "not-detected" };
+  }
+
+  let existing: Record<string, unknown>;
+  try {
+    existing = readExistingConfig(configPath);
+  } catch (e) {
+    return {
+      client,
+      configPath,
+      status: "error",
+      detail: `Existing config is malformed JSON; left untouched. Error: ${
+        (e as Error).message
+      }`,
+    };
+  }
+
+  const mcpServers =
+    (existing.mcpServers as Record<string, unknown> | undefined) ?? {};
+  if ("vaultpilot-mcp" in mcpServers) {
+    return {
+      client,
+      configPath,
+      status: "already-present",
+    };
+  }
+
+  const serverEntry = opts.serverEntry ?? buildServerEntry();
+  const next = {
+    ...existing,
+    mcpServers: { ...mcpServers, "vaultpilot-mcp": serverEntry },
+  };
+
+  // Backup before write — only if there's something to back up.
+  let backupPath: string | undefined;
+  if (state === "configured") {
+    backupPath = `${configPath}.vaultpilot.bak`;
+    try {
+      copyFileSync(configPath, backupPath);
+    } catch (e) {
+      return {
+        client,
+        configPath,
+        status: "error",
+        detail: `Could not write backup file ${backupPath}: ${
+          (e as Error).message
+        }. Refusing to overwrite original.`,
+      };
+    }
+  }
+
+  try {
+    atomicWriteJson(configPath, next);
+  } catch (e) {
+    return {
+      client,
+      configPath,
+      status: "error",
+      detail: `Atomic write failed: ${(e as Error).message}`,
+    };
+  }
+
+  return {
+    client,
+    configPath,
+    status: "added",
+    detail: backupPath ? `Backup at ${backupPath}` : "(no backup; file did not exist before)",
+  };
+}
+
+/** Patch every detected client. Errors on one client don't stop the others. */
+export function registerVaultPilotWithClients(
+  opts: PatchOptions = {},
+): ClientPatchResult[] {
+  const targets = getClientConfigPaths();
+  return targets.map(({ client, configPath }) =>
+    patchClientConfig(client, configPath, opts),
+  );
+}
+
+/** Format the per-client results into a multi-line summary suitable for the
+ * setup wizard's terminal output. */
+export function summarizePatchResults(results: ClientPatchResult[]): string {
+  const lines: string[] = [];
+  for (const r of results) {
+    const tag =
+      r.status === "added"
+        ? "✓ Added"
+        : r.status === "already-present"
+          ? "✓ Already configured"
+          : r.status === "not-detected"
+            ? "·  Not detected"
+            : "✗ Error";
+    lines.push(`  ${tag}: ${r.client}`);
+    if (r.status === "added" || r.status === "error") {
+      lines.push(`      ${r.configPath}`);
+      if (r.detail) lines.push(`      ${r.detail}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/test/register-clients.test.ts
+++ b/test/register-clients.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the agent-client auto-register module — mounts a temp HOME so
+ * the `homedir()`-relative paths land somewhere we control, then exercises
+ * the patch logic against synthetic fixtures.
+ *
+ * The MCP-server entry is dependent on this test file's runtime location
+ * (it resolves via `import.meta.url`), so most tests pass an explicit
+ * `serverEntry` opt to keep assertions deterministic.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  detectClient,
+  getClientConfigPaths,
+  patchClientConfig,
+  registerVaultPilotWithClients,
+  summarizePatchResults,
+} from "../src/setup/register-clients.js";
+
+const FAKE_SERVER_ENTRY = {
+  command: "node",
+  args: ["/abs/dist/index.js"],
+};
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "vaultpilot-register-test-"));
+  vi.spyOn({ homedir }, "homedir").mockReturnValue(tmpHome);
+  // homedir() is imported by the module under test at module-evaluation
+  // time; spying on the local import doesn't affect it. Override via the
+  // HOME env var instead, which os.homedir() reads on POSIX.
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome; // Windows
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("getClientConfigPaths", () => {
+  it("includes Claude Desktop on the running platform with a non-empty path", () => {
+    const paths = getClientConfigPaths();
+    const claudeDesktop = paths.find((p) => p.client === "Claude Desktop");
+    if (platform() !== "win32" || process.env.APPDATA) {
+      expect(claudeDesktop).toBeDefined();
+      expect(claudeDesktop!.configPath).toContain("Claude");
+    }
+  });
+
+  it("includes Claude Code at ~/.claude.json", () => {
+    const paths = getClientConfigPaths();
+    const claudeCode = paths.find((p) => p.client === "Claude Code");
+    expect(claudeCode).toBeDefined();
+    expect(claudeCode!.configPath).toBe(join(homedir(), ".claude.json"));
+  });
+
+  it("includes Cursor at ~/.cursor/mcp.json", () => {
+    const paths = getClientConfigPaths();
+    const cursor = paths.find((p) => p.client === "Cursor");
+    expect(cursor).toBeDefined();
+    expect(cursor!.configPath).toBe(join(homedir(), ".cursor", "mcp.json"));
+  });
+});
+
+describe("detectClient", () => {
+  it("returns 'absent' when neither file nor parent exists", () => {
+    const target = join(tmpHome, "no-such-app", "config.json");
+    expect(detectClient(target)).toBe("absent");
+  });
+
+  it("returns 'installed' when parent dir exists but config does not", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    expect(detectClient(join(dir, "config.json"))).toBe("installed");
+  });
+
+  it("returns 'configured' when the config file itself exists", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+    writeFileSync(file, "{}");
+    expect(detectClient(file)).toBe("configured");
+  });
+});
+
+describe("patchClientConfig", () => {
+  it("returns 'not-detected' when the client isn't installed", () => {
+    const result = patchClientConfig(
+      "Imaginary",
+      join(tmpHome, "no-such-dir", "config.json"),
+      { serverEntry: FAKE_SERVER_ENTRY },
+    );
+    expect(result.status).toBe("not-detected");
+  });
+
+  it("creates the config file with the vaultpilot-mcp entry when the parent dir exists but config does not", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+
+    const result = patchClientConfig("FakeApp", file, {
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    expect(result.status).toBe("added");
+    expect(existsSync(file)).toBe(true);
+    const written = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(written.mcpServers).toEqual({
+      "vaultpilot-mcp": FAKE_SERVER_ENTRY,
+    });
+    // No backup when the file didn't exist before.
+    expect(existsSync(`${file}.vaultpilot.bak`)).toBe(false);
+  });
+
+  it("preserves unrelated keys + adds vaultpilot-mcp alongside existing servers", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+    const before = {
+      foo: { bar: 1 },
+      mcpServers: {
+        "some-other-server": { command: "other", args: ["x"] },
+      },
+    };
+    writeFileSync(file, JSON.stringify(before, null, 2));
+
+    const result = patchClientConfig("FakeApp", file, {
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    expect(result.status).toBe("added");
+    expect(existsSync(`${file}.vaultpilot.bak`)).toBe(true);
+    expect(JSON.parse(readFileSync(`${file}.vaultpilot.bak`, "utf8"))).toEqual(
+      before,
+    );
+    const after = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(after.foo).toEqual({ bar: 1 });
+    expect(after.mcpServers).toEqual({
+      "some-other-server": { command: "other", args: ["x"] },
+      "vaultpilot-mcp": FAKE_SERVER_ENTRY,
+    });
+  });
+
+  it("is idempotent — re-running on a config that already has vaultpilot-mcp returns 'already-present' without writing", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+    const before = {
+      mcpServers: {
+        "vaultpilot-mcp": { command: "node", args: ["/different/path"] },
+      },
+    };
+    writeFileSync(file, JSON.stringify(before, null, 2));
+
+    const result = patchClientConfig("FakeApp", file, {
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    expect(result.status).toBe("already-present");
+    // Existing entry not overwritten with the new server entry.
+    const after = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(after.mcpServers).toEqual(before.mcpServers);
+    // No backup created on the no-op path.
+    expect(existsSync(`${file}.vaultpilot.bak`)).toBe(false);
+  });
+
+  it("returns 'error' when the existing config is malformed JSON, leaves the file untouched", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+    const malformed = "{ not really json";
+    writeFileSync(file, malformed);
+
+    const result = patchClientConfig("FakeApp", file, {
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.detail).toMatch(/malformed/i);
+    // Original file untouched.
+    expect(readFileSync(file, "utf8")).toBe(malformed);
+    expect(existsSync(`${file}.vaultpilot.bak`)).toBe(false);
+  });
+
+  it("writes the config with 0o600 mode (configs may carry secrets)", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+
+    patchClientConfig("FakeApp", file, { serverEntry: FAKE_SERVER_ENTRY });
+
+    const { statSync } = require("node:fs") as typeof import("node:fs");
+    const mode = statSync(file).mode & 0o777;
+    if (process.platform !== "win32") {
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  it("treats an empty-string config file as absent-content (still adds the entry without throwing)", () => {
+    const dir = join(tmpHome, "FakeApp");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "config.json");
+    writeFileSync(file, "");
+
+    const result = patchClientConfig("FakeApp", file, {
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    expect(result.status).toBe("added");
+    const after = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(after.mcpServers).toEqual({ "vaultpilot-mcp": FAKE_SERVER_ENTRY });
+  });
+});
+
+describe("registerVaultPilotWithClients (integration)", () => {
+  it("returns one result per detected client + 'not-detected' for absent ones", () => {
+    // Create only the Claude Code config dir/file so a single client is
+    // detectable; leave Claude Desktop and Cursor absent.
+    writeFileSync(join(tmpHome, ".claude.json"), "{}");
+
+    const results = registerVaultPilotWithClients({
+      serverEntry: FAKE_SERVER_ENTRY,
+    });
+
+    const byClient = new Map(results.map((r) => [r.client, r]));
+    expect(byClient.get("Claude Code")?.status).toBe("added");
+    // The other two clients should report not-detected.
+    expect(byClient.get("Claude Desktop")?.status).toBe("not-detected");
+    expect(byClient.get("Cursor")?.status).toBe("not-detected");
+  });
+});
+
+describe("summarizePatchResults", () => {
+  it("formats added / already-present / not-detected / error rows distinctly", () => {
+    const out = summarizePatchResults([
+      { client: "A", configPath: "/a", status: "added", detail: "Backup at /a.bak" },
+      { client: "B", configPath: "/b", status: "already-present" },
+      { client: "C", configPath: "/c", status: "not-detected" },
+      { client: "D", configPath: "/d", status: "error", detail: "boom" },
+    ]);
+    expect(out).toContain("✓ Added: A");
+    expect(out).toContain("Backup at /a.bak");
+    expect(out).toContain("✓ Already configured: B");
+    expect(out).toContain("Not detected: C");
+    expect(out).toContain("✗ Error: D");
+    expect(out).toContain("boom");
+  });
+});


### PR DESCRIPTION
## Summary

**Stacked on top of #142.** Set the base of this PR to `feat/broad-audience-onboarding-v1` so the diff is just this milestone's content; merge order is #142 → this.

Item 1.2 from `claude-work/HIGH-plan-broad-audience-onboarding.md`. Eliminates the single biggest non-dev friction point — finding + editing `claude_desktop_config.json` (or per-OS equivalents) by hand.

## What ships

`src/setup/register-clients.ts` — pure module, no console output, no prompts. Three exports the wizard composes:

- `getClientConfigPaths()` — per-OS list of (Claude Desktop, Claude Code, Cursor) user-level config paths.
- `detectClient(configPath)` — `configured` / `installed` / `absent`. `installed` = parent dir exists but config doesn't (Claude Desktop creates `~/Library/Application Support/Claude` on install whether or not any MCP servers are configured).
- `patchClientConfig(client, configPath, opts?)` — additive + idempotent + atomic + reversible. Reads existing JSON, merges in `mcpServers.vaultpilot-mcp`, atomic-renames, leaves a `<file>.vaultpilot.bak` next to it.

The MCP entry is `{ command: "node", args: ["<abs path>/dist/index.js"] }`, resolved via `import.meta.url`. Works whether the user `npm i -g`'d or cloned from source — absolute path doesn't depend on PATH and won't break under a reinstall under a different prefix.

## Wizard wiring

`src/setup.ts` gains an `offerClientAutoRegister(p)` helper called at the end of `runFullWizard()`. Detects clients, prints which were found, asks `[Y/n]`, runs the patch sweep, prints a per-client summary (`✓ Added` / `✓ Already configured` / `· Not detected` / `✗ Error`).

Auto-register is opt-in (default Y, but the user must press enter): even with backups, touching another app's config is the kind of thing to ask before doing.

## Per-project / per-workspace configs are NOT touched

`<project>/.claude/settings.json` and `<workspace>/.cursor/mcp.json` are deliberately skipped. The wizard runs from an arbitrary CWD; the user might be in `~`, in a personal-finance repo, or anywhere. Patching the wrong project's config is worse than skipping. Documented in the module doc-comment + the README.

## Hardening

- Atomic write via tmp + rename. A crashed wizard never leaves a half-written config.
- 0o600 file mode preserved. MCP configs may carry API keys; tightening perms is cheap insurance.
- Malformed-JSON-existing-config returns a structured `error` result rather than crashing or overwriting.
- Empty-file existing config is treated as `{}` and patched normally.
- `vaultpilot-mcp` already present → `already-present` result with no write. Re-running the wizard is safe.

## README

"Use with Claude Desktop" section rewritten to mention auto-register first and surface the manual JSON snippet as a fallback for users who prefer to edit by hand. Lists every detected path so users know what the wizard is reaching for.

## Test plan

- [x] `npm test` — **810/810** pass (+15 new register-clients tests covering: per-OS path detection, three detect states, six patch paths including idempotent + malformed-JSON + perms, integration test for partial-detection, and the summary formatter).
- [x] `npm run build` — clean TS.
- [ ] Manual: smoke-test the wizard on each OS (Linux ✓ in dev; macOS + Windows pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)