### PR TITLE
feat(native-stake): prepare_native_stake_delegate / deactivate / withdraw (roadmap #3 PR2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,9 @@ import {
   prepareMarginfiRepay,
   prepareMarinadeStake,
   prepareMarinadeUnstakeImmediate,
+  prepareNativeStakeDelegate,
+  prepareNativeStakeDeactivate,
+  prepareNativeStakeWithdraw,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -109,6 +112,9 @@ import {
   prepareMarginfiRepayInput,
   prepareMarinadeStakeInput,
   prepareMarinadeUnstakeImmediateInput,
+  prepareNativeStakeDelegateInput,
+  prepareNativeStakeDeactivateInput,
+  prepareNativeStakeWithdrawInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1432,6 +1438,55 @@ async function main() {
       inputSchema: prepareMarinadeUnstakeImmediateInput.shape,
     },
     handler(prepareMarinadeUnstakeImmediate)
+  );
+
+  server.registerTool(
+    "prepare_native_stake_delegate",
+    {
+      description:
+        "Build an unsigned native-stake-program tx that creates a fresh stake account at a " +
+        "deterministic address (derived per (wallet, validator) via createAccountWithSeed) and " +
+        "delegates it to the given validator vote account. Funds the stake account with " +
+        "`amountSol` SOL of active principal PLUS a ~0.00228 SOL rent-exempt seed (reclaimable " +
+        "on full withdraw). Authority is the user's wallet for both staker + withdrawer roles " +
+        "— no separate authority handoff is supported in this server. DURABLE NONCE REQUIRED. " +
+        "Refuses if a stake account already exists at the deterministic address (the user " +
+        "almost certainly meant prepare_native_stake_deactivate / withdraw on the existing " +
+        "position). BLIND-SIGN on Ledger by default — match the Message Hash on-device.",
+      inputSchema: prepareNativeStakeDelegateInput.shape,
+    },
+    handler(prepareNativeStakeDelegate)
+  );
+
+  server.registerTool(
+    "prepare_native_stake_deactivate",
+    {
+      description:
+        "Build an unsigned native-stake deactivate tx. Initiates the one-epoch (~2-3 days) " +
+        "cooldown after which the stake becomes withdrawable; the stake earns no rewards during " +
+        "deactivation. Wallet must be the stake account's staker authority. After the cooldown " +
+        "lapses, run prepare_native_stake_withdraw to drain the account (or partial-withdraw to " +
+        "leave it open). DURABLE NONCE REQUIRED + same Ledger blind-sign treatment as " +
+        "prepare_native_stake_delegate. The on-chain stake program reverts if the stake is " +
+        "already deactivating/inactive — the simulation gate catches it.",
+      inputSchema: prepareNativeStakeDeactivateInput.shape,
+    },
+    handler(prepareNativeStakeDeactivate)
+  );
+
+  server.registerTool(
+    "prepare_native_stake_withdraw",
+    {
+      description:
+        "Build an unsigned native-stake withdraw tx. Pulls `amountSol` SOL (or 'max' for the " +
+        "full lamport balance) from an inactive stake account back into the wallet. 'max' closes " +
+        "the account and reclaims the rent-exempt seed; partial-withdraw leaves the account open. " +
+        "Stake MUST be inactive (one full epoch after deactivate) — on-chain reverts otherwise; " +
+        "the simulation gate catches it. DURABLE NONCE REQUIRED + same Ledger blind-sign treatment " +
+        "as prepare_native_stake_delegate.",
+      inputSchema: prepareNativeStakeWithdrawInput.shape,
+    },
+    handler(prepareNativeStakeWithdraw)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -99,6 +99,9 @@ import type {
   PrepareMarginfiRepayArgs,
   PrepareMarinadeStakeArgs,
   PrepareMarinadeUnstakeImmediateArgs,
+  PrepareNativeStakeDelegateArgs,
+  PrepareNativeStakeDeactivateArgs,
+  PrepareNativeStakeWithdrawArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -360,6 +363,47 @@ export async function prepareMarinadeUnstakeImmediate(
   const prepared = await buildMarinadeUnstakeImmediate({
     wallet: args.wallet,
     amountMSol: args.amountMSol,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareNativeStakeDelegate(
+  args: PrepareNativeStakeDelegateArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildNativeStakeDelegate } = await import(
+    "../solana/native-stake.js"
+  );
+  const prepared = await buildNativeStakeDelegate({
+    wallet: args.wallet,
+    validator: args.validator,
+    amountSol: args.amountSol,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareNativeStakeDeactivate(
+  args: PrepareNativeStakeDeactivateArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildNativeStakeDeactivate } = await import(
+    "../solana/native-stake.js"
+  );
+  const prepared = await buildNativeStakeDeactivate({
+    wallet: args.wallet,
+    stakeAccount: args.stakeAccount,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareNativeStakeWithdraw(
+  args: PrepareNativeStakeWithdrawArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildNativeStakeWithdraw } = await import(
+    "../solana/native-stake.js"
+  );
+  const prepared = await buildNativeStakeWithdraw({
+    wallet: args.wallet,
+    stakeAccount: args.stakeAccount,
+    amountSol: args.amountSol,
   });
   return prepared as unknown as PreparedSolanaTx;
 }
@@ -1751,7 +1795,10 @@ export interface SolanaVerificationArtifact {
     | "marginfi_borrow"
     | "marginfi_repay"
     | "marinade_stake"
-    | "marinade_unstake_immediate";
+    | "marinade_unstake_immediate"
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
   from: string;
   messageBase64: string;
   recentBlockhash: string;
@@ -1867,6 +1914,9 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       "marginfi_repay",
       "marinade_stake",
       "marinade_unstake_immediate",
+      "native_stake_delegate",
+      "native_stake_deactivate",
+      "native_stake_withdraw",
     ]);
     const ledgerMessageHash = blindSignActions.has(tx.action)
       ? solanaLedgerMessageHash(tx.messageBase64)

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -301,6 +301,75 @@ export const prepareMarinadeUnstakeImmediateInput = z.object({
     ),
 });
 
+/**
+ * Native Solana stake-program write actions. Stake account is deterministic
+ * per (wallet, validator) — the same `(wallet, validator)` pair always
+ * yields the same stake-account address. To exit a position, run
+ * `prepare_native_stake_deactivate` (one-epoch cooldown), then
+ * `prepare_native_stake_withdraw` once the cooldown lapses.
+ */
+export const prepareNativeStakeDelegateInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet that funds the stake account and becomes its staker + " +
+      "withdrawer authority. Must have an initialized durable-nonce account " +
+      "(prepare_solana_nonce_init) and enough SOL to cover the stake amount + " +
+      "rent-exempt seed (~0.00228 SOL) + tx fee. Refuses if a stake account " +
+      "already exists at the deterministic address for this (wallet, validator)."
+  ),
+  validator: solanaAddressSchema.describe(
+    "Vote-account address (NOT validator identity) of the validator to delegate " +
+      "to. Solana's stake program delegates to vote accounts, which validators " +
+      "publish alongside their identity. Use a Solana explorer to find the " +
+      "vote account for a chosen validator."
+  ),
+  amountSol: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable SOL amount to stake (e.g. "1.5"). Decimals are SOL-native ' +
+        '(9). The actual lamports moved from the wallet are this value PLUS the ' +
+        'stake account rent-exempt minimum (~0.00228 SOL); the rent-exempt floor ' +
+        'is reclaimable on full withdraw after deactivation.'
+    ),
+});
+
+export const prepareNativeStakeDeactivateInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet — must be the stake account's staker authority (the wallet " +
+      "that originally created the stake)."
+  ),
+  stakeAccount: solanaAddressSchema.describe(
+    "Base58 stake account address to deactivate. Discovery: call " +
+      "get_solana_staking_positions; the wallet's native stake accounts are " +
+      "listed under `native[].stakePubkey`. Deactivation takes one epoch " +
+      "(~2-3 days); the stake earns no rewards during the cooldown but stays " +
+      "non-withdrawable until it lapses."
+  ),
+});
+
+export const prepareNativeStakeWithdrawInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet — must be the stake account's withdrawer authority + " +
+      "receives the SOL. (For stakes created via prepare_native_stake_delegate, " +
+      "wallet === staker === withdrawer; no authority handoff is supported in " +
+      "this server.)"
+  ),
+  stakeAccount: solanaAddressSchema.describe(
+    "Base58 stake account address to withdraw from. Stake must be inactive " +
+      "(one full epoch after prepare_native_stake_deactivate). On-chain reverts " +
+      "if the stake is still cooling down — the simulation gate catches it."
+  ),
+  amountSol: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable SOL amount to withdraw (e.g. "1.5"), OR the literal ' +
+        'string "max" to withdraw the full lamport balance (closes the stake ' +
+        'account and reclaims the rent-exempt seed). Partial withdraws leave ' +
+        'the account open with a smaller balance.'
+    ),
+});
+
 export const getSolanaSetupStatusInput = z.object({
   wallet: solanaAddressSchema.describe(
     "Solana wallet to probe. Returns the state of the durable-nonce account " +
@@ -609,6 +678,15 @@ export type PrepareMarginfiRepayArgs = z.infer<typeof prepareMarginfiRepayInput>
 export type PrepareMarinadeStakeArgs = z.infer<typeof prepareMarinadeStakeInput>;
 export type PrepareMarinadeUnstakeImmediateArgs = z.infer<
   typeof prepareMarinadeUnstakeImmediateInput
+>;
+export type PrepareNativeStakeDelegateArgs = z.infer<
+  typeof prepareNativeStakeDelegateInput
+>;
+export type PrepareNativeStakeDeactivateArgs = z.infer<
+  typeof prepareNativeStakeDeactivateInput
+>;
+export type PrepareNativeStakeWithdrawArgs = z.infer<
+  typeof prepareNativeStakeWithdrawInput
 >;
 export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;
 export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPositionsInput>;

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -121,7 +121,10 @@ export interface PreparedSolanaTx {
     | "marginfi_borrow"
     | "marginfi_repay"
     | "marinade_stake"
-    | "marinade_unstake_immediate";
+    | "marinade_unstake_immediate"
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
   chain: "solana";
   from: string;
   description: string;

--- a/src/modules/solana/native-stake.ts
+++ b/src/modules/solana/native-stake.ts
@@ -1,0 +1,384 @@
+import {
+  PublicKey,
+  StakeProgram,
+  Authorized,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+
+/**
+ * Native Solana stake-program write actions — `prepare_native_stake_delegate`,
+ * `prepare_native_stake_deactivate`, `prepare_native_stake_withdraw`.
+ *
+ * Strategy mirrors `nonce.ts` for the create+initialize ceremony: derive the
+ * stake account address deterministically via `createAccountWithSeed`. The
+ * user wallet (basePubkey === fromPubkey) is the only signer — no ephemeral
+ * keypair, Ledger-compatible. One stake account per `(wallet, validator)`
+ * tuple; re-running delegate against the same validator hits an "account
+ * already exists" check at preflight.
+ *
+ * Stake authority defaults to the user's wallet (both staker + withdrawer).
+ * Lockup is `Lockup.default` (zero-lockup) — no custodian, no epoch lock.
+ *
+ * Treated as BLIND-SIGN on Ledger by default. `StakeInstruction` ops
+ * (`Delegate`, `Deactivate`, `Withdraw`) may or may not be in the Solana
+ * app's clear-sign allowlist; without device-confirmed evidence we assume
+ * the most conservative path (matches Marinade / MarginFi treatment).
+ *
+ * For deactivate / withdraw the user passes the stake account pubkey
+ * directly. Recommended discovery path: call `get_solana_staking_positions`
+ * first — its `native[]` section enumerates the user's existing stakes.
+ *
+ * Pre-flight delegated to `simulatePinnedSolanaTx` (the Solana sim gate).
+ * The on-chain stake program enforces invariant rules (deactivate requires
+ * active stake; withdraw requires inactive stake; etc.) — simulation
+ * surfaces a clear error before the user signs.
+ */
+
+export interface PrepareNativeStakeDelegateParams {
+  /** Base58 wallet address — funds the stake account, becomes its staker + withdrawer authority. */
+  wallet: string;
+  /**
+   * Base58 vote account address of the validator to delegate to. NOT the
+   * validator's identity address — Solana's stake program delegates to a
+   * vote account, which the validator publishes alongside its identity.
+   */
+  validator: string;
+  /**
+   * Human-readable SOL amount to stake. Decimals are SOL-native (9). Note:
+   * the actual lamports moved from the wallet are this value PLUS the
+   * stake account's rent-exempt minimum (~0.00228 SOL); the rent-exempt
+   * floor is reclaimable on full withdraw after deactivation.
+   */
+  amountSol: string;
+}
+
+export interface PrepareNativeStakeDeactivateParams {
+  /** Base58 wallet address — must be the stake account's staker authority. */
+  wallet: string;
+  /** Base58 stake account pubkey to deactivate. */
+  stakeAccount: string;
+}
+
+export interface PrepareNativeStakeWithdrawParams {
+  /** Base58 wallet address — must be the stake account's withdrawer authority + receives the SOL. */
+  wallet: string;
+  /** Base58 stake account pubkey to withdraw from. */
+  stakeAccount: string;
+  /**
+   * Human-readable SOL amount to withdraw, OR the literal string "max" to
+   * withdraw the full lamport balance (which closes the account and
+   * reclaims the rent-exempt seed). On-chain the program enforces that
+   * the stake be inactive — partial-withdraw on an active stake reverts.
+   */
+  amountSol: string;
+}
+
+export interface PreparedNativeStakeTx {
+  handle: string;
+  action:
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  /** Nonce-account PDA for this wallet (durable-nonce-protected). */
+  nonceAccount: string;
+  /** Rent cost of the new stake account, surfaced on delegate only. */
+  rentLamports?: number;
+  /** Stake account address — surfaced on delegate so the user can refer to it later. */
+  stakeAccount?: string;
+}
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+/**
+ * Per-validator stake-account seed prefix. Constant tag plus a 12-char
+ * suffix derived from the validator's vote account address keeps each
+ * `(wallet, validator)` pair on its own deterministic stake account
+ * while staying well under the 32-char seed limit.
+ */
+const STAKE_SEED_PREFIX = "vps-v1-";
+
+function deriveStakeSeed(validator: PublicKey): string {
+  // 12-char suffix gives ~62-bit collision space across validators per
+  // wallet. Vote-account addresses are dense enough that any 12-char prefix
+  // is unique in practice; collisions don't break safety (a collision just
+  // means two validators would share an address, which fails on-chain at
+  // delegate time because the stake account's vote target would be wrong).
+  return `${STAKE_SEED_PREFIX}${validator.toBase58().slice(0, 12)}`;
+}
+
+export async function deriveStakeAccountAddress(
+  wallet: PublicKey,
+  validator: PublicKey,
+): Promise<PublicKey> {
+  const seed = deriveStakeSeed(validator);
+  return PublicKey.createWithSeed(wallet, seed, StakeProgram.programId);
+}
+
+function solToLamports(solDecimal: string): bigint {
+  const bn = new BigNumber(solDecimal);
+  if (!bn.isFinite() || bn.lte(0)) {
+    throw new Error(
+      `Invalid SOL amount "${solDecimal}" — expected a positive decimal (e.g. "1.5").`,
+    );
+  }
+  return BigInt(
+    bn.times(LAMPORTS_PER_SOL).integerValue(BigNumber.ROUND_DOWN).toString(10),
+  );
+}
+
+async function loadNonceContext(walletStr: string): Promise<{
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+}> {
+  const fromPubkey = assertSolanaAddress(walletStr);
+  const conn = getSolanaConnection();
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(walletStr);
+  return { fromPubkey, noncePubkey, nonceValue: nonceState!.nonce };
+}
+
+function buildDraft(args: {
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+  walletStr: string;
+  action: PreparedNativeStakeTx["action"];
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  actionIxs: TransactionInstruction[];
+  rentLamports?: number;
+}): SolanaTxDraft {
+  const nonceIx = buildAdvanceNonceIx(args.noncePubkey, args.fromPubkey);
+  const instructions: TransactionInstruction[] = [nonceIx, ...args.actionIxs];
+  return {
+    kind: "v0",
+    payerKey: args.fromPubkey,
+    instructions,
+    addressLookupTableAccounts: [],
+    meta: {
+      action: args.action,
+      from: args.walletStr,
+      description: args.description,
+      decoded: args.decoded,
+      ...(args.rentLamports !== undefined
+        ? { rentLamports: args.rentLamports }
+        : {}),
+      nonce: {
+        account: args.noncePubkey.toBase58(),
+        authority: args.fromPubkey.toBase58(),
+        value: args.nonceValue,
+      },
+    },
+  };
+}
+
+export async function buildNativeStakeDelegate(
+  p: PrepareNativeStakeDelegateParams,
+): Promise<PreparedNativeStakeTx> {
+  const stakeLamports = solToLamports(p.amountSol);
+  const validatorPk = assertSolanaAddress(p.validator);
+  const ctx = await loadNonceContext(p.wallet);
+  const conn = getSolanaConnection();
+
+  const stakePubkey = await deriveStakeAccountAddress(ctx.fromPubkey, validatorPk);
+  // Refuse if a stake account already exists at this deterministic address —
+  // the user almost certainly meant to manage it (deactivate/withdraw) rather
+  // than re-delegate. createAccountWithSeed would revert anyway, but a
+  // structured pre-flight error is a better UX.
+  const existing = await conn.getAccountInfo(stakePubkey);
+  if (existing) {
+    throw new Error(
+      `Stake account ${stakePubkey.toBase58()} already exists for wallet ${p.wallet} ` +
+        `+ validator ${p.validator}. Manage the existing position via prepare_native_stake_deactivate ` +
+        `/ prepare_native_stake_withdraw — this tool only creates fresh stakes. ` +
+        `(Stake account is deterministic per (wallet, validator); to create a second ` +
+        `stake to the same validator you'd need a non-deterministic flow that isn't shipped here.)`,
+    );
+  }
+  const rentLamports = await conn.getMinimumBalanceForRentExemption(
+    StakeProgram.space,
+  );
+
+  const seed = deriveStakeSeed(validatorPk);
+  // StakeProgram.createAccountWithSeed returns a Transaction containing two
+  // ixs (SystemProgram.createAccountWithSeed + StakeInstruction.initialize).
+  // Extract them and splice into the v0 message. lamports = stake principal
+  // + rent-exempt seed; the seed is reclaimable on full withdraw after
+  // deactivation.
+  const createTx = StakeProgram.createAccountWithSeed({
+    fromPubkey: ctx.fromPubkey,
+    stakePubkey,
+    basePubkey: ctx.fromPubkey,
+    seed,
+    authorized: new Authorized(ctx.fromPubkey, ctx.fromPubkey),
+    lamports: Number(stakeLamports) + rentLamports,
+  });
+  const delegateTx = StakeProgram.delegate({
+    stakePubkey,
+    authorizedPubkey: ctx.fromPubkey,
+    votePubkey: validatorPk,
+  });
+  const actionIxs = [...createTx.instructions, ...delegateTx.instructions];
+
+  const description =
+    `Native stake delegate: ${p.amountSol} SOL → validator ${p.validator} ` +
+    `(stake account ${stakePubkey.toBase58()})`;
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    action: "native_stake_delegate",
+    description,
+    decoded: {
+      functionName: "stake.createWithSeed+delegate",
+      args: {
+        wallet: p.wallet,
+        validator: p.validator,
+        amountSol: p.amountSol,
+        stakeAccount: stakePubkey.toBase58(),
+        rentLamports: String(rentLamports),
+        nonceAccount: ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+    rentLamports,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "native_stake_delegate",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+    rentLamports,
+    stakeAccount: stakePubkey.toBase58(),
+  };
+}
+
+export async function buildNativeStakeDeactivate(
+  p: PrepareNativeStakeDeactivateParams,
+): Promise<PreparedNativeStakeTx> {
+  const stakePubkey = assertSolanaAddress(p.stakeAccount);
+  const ctx = await loadNonceContext(p.wallet);
+
+  const deactivateTx = StakeProgram.deactivate({
+    stakePubkey,
+    authorizedPubkey: ctx.fromPubkey,
+  });
+  const description = `Native stake deactivate: ${p.stakeAccount} (takes one epoch ≈ 2-3 days before withdrawable)`;
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    action: "native_stake_deactivate",
+    description,
+    decoded: {
+      functionName: "stake.deactivate",
+      args: {
+        wallet: p.wallet,
+        stakeAccount: p.stakeAccount,
+        nonceAccount: ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs: [...deactivateTx.instructions],
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "native_stake_deactivate",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}
+
+export async function buildNativeStakeWithdraw(
+  p: PrepareNativeStakeWithdrawParams,
+): Promise<PreparedNativeStakeTx> {
+  const stakePubkey = assertSolanaAddress(p.stakeAccount);
+  const ctx = await loadNonceContext(p.wallet);
+  const conn = getSolanaConnection();
+
+  let withdrawLamports: bigint;
+  if (p.amountSol === "max") {
+    const info = await conn.getAccountInfo(stakePubkey);
+    if (!info) {
+      throw new Error(
+        `Stake account ${p.stakeAccount} not found on-chain. Confirm the address ` +
+          `via get_solana_staking_positions.`,
+      );
+    }
+    withdrawLamports = BigInt(info.lamports);
+  } else {
+    withdrawLamports = solToLamports(p.amountSol);
+  }
+
+  const withdrawTx = StakeProgram.withdraw({
+    stakePubkey,
+    authorizedPubkey: ctx.fromPubkey,
+    toPubkey: ctx.fromPubkey,
+    lamports: Number(withdrawLamports),
+  });
+  const amountLabel =
+    p.amountSol === "max"
+      ? `MAX (${(Number(withdrawLamports) / LAMPORTS_PER_SOL).toFixed(9)} SOL — closes the stake account)`
+      : `${p.amountSol} SOL`;
+  const description = `Native stake withdraw: ${amountLabel} from ${p.stakeAccount} → ${p.wallet}`;
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    action: "native_stake_withdraw",
+    description,
+    decoded: {
+      functionName: "stake.withdraw",
+      args: {
+        wallet: p.wallet,
+        stakeAccount: p.stakeAccount,
+        amountSol: p.amountSol,
+        lamports: String(withdrawLamports),
+        nonceAccount: ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs: [...withdrawTx.instructions],
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "native_stake_withdraw",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -894,7 +894,10 @@ export interface RenderableSolanaPrepareResult {
     | "marginfi_borrow"
     | "marginfi_repay"
     | "marinade_stake"
-    | "marinade_unstake_immediate";
+    | "marinade_unstake_immediate"
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -936,6 +939,12 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "Marinade stake (SOL → mSOL)";
     case "marinade_unstake_immediate":
       return "Marinade liquid unstake (mSOL → SOL via pool)";
+    case "native_stake_delegate":
+      return "Native stake delegate (create stake account + delegate to validator)";
+    case "native_stake_deactivate":
+      return "Native stake deactivate (one-epoch cooldown before withdrawable)";
+    case "native_stake_withdraw":
+      return "Native stake withdraw (from inactive stake account)";
   }
 }
 
@@ -995,6 +1004,7 @@ export function renderSolanaPrepareAgentTaskBlock(
 ): string {
   const isMarginfi = r.action.startsWith("marginfi_");
   const isMarinade = r.action.startsWith("marinade_");
+  const isNativeStake = r.action.startsWith("native_stake_");
   const marginfiActionWord =
     r.action === "marginfi_init"
       ? "MarginFi account init"
@@ -1013,6 +1023,14 @@ export function renderSolanaPrepareAgentTaskBlock(
       : r.action === "marinade_unstake_immediate"
         ? "Marinade liquid unstake"
         : null;
+  const nativeStakeActionWord =
+    r.action === "native_stake_delegate"
+      ? "native stake delegate"
+      : r.action === "native_stake_deactivate"
+        ? "native stake deactivate"
+        : r.action === "native_stake_withdraw"
+          ? "native stake withdraw"
+          : null;
   const actionWord =
     r.action === "native_send"
       ? "native SOL send"
@@ -1024,7 +1042,7 @@ export function renderSolanaPrepareAgentTaskBlock(
             ? "durable-nonce close"
             : r.action === "jupiter_swap"
               ? "Jupiter swap"
-              : marginfiActionWord ?? marinadeActionWord ?? "Solana tx";
+              : marginfiActionWord ?? marinadeActionWord ?? nativeStakeActionWord ?? "Solana tx";
   const nonceBullet =
     r.nonceAccount && r.action !== "nonce_init"
       ? ["  - Nonce: <short nonce-account addr>"]
@@ -1118,6 +1136,34 @@ export function renderSolanaPrepareAgentTaskBlock(
                       "  - Wallet: <from address>",
                       "  - Amount: <amountMSol> mSOL (burned)",
                       "  - mSOL ATA: <mSolAta from decoded.args>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : r.action === "native_stake_delegate"
+                  ? [
+                      "  - Headline: \"Prepared native stake delegate — <amountSol> SOL → validator <short>\"",
+                      "  - Wallet: <from address>",
+                      "  - Validator: <validator from decoded.args>",
+                      "  - Stake amount: <amountSol> SOL",
+                      "  - Stake account: <stakeAccount from decoded.args>",
+                      "  - Rent-exempt seed: <rentLamports>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : r.action === "native_stake_deactivate"
+                  ? [
+                      "  - Headline: \"Prepared native stake deactivate — <stakeAccount short>\"",
+                      "  - Wallet: <from address>",
+                      "  - Stake account: <stakeAccount from decoded.args>",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : r.action === "native_stake_withdraw"
+                  ? [
+                      "  - Headline: \"Prepared native stake withdraw — <amountSol> SOL from <stakeAccount short>\"",
+                      "  - Wallet: <from + recipient>",
+                      "  - Stake account: <stakeAccount from decoded.args>",
+                      "  - Amount: <amountSol> SOL (or 'max')",
                       ...nonceBullet,
                       "  - Fee: <est. fee in SOL>",
                     ]
@@ -1277,6 +1323,10 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   const isMarinade =
     tx.action === "marinade_stake" ||
     tx.action === "marinade_unstake_immediate";
+  const isNativeStake =
+    tx.action === "native_stake_delegate" ||
+    tx.action === "native_stake_deactivate" ||
+    tx.action === "native_stake_withdraw";
   const marginfiActionLabel =
     tx.action === "marginfi_init"
       ? "account init"
@@ -1356,14 +1406,14 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // as ix[0] — this flag drives the "DURABLE-NONCE MODE" explainer text +
   // the Nonce bullet in the summary + the expected-shape text for CHECK 1.
   const hasAdvanceNonceIx =
-    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi || isMarinade;
+    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi || isMarinade || isNativeStake;
   // The Ledger Solana app only clear-signs a small allowlist of programs
   // (System Program's transfer/advance/initialize/withdraw, and a few
   // others). Everything else falls to blind-sign, which shows only the
   // Message Hash on-device and requires the user to match it against the
   // hash the server displayed. SPL TransferChecked AND Jupiter swaps both
   // fall in that bucket.
-  const isBlindSign = isSpl || isJupiterSwap || isMarginfi || isMarinade;
+  const isBlindSign = isSpl || isJupiterSwap || isMarginfi || isMarinade || isNativeStake;
   const ledgerHash = isBlindSign ? solanaLedgerMessageHash(tx.messageBase64) : null;
 
   const checksPayload = {
@@ -1471,7 +1521,38 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
                       ...(nonceBullet ? [nonceBullet] : []),
                       "  - Fee: <est. fee in SOL>",
                     ]
-                  : [
+                  : tx.action === "native_stake_delegate"
+                    ? [
+                        "  - Headline: \"Prepared native stake delegate — <amountSol> SOL → validator <short>\"",
+                        "  - Wallet: <from address>",
+                        "  - Validator: <validator vote pubkey from decoded.args>",
+                        "  - Stake amount: <amountSol> SOL (active principal)",
+                        "  - Stake account: <stakeAccount from decoded.args (deterministic per (wallet, validator))>",
+                        "  - Rent-exempt seed: <rentLamports from decoded.args> lamports (~0.00228 SOL — reclaimable on full withdraw)",
+                        ...(nonceBullet ? [nonceBullet] : []),
+                        "  - Fee: <est. fee in SOL>",
+                        "  - Note: stake activates next epoch (~2-3 days); use prepare_native_stake_deactivate then prepare_native_stake_withdraw to exit",
+                      ]
+                    : tx.action === "native_stake_deactivate"
+                      ? [
+                          "  - Headline: \"Prepared native stake deactivate — <stakeAccount short>\"",
+                          "  - Wallet: <from address>",
+                          "  - Stake account: <stakeAccount from decoded.args>",
+                          ...(nonceBullet ? [nonceBullet] : []),
+                          "  - Fee: <est. fee in SOL>",
+                          "  - Note: deactivation takes one epoch (~2-3 days). After it lands, prepare_native_stake_withdraw can fully drain.",
+                        ]
+                      : tx.action === "native_stake_withdraw"
+                        ? [
+                            "  - Headline: \"Prepared native stake withdraw — <amountSol> SOL from <stakeAccount short>\"",
+                            "  - Wallet: <from + recipient (same address)>",
+                            "  - Stake account: <stakeAccount from decoded.args>",
+                            "  - Amount: <amountSol> SOL (or 'max' = full balance, closes the account)",
+                            ...(nonceBullet ? [nonceBullet] : []),
+                            "  - Fee: <est. fee in SOL>",
+                            "  - Note: stake account must already be inactive (1 epoch after deactivate); on-chain reverts otherwise",
+                          ]
+                        : [
                       // marginfi_supply / withdraw / borrow / repay — same shape,
                       // only the "Action" bullet text differs; keep one template.
                       `  - Headline: \"Prepared MarginFi ${marginfiActionLabel} — <amount> <symbol>\"`,

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -51,7 +51,10 @@ export interface SolanaDraftMeta {
     | "marginfi_borrow"
     | "marginfi_repay"
     | "marinade_stake"
-    | "marinade_unstake_immediate";
+    | "marinade_unstake_immediate"
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
   from: string;
   description: string;
   decoded: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -780,7 +780,10 @@ export interface UnsignedSolanaTx {
     | "marginfi_borrow"
     | "marginfi_repay"
     | "marinade_stake"
-    | "marinade_unstake_immediate";
+    | "marinade_unstake_immediate"
+    | "native_stake_delegate"
+    | "native_stake_deactivate"
+    | "native_stake_withdraw";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/solana-native-stake.test.ts
+++ b/test/solana-native-stake.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair, PublicKey, StakeProgram } from "@solana/web3.js";
+
+/**
+ * Native stake-program write builders. Mocks the RPC at the Connection
+ * boundary (getAccountInfo + getMinimumBalanceForRentExemption + nonce). The
+ * builders themselves call into `@solana/web3.js`'s `StakeProgram` static
+ * helpers, which are pure ix factories — no network, no signing — so we
+ * leave them un-mocked and let the real ix bytes flow through.
+ *
+ * Asserts:
+ *   - ix[0] is SystemProgram.nonceAdvance (durable-nonce protection).
+ *   - delegate path: createAccountWithSeed + StakeInstruction.Initialize +
+ *     StakeInstruction.Delegate, in order, on the same deterministic
+ *     stake-account address derived from (wallet, validator).
+ *   - deactivate / withdraw operate on user-supplied stake account; correct
+ *     authority + amount semantics.
+ *   - "max" withdraw path reads on-chain lamports.
+ *   - Pre-flight: missing nonce → throwNonceRequired; existing stake →
+ *     refuses to overwrite.
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const VALIDATOR_KEYPAIR = Keypair.generate();
+const VALIDATOR = VALIDATOR_KEYPAIR.publicKey.toBase58();
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const STAKE_PROGRAM = StakeProgram.programId.toBase58();
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+  getMinimumBalanceForRentExemption: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    authority: WALLET_KEYPAIR.publicKey,
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  connectionStub.getMinimumBalanceForRentExemption.mockReset();
+  // Live mainnet rent-exempt minimum for the 200-byte stake account.
+  connectionStub.getMinimumBalanceForRentExemption.mockResolvedValue(2_282_880);
+  connectionStub.getLatestBlockhash.mockReset();
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("deriveStakeAccountAddress", () => {
+  it("is deterministic for the same (wallet, validator) pair", async () => {
+    const { deriveStakeAccountAddress } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const a = await deriveStakeAccountAddress(
+      WALLET_KEYPAIR.publicKey,
+      VALIDATOR_KEYPAIR.publicKey,
+    );
+    const b = await deriveStakeAccountAddress(
+      WALLET_KEYPAIR.publicKey,
+      VALIDATOR_KEYPAIR.publicKey,
+    );
+    expect(a.toBase58()).toBe(b.toBase58());
+  });
+
+  it("yields different addresses for different validators under the same wallet", async () => {
+    const { deriveStakeAccountAddress } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const v2 = Keypair.generate();
+    const a = await deriveStakeAccountAddress(
+      WALLET_KEYPAIR.publicKey,
+      VALIDATOR_KEYPAIR.publicKey,
+    );
+    const b = await deriveStakeAccountAddress(WALLET_KEYPAIR.publicKey, v2.publicKey);
+    expect(a.toBase58()).not.toBe(b.toBase58());
+  });
+});
+
+describe("buildNativeStakeDelegate", () => {
+  it("composes nonceAdvance + createAccountWithSeed + initialize + delegate, in order", async () => {
+    await setNoncePresent();
+    // Stake account doesn't exist yet (the common path).
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+
+    const { buildNativeStakeDelegate, deriveStakeAccountAddress } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const expectedStakePk = await deriveStakeAccountAddress(
+      WALLET_KEYPAIR.publicKey,
+      VALIDATOR_KEYPAIR.publicKey,
+    );
+
+    const prepared = await buildNativeStakeDelegate({
+      wallet: WALLET,
+      validator: VALIDATOR,
+      amountSol: "1.5",
+    });
+
+    expect(prepared.action).toBe("native_stake_delegate");
+    expect(prepared.from).toBe(WALLET);
+    expect(prepared.stakeAccount).toBe(expectedStakePk.toBase58());
+    expect(prepared.rentLamports).toBe(2_282_880);
+    expect(prepared.decoded.functionName).toBe("stake.createWithSeed+delegate");
+    expect(prepared.decoded.args.validator).toBe(VALIDATOR);
+    expect(prepared.decoded.args.amountSol).toBe("1.5");
+    expect(prepared.decoded.args.stakeAccount).toBe(expectedStakePk.toBase58());
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+
+    // ix[0] = SystemProgram.nonceAdvance, tag 0x04.
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+
+    // StakeProgram.createAccountWithSeed returns a 2-ix Transaction
+    // (system createWithSeed + stake initialize). Plus the delegate ix
+    // appended after = 4 total action ixs (1 nonce + 3 stake).
+    // Actual breakdown:
+    //   ix[1] = SystemProgram.createAccountWithSeed
+    //   ix[2] = StakeInstruction.Initialize
+    //   ix[3] = StakeInstruction.Delegate
+    expect(draft.instructions.length).toBe(4);
+    expect(draft.instructions[1].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[2].programId.toBase58()).toBe(STAKE_PROGRAM);
+    expect(draft.instructions[3].programId.toBase58()).toBe(STAKE_PROGRAM);
+
+    expect(draft.meta.action).toBe("native_stake_delegate");
+    expect(draft.meta.rentLamports).toBe(2_282_880);
+    expect(draft.meta.nonce?.account).toBe(prepared.nonceAccount);
+  });
+
+  it("refuses when a stake account already exists at the deterministic address", async () => {
+    await setNoncePresent();
+    // Stake account already exists.
+    connectionStub.getAccountInfo.mockResolvedValue({
+      lamports: 1_000_000_000,
+      owner: StakeProgram.programId,
+      data: Buffer.alloc(200),
+      executable: false,
+      rentEpoch: 0,
+    });
+
+    const { buildNativeStakeDelegate } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    await expect(
+      buildNativeStakeDelegate({
+        wallet: WALLET,
+        validator: VALIDATOR,
+        amountSol: "1.5",
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it("rejects bad SOL amounts", async () => {
+    await setNoncePresent();
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+    const { buildNativeStakeDelegate } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    await expect(
+      buildNativeStakeDelegate({
+        wallet: WALLET,
+        validator: VALIDATOR,
+        amountSol: "0",
+      }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+  });
+
+  it("throws nonce-required when the wallet has no durable-nonce account", async () => {
+    await setNonceMissing();
+    const { buildNativeStakeDelegate } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    await expect(
+      buildNativeStakeDelegate({
+        wallet: WALLET,
+        validator: VALIDATOR,
+        amountSol: "1",
+      }),
+    ).rejects.toThrow(/nonce account not initialized/i);
+  });
+});
+
+describe("buildNativeStakeDeactivate", () => {
+  it("wraps StakeProgram.deactivate with nonceAdvance at ix[0]", async () => {
+    await setNoncePresent();
+    const stakeAccount = Keypair.generate().publicKey.toBase58();
+
+    const { buildNativeStakeDeactivate } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const prepared = await buildNativeStakeDeactivate({
+      wallet: WALLET,
+      stakeAccount,
+    });
+
+    expect(prepared.action).toBe("native_stake_deactivate");
+    expect(prepared.description).toContain(stakeAccount);
+    expect(prepared.decoded.functionName).toBe("stake.deactivate");
+    expect(prepared.decoded.args.stakeAccount).toBe(stakeAccount);
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    expect(draft.instructions.length).toBe(2);
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+    expect(draft.instructions[1].programId.toBase58()).toBe(STAKE_PROGRAM);
+  });
+});
+
+describe("buildNativeStakeWithdraw", () => {
+  it("withdraws an explicit SOL amount", async () => {
+    await setNoncePresent();
+    const stakeAccount = Keypair.generate().publicKey.toBase58();
+
+    const { buildNativeStakeWithdraw } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const prepared = await buildNativeStakeWithdraw({
+      wallet: WALLET,
+      stakeAccount,
+      amountSol: "0.5",
+    });
+
+    expect(prepared.action).toBe("native_stake_withdraw");
+    expect(prepared.decoded.args.amountSol).toBe("0.5");
+    expect(prepared.decoded.args.lamports).toBe("500000000");
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    expect(draft.instructions.length).toBe(2);
+    expect(draft.instructions[1].programId.toBase58()).toBe(STAKE_PROGRAM);
+  });
+
+  it("'max' withdraws the full on-chain lamport balance", async () => {
+    await setNoncePresent();
+    const stakeAccount = Keypair.generate().publicKey.toBase58();
+    connectionStub.getAccountInfo.mockResolvedValue({
+      lamports: 7_500_000_000,
+      owner: StakeProgram.programId,
+      data: Buffer.alloc(200),
+      executable: false,
+      rentEpoch: 0,
+    });
+
+    const { buildNativeStakeWithdraw } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const prepared = await buildNativeStakeWithdraw({
+      wallet: WALLET,
+      stakeAccount,
+      amountSol: "max",
+    });
+
+    expect(prepared.decoded.args.amountSol).toBe("max");
+    expect(prepared.decoded.args.lamports).toBe("7500000000");
+    expect(prepared.description).toContain("MAX");
+    expect(prepared.description).toContain("7.500000000 SOL");
+  });
+
+  it("'max' errors clearly when the stake account doesn't exist", async () => {
+    await setNoncePresent();
+    const stakeAccount = Keypair.generate().publicKey.toBase58();
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+
+    const { buildNativeStakeWithdraw } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    await expect(
+      buildNativeStakeWithdraw({
+        wallet: WALLET,
+        stakeAccount,
+        amountSol: "max",
+      }),
+    ).rejects.toThrow(/not found on-chain/);
+  });
+});
+
+describe("renderSolanaAgentTaskBlock — native stake actions", () => {
+  it("treats native_stake_delegate as blind-sign and surfaces validator + amount", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const { solanaLedgerMessageHash } = await import(
+      "../src/signing/verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "native_stake_delegate" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description: "Native stake delegate: 1.5 SOL → validator " + VALIDATOR,
+      decoded: {
+        functionName: "stake.createWithSeed+delegate",
+        args: {
+          wallet: WALLET,
+          validator: VALIDATOR,
+          amountSol: "1.5",
+          stakeAccount: "Stake1111111111111111111111111111111111111",
+          rentLamports: "2282880",
+        },
+      },
+      nonce: {
+        account: "NonceAcct1",
+        authority: WALLET,
+        value: "Gfnhk",
+      },
+    };
+    const expectedHash = solanaLedgerMessageHash(tx.messageBase64);
+    const block = renderSolanaAgentTaskBlock(tx);
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain(expectedHash);
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    expect(block).toContain("native stake delegate");
+    expect(block).toContain("durable-nonce-protected");
+  });
+
+  it("treats native_stake_deactivate / withdraw as blind-sign with action-specific summaries", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const stakeAccount = "Stake1111111111111111111111111111111111111";
+    const deactivateBlock = renderSolanaAgentTaskBlock({
+      chain: "solana" as const,
+      action: "native_stake_deactivate" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description: `Native stake deactivate: ${stakeAccount}`,
+      decoded: {
+        functionName: "stake.deactivate",
+        args: { wallet: WALLET, stakeAccount },
+      },
+      nonce: { account: "NonceAcct1", authority: WALLET, value: "Gfnhk" },
+    });
+    expect(deactivateBlock).toContain("BLIND-SIGN");
+    expect(deactivateBlock).toContain("native stake deactivate");
+    expect(deactivateBlock).toContain("one epoch");
+
+    const withdrawBlock = renderSolanaAgentTaskBlock({
+      chain: "solana" as const,
+      action: "native_stake_withdraw" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+      description: `Native stake withdraw: 1 SOL from ${stakeAccount} → ${WALLET}`,
+      decoded: {
+        functionName: "stake.withdraw",
+        args: {
+          wallet: WALLET,
+          stakeAccount,
+          amountSol: "1",
+          lamports: "1000000000",
+        },
+      },
+      nonce: { account: "NonceAcct1", authority: WALLET, value: "Gfnhk" },
+    });
+    expect(withdrawBlock).toContain("native stake withdraw");
+    expect(withdrawBlock).toContain("inactive");
+  });
+});
+
+describe("verification artifact wiring", () => {
+  it("stamps ledgerMessageHash on the Solana artifact for native stake actions", async () => {
+    await setNoncePresent();
+    const stakeAccount = Keypair.generate().publicKey.toBase58();
+
+    const { buildNativeStakeDeactivate } = await import(
+      "../src/modules/solana/native-stake.js"
+    );
+    const prepared = await buildNativeStakeDeactivate({
+      wallet: WALLET,
+      stakeAccount,
+    });
+
+    const { pinSolanaHandle } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    pinSolanaHandle(
+      prepared.handle,
+      "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    );
+
+    const { getVerificationArtifact } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const artifact = getVerificationArtifact({ handle: prepared.handle });
+    expect(artifact.chain).toBe("solana");
+    if (artifact.chain !== "solana") throw new Error("unreachable");
+    expect(artifact.action).toBe("native_stake_deactivate");
+    expect(artifact.ledgerMessageHash).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Roadmap #3 closes with native Solana stake-program writes. Originally PR2 targeted Jito, but a scope-probe ([memory: `project_jito_stake_pool_sdk_scope`](../tree/main/.claude)) found `@solana/spl-stake-pool`'s `depositSol` / `withdrawSol` both generate ephemeral `Keypair` signers internally — incompatible with Ledger-only signing without bypassing the SDK wrappers. User dropped Jito writes from the roadmap entirely; PR2 swaps in native stakes, which use the deterministic `createAccountWithSeed` pattern (same as our `nonce.ts`) and avoid the issue cleanly.

Three new tools:

- **`prepare_native_stake_delegate(wallet, validator, amountSol)`** — creates a fresh stake account at a deterministic address derived per `(wallet, validator)` and delegates to the validator vote account. Wallet stays as both staker + withdrawer authority. Refuses if a stake already exists at the deterministic address.
- **`prepare_native_stake_deactivate(wallet, stakeAccount)`** — initiates the one-epoch (~2-3 days) cooldown.
- **`prepare_native_stake_withdraw(wallet, stakeAccount, amountSol|\"max\")`** — pulls SOL back from an inactive stake; `\"max\"` closes the account and reclaims the rent-exempt seed.

All three reuse the durable-nonce pipeline (`ix[0] = nonceAdvance`) and the standard CHECKS PERFORMED render path. Treated as blind-sign on Ledger by default — `StakeInstruction` ops may or may not be in the Solana app's clear-sign allowlist; conservative default until live device testing says otherwise.

## What's wired

- `src/modules/solana/native-stake.ts` — builders + nonce wrapper + deterministic stake-account derivation (`vps-v1-<validator-12chars>` seed)
- Schemas + handlers + tool registration
- Action variants on `UnsignedSolanaTx`, `SolanaDraftMeta`, `PreparedSolanaTx`, `RenderableSolanaPrepareResult`, `SolanaVerificationArtifact`
- Summary shapes in `renderSolanaAgentTaskBlock` / `renderSolanaPrepareAgentTaskBlock`
- Blind-sign list in `getVerificationArtifact`

## Test plan

- [x] 13 new unit tests cover: deterministic derivation; delegate ix composition (nonceAdvance + createAccountWithSeed + Initialize + Delegate); existing-stake refusal; deactivate / withdraw composition; `\"max\"` on-chain balance read; amount validation; missing-nonce preflight; blind-sign render branch; verification artifact ledger-message-hash path
- [x] `npm run build` clean
- [x] `npx vitest run` — 843 tests, 68 files, all green
- [ ] Live mainnet smoke test on a small delegate → wait epoch → deactivate → wait epoch → withdraw cycle (deferred to user; the cooldown means this is a multi-day exercise)

## Roadmap status after this PR

Roadmap #3 (Solana staking writes) closes here:
- ✅ Marinade stake / liquid unstake (#145)
- ⏭️ Jito stake / unstake — dropped (SDK ephemeral-signer; Path B feasible but not pursued)
- ✅ Native stake delegate / deactivate / withdraw (this PR)

Next up is roadmap #4 (multi-tx send pipeline) which is a prerequisite for #5 (Kamino).

🤖 Generated with [Claude Code](https://claude.com/claude-code)