### PR TITLE
feat(pair): enrich pair_ledger_* errors with live device-state hints

### DIFF
--- a/src/modules/diagnostics/ledger-device-info.ts
+++ b/src/modules/diagnostics/ledger-device-info.ts
@@ -148,6 +148,51 @@ function hintForOpenError(msg: string): string {
 }
 
 /**
+ * Compute a one-line, error-message-appendable hint based on the current
+ * device state, given the expected app name (e.g. `"Solana"`, `"Tron"`).
+ *
+ * Designed for catch-blocks in `pair_ledger_solana` / `pair_ledger_tron`
+ * (and future signing flows) so a generic `mapLedgerError` message like
+ * *"Ledger is connected but the Tron app isn't open"* can be enriched
+ * with what's *actually* open right now: *"...your Bitcoin app is open
+ * — switch to Tron."*
+ *
+ * Returns `undefined` (caller appends nothing) when:
+ *   - The probe itself fails (no point making one error message about
+ *     a different probe's failure).
+ *   - The device isn't connected — `mapLedgerError` already handles
+ *     that case with its own "plug in / unlock" guidance.
+ *   - The expected app IS already open — the original error must be
+ *     about something else (locked, USB glitch, …) and a "wrong app"
+ *     hint would be misleading.
+ *
+ * Otherwise returns a single sentence describing what to do.
+ */
+export async function getDeviceStateHint(
+  expectedApp: string,
+): Promise<string | undefined> {
+  let info: LedgerDeviceInfo;
+  try {
+    info = await getLedgerDeviceInfo();
+  } catch {
+    return undefined;
+  }
+  if (!info.deviceConnected || !info.openApp) return undefined;
+  if (info.openApp.name === expectedApp) return undefined;
+  if (info.openApp.isDashboard) {
+    return (
+      `Device is on the dashboard right now — open the ${expectedApp} ` +
+      `app on-device (scroll with the side buttons, both buttons to select).`
+    );
+  }
+  return (
+    `Device probe says the ${info.openApp.name} app is open — switch to ` +
+    `the ${expectedApp} app on-device (scroll with the side buttons, both ` +
+    `buttons to select), then retry.`
+  );
+}
+
+/**
  * Probe the currently-connected Ledger's app state. Opens a raw USB HID
  * transport, issues GET_APP_AND_VERSION, closes the transport. One USB
  * roundtrip; safe to call multiple times.

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -47,6 +47,7 @@ import {
   type PreparedSolanaTx,
 } from "../solana/actions.js";
 import { getSolanaConnection } from "../solana/rpc.js";
+import { getDeviceStateHint } from "../diagnostics/ledger-device-info.js";
 import { assertTransactionSafe } from "../../signing/pre-sign-check.js";
 import {
   eip1559PreSignHash,
@@ -173,7 +174,21 @@ export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
 }> {
   const accountIndex = args.accountIndex ?? 0;
   const path = tronPathForAccountIndex(accountIndex);
-  const result = await getTronLedgerAddress(path);
+  let result;
+  try {
+    result = await getTronLedgerAddress(path);
+  } catch (e) {
+    // Enrich the error with device-state probe data (which app is open
+    // RIGHT NOW). The probe runs only on the failure path so successful
+    // pairs don't pay the extra USB round-trip. If the probe itself
+    // fails — likely because the same USB-HID resource is still busy —
+    // we silently fall through to the original error message.
+    const hint = await getDeviceStateHint("Tron");
+    if (hint && e instanceof Error) {
+      throw new Error(`${e.message} ${hint}`, { cause: e });
+    }
+    throw e;
+  }
   setPairedTronAddress(result);
   return {
     address: result.address,
@@ -208,7 +223,17 @@ export async function pairLedgerSolana(
 }> {
   const accountIndex = args.accountIndex ?? 0;
   const path = solanaPathForAccountIndex(accountIndex);
-  const result = await getSolanaLedgerAddress(path);
+  let result;
+  try {
+    result = await getSolanaLedgerAddress(path);
+  } catch (e) {
+    // Same enrichment pattern as pairLedgerTron — see comment there.
+    const hint = await getDeviceStateHint("Solana");
+    if (hint && e instanceof Error) {
+      throw new Error(`${e.message} ${hint}`, { cause: e });
+    }
+    throw e;
+  }
   setPairedSolanaAddress(result);
   return {
     address: result.address,

--- a/test/ledger-device-info.test.ts
+++ b/test/ledger-device-info.test.ts
@@ -188,3 +188,62 @@ describe("getLedgerDeviceInfo (integration with mocked transport)", () => {
     expect(info.openApp?.name).toBe("Ethereum");
   });
 });
+
+describe("getDeviceStateHint (error-message enrichment)", () => {
+  it("returns undefined when the device isn't connected — mapLedgerError already handles it", async () => {
+    openRawLedgerTransport.mockRejectedValue(new Error("No such device"));
+    const { getDeviceStateHint } = await import(
+      "../src/modules/diagnostics/ledger-device-info.js"
+    );
+    expect(await getDeviceStateHint("Solana")).toBeUndefined();
+  });
+
+  it("returns undefined when the expected app is already open", async () => {
+    openRawLedgerTransport.mockResolvedValue({
+      send: vi.fn().mockResolvedValue(buildResponse("Solana", "1.10.2")),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    const { getDeviceStateHint } = await import(
+      "../src/modules/diagnostics/ledger-device-info.js"
+    );
+    expect(await getDeviceStateHint("Solana")).toBeUndefined();
+  });
+
+  it("returns a 'switch app' hint when a different chain app is open", async () => {
+    openRawLedgerTransport.mockResolvedValue({
+      send: vi.fn().mockResolvedValue(buildResponse("Bitcoin", "2.3.0")),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    const { getDeviceStateHint } = await import(
+      "../src/modules/diagnostics/ledger-device-info.js"
+    );
+    const hint = await getDeviceStateHint("Solana");
+    expect(hint).toContain("Bitcoin app is open");
+    expect(hint).toContain("switch to");
+    expect(hint).toContain("Solana");
+  });
+
+  it("returns a 'dashboard' hint when the device is on the dashboard", async () => {
+    openRawLedgerTransport.mockResolvedValue({
+      send: vi.fn().mockResolvedValue(buildResponse("BOLOS", "2.2.0")),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    const { getDeviceStateHint } = await import(
+      "../src/modules/diagnostics/ledger-device-info.js"
+    );
+    const hint = await getDeviceStateHint("Tron");
+    expect(hint).toMatch(/on the dashboard/i);
+    expect(hint).toContain("Tron");
+  });
+
+  it("returns undefined silently when the probe itself throws (no error-on-error)", async () => {
+    openRawLedgerTransport.mockResolvedValue({
+      send: vi.fn().mockRejectedValue(new Error("USB busy")),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    const { getDeviceStateHint } = await import(
+      "../src/modules/diagnostics/ledger-device-info.js"
+    );
+    expect(await getDeviceStateHint("Solana")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Natural follow-up to PR #150 (`get_ledger_device_info`): wires the new probe into the error path of `pair_ledger_solana` / `pair_ledger_tron`.
- When the initial `getAddress` call throws, we run a device-state probe and append a context-aware hint to the error message — e.g. *"your Bitcoin app is open — switch to Solana"* or *"device is on the dashboard — open the Tron app"*.
- Probe is failure-path only, so successful pairs pay no extra USB round-trip. If the probe itself errors (USB still busy on the resource we just failed on), we silently fall through to the original message — no error-on-error.

## Why
Plan item 2.3 of `claude-work/HIGH-plan-broad-audience-onboarding.md`: turn vague "open the X app" boilerplate into concrete next steps the agent can relay verbatim.

## Test plan
- [x] `npm test` — 879 tests pass (5 new tests for `getDeviceStateHint`)
- [x] `npm run build` — clean TS
- [ ] Manual: unplug Ledger → call `pair_ledger_tron` → verify generic "no device" message (probe correctly returns undefined)
- [ ] Manual: dashboard open → call `pair_ledger_solana` → expect "device is on the dashboard — open the Solana app" appended
- [ ] Manual: Bitcoin app open → call `pair_ledger_solana` → expect "Bitcoin app is open — switch to Solana" appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)