### PR TITLE
feat(marinade): prepare_marinade_stake + prepare_marinade_unstake_immediate (roadmap #3 PR1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ import {
   prepareMarginfiWithdraw,
   prepareMarginfiBorrow,
   prepareMarginfiRepay,
+  prepareMarinadeStake,
+  prepareMarinadeUnstakeImmediate,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -105,6 +107,8 @@ import {
   prepareMarginfiWithdrawInput,
   prepareMarginfiBorrowInput,
   prepareMarginfiRepayInput,
+  prepareMarinadeStakeInput,
+  prepareMarinadeUnstakeImmediateInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1395,6 +1399,39 @@ async function main() {
       inputSchema: prepareMarginfiRepayInput.shape,
     },
     handler(prepareMarginfiRepay)
+  );
+
+  server.registerTool(
+    "prepare_marinade_stake",
+    {
+      description:
+        "Build an unsigned Marinade stake tx: deposit `amountSol` SOL into Marinade " +
+        "and receive mSOL (Marinade's liquid-staking token). Uses the Marinade SDK's " +
+        "`marinade.deposit` so the on-chain Authorized signer is the user's wallet — no " +
+        "ephemeral keypair, Ledger-compatible. The mSOL ATA is created automatically on " +
+        "first stake (~0.002 SOL ATA rent, reclaimable). DURABLE NONCE REQUIRED — the " +
+        "wallet must have run `prepare_solana_nonce_init` first; otherwise this tool errors. " +
+        "BLIND-SIGN on Ledger (Marinade's program is not in the Solana app's clear-sign " +
+        "registry) — match the Message Hash on-device after `preview_solana_send`.",
+      inputSchema: prepareMarinadeStakeInput.shape,
+    },
+    handler(prepareMarinadeStake)
+  );
+
+  server.registerTool(
+    "prepare_marinade_unstake_immediate",
+    {
+      description:
+        "Build an unsigned Marinade IMMEDIATE liquid-unstake tx: burn `amountMSol` mSOL and " +
+        "receive SOL in the same tx via Marinade's liquidity pool (NOT delayed-unstake / " +
+        "OrderUnstake — that flow returns full SOL after one epoch but requires an ephemeral " +
+        "ticket-account signer the Ledger-only signing model can't provide; tracked as a " +
+        "follow-up). The pool charges a small fee (typically 0.3% — varies with pool depth) " +
+        "in exchange for instant liquidity. DURABLE NONCE REQUIRED + same Ledger signing " +
+        "constraints as `prepare_marinade_stake`. BLIND-SIGN on Ledger.",
+      inputSchema: prepareMarinadeUnstakeImmediateInput.shape,
+    },
+    handler(prepareMarinadeUnstakeImmediate)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -97,6 +97,8 @@ import type {
   PrepareMarginfiWithdrawArgs,
   PrepareMarginfiBorrowArgs,
   PrepareMarginfiRepayArgs,
+  PrepareMarinadeStakeArgs,
+  PrepareMarinadeUnstakeImmediateArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -334,6 +336,30 @@ export async function prepareMarginfiRepay(
     amount: args.amount,
     ...(args.accountIndex !== undefined ? { accountIndex: args.accountIndex } : {}),
     ...(args.repayAll !== undefined ? { repayAll: args.repayAll } : {}),
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarinadeStake(
+  args: PrepareMarinadeStakeArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarinadeStake } = await import("../solana/marinade.js");
+  const prepared = await buildMarinadeStake({
+    wallet: args.wallet,
+    amountSol: args.amountSol,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareMarinadeUnstakeImmediate(
+  args: PrepareMarinadeUnstakeImmediateArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildMarinadeUnstakeImmediate } = await import(
+    "../solana/marinade.js"
+  );
+  const prepared = await buildMarinadeUnstakeImmediate({
+    wallet: args.wallet,
+    amountMSol: args.amountMSol,
   });
   return prepared as unknown as PreparedSolanaTx;
 }
@@ -1723,7 +1749,9 @@ export interface SolanaVerificationArtifact {
     | "marginfi_supply"
     | "marginfi_withdraw"
     | "marginfi_borrow"
-    | "marginfi_repay";
+    | "marginfi_repay"
+    | "marinade_stake"
+    | "marinade_unstake_immediate";
   from: string;
   messageBase64: string;
   recentBlockhash: string;
@@ -1837,6 +1865,8 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       "marginfi_withdraw",
       "marginfi_borrow",
       "marginfi_repay",
+      "marinade_stake",
+      "marinade_unstake_immediate",
     ]);
     const ledgerMessageHash = blindSignActions.has(tx.action)
       ? solanaLedgerMessageHash(tx.messageBase64)

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -265,6 +265,42 @@ export const prepareMarginfiRepayInput = z.object({
     ),
 });
 
+/**
+ * Marinade liquid-staking action schemas. Both flows share the
+ * durable-nonce-account requirement (ix[0] = nonceAdvance) so the wallet
+ * must have run prepare_solana_nonce_init first.
+ */
+export const prepareMarinadeStakeInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet that funds the deposit and receives mSOL. Must have an " +
+      "initialized durable-nonce account (prepare_solana_nonce_init) and enough " +
+      "SOL to cover the deposit + ATA rent (if mSOL ATA doesn't exist) + tx fee."
+  ),
+  amountSol: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable SOL amount to stake (e.g. "1.5"). Decimals are SOL-native ' +
+        '(9 dec); the builder rounds down to lamport precision.'
+    ),
+});
+
+export const prepareMarinadeUnstakeImmediateInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet that burns mSOL and receives SOL. Must have an initialized " +
+      "durable-nonce account and an mSOL position to unstake from. Liquid unstake " +
+      "routes through Marinade's liquidity pool (NOT delayed-unstake / OrderUnstake) " +
+      "so the user pays a small fee but receives SOL in the same tx — no one-epoch wait."
+  ),
+  amountMSol: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable mSOL amount to unstake (e.g. "1.5"). Builder converts to ' +
+        'mSOL base units (9 dec) and rounds down.'
+    ),
+});
+
 export const getSolanaSetupStatusInput = z.object({
   wallet: solanaAddressSchema.describe(
     "Solana wallet to probe. Returns the state of the durable-nonce account " +
@@ -570,6 +606,10 @@ export type PrepareMarginfiSupplyArgs = z.infer<typeof prepareMarginfiSupplyInpu
 export type PrepareMarginfiWithdrawArgs = z.infer<typeof prepareMarginfiWithdrawInput>;
 export type PrepareMarginfiBorrowArgs = z.infer<typeof prepareMarginfiBorrowInput>;
 export type PrepareMarginfiRepayArgs = z.infer<typeof prepareMarginfiRepayInput>;
+export type PrepareMarinadeStakeArgs = z.infer<typeof prepareMarinadeStakeInput>;
+export type PrepareMarinadeUnstakeImmediateArgs = z.infer<
+  typeof prepareMarinadeUnstakeImmediateInput
+>;
 export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;
 export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPositionsInput>;
 export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -119,7 +119,9 @@ export interface PreparedSolanaTx {
     | "marginfi_supply"
     | "marginfi_withdraw"
     | "marginfi_borrow"
-    | "marginfi_repay";
+    | "marginfi_repay"
+    | "marinade_stake"
+    | "marinade_unstake_immediate";
   chain: "solana";
   from: string;
   description: string;

--- a/src/modules/solana/marinade.ts
+++ b/src/modules/solana/marinade.ts
@@ -1,0 +1,259 @@
+import {
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+
+/**
+ * Marinade liquid-staking write actions — `prepare_marinade_stake`
+ * (deposit SOL → mSOL) and `prepare_marinade_unstake_immediate`
+ * (liquidUnstake mSOL → SOL via Marinade's liquidity pool, with fee).
+ *
+ * Both flows reuse the shared durable-nonce pipeline (ix[0] =
+ * nonceAdvance) — same as every other Solana send this server builds
+ * except `nonce_init`. Marinade's program clear-signs nothing on the
+ * Ledger Solana app (not in the app's plugin allowlist), so the device
+ * displays only a Message Hash; users match it against the value the
+ * server publishes in the VERIFY block.
+ *
+ * Delayed unstake (OrderUnstake — wait one epoch, get full SOL) is NOT
+ * shipped here. The SDK's `orderUnstake` returns a
+ * `ticketAccountKeypair: web3.Keypair` ephemeral signer — incompatible
+ * with our Ledger-only signing model without separate ticket-account
+ * derivation work. Tracked as a follow-up; immediate-via-pool covers
+ * the user need for "exit my mSOL position now" with a fee disclosure.
+ *
+ * SDK integration:
+ * - `marinade.deposit(amountLamports)` returns `{ associatedMSolTokenAccountAddress, transaction: web3.Transaction }`.
+ *   We extract `transaction.instructions` and splice them into a v0
+ *   message after the nonceAdvance instruction.
+ * - `marinade.liquidUnstake(amountLamports)` returns the same shape.
+ *
+ * Read-only constructor: the SDK's `MarinadeConfig` accepts `publicKey`
+ * — we pass the user's wallet so Marinade can derive the associated
+ * mSOL token account (the recipient of the LST). `marinade.deposit`
+ * builds an `Authorized` ix where the signer is `publicKey`; no
+ * provider-side signing happens at build time. The Ledger signs the
+ * resulting message bytes via our normal pipeline.
+ */
+
+export interface MarinadeStakeParams {
+  /** Base58 wallet address — funds the deposit, receives mSOL. */
+  wallet: string;
+  /** Human-readable SOL amount (decimal string, e.g. "1.5"). */
+  amountSol: string;
+}
+
+export interface MarinadeUnstakeImmediateParams {
+  /** Base58 wallet address — burns mSOL, receives SOL. */
+  wallet: string;
+  /** Human-readable mSOL amount (decimal string). */
+  amountMSol: string;
+}
+
+export interface PreparedMarinadeTx {
+  handle: string;
+  action: "marinade_stake" | "marinade_unstake_immediate";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  /** Nonce-account PDA for this wallet (durable-nonce-protected). */
+  nonceAccount: string;
+}
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+const MSOL_DECIMALS = 9;
+
+function solToLamports(solDecimal: string): bigint {
+  const bn = new BigNumber(solDecimal);
+  if (!bn.isFinite() || bn.lte(0)) {
+    throw new Error(
+      `Invalid SOL amount "${solDecimal}" — expected a positive decimal (e.g. "1.5").`,
+    );
+  }
+  // Round down to lamport precision to avoid floating-point overshoot.
+  return BigInt(bn.times(LAMPORTS_PER_SOL).integerValue(BigNumber.ROUND_DOWN).toString(10));
+}
+
+function mSolToBaseUnits(mSolDecimal: string): bigint {
+  const bn = new BigNumber(mSolDecimal);
+  if (!bn.isFinite() || bn.lte(0)) {
+    throw new Error(
+      `Invalid mSOL amount "${mSolDecimal}" — expected a positive decimal (e.g. "1.5").`,
+    );
+  }
+  return BigInt(
+    bn
+      .times(new BigNumber(10).pow(MSOL_DECIMALS))
+      .integerValue(BigNumber.ROUND_DOWN)
+      .toString(10),
+  );
+}
+
+/**
+ * Construct the Marinade SDK in read-only-constructor mode. The SDK
+ * needs `publicKey` to derive the associated mSOL token account and
+ * encode the deposit/unstake authority field — but never invokes a
+ * provider-signing path during ix construction.
+ */
+async function loadMarinadeForWallet(walletPk: PublicKey) {
+  const { Marinade, MarinadeConfig } = await import(
+    "@marinade.finance/marinade-ts-sdk"
+  );
+  const conn = getSolanaConnection();
+  const config = new MarinadeConfig({
+    connection: conn,
+    publicKey: walletPk,
+  });
+  return new Marinade(config);
+}
+
+async function loadNonceContext(walletStr: string): Promise<{
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+}> {
+  const fromPubkey = assertSolanaAddress(walletStr);
+  const conn = getSolanaConnection();
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(walletStr);
+  return { fromPubkey, noncePubkey, nonceValue: nonceState!.nonce };
+}
+
+/**
+ * Wrap an action's instructions into a durable-nonce-protected v0 draft.
+ * Same pattern as `wrapWithNonce` in `marginfi.ts` — nonceAdvance at
+ * ix[0] is the agave-detected marker that bypasses the ~60s blockhash
+ * validity window in favor of the on-chain nonce value as the validity
+ * gate.
+ */
+function buildDraft(args: {
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+  walletStr: string;
+  action: "marinade_stake" | "marinade_unstake_immediate";
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  actionIxs: TransactionInstruction[];
+}): SolanaTxDraft {
+  const nonceIx = buildAdvanceNonceIx(args.noncePubkey, args.fromPubkey);
+  const instructions: TransactionInstruction[] = [nonceIx, ...args.actionIxs];
+  return {
+    kind: "v0",
+    payerKey: args.fromPubkey,
+    instructions,
+    addressLookupTableAccounts: [],
+    meta: {
+      action: args.action,
+      from: args.walletStr,
+      description: args.description,
+      decoded: args.decoded,
+      nonce: {
+        account: args.noncePubkey.toBase58(),
+        authority: args.fromPubkey.toBase58(),
+        value: args.nonceValue,
+      },
+    },
+  };
+}
+
+export async function buildMarinadeStake(
+  p: MarinadeStakeParams,
+): Promise<PreparedMarinadeTx> {
+  const lamports = solToLamports(p.amountSol);
+  const ctx = await loadNonceContext(p.wallet);
+
+  const marinade = await loadMarinadeForWallet(ctx.fromPubkey);
+  // Bring in BN from the SDK's transitive dep tree — Marinade's SDK
+  // accepts only its own BN type, not bigint.
+  const { BN } = await import("@coral-xyz/anchor");
+  const result = await marinade.deposit(new BN(lamports.toString()));
+  const actionIxs = result.transaction.instructions;
+
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    action: "marinade_stake",
+    description: `Marinade stake: deposit ${p.amountSol} SOL → mSOL`,
+    decoded: {
+      functionName: "marinade.deposit",
+      args: {
+        wallet: p.wallet,
+        amountSol: p.amountSol,
+        mSolAta: result.associatedMSolTokenAccountAddress.toBase58(),
+        nonceAccount: ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "marinade_stake",
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}
+
+export async function buildMarinadeUnstakeImmediate(
+  p: MarinadeUnstakeImmediateParams,
+): Promise<PreparedMarinadeTx> {
+  const baseUnits = mSolToBaseUnits(p.amountMSol);
+  const ctx = await loadNonceContext(p.wallet);
+
+  const marinade = await loadMarinadeForWallet(ctx.fromPubkey);
+  const { BN } = await import("@coral-xyz/anchor");
+  const result = await marinade.liquidUnstake(new BN(baseUnits.toString()));
+  const actionIxs = result.transaction.instructions;
+
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    action: "marinade_unstake_immediate",
+    description: `Marinade liquid unstake: ${p.amountMSol} mSOL → SOL (via liquidity pool, with fee)`,
+    decoded: {
+      functionName: "marinade.liquidUnstake",
+      args: {
+        wallet: p.wallet,
+        amountMSol: p.amountMSol,
+        mSolAta: result.associatedMSolTokenAccountAddress.toBase58(),
+        nonceAccount: ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "marinade_unstake_immediate",
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -892,7 +892,9 @@ export interface RenderableSolanaPrepareResult {
     | "marginfi_supply"
     | "marginfi_withdraw"
     | "marginfi_borrow"
-    | "marginfi_repay";
+    | "marginfi_repay"
+    | "marinade_stake"
+    | "marinade_unstake_immediate";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -930,6 +932,10 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "MarginFi borrow";
     case "marginfi_repay":
       return "MarginFi repay";
+    case "marinade_stake":
+      return "Marinade stake (SOL → mSOL)";
+    case "marinade_unstake_immediate":
+      return "Marinade liquid unstake (mSOL → SOL via pool)";
   }
 }
 
@@ -988,6 +994,7 @@ export function renderSolanaPrepareAgentTaskBlock(
   r: RenderableSolanaPrepareResult,
 ): string {
   const isMarginfi = r.action.startsWith("marginfi_");
+  const isMarinade = r.action.startsWith("marinade_");
   const marginfiActionWord =
     r.action === "marginfi_init"
       ? "MarginFi account init"
@@ -1000,6 +1007,12 @@ export function renderSolanaPrepareAgentTaskBlock(
             : r.action === "marginfi_repay"
               ? "MarginFi repay"
               : null;
+  const marinadeActionWord =
+    r.action === "marinade_stake"
+      ? "Marinade stake"
+      : r.action === "marinade_unstake_immediate"
+        ? "Marinade liquid unstake"
+        : null;
   const actionWord =
     r.action === "native_send"
       ? "native SOL send"
@@ -1011,7 +1024,7 @@ export function renderSolanaPrepareAgentTaskBlock(
             ? "durable-nonce close"
             : r.action === "jupiter_swap"
               ? "Jupiter swap"
-              : marginfiActionWord ?? "Solana tx";
+              : marginfiActionWord ?? marinadeActionWord ?? "Solana tx";
   const nonceBullet =
     r.nonceAccount && r.action !== "nonce_init"
       ? ["  - Nonce: <short nonce-account addr>"]
@@ -1087,6 +1100,24 @@ export function renderSolanaPrepareAgentTaskBlock(
                       "  - MarginfiAccount: <marginfiAccount from decoded.args>",
                       "  - Bank: <bank from decoded.args> (<symbol>)",
                       "  - Amount: <human amount + symbol>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : r.action === "marinade_stake"
+                  ? [
+                      "  - Headline: \"Prepared Marinade stake — <amountSol> SOL → mSOL\"",
+                      "  - Wallet: <from address>",
+                      "  - Amount: <amountSol> SOL (deposit)",
+                      "  - mSOL ATA: <mSolAta from decoded.args>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : r.action === "marinade_unstake_immediate"
+                  ? [
+                      "  - Headline: \"Prepared Marinade liquid unstake — <amountMSol> mSOL → SOL (pool, with fee)\"",
+                      "  - Wallet: <from address>",
+                      "  - Amount: <amountMSol> mSOL (burned)",
+                      "  - mSOL ATA: <mSolAta from decoded.args>",
                       ...nonceBullet,
                       "  - Fee: <est. fee in SOL>",
                     ]
@@ -1243,6 +1274,9 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     tx.action === "marginfi_withdraw" ||
     tx.action === "marginfi_borrow" ||
     tx.action === "marginfi_repay";
+  const isMarinade =
+    tx.action === "marinade_stake" ||
+    tx.action === "marinade_unstake_immediate";
   const marginfiActionLabel =
     tx.action === "marginfi_init"
       ? "account init"
@@ -1322,14 +1356,14 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // as ix[0] — this flag drives the "DURABLE-NONCE MODE" explainer text +
   // the Nonce bullet in the summary + the expected-shape text for CHECK 1.
   const hasAdvanceNonceIx =
-    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi;
+    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi || isMarinade;
   // The Ledger Solana app only clear-signs a small allowlist of programs
   // (System Program's transfer/advance/initialize/withdraw, and a few
   // others). Everything else falls to blind-sign, which shows only the
   // Message Hash on-device and requires the user to match it against the
   // hash the server displayed. SPL TransferChecked AND Jupiter swaps both
   // fall in that bucket.
-  const isBlindSign = isSpl || isJupiterSwap || isMarginfi;
+  const isBlindSign = isSpl || isJupiterSwap || isMarginfi || isMarinade;
   const ledgerHash = isBlindSign ? solanaLedgerMessageHash(tx.messageBase64) : null;
 
   const checksPayload = {
@@ -1418,17 +1452,36 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
                   "  - Fee: <est. fee in SOL>",
                   "  - Note: one-time deterministic PDA — no rent-exempt seed moved",
                 ]
-              : [
-                  // marginfi_supply / withdraw / borrow / repay — same shape,
-                  // only the "Action" bullet text differs; keep one template.
-                  `  - Headline: \"Prepared MarginFi ${marginfiActionLabel} — <amount> <symbol>\"`,
-                  "  - Wallet: <from address>",
-                  "  - MarginfiAccount: <marginfiAccount from decoded.args>",
-                  "  - Bank: <bank from decoded.args> (<symbol>)",
-                  "  - Amount: <human amount + symbol>",
-                  ...(nonceBullet ? [nonceBullet] : []),
-                  "  - Fee: <est. fee in SOL>",
-                ];
+              : tx.action === "marinade_stake"
+                ? [
+                    "  - Headline: \"Prepared Marinade stake — <amountSol> SOL → mSOL\"",
+                    "  - Wallet: <from address>",
+                    "  - Amount: <amountSol> SOL (deposit)",
+                    "  - mSOL ATA: <mSolAta from decoded.args (created on first stake if missing)>",
+                    ...(nonceBullet ? [nonceBullet] : []),
+                    "  - Fee: <est. fee in SOL>",
+                  ]
+                : tx.action === "marinade_unstake_immediate"
+                  ? [
+                      "  - Headline: \"Prepared Marinade liquid unstake — <amountMSol> mSOL → SOL (via pool, with fee)\"",
+                      "  - Wallet: <from address>",
+                      "  - Amount: <amountMSol> mSOL (burned)",
+                      "  - mSOL ATA: <mSolAta from decoded.args>",
+                      "  - Note: routes via Marinade's liquidity pool — small fee, immediate (NOT delayed-unstake / OrderUnstake — that flow needs an ephemeral signer and isn't shipped here)",
+                      ...(nonceBullet ? [nonceBullet] : []),
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : [
+                      // marginfi_supply / withdraw / borrow / repay — same shape,
+                      // only the "Action" bullet text differs; keep one template.
+                      `  - Headline: \"Prepared MarginFi ${marginfiActionLabel} — <amount> <symbol>\"`,
+                      "  - Wallet: <from address>",
+                      "  - MarginfiAccount: <marginfiAccount from decoded.args>",
+                      "  - Bank: <bank from decoded.args> (<symbol>)",
+                      "  - Amount: <human amount + symbol>",
+                      ...(nonceBullet ? [nonceBullet] : []),
+                      "  - Fee: <est. fee in SOL>",
+                    ];
 
   const inspectorUrl = solanaInspectorUrl(tx.messageBase64);
 

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -49,7 +49,9 @@ export interface SolanaDraftMeta {
     | "marginfi_supply"
     | "marginfi_withdraw"
     | "marginfi_borrow"
-    | "marginfi_repay";
+    | "marginfi_repay"
+    | "marinade_stake"
+    | "marinade_unstake_immediate";
   from: string;
   description: string;
   decoded: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -778,7 +778,9 @@ export interface UnsignedSolanaTx {
     | "marginfi_supply"
     | "marginfi_withdraw"
     | "marginfi_borrow"
-    | "marginfi_repay";
+    | "marginfi_repay"
+    | "marinade_stake"
+    | "marinade_unstake_immediate";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/solana-marinade.test.ts
+++ b/test/solana-marinade.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+
+/**
+ * Marinade write-builder tests. Mocks the Marinade SDK so we never touch
+ * Marinade's heavy transitive deps (Anchor + a Borsh codec for the on-chain
+ * state) and never hit a real Solana RPC. Asserts:
+ *   - ix[0] is SystemProgram.nonceAdvance (durable-nonce protection mirror
+ *     of marginfi/jupiter); the SDK's deposit/liquidUnstake instructions
+ *     are appended after.
+ *   - The stored draft is v0 (carries empty addressLookupTableAccounts) and
+ *     has the right meta (action, decoded.args, nonce metadata).
+ *   - Pre-flight: missing nonce account → throwNonceRequired error.
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const MARINADE_PROGRAM_ID = new PublicKey(
+  "MarBmsSgKXdrN1egZf5sqe1TMThczhMLJhJtoesFiF1",
+);
+const FAKE_MSOL_ATA = new PublicKey(
+  "8JUjWjAyXTMB4ZXcV7nk3p6Gg1fWAAoSCHEPugYzj22h",
+);
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+// SDK fake — we drive the result shape from each test (deposit + liquidUnstake
+// both return `{ associatedMSolTokenAccountAddress, transaction }`).
+const depositMock = vi.fn();
+const liquidUnstakeMock = vi.fn();
+vi.mock("@marinade.finance/marinade-ts-sdk", () => {
+  class MarinadeConfig {
+    constructor(public opts: unknown) {}
+  }
+  class Marinade {
+    constructor(public config: unknown) {}
+    deposit(...args: unknown[]) {
+      return depositMock(...args);
+    }
+    liquidUnstake(...args: unknown[]) {
+      return liquidUnstakeMock(...args);
+    }
+  }
+  return { MarinadeConfig, Marinade };
+});
+
+// Anchor BN — we don't need a real BN, just a `toString` method since
+// the builder only converts the bigint via `new BN(lamports.toString())`
+// and hands it to the SDK (which we've mocked).
+vi.mock("@coral-xyz/anchor", () => ({
+  BN: class {
+    constructor(public value: string) {}
+    toString(): string {
+      return this.value;
+    }
+  },
+}));
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    authority: WALLET_KEYPAIR.publicKey,
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+function fakeMarinadeIx(label: string): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: MARINADE_PROGRAM_ID,
+    keys: [],
+    data: Buffer.from(label, "utf-8"),
+  });
+}
+
+function fakeMarinadeResult(actionLabel: string) {
+  const tx = new Transaction();
+  tx.add(fakeMarinadeIx(`${actionLabel}-1`));
+  tx.add(fakeMarinadeIx(`${actionLabel}-2`));
+  return {
+    associatedMSolTokenAccountAddress: FAKE_MSOL_ATA,
+    transaction: tx,
+  };
+}
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  connectionStub.getLatestBlockhash.mockReset();
+  depositMock.mockReset();
+  liquidUnstakeMock.mockReset();
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildMarinadeStake", () => {
+  it("wraps marinade.deposit with nonceAdvance at ix[0] and stamps decoded args", async () => {
+    await setNoncePresent();
+    depositMock.mockResolvedValue(fakeMarinadeResult("deposit"));
+
+    const { buildMarinadeStake } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    const prepared = await buildMarinadeStake({
+      wallet: WALLET,
+      amountSol: "1.5",
+    });
+
+    expect(prepared.action).toBe("marinade_stake");
+    expect(prepared.chain).toBe("solana");
+    expect(prepared.from).toBe(WALLET);
+    expect(prepared.description).toContain("1.5 SOL");
+    expect(prepared.decoded.functionName).toBe("marinade.deposit");
+    expect(prepared.decoded.args.wallet).toBe(WALLET);
+    expect(prepared.decoded.args.amountSol).toBe("1.5");
+    expect(prepared.decoded.args.mSolAta).toBe(FAKE_MSOL_ATA.toBase58());
+    expect(prepared.nonceAccount).toBeDefined();
+
+    // SDK got the lamport-quantized amount (1.5 SOL = 1_500_000_000).
+    expect(depositMock).toHaveBeenCalledTimes(1);
+    const bnArg = depositMock.mock.calls[0][0] as { toString(): string };
+    expect(bnArg.toString()).toBe("1500000000");
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    expect(draft.kind).toBe("v0");
+    if (draft.kind !== "v0") throw new Error("unreachable");
+
+    // ix[0] = SystemProgram.nonceAdvance, tag 04000000.
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+
+    // ix[1..] = the SDK's deposit instructions, in order.
+    expect(draft.instructions.length).toBe(3);
+    expect(draft.instructions[1].programId.toBase58()).toBe(
+      MARINADE_PROGRAM_ID.toBase58(),
+    );
+    expect(draft.instructions[1].data.toString("utf-8")).toBe("deposit-1");
+    expect(draft.instructions[2].data.toString("utf-8")).toBe("deposit-2");
+
+    // Empty ALTs (this PR doesn't ship any Marinade-specific lookup tables).
+    expect(draft.addressLookupTableAccounts).toEqual([]);
+
+    // Nonce meta survives for the pin step's consistency guard.
+    expect(draft.meta.nonce?.account).toBe(prepared.nonceAccount);
+    expect(draft.meta.nonce?.authority).toBe(WALLET);
+    expect(draft.meta.action).toBe("marinade_stake");
+  });
+
+  it("rejects non-positive / non-finite SOL amounts with a clear error", async () => {
+    await setNoncePresent();
+    const { buildMarinadeStake } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    await expect(
+      buildMarinadeStake({ wallet: WALLET, amountSol: "0" }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+    await expect(
+      buildMarinadeStake({ wallet: WALLET, amountSol: "-1" }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+    await expect(
+      buildMarinadeStake({ wallet: WALLET, amountSol: "abc" }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+  });
+
+  it("throws nonce-required when the wallet has no durable-nonce account", async () => {
+    await setNonceMissing();
+    const { buildMarinadeStake } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    await expect(
+      buildMarinadeStake({ wallet: WALLET, amountSol: "1" }),
+    ).rejects.toThrow(/nonce account not initialized/i);
+  });
+});
+
+describe("buildMarinadeUnstakeImmediate", () => {
+  it("wraps marinade.liquidUnstake with nonceAdvance at ix[0] and stamps decoded args", async () => {
+    await setNoncePresent();
+    liquidUnstakeMock.mockResolvedValue(fakeMarinadeResult("liquidUnstake"));
+
+    const { buildMarinadeUnstakeImmediate } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    const prepared = await buildMarinadeUnstakeImmediate({
+      wallet: WALLET,
+      amountMSol: "0.25",
+    });
+
+    expect(prepared.action).toBe("marinade_unstake_immediate");
+    expect(prepared.description).toContain("0.25 mSOL");
+    expect(prepared.description).toContain("via liquidity pool");
+    expect(prepared.decoded.functionName).toBe("marinade.liquidUnstake");
+    expect(prepared.decoded.args.amountMSol).toBe("0.25");
+    expect(prepared.decoded.args.mSolAta).toBe(FAKE_MSOL_ATA.toBase58());
+
+    // mSOL has 9 decimals; 0.25 → 250_000_000 base units.
+    const bnArg = liquidUnstakeMock.mock.calls[0][0] as {
+      toString(): string;
+    };
+    expect(bnArg.toString()).toBe("250000000");
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+    expect(draft.instructions[1].data.toString("utf-8")).toBe("liquidUnstake-1");
+    expect(draft.meta.action).toBe("marinade_unstake_immediate");
+  });
+
+  it("rejects bad mSOL amounts with a clear error", async () => {
+    await setNoncePresent();
+    const { buildMarinadeUnstakeImmediate } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    await expect(
+      buildMarinadeUnstakeImmediate({ wallet: WALLET, amountMSol: "0" }),
+    ).rejects.toThrow(/Invalid mSOL amount/);
+  });
+});
+
+describe("renderSolanaAgentTaskBlock — marinade actions", () => {
+  it("treats marinade_stake as blind-sign (Message Hash on-device, CHECK 2 runs)", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const { solanaLedgerMessageHash } = await import(
+      "../src/signing/verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "marinade_stake" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description: "Marinade stake: deposit 1.5 SOL → mSOL",
+      decoded: {
+        functionName: "marinade.deposit",
+        args: {
+          wallet: WALLET,
+          amountSol: "1.5",
+          mSolAta: FAKE_MSOL_ATA.toBase58(),
+        },
+      },
+      nonce: {
+        account: "NonceAcct1",
+        authority: WALLET,
+        value: "Gfnhk",
+      },
+    };
+    const expectedHash = solanaLedgerMessageHash(tx.messageBase64);
+    const block = renderSolanaAgentTaskBlock(tx);
+
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain(expectedHash);
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    // Stake-flavored summary lines.
+    expect(block).toContain("SOL → mSOL");
+    expect(block).toContain("Marinade stake");
+    // Durable-nonce mode reaffirmed.
+    expect(block).toContain("durable-nonce-protected");
+  });
+
+  it("treats marinade_unstake_immediate as blind-sign with the unstake-flavored summary", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "marinade_unstake_immediate" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description:
+        "Marinade liquid unstake: 0.25 mSOL → SOL (via liquidity pool, with fee)",
+      decoded: {
+        functionName: "marinade.liquidUnstake",
+        args: {
+          wallet: WALLET,
+          amountMSol: "0.25",
+          mSolAta: FAKE_MSOL_ATA.toBase58(),
+        },
+      },
+      nonce: {
+        account: "NonceAcct1",
+        authority: WALLET,
+        value: "Gfnhk",
+      },
+    };
+    const block = renderSolanaAgentTaskBlock(tx);
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    expect(block).toContain("Marinade liquid unstake");
+    expect(block).toContain("mSOL → SOL");
+  });
+});
+
+describe("solanaActionLabel + verification artifact wiring", () => {
+  it("renderSolanaPrepareSummaryBlock surfaces the human label for marinade_stake", async () => {
+    const { renderSolanaPrepareSummaryBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderSolanaPrepareSummaryBlock({
+      handle: "h",
+      action: "marinade_stake",
+      from: WALLET,
+      description: "Marinade stake: deposit 1 SOL → mSOL",
+      decoded: {
+        functionName: "marinade.deposit",
+        args: { wallet: WALLET, amountSol: "1" },
+      },
+    });
+    expect(block).toContain("Marinade stake (SOL → mSOL)");
+  });
+
+  it("includes ledgerMessageHash in the Solana verification artifact for marinade actions", async () => {
+    await setNoncePresent();
+    depositMock.mockResolvedValue(fakeMarinadeResult("deposit"));
+
+    const { buildMarinadeStake } = await import(
+      "../src/modules/solana/marinade.js"
+    );
+    const prepared = await buildMarinadeStake({
+      wallet: WALLET,
+      amountSol: "1",
+    });
+
+    // Pin a fresh blockhash so the artifact path has a `messageBase64` to hash.
+    const { pinSolanaHandle } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    pinSolanaHandle(
+      prepared.handle,
+      "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    );
+
+    const { getVerificationArtifact } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const artifact = getVerificationArtifact({ handle: prepared.handle });
+    expect(artifact.chain).toBe("solana");
+    if (artifact.chain !== "solana") throw new Error("unreachable");
+    expect(artifact.action).toBe("marinade_stake");
+    expect(artifact.ledgerMessageHash).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

First batch of Solana staking writes from the roadmap. Adds two new `prepare_*` tools driving Marinade's liquid staking:

- **`prepare_marinade_stake`** — `marinade.deposit` (SOL → mSOL).
- **`prepare_marinade_unstake_immediate`** — `marinade.liquidUnstake` (mSOL → SOL via the liquidity pool, with a small fee).

Both reuse the durable-nonce pipeline (`ix[0] = nonceAdvance`) and the standard CHECKS PERFORMED render path — treated as blind-sign on Ledger since Marinade's program isn't in the Solana app's clear-sign registry.

## Why no delayed-unstake (`OrderUnstake`) here

The SDK's `marinade.orderUnstake` returns a `ticketAccountKeypair: web3.Keypair` ephemeral signer, which isn't compatible with the Ledger-only signing model without separate ticket-account derivation work. Tracked as a follow-up; immediate-via-pool covers the user need for \"exit my mSOL position now\" with a fee disclosure.

## What's wired

- `src/modules/solana/marinade.ts` — builders + nonce wrapper
- Schemas + handlers + tool registration in `index.ts` / `execution/index.ts` / `execution/schemas.ts`
- Action variants on `UnsignedSolanaTx`, `SolanaDraftMeta`, `PreparedSolanaTx`, `RenderableSolanaPrepareResult`, `SolanaVerificationArtifact`
- Summary shapes in `renderSolanaAgentTaskBlock` / `renderSolanaPrepareAgentTaskBlock`
- Blind-sign list in `getVerificationArtifact`

## Test plan

- [x] Unit tests cover: nonceAdvance ix[0] composition, decoded.args stamping, draft v0 shape + nonce meta survival, amount validation, missing-nonce preflight, blind-sign render branch, and the verification artifact ledger-message-hash path
- [x] `npm run build` clean
- [x] `npx vitest run` — 814 tests, 66 files, all green
- [ ] Live mainnet smoke test on a small mSOL stake/unstake pair (deferred to user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)