### PR TITLE
feat(diagnostics): get_vaultpilot_config_status — read-only config snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 - `get_transaction_history` — merged recent-tx reader across external / ERC-20 / internal (and Solana `program_interaction`) with 4byte-decoded methods and historical USD values (Etherscan for EVM, TronGrid for TRON, Solana RPC for Solana)
 - `get_tron_staking`, `list_tron_witnesses` — TRON staking state + SR list
 - `get_solana_setup_status` — cheap probe of a wallet's Solana setup PDAs (nonce + MarginFi account existence)
+- `get_vaultpilot_config_status` — diagnostic snapshot of the local server config (RPC source per chain, API-key presence per service, paired-account counts, WC session-topic suffix, preflight-skill state). Strict no-secrets contract — booleans / counts / source enums / topic suffix only, never values. Use to triage "why isn't my balance read working" before suggesting `vaultpilot-mcp-setup`.
 - `resolve_ens_name`, `reverse_resolve_ens` — ENS forward/reverse
 - `get_swap_quote` (LiFi, EVM), `get_solana_swap_quote` (Jupiter v6)
 - `check_contract_security`, `check_permission_risks`, `get_protocol_risk_score` — risk tooling

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ import {
 import { getPortfolioSummary } from "./modules/portfolio/index.js";
 import { getPortfolioSummaryInput } from "./modules/portfolio/schemas.js";
 
+import { getVaultPilotConfigStatus } from "./modules/diagnostics/index.js";
+
 import { getTransactionHistory } from "./modules/history/index.js";
 import { getTransactionHistoryInput } from "./modules/history/schemas.js";
 
@@ -113,6 +115,7 @@ import {
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
   getSolanaSetupStatusInput,
+  getVaultPilotConfigStatusInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -1449,6 +1452,25 @@ async function main() {
       inputSchema: getSolanaSetupStatusInput.shape,
     },
     handler(getSolanaSetupStatus)
+  );
+
+  server.registerTool(
+    "get_vaultpilot_config_status",
+    {
+      description:
+        "READ-ONLY — report what the server knows about its local config without revealing any " +
+        "secret values. Returns the config-file path + existence, server version, per-chain RPC " +
+        "URL source classification (env-var / provider-key / custom-url / public-fallback), " +
+        "API-key presence + source per service (Etherscan, 1inch, TronGrid, WalletConnect — " +
+        "boolean + source enum, never values), counts of paired Ledger accounts (Solana / TRON), " +
+        "the WC session-topic SUFFIX (last 8 chars only — same convention as get_ledger_status), " +
+        "and the agent-side preflight-skill install state. Pure local I/O — reads " +
+        "~/.vaultpilot-mcp/config.json + process.env, no RPC calls, no network. Use this when " +
+        "the user asks 'is my config set up correctly' or 'why is my Solana balance read failing' " +
+        "before suggesting they re-run setup or paste keys.",
+      inputSchema: getVaultPilotConfigStatusInput.shape,
+    },
+    handler(getVaultPilotConfigStatus)
   );
 
   server.registerTool(

--- a/src/modules/diagnostics/index.ts
+++ b/src/modules/diagnostics/index.ts
@@ -1,0 +1,194 @@
+/**
+ * Read-only diagnostic tool: report what the server knows about its config
+ * without revealing any secret values. Intended for the future agent-guided
+ * `/setup` skill (separate repo) but immediately useful for a user
+ * diagnosing "is my server configured the way I think it is?".
+ *
+ * Strict no-secrets contract:
+ *  - Never echoes raw API keys, RPC URLs (which may carry keys in the path),
+ *    WC session symkeys, or paired-account private material.
+ *  - WC session topic surfaces only as the last 8 chars (matches the
+ *    existing `get_ledger_status` convention — enough to cross-check
+ *    against Ledger Live's connected-apps list).
+ *  - Per-key fields are reduced to `{ set: boolean; source: "env-var" |
+ *    "config" | "unset" }`.
+ *
+ * Pure local I/O: reads `~/.vaultpilot-mcp/config.json` and inspects
+ * `process.env`. No RPC calls, no network. Cheap to invoke on every
+ * `/setup` step.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readUserConfig, getConfigPath } from "../../config/user-config.js";
+import { SUPPORTED_CHAINS, type SupportedChain } from "../../types/index.js";
+
+type EvmRpcSource =
+  | "env-var"
+  | "provider-key-env"
+  | "provider-key-config"
+  | "custom-url-config"
+  | "public-fallback";
+
+type SolanaRpcSource = "env-var" | "config-url" | "public-fallback";
+
+type ApiKeySource = "env-var" | "config" | "unset";
+
+const ENV_URL_VAR: Record<SupportedChain, string> = {
+  ethereum: "ETHEREUM_RPC_URL",
+  arbitrum: "ARBITRUM_RPC_URL",
+  polygon: "POLYGON_RPC_URL",
+  base: "BASE_RPC_URL",
+  optimism: "OPTIMISM_RPC_URL",
+};
+
+/**
+ * Determine the source of the EVM RPC URL for a given chain. Mirrors the
+ * priority order in `src/config/chains.ts:resolveRpcUrlRaw`. Replicated
+ * deliberately rather than refactored-and-shared so a refactor of the
+ * resolver doesn't accidentally change diagnostic output.
+ */
+function classifyEvmRpcSource(chain: SupportedChain): EvmRpcSource {
+  if (process.env[ENV_URL_VAR[chain]]) return "env-var";
+  const envProvider = process.env.RPC_PROVIDER?.toLowerCase();
+  if (
+    (envProvider === "infura" || envProvider === "alchemy") &&
+    process.env.RPC_API_KEY
+  ) {
+    return "provider-key-env";
+  }
+  const cfg = readUserConfig();
+  if (cfg) {
+    if (cfg.rpc.provider === "custom" && cfg.rpc.customUrls?.[chain]) {
+      return "custom-url-config";
+    }
+    if (
+      (cfg.rpc.provider === "infura" || cfg.rpc.provider === "alchemy") &&
+      cfg.rpc.apiKey
+    ) {
+      return "provider-key-config";
+    }
+  }
+  return "public-fallback";
+}
+
+function classifySolanaRpcSource(): SolanaRpcSource {
+  if (process.env.SOLANA_RPC_URL) return "env-var";
+  if (readUserConfig()?.solanaRpcUrl) return "config-url";
+  return "public-fallback";
+}
+
+function classifyApiKey(envName: string, configValue: unknown): { set: boolean; source: ApiKeySource } {
+  if (process.env[envName]) return { set: true, source: "env-var" };
+  if (typeof configValue === "string" && configValue.length > 0) {
+    return { set: true, source: "config" };
+  }
+  return { set: false, source: "unset" };
+}
+
+interface VaultPilotConfigStatus {
+  /** Where this server expects to read / write its config file. */
+  configPath: string;
+  /** Whether the config file exists on disk right now. */
+  configFileExists: boolean;
+  /** vaultpilot-mcp version (read from package.json at process start). */
+  serverVersion: string;
+  /** Per-chain RPC URL source classification (no URLs leaked). */
+  rpc: Record<SupportedChain | "solana", { source: EvmRpcSource | SolanaRpcSource }>;
+  /** Per-service API key presence + source. Boolean-only — values never leak. */
+  apiKeys: {
+    etherscan: { set: boolean; source: ApiKeySource };
+    oneInch: { set: boolean; source: ApiKeySource };
+    tronGrid: { set: boolean; source: ApiKeySource };
+    walletConnectProjectId: { set: boolean; source: ApiKeySource };
+  };
+  /** Counts of paired Ledger accounts + WC session-topic suffix (last 8 chars). */
+  pairings: {
+    walletConnect: { sessionTopicSuffix?: string };
+    solana: { count: number };
+    tron: { count: number };
+  };
+  /**
+   * Agent-side preflight skill state — checked by path, no content read.
+   * Override path via VAULTPILOT_SKILL_MARKER_PATH env var (read-only sniff —
+   * we don't validate the skill content here).
+   */
+  preflightSkill: {
+    expectedPath: string;
+    installed: boolean;
+  };
+}
+
+/**
+ * Resolve the server version by reading `package.json` relative to this
+ * file's compiled location. Falls back to `"unknown"` if the file isn't
+ * found (e.g. unusual install layouts) — diagnostic output, not load-bearing.
+ */
+function readServerVersion(): string {
+  try {
+    const here = fileURLToPath(import.meta.url);
+    // Compiled location: dist/modules/diagnostics/index.js → ../../../package.json
+    const pkgPath = join(here, "..", "..", "..", "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+const DEFAULT_SKILL_MARKER = join(
+  homedir(),
+  ".claude",
+  "skills",
+  "vaultpilot-preflight",
+  "SKILL.md",
+);
+
+function skillMarkerPath(): string {
+  return process.env.VAULTPILOT_SKILL_MARKER_PATH ?? DEFAULT_SKILL_MARKER;
+}
+
+export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): VaultPilotConfigStatus {
+  const cfg = readUserConfig();
+  const configPath = getConfigPath();
+
+  const rpc = {} as VaultPilotConfigStatus["rpc"];
+  for (const chain of SUPPORTED_CHAINS) {
+    rpc[chain] = { source: classifyEvmRpcSource(chain) };
+  }
+  rpc.solana = { source: classifySolanaRpcSource() };
+
+  // WC session-topic last-8-chars suffix only (mirrors `get_ledger_status`).
+  const sessionTopic = cfg?.walletConnect?.sessionTopic;
+  const sessionTopicSuffix =
+    typeof sessionTopic === "string" && sessionTopic.length >= 8
+      ? sessionTopic.slice(-8)
+      : undefined;
+
+  const skillPath = skillMarkerPath();
+  return {
+    configPath,
+    configFileExists: existsSync(configPath),
+    serverVersion: readServerVersion(),
+    rpc,
+    apiKeys: {
+      etherscan: classifyApiKey("ETHERSCAN_API_KEY", cfg?.etherscanApiKey),
+      oneInch: classifyApiKey("ONEINCH_API_KEY", cfg?.oneInchApiKey),
+      tronGrid: classifyApiKey("TRON_API_KEY", cfg?.tronApiKey),
+      walletConnectProjectId: classifyApiKey(
+        "WALLETCONNECT_PROJECT_ID",
+        cfg?.walletConnect?.projectId,
+      ),
+    },
+    pairings: {
+      walletConnect: sessionTopicSuffix ? { sessionTopicSuffix } : {},
+      solana: { count: cfg?.pairings?.solana?.length ?? 0 },
+      tron: { count: cfg?.pairings?.tron?.length ?? 0 },
+    },
+    preflightSkill: {
+      expectedPath: skillPath,
+      installed: existsSync(skillPath),
+    },
+  };
+}

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -310,6 +310,16 @@ export const getSolanaSetupStatusInput = z.object({
   ),
 });
 
+/**
+ * No args — `get_vaultpilot_config_status` returns a structured snapshot of
+ * the local server config, intended for diagnostic / onboarding flows.
+ * The output deliberately never echoes any secret values (API keys, RPC
+ * URLs that may carry keys, full WC session topics) — every field is
+ * either a boolean, a count, a category enum, or a session-topic suffix
+ * (last 8 chars).
+ */
+export const getVaultPilotConfigStatusInput = z.object({});
+
 export const getMarginfiPositionsInput = z.object({
   wallet: solanaAddressSchema.describe(
     "Solana wallet to enumerate MarginFi positions for. Probes the first 4 MarginfiAccount " +
@@ -613,3 +623,4 @@ export type PrepareMarinadeUnstakeImmediateArgs = z.infer<
 export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;
 export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPositionsInput>;
 export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;
+export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;

--- a/test/diagnostics-config-status.test.ts
+++ b/test/diagnostics-config-status.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `get_vaultpilot_config_status`. Mounts a temp HOME so the
+ * config-file resolver lands somewhere we control, then exercises every
+ * source-classification branch by combining env-var presence and config-
+ * file content.
+ *
+ * The strict no-secrets contract is verified by sweeping the output for
+ * known secret-shaped values that were planted in env/config — none of
+ * them should appear anywhere in the structured response.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "vaultpilot-config-status-test-"));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  process.env.VAULTPILOT_CONFIG_DIR = join(tmpHome, ".vaultpilot-mcp");
+  // Make sure no leftover process env from another test affects classification.
+  delete process.env.ETHEREUM_RPC_URL;
+  delete process.env.ARBITRUM_RPC_URL;
+  delete process.env.POLYGON_RPC_URL;
+  delete process.env.BASE_RPC_URL;
+  delete process.env.OPTIMISM_RPC_URL;
+  delete process.env.SOLANA_RPC_URL;
+  delete process.env.RPC_PROVIDER;
+  delete process.env.RPC_API_KEY;
+  delete process.env.ETHERSCAN_API_KEY;
+  delete process.env.ONEINCH_API_KEY;
+  delete process.env.TRON_API_KEY;
+  delete process.env.WALLETCONNECT_PROJECT_ID;
+  delete process.env.VAULTPILOT_SKILL_MARKER_PATH;
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.VAULTPILOT_CONFIG_DIR;
+});
+
+/**
+ * Force a fresh module load so each test sees its own env / fs state. The
+ * diagnostics module reads `process.env` and the config file at call time
+ * rather than at module-eval, so this isn't strictly required, but it's
+ * cheap insurance against module-cache surprises.
+ */
+async function loadFresh() {
+  return await import(
+    "../src/modules/diagnostics/index.js?ts=" + Date.now()
+  );
+}
+
+function writeConfig(content: Record<string, unknown>): void {
+  const dir = join(tmpHome, ".vaultpilot-mcp");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = join(dir, "config.json");
+  writeFileSync(path, JSON.stringify(content, null, 2), { mode: 0o600 });
+  // The reader rejects symlinks/hardlinks; ensure mode is 0o600.
+  chmodSync(path, 0o600);
+}
+
+describe("get_vaultpilot_config_status — RPC source classification", () => {
+  it("reports public-fallback for every chain when nothing is configured", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.ethereum.source).toBe("public-fallback");
+    expect(status.rpc.arbitrum.source).toBe("public-fallback");
+    expect(status.rpc.polygon.source).toBe("public-fallback");
+    expect(status.rpc.base.source).toBe("public-fallback");
+    expect(status.rpc.optimism.source).toBe("public-fallback");
+    expect(status.rpc.solana.source).toBe("public-fallback");
+  });
+
+  it("reports env-var when ETHEREUM_RPC_URL is set", async () => {
+    process.env.ETHEREUM_RPC_URL = "https://my-eth-rpc.example.com/SECRET";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.ethereum.source).toBe("env-var");
+    // Other chains stay public-fallback.
+    expect(status.rpc.arbitrum.source).toBe("public-fallback");
+  });
+
+  it("reports provider-key-env when RPC_PROVIDER + RPC_API_KEY are set", async () => {
+    process.env.RPC_PROVIDER = "alchemy";
+    process.env.RPC_API_KEY = "secret-key-do-not-leak";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.ethereum.source).toBe("provider-key-env");
+    expect(status.rpc.arbitrum.source).toBe("provider-key-env");
+  });
+
+  it("reports provider-key-config when config has infura+key but no env", async () => {
+    writeConfig({ rpc: { provider: "infura", apiKey: "config-key-secret" } });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.ethereum.source).toBe("provider-key-config");
+  });
+
+  it("reports custom-url-config when config has a custom URL for that chain", async () => {
+    writeConfig({
+      rpc: {
+        provider: "custom",
+        customUrls: { ethereum: "https://node.example.com/" },
+      },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.ethereum.source).toBe("custom-url-config");
+    // Chains without a custom URL fall back to public.
+    expect(status.rpc.arbitrum.source).toBe("public-fallback");
+  });
+
+  it("reports env-var for Solana when SOLANA_RPC_URL is set", async () => {
+    process.env.SOLANA_RPC_URL = "https://mainnet.helius-rpc.com/?api-key=SECRET";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.solana.source).toBe("env-var");
+  });
+
+  it("reports config-url for Solana when only the config field is set", async () => {
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      solanaRpcUrl: "https://mainnet.helius-rpc.com/?api-key=CONFIG-SECRET",
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.rpc.solana.source).toBe("config-url");
+  });
+});
+
+describe("get_vaultpilot_config_status — API key source classification", () => {
+  it("all keys unset when nothing is set", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.apiKeys.etherscan).toEqual({ set: false, source: "unset" });
+    expect(status.apiKeys.oneInch).toEqual({ set: false, source: "unset" });
+    expect(status.apiKeys.tronGrid).toEqual({ set: false, source: "unset" });
+    expect(status.apiKeys.walletConnectProjectId).toEqual({
+      set: false,
+      source: "unset",
+    });
+  });
+
+  it("env-var source wins over config", async () => {
+    process.env.ETHERSCAN_API_KEY = "env-secret";
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      etherscanApiKey: "config-secret",
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.apiKeys.etherscan.set).toBe(true);
+    expect(status.apiKeys.etherscan.source).toBe("env-var");
+  });
+
+  it("falls back to config when env var is unset", async () => {
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      tronApiKey: "config-tron-secret",
+      walletConnect: { projectId: "config-wc-secret" },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.apiKeys.tronGrid).toEqual({ set: true, source: "config" });
+    expect(status.apiKeys.walletConnectProjectId).toEqual({
+      set: true,
+      source: "config",
+    });
+  });
+});
+
+describe("get_vaultpilot_config_status — pairings + WC topic suffix", () => {
+  it("returns zero counts + no topic suffix when nothing is paired", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.pairings.solana.count).toBe(0);
+    expect(status.pairings.tron.count).toBe(0);
+    expect(status.pairings.walletConnect).toEqual({});
+  });
+
+  it("returns pairings count from the persisted config", async () => {
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      pairings: {
+        solana: [
+          {
+            address: "wallet1",
+            path: "44'/501'/0'",
+            accountIndex: 0,
+            appVersion: "1",
+          },
+          {
+            address: "wallet2",
+            path: "44'/501'/1'",
+            accountIndex: 1,
+            appVersion: "1",
+          },
+        ],
+        tron: [
+          { address: "T1", path: "44'/195'/0'", accountIndex: 0, appVersion: "1" },
+        ],
+      },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.pairings.solana.count).toBe(2);
+    expect(status.pairings.tron.count).toBe(1);
+  });
+
+  it("surfaces only the LAST 8 chars of the WC session topic, never the full value", async () => {
+    const fullTopic =
+      "abcdef0123456789abcdef0123456789abcdef0123456789a1b2c3d4";
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      walletConnect: { projectId: "wc-secret", sessionTopic: fullTopic },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.pairings.walletConnect.sessionTopicSuffix).toBe("a1b2c3d4");
+    // Sweep the entire output for the full topic — must not appear anywhere.
+    expect(JSON.stringify(status)).not.toContain(fullTopic.slice(0, 16));
+  });
+});
+
+describe("get_vaultpilot_config_status — preflight skill detection", () => {
+  it("reports installed:false when the marker file doesn't exist", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.preflightSkill.installed).toBe(false);
+    expect(status.preflightSkill.expectedPath).toContain("vaultpilot-preflight");
+  });
+
+  it("respects VAULTPILOT_SKILL_MARKER_PATH override", async () => {
+    const marker = join(tmpHome, "fake-skill-marker");
+    writeFileSync(marker, "x");
+    process.env.VAULTPILOT_SKILL_MARKER_PATH = marker;
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.preflightSkill.expectedPath).toBe(marker);
+    expect(status.preflightSkill.installed).toBe(true);
+  });
+});
+
+describe("get_vaultpilot_config_status — strict no-secrets contract", () => {
+  it("never echoes any planted secret value anywhere in the output", async () => {
+    const SECRETS = {
+      etherscan: "ETHSCAN-PLANT-SECRET-DO-NOT-LEAK",
+      oneInch: "ONEINCH-PLANT-SECRET-DO-NOT-LEAK",
+      tron: "TRON-PLANT-SECRET-DO-NOT-LEAK",
+      wcProject: "WC-PLANT-SECRET-DO-NOT-LEAK",
+      ethRpc: "https://mainnet.example.com/PLANT-RPC-SECRET",
+      providerKey: "ALCHEMY-PLANT-PROVIDER-KEY-SECRET",
+      solanaRpc: "https://helius.example.com/?api-key=PLANT-SOLANA-SECRET",
+      wcTopic: "topic_with_secret_session_keying_material_do_not_leak",
+    } as const;
+    process.env.ETHERSCAN_API_KEY = SECRETS.etherscan;
+    process.env.ONEINCH_API_KEY = SECRETS.oneInch;
+    process.env.TRON_API_KEY = SECRETS.tron;
+    process.env.WALLETCONNECT_PROJECT_ID = SECRETS.wcProject;
+    process.env.ETHEREUM_RPC_URL = SECRETS.ethRpc;
+    process.env.RPC_PROVIDER = "alchemy";
+    process.env.RPC_API_KEY = SECRETS.providerKey;
+    process.env.SOLANA_RPC_URL = SECRETS.solanaRpc;
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "irrelevant-env-overrides" },
+      walletConnect: {
+        projectId: "config-irrelevant-env-overrides",
+        sessionTopic: SECRETS.wcTopic,
+      },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    const serialized = JSON.stringify(status);
+    for (const planted of Object.values(SECRETS)) {
+      expect(serialized).not.toContain(planted);
+    }
+    // But the source classifications are still correct.
+    expect(status.apiKeys.etherscan.source).toBe("env-var");
+    expect(status.rpc.solana.source).toBe("env-var");
+  });
+});
+
+describe("get_vaultpilot_config_status — basic shape", () => {
+  it("includes serverVersion + configPath + configFileExists", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.configPath).toContain(".vaultpilot-mcp");
+    expect(status.configFileExists).toBe(false);
+    expect(typeof status.serverVersion).toBe("string");
+    expect(status.serverVersion.length).toBeGreaterThan(0);
+  });
+
+  it("flips configFileExists when the file is written", async () => {
+    writeConfig({ rpc: { provider: "infura", apiKey: "k" } });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.configFileExists).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Item 2.1 (server-side half) from `claude-work/HIGH-plan-broad-audience-onboarding.md`. Ships the diagnostic tool the future agent-guided `/setup` skill will call to know what the user's already configured. Independently useful for triage today.

Branched directly off latest `main` (post-#147 + #145).

## What ships

New tool `get_vaultpilot_config_status` registered in `src/index.ts` and backed by `src/modules/diagnostics/index.ts`. Read-only, pure local I/O — reads `~/.vaultpilot-mcp/config.json` and inspects `process.env`. No RPC calls, no network.

## Output shape (every field is non-secret)

| Field | Type | Notes |
|---|---|---|
| `configPath` + `configFileExists` + `serverVersion` | strings + boolean | Where the server reads / writes its config |
| `rpc.<chain>.source` (EVM, per chain) | enum | `env-var` \| `provider-key-env` \| `provider-key-config` \| `custom-url-config` \| `public-fallback` |
| `rpc.solana.source` | enum | `env-var` \| `config-url` \| `public-fallback` |
| `apiKeys.{etherscan,oneInch,tronGrid,walletConnectProjectId}` | `{ set: boolean, source: "env-var" \| "config" \| "unset" }` | Boolean only — values never leak |
| `pairings.{solana,tron}.count` | integer | Counts, not addresses |
| `pairings.walletConnect.sessionTopicSuffix` | string \| undefined | Last 8 chars only, matching `get_ledger_status` convention |
| `preflightSkill.{expectedPath, installed}` | string + boolean | Respects `VAULTPILOT_SKILL_MARKER_PATH` override |

## Strict no-secrets contract

The output is booleans, counts, source-classification enums, and an 8-char topic suffix. **Never raw API keys, RPC URLs, or session topics.** A dedicated test plants seven distinct secrets across env vars + config and asserts none appear in the serialized response.

## Test plan

- [x] `npm test` — **848/848** pass (+18 new diagnostics tests).
- [x] `npm run build` — clean.
- [x] Coverage: 5 EVM RPC source-classification branches, 3 Solana branches, env-vs-config priority, WC topic-suffix extraction, pairings count, preflight-skill detection + override, no-secrets sweep.
- [ ] Manual: invoke the tool against a fresh install + a fully-configured install and eyeball the output.

## Deferred

The agent-guided `/setup` slash command (the SKILL side of item 2.1) is a separate external repo (`vaultpilot-setup-skill`) — out of scope. This tool is the contract the skill will call against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)