### PR TITLE
feat(lifi): prepare_solana_lifi_swap — Solana-source swap + bridge via LiFi

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import {
   prepareNativeStakeDelegate,
   prepareNativeStakeDeactivate,
   prepareNativeStakeWithdraw,
+  prepareSolanaLifiSwap,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -118,6 +119,7 @@ import {
   prepareNativeStakeDelegateInput,
   prepareNativeStakeDeactivateInput,
   prepareNativeStakeWithdrawInput,
+  prepareSolanaLifiSwapInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1492,6 +1494,28 @@ async function main() {
       inputSchema: prepareNativeStakeWithdrawInput.shape,
     },
     handler(prepareNativeStakeWithdraw)
+  );
+
+  server.registerTool(
+    "prepare_solana_lifi_swap",
+    {
+      description:
+        "Build an unsigned LiFi-routed swap or bridge with Solana as the source chain. " +
+        "Returns a Solana v0 tx the user signs on Ledger. Two flows share this surface: " +
+        "(1) IN-CHAIN swap when toChain=\"solana\" — LiFi internally routes through Jupiter " +
+        "/ Orca / similar; consider `prepare_solana_swap` (Jupiter direct) as the more " +
+        "direct path for in-chain only. (2) CROSS-CHAIN bridge when toChain is an EVM chain " +
+        "— LiFi aggregates Wormhole, deBridge, Mayan, Allbridge. The Solana source tx " +
+        "confirms first; destination delivery happens after via the bridge protocol " +
+        "(typically 1-15 min). DURABLE NONCE REQUIRED. The builder rejects multi-tx routes " +
+        "(returned by some bridge variants) and multi-signer routes (which would need an " +
+        "ephemeral signer LiFi normally provides via its wallet adapter — Ledger-only " +
+        "signing can't supply it). Reverse direction (EVM → Solana) is not yet wired in " +
+        "this server; track as a follow-up. BLIND-SIGN on Ledger — match the Message Hash " +
+        "on-device after `preview_solana_send`.",
+      inputSchema: prepareSolanaLifiSwapInput.shape,
+    },
+    handler(prepareSolanaLifiSwap)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -103,6 +103,7 @@ import type {
   PrepareNativeStakeDelegateArgs,
   PrepareNativeStakeDeactivateArgs,
   PrepareNativeStakeWithdrawArgs,
+  PrepareSolanaLifiSwapArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -429,6 +430,24 @@ export async function prepareNativeStakeWithdraw(
     wallet: args.wallet,
     stakeAccount: args.stakeAccount,
     amountSol: args.amountSol,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareSolanaLifiSwap(
+  args: PrepareSolanaLifiSwapArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildLifiSolanaSwap } = await import("../solana/lifi-swap.js");
+  const slippage =
+    args.slippageBps !== undefined ? args.slippageBps / 10_000 : undefined;
+  const prepared = await buildLifiSolanaSwap({
+    wallet: args.wallet,
+    fromMint: args.fromMint,
+    fromAmount: args.fromAmount,
+    toChain: args.toChain as Parameters<typeof buildLifiSolanaSwap>[0]["toChain"],
+    toToken: args.toToken,
+    ...(args.toAddress !== undefined ? { toAddress: args.toAddress } : {}),
+    ...(slippage !== undefined ? { slippage } : {}),
   });
   return prepared as unknown as PreparedSolanaTx;
 }
@@ -1823,7 +1842,8 @@ export interface SolanaVerificationArtifact {
     | "marinade_unstake_immediate"
     | "native_stake_delegate"
     | "native_stake_deactivate"
-    | "native_stake_withdraw";
+    | "native_stake_withdraw"
+    | "lifi_solana_swap";
   from: string;
   messageBase64: string;
   recentBlockhash: string;
@@ -1942,6 +1962,7 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       "native_stake_delegate",
       "native_stake_deactivate",
       "native_stake_withdraw",
+      "lifi_solana_swap",
     ]);
     const ledgerMessageHash = blindSignActions.has(tx.action)
       ? solanaLedgerMessageHash(tx.messageBase64)

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -380,6 +380,79 @@ export const getSolanaSetupStatusInput = z.object({
 });
 
 /**
+ * LiFi-on-Solana write action. Cross-chain bridges (Solana → EVM) and
+ * in-chain swaps (Solana → Solana) share one tool surface; LiFi internally
+ * picks the right protocol (Jupiter for in-chain, Wormhole / deBridge /
+ * Mayan / Allbridge for bridges).
+ *
+ * For pure in-chain Solana swaps `prepare_solana_swap` (Jupiter, single
+ * aggregator) is the more direct path — fewer hops, simpler routing.
+ * Reach for `prepare_solana_lifi_swap` when you need Solana → EVM bridge
+ * functionality, or you explicitly want LiFi's multi-aggregator routing
+ * on Solana.
+ */
+export const prepareSolanaLifiSwapInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana base58 wallet — funds the swap and signs the source tx. Must " +
+      "have an initialized durable-nonce account (prepare_solana_nonce_init)."
+  ),
+  fromMint: z
+    .string()
+    .max(50)
+    .describe(
+      "Source token: SPL mint address (base58) or the literal string \"native\" " +
+        "to swap SOL (LiFi maps \"native\" to wrapped-SOL internally; the wrap " +
+        "ix is built into the route)."
+    ),
+  fromAmount: z
+    .string()
+    .max(50)
+    .regex(/^\d+$/)
+    .describe(
+      "Raw integer amount in base units (NOT decimal-adjusted). Decimals are " +
+        "the source token's decimals — e.g. 1 USDC (6 decimals) = '1000000', " +
+        "1 SOL (9 decimals) = '1000000000'."
+    ),
+  toChain: z
+    .enum([
+      "solana",
+      ...(SUPPORTED_CHAINS as unknown as [string, ...string[]]),
+    ])
+    .describe(
+      "Destination chain. \"solana\" runs an in-chain swap (LiFi routes " +
+        "through Jupiter / Orca / similar — consider prepare_solana_swap for " +
+        "the more direct path). EVM chains run a cross-chain bridge."
+    ),
+  toToken: z
+    .string()
+    .max(80)
+    .describe(
+      "Destination token. SPL mint (base58) when toChain=\"solana\"; 0x-prefixed " +
+        "EVM token address otherwise. \"native\" works on both (resolves to the " +
+        "chain's conventional native sentinel)."
+    ),
+  toAddress: z
+    .string()
+    .max(80)
+    .optional()
+    .describe(
+      "Optional destination wallet. Defaults to the source wallet for in-chain " +
+        "swaps. REQUIRED for cross-chain bridges since the Solana base58 source " +
+        "wallet won't be a valid EVM-chain recipient."
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(10_000)
+    .optional()
+    .describe(
+      "Slippage tolerance in basis points (50 = 0.5%). Omit for LiFi's default " +
+        "(0.5%). Cross-chain bridges may impose their own minimums above this."
+    ),
+});
+
+/**
  * No args — `get_vaultpilot_config_status` returns a structured snapshot of
  * the local server config, intended for diagnostic / onboarding flows.
  * The output deliberately never echoes any secret values (API keys, RPC
@@ -710,5 +783,6 @@ export type PrepareNativeStakeWithdrawArgs = z.infer<
 export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>;
 export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPositionsInput>;
 export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;
+export type PrepareSolanaLifiSwapArgs = z.infer<typeof prepareSolanaLifiSwapInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -124,7 +124,8 @@ export interface PreparedSolanaTx {
     | "marinade_unstake_immediate"
     | "native_stake_delegate"
     | "native_stake_deactivate"
-    | "native_stake_withdraw";
+    | "native_stake_withdraw"
+    | "lifi_solana_swap";
   chain: "solana";
   from: string;
   description: string;

--- a/src/modules/solana/lifi-swap.ts
+++ b/src/modules/solana/lifi-swap.ts
@@ -1,0 +1,286 @@
+import {
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+  type TransactionInstruction,
+} from "@solana/web3.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import { resolveAddressLookupTables } from "./alt.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+import {
+  fetchSolanaQuote,
+  type LifiSolanaQuoteRequest,
+  SOLANA_WSOL_MINT,
+} from "../swap/lifi.js";
+import type { SupportedChain } from "../../types/index.js";
+
+/**
+ * LiFi-on-Solana write action. The single tool wraps both:
+ *   1. **In-chain swaps** (Solana → Solana): LiFi internally routes
+ *      through Jupiter / Orca / similar. Useful when callers want a
+ *      single tool surface for in-chain + cross-chain rather than
+ *      switching between Jupiter and LiFi by hand. (`prepare_solana_swap`
+ *      via Jupiter is still the more direct path for in-chain.)
+ *   2. **Cross-chain bridges** (Solana → EVM): LiFi aggregates across
+ *      Wormhole, deBridge, Mayan, Allbridge. The user signs the Solana
+ *      source tx; the destination chain delivery is handled by the
+ *      bridge protocol after the source tx confirms.
+ *
+ * Reverse direction (EVM → Solana) is OUT OF SCOPE this PR — that needs
+ * extending `prepare_swap` (EVM-source) to accept a Solana destination
+ * address and route via LiFi's existing EVM-source flow. Tracked as a
+ * follow-up.
+ *
+ * ## Tx-shape surgery (the load-bearing piece)
+ *
+ * LiFi's API hands back a fully-formed `VersionedTransaction` (base64) in
+ * `quote.transactionRequest.data`. To put it through our durable-nonce
+ * pipeline (ix[0] = `nonceAdvance`) the builder:
+ *
+ *   1. Deserializes the v0 message.
+ *   2. Validates: `numRequiredSignatures === 1` and `staticAccountKeys[0]`
+ *      equals the user wallet. Multi-signer routes (some bridge variants
+ *      use ephemeral keypairs LiFi keeps in the wallet adapter) are
+ *      rejected — Ledger-only signing can't supply the extra signers.
+ *   3. Resolves any external ALTs the message references (LiFi commonly
+ *      uses Jupiter's group ALT for in-chain routes; bridges may
+ *      reference their own).
+ *   4. Decompiles the message → flat `TransactionInstruction[]`,
+ *      preserving each ix's data + account refs by resolving ALT lookups
+ *      against the fetched ALT contents.
+ *   5. Prepends `SystemProgram.nonceAdvance(nonceAccount, walletAuthority)`
+ *      at ix[0]. Reattaches the ALTs as the `addressLookupTableAccounts`
+ *      argument when we re-compile a fresh `MessageV0` at pin time.
+ *
+ * The LiFi-returned blockhash is discarded — `pinSolanaHandle` overwrites
+ * it with the current nonce value. This is fine: LiFi's bridge intent is
+ * encoded in the *instructions*, not the blockhash, and our nonce-only
+ * validity gate gives the user generous review time on Ledger.
+ *
+ * Multi-tx routes (`transactionRequest.data` returned as an array, e.g.
+ * setup-tx + main-tx) are rejected with a clear error pointing at
+ * Jupiter (`prepare_solana_swap`) for in-chain alternatives. Building
+ * the multi-tx pipeline is roadmap #4 (deferred per the Kamino scope-
+ * probe finding that Kamino's lending surface doesn't actually require
+ * it).
+ *
+ * Treated as BLIND-SIGN on Ledger — LiFi's bridge programs aren't in the
+ * Solana app's clear-sign allowlist; same posture as Jupiter / MarginFi /
+ * Marinade.
+ */
+
+export interface PrepareLifiSolanaSwapParams {
+  /** Base58 wallet address — source of funds + Solana tx signer. */
+  wallet: string;
+  /** SPL mint (base58) or the literal string "native" (= SOL via wSOL). */
+  fromMint: string;
+  /** Raw integer base units to sell. */
+  fromAmount: string;
+  /** Destination chain — "solana" (in-chain) or an EVM chain (bridge). */
+  toChain: SupportedChain | "solana";
+  /**
+   * Destination token. SPL mint when `toChain === "solana"`; 0x-prefixed
+   * EVM token address otherwise. "native" works on both (resolves to
+   * wSOL on Solana, 0x0…0 on EVM).
+   */
+  toToken: string | "native";
+  /**
+   * Destination wallet. Defaults to the source wallet for in-chain
+   * swaps. REQUIRED for cross-chain bridges since the source wallet's
+   * format (Solana base58) won't be valid on the destination chain.
+   */
+  toAddress?: string;
+  /** Slippage as fraction (0.005 = 50 bps). LiFi default 0.005. */
+  slippage?: number;
+}
+
+export interface PreparedLifiSolanaSwapTx {
+  handle: string;
+  action: "lifi_solana_swap";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  /** Nonce-account PDA for this wallet (durable-nonce-protected). */
+  nonceAccount: string;
+}
+
+async function loadNonceContext(walletStr: string): Promise<{
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+}> {
+  const fromPubkey = assertSolanaAddress(walletStr);
+  const conn = getSolanaConnection();
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(walletStr);
+  return { fromPubkey, noncePubkey, nonceValue: nonceState!.nonce };
+}
+
+/**
+ * Deserialize LiFi's base64 v0 tx, validate single-signer / single-tx,
+ * resolve ALTs, decompile to raw ixs, and prepend `nonceAdvance`. Returns
+ * the assembled draft pieces ready for `issueSolanaDraftHandle`.
+ */
+async function spliceLifiSolanaTx(args: {
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  txData: string | string[] | undefined;
+}): Promise<{
+  instructions: TransactionInstruction[];
+  altKeys: PublicKey[];
+}> {
+  if (args.txData === undefined) {
+    throw new Error(
+      `LiFi quote returned no transaction data. The route may not be ` +
+        `supported for Solana source — try a different inputMint / outputMint / outputChain combination.`,
+    );
+  }
+  if (Array.isArray(args.txData)) {
+    throw new Error(
+      `LiFi route returned ${args.txData.length} transactions; this server's ` +
+        `Solana signing pipeline supports single-tx routes only. For in-chain ` +
+        `swaps use prepare_solana_swap (Jupiter, single-tx by design); for ` +
+        `multi-tx bridges, wait until the multi-tx pipeline lands.`,
+    );
+  }
+
+  const txBytes = Buffer.from(args.txData, "base64");
+  const versionedTx = VersionedTransaction.deserialize(txBytes);
+  const message = versionedTx.message;
+
+  if (message.header.numRequiredSignatures !== 1) {
+    throw new Error(
+      `LiFi route requires ${message.header.numRequiredSignatures} signers ` +
+        `but Ledger-only signing supports exactly 1. The route likely uses an ` +
+        `ephemeral signer LiFi normally provides via its wallet adapter — pick ` +
+        `a different bridge protocol via slippage / route preferences.`,
+    );
+  }
+  const staticKeys = message.staticAccountKeys;
+  if (staticKeys.length === 0 || !staticKeys[0].equals(args.fromPubkey)) {
+    throw new Error(
+      `LiFi route's fee payer (${staticKeys[0]?.toBase58() ?? "<empty>"}) ` +
+        `does not match the user wallet (${args.fromPubkey.toBase58()}). ` +
+        `Refusing to sign — the route was built for a different account.`,
+    );
+  }
+
+  // Resolve external ALTs (LiFi commonly uses Jupiter's group ALT for
+  // in-chain routes; bridges may reference their own).
+  const altKeys = message.addressTableLookups.map((l) => l.accountKey);
+  const conn = getSolanaConnection();
+  const alts = await resolveAddressLookupTables(conn, altKeys);
+
+  // Decompile to raw instructions, then prepend nonceAdvance.
+  const txMessage = TransactionMessage.decompile(message, {
+    addressLookupTableAccounts: alts,
+  });
+  const lifiIxs = txMessage.instructions;
+  const nonceIx = buildAdvanceNonceIx(args.noncePubkey, args.fromPubkey);
+  return {
+    instructions: [nonceIx, ...lifiIxs],
+    altKeys,
+  };
+}
+
+export async function buildLifiSolanaSwap(
+  p: PrepareLifiSolanaSwapParams,
+): Promise<PreparedLifiSolanaSwapTx> {
+  const ctx = await loadNonceContext(p.wallet);
+
+  const quoteReq: LifiSolanaQuoteRequest = {
+    fromAddress: p.wallet,
+    fromToken: p.fromMint,
+    fromAmount: p.fromAmount,
+    toChain: p.toChain,
+    toToken: p.toToken,
+    ...(p.toAddress !== undefined ? { toAddress: p.toAddress } : {}),
+    ...(p.slippage !== undefined ? { slippage: p.slippage } : {}),
+  };
+  const quote = await fetchSolanaQuote(quoteReq);
+
+  const { instructions: actionIxs, altKeys } = await spliceLifiSolanaTx({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    txData: quote.transactionRequest?.data,
+  });
+
+  // Resolve the ALTs again for the draft (the resolver caches, so this
+  // hits the cache; we keep it explicit so the draft owns the ALT list
+  // for MessageV0.compile at pin time).
+  const conn = getSolanaConnection();
+  const addressLookupTableAccounts = await resolveAddressLookupTables(
+    conn,
+    altKeys,
+  );
+
+  const tool = quote.toolDetails?.name ?? quote.tool ?? "lifi";
+  const inputSymbol =
+    p.fromMint === SOLANA_WSOL_MINT || p.fromMint === "native"
+      ? "SOL"
+      : quote.action.fromToken.symbol ?? p.fromMint;
+  const outputSymbol = quote.action.toToken.symbol ?? p.toToken;
+  const description =
+    p.toChain === "solana"
+      ? `LiFi swap on Solana — ${quote.action.fromAmount} ${inputSymbol} → ~${quote.estimate.toAmount} ${outputSymbol} via ${tool}`
+      : `LiFi bridge — ${quote.action.fromAmount} ${inputSymbol} (Solana) → ~${quote.estimate.toAmount} ${outputSymbol} on ${p.toChain} via ${tool}`;
+
+  const draft: SolanaTxDraft = {
+    kind: "v0",
+    payerKey: ctx.fromPubkey,
+    instructions: actionIxs,
+    addressLookupTableAccounts,
+    meta: {
+      action: "lifi_solana_swap",
+      from: p.wallet,
+      description,
+      decoded: {
+        functionName: "lifi.solana.swap",
+        args: {
+          wallet: p.wallet,
+          fromMint: p.fromMint,
+          fromAmount: p.fromAmount,
+          toChain: p.toChain,
+          toToken: p.toToken,
+          ...(p.toAddress !== undefined ? { toAddress: p.toAddress } : {}),
+          inputSymbol,
+          outputSymbol,
+          minOutput: quote.estimate.toAmountMin,
+          tool: String(tool),
+          slippageBps: String(
+            Math.round((p.slippage ?? Number(quote.action.slippage ?? 0.005)) * 10_000),
+          ),
+          nonceAccount: ctx.noncePubkey.toBase58(),
+        },
+      },
+      nonce: {
+        account: ctx.noncePubkey.toBase58(),
+        authority: ctx.fromPubkey.toBase58(),
+        value: ctx.nonceValue,
+      },
+    },
+  };
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "lifi_solana_swap",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -13,6 +13,15 @@ export function initLifi(): void {
   initialized = true;
 }
 
+/**
+ * LiFi numeric chain ID for Solana. Authoritative value from
+ * `@lifi/types/chains/base.ChainId.SOL` (= 1151111081099710 — derived from
+ * the bytes "sol" interpreted as ASCII codes appended to a marker prefix).
+ * Hoisted to a constant here so callers passing through the EVM-only
+ * `toLifiChain` helper aren't forced to reach into the SDK.
+ */
+export const LIFI_SOLANA_CHAIN_ID = 1151111081099710 as const;
+
 /** Map our chain name to LiFi's numeric chain ID. */
 function toLifiChain(chain: SupportedChain): number {
   return CHAIN_IDS[chain];
@@ -80,3 +89,87 @@ export async function fetchStatus(txHash: string, fromChain: SupportedChain, toC
     toChain: toLifiChain(toChain) as LifiChainId,
   });
 }
+
+/**
+ * Solana-source LiFi quote. Distinct shape from `LifiQuoteRequest` because
+ * Solana addresses are base58 (not 0x-prefixed hex) and the destination can
+ * be EVM (cross-chain bridge) or Solana (in-chain swap; LiFi will internally
+ * route through Jupiter / similar). Output is a LiFi `Quote` whose
+ * `transactionRequest.data` field carries the base64-encoded
+ * `VersionedTransaction` for the source chain (= Solana) — see
+ * `@lifi/sdk/src/_esm/core/Solana/SolanaStepExecutor.js`.
+ *
+ * `fromToken` accepts either:
+ *   - a base58 SPL mint (e.g. USDC mint EPjFW...Dt1v)
+ *   - the literal string "native" — interpreted as wrapped-SOL
+ *     (So11111111111111111111111111111111111111112), the canonical token
+ *     for SOL value transfer in LiFi's API
+ *
+ * `toToken` accepts:
+ *   - base58 SPL mint (when toChain is "solana")
+ *   - 0x-prefixed EVM token address (when toChain is an EVM chain)
+ *   - "native" for native-asset on either chain (mapped to the chain's
+ *     conventional native sentinel by LiFi)
+ */
+export interface LifiSolanaQuoteRequest {
+  /** Solana base58 wallet — funds the swap, signs the source tx. */
+  fromAddress: string;
+  /** Source token: SPL mint (base58) or "native" for SOL. */
+  fromToken: string | "native";
+  /** Raw integer base units to sell (e.g. "1000000000" for 1 SOL @ 9 decimals). */
+  fromAmount: string;
+  /** Destination chain — either "solana" (in-chain swap) or an EVM chain (bridge). */
+  toChain: SupportedChain | "solana";
+  /** Destination token; format depends on toChain (see jsdoc on the type). */
+  toToken: string | "native";
+  /** Optional explicit destination wallet (defaults to fromAddress for same-chain). */
+  toAddress?: string;
+  /** Slippage as a fraction — e.g. 0.005 = 50 bps. LiFi default is 0.005. */
+  slippage?: number;
+}
+
+const SOLANA_NATIVE_SENTINEL = "11111111111111111111111111111111";
+const SOLANA_WSOL_MINT = "So11111111111111111111111111111111111111112";
+const EVM_NATIVE_SENTINEL = NATIVE; // 0x0…0
+
+/**
+ * Fetch a LiFi quote with Solana as the source chain. Wraps the SDK's
+ * `getQuote` (which is chain-agnostic — it accepts numeric chain IDs and
+ * `string`-typed addresses + tokens, so this isn't a separate API endpoint).
+ *
+ * Native-token coercion:
+ *   - Source: "native" → wrapped-SOL mint (LiFi treats wSOL as the canonical
+ *     SOL handle in its routing graph; the Solana step builds in the wrap
+ *     ix when needed).
+ *   - Destination: "native" → 0x0…0 if EVM destination, else wrapped-SOL.
+ */
+export async function fetchSolanaQuote(req: LifiSolanaQuoteRequest) {
+  initLifi();
+  const fromTokenResolved =
+    req.fromToken === "native" ? SOLANA_WSOL_MINT : req.fromToken;
+  const toIsSolana = req.toChain === "solana";
+  let toTokenResolved: string;
+  if (req.toToken === "native") {
+    toTokenResolved = toIsSolana ? SOLANA_WSOL_MINT : EVM_NATIVE_SENTINEL;
+  } else {
+    toTokenResolved = req.toToken;
+  }
+  const toChainId = toIsSolana
+    ? LIFI_SOLANA_CHAIN_ID
+    : CHAIN_IDS[req.toChain as SupportedChain];
+
+  return getQuote({
+    fromChain: LIFI_SOLANA_CHAIN_ID as LifiChainId,
+    toChain: toChainId as LifiChainId,
+    fromToken: fromTokenResolved,
+    toToken: toTokenResolved,
+    fromAmount: req.fromAmount,
+    fromAddress: req.fromAddress,
+    ...(req.toAddress !== undefined ? { toAddress: req.toAddress } : {}),
+    ...(req.slippage !== undefined ? { slippage: req.slippage } : {}),
+  });
+}
+
+// Re-export so the Solana wrapper module can use the wSOL constant without
+// re-defining it (single source of truth).
+export { SOLANA_WSOL_MINT, SOLANA_NATIVE_SENTINEL };

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -897,7 +897,8 @@ export interface RenderableSolanaPrepareResult {
     | "marinade_unstake_immediate"
     | "native_stake_delegate"
     | "native_stake_deactivate"
-    | "native_stake_withdraw";
+    | "native_stake_withdraw"
+    | "lifi_solana_swap";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -945,6 +946,8 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "Native stake deactivate (one-epoch cooldown before withdrawable)";
     case "native_stake_withdraw":
       return "Native stake withdraw (from inactive stake account)";
+    case "lifi_solana_swap":
+      return "LiFi swap / bridge (Solana source)";
   }
 }
 
@@ -1005,6 +1008,7 @@ export function renderSolanaPrepareAgentTaskBlock(
   const isMarginfi = r.action.startsWith("marginfi_");
   const isMarinade = r.action.startsWith("marinade_");
   const isNativeStake = r.action.startsWith("native_stake_");
+  const isLifiSolana = r.action === "lifi_solana_swap";
   const marginfiActionWord =
     r.action === "marginfi_init"
       ? "MarginFi account init"
@@ -1042,7 +1046,7 @@ export function renderSolanaPrepareAgentTaskBlock(
             ? "durable-nonce close"
             : r.action === "jupiter_swap"
               ? "Jupiter swap"
-              : marginfiActionWord ?? marinadeActionWord ?? nativeStakeActionWord ?? "Solana tx";
+              : marginfiActionWord ?? marinadeActionWord ?? nativeStakeActionWord ?? (isLifiSolana ? "LiFi swap / bridge (Solana source)" : "Solana tx");
   const nonceBullet =
     r.nonceAccount && r.action !== "nonce_init"
       ? ["  - Nonce: <short nonce-account addr>"]
@@ -1164,6 +1168,18 @@ export function renderSolanaPrepareAgentTaskBlock(
                       "  - Wallet: <from + recipient>",
                       "  - Stake account: <stakeAccount from decoded.args>",
                       "  - Amount: <amountSol> SOL (or 'max')",
+                      ...nonceBullet,
+                      "  - Fee: <est. fee in SOL>",
+                    ]
+                  : isLifiSolana
+                  ? [
+                      "  - Headline: \"Prepared LiFi <swap|bridge> — <fromAmount> <inputSymbol> → ~<minOutput> <outputSymbol> on <toChain>\"",
+                      "  - From wallet: <from address>",
+                      "  - Input: <fromAmount from decoded.args> <inputSymbol> (mint: <fromMint>)",
+                      "  - Output: ~<minOutput> <outputSymbol> on <toChain> (token: <toToken>)",
+                      "  - Tool / route: <tool from decoded.args>",
+                      "  - Slippage: <slippageBps from decoded.args> bps",
+                      "  - Destination wallet: <toAddress, or 'same as source' if absent>",
                       ...nonceBullet,
                       "  - Fee: <est. fee in SOL>",
                     ]
@@ -1327,6 +1343,7 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     tx.action === "native_stake_delegate" ||
     tx.action === "native_stake_deactivate" ||
     tx.action === "native_stake_withdraw";
+  const isLifiSolana = tx.action === "lifi_solana_swap";
   const marginfiActionLabel =
     tx.action === "marginfi_init"
       ? "account init"
@@ -1406,14 +1423,14 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
   // as ix[0] — this flag drives the "DURABLE-NONCE MODE" explainer text +
   // the Nonce bullet in the summary + the expected-shape text for CHECK 1.
   const hasAdvanceNonceIx =
-    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi || isMarinade || isNativeStake;
+    isNativeSend || isSpl || isNonceClose || isJupiterSwap || isMarginfi || isMarinade || isNativeStake || isLifiSolana;
   // The Ledger Solana app only clear-signs a small allowlist of programs
   // (System Program's transfer/advance/initialize/withdraw, and a few
   // others). Everything else falls to blind-sign, which shows only the
   // Message Hash on-device and requires the user to match it against the
   // hash the server displayed. SPL TransferChecked AND Jupiter swaps both
   // fall in that bucket.
-  const isBlindSign = isSpl || isJupiterSwap || isMarginfi || isMarinade || isNativeStake;
+  const isBlindSign = isSpl || isJupiterSwap || isMarginfi || isMarinade || isNativeStake || isLifiSolana;
   const ledgerHash = isBlindSign ? solanaLedgerMessageHash(tx.messageBase64) : null;
 
   const checksPayload = {
@@ -1552,7 +1569,20 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
                             "  - Fee: <est. fee in SOL>",
                             "  - Note: stake account must already be inactive (1 epoch after deactivate); on-chain reverts otherwise",
                           ]
-                        : [
+                        : tx.action === "lifi_solana_swap"
+                          ? [
+                              "  - Headline: \"Prepared LiFi <swap|bridge> — <fromAmount> <inputSymbol> → ~<minOutput> <outputSymbol>\"",
+                              "  - From wallet: <from address>",
+                              "  - Input: <fromAmount> <inputSymbol> (mint: <fromMint from decoded.args>)",
+                              "  - Output: ~<minOutput> <outputSymbol> on <toChain> (token: <toToken from decoded.args>)",
+                              "  - Tool / route: <tool from decoded.args>",
+                              "  - Slippage: <slippageBps from decoded.args> bps",
+                              "  - Destination wallet: <toAddress from decoded.args, or 'same as source' if omitted>",
+                              ...(nonceBullet ? [nonceBullet] : []),
+                              "  - Fee: <est. fee in SOL>",
+                              "  - Note: cross-chain bridges complete in 2 stages — Solana source tx confirms first; destination delivery happens after via the bridge protocol (typically 1-15 min depending on tool).",
+                            ]
+                          : [
                       // marginfi_supply / withdraw / borrow / repay — same shape,
                       // only the "Action" bullet text differs; keep one template.
                       `  - Headline: \"Prepared MarginFi ${marginfiActionLabel} — <amount> <symbol>\"`,

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -54,7 +54,8 @@ export interface SolanaDraftMeta {
     | "marinade_unstake_immediate"
     | "native_stake_delegate"
     | "native_stake_deactivate"
-    | "native_stake_withdraw";
+    | "native_stake_withdraw"
+    | "lifi_solana_swap";
   from: string;
   description: string;
   decoded: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -783,7 +783,8 @@ export interface UnsignedSolanaTx {
     | "marinade_unstake_immediate"
     | "native_stake_delegate"
     | "native_stake_deactivate"
-    | "native_stake_withdraw";
+    | "native_stake_withdraw"
+    | "lifi_solana_swap";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/solana-lifi-swap.test.ts
+++ b/test/solana-lifi-swap.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  Keypair,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+/**
+ * LiFi-on-Solana write-builder tests. Mocks the LiFi SDK's `getQuote` to
+ * return a synthetic v0 transaction we control, plus the connection /
+ * nonce / ALT-resolver. The builder's load-bearing piece is the
+ * decompile-then-prepend-nonceAdvance dance — these tests pin its
+ * invariants:
+ *   - ix[0] is SystemProgram.nonceAdvance
+ *   - ix[1+] preserves the LiFi-returned ixs in order
+ *   - draft has the wallet as feePayer, the resolved ALTs, and the right
+ *     action / decoded.args / nonce meta
+ *   - multi-tx, multi-signer, and fee-payer-mismatch routes raise clear
+ *     errors
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const FAKE_BRIDGE_PROGRAM = Keypair.generate().publicKey;
+const FAKE_BLOCKHASH = "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+  getAddressLookupTable: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+  getSolanaRpcUrl: () => "https://test",
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+const resolveAltMock = vi.fn();
+vi.mock("../src/modules/solana/alt.js", () => ({
+  resolveAddressLookupTables: (...args: unknown[]) => resolveAltMock(...args),
+  clearAltCache: () => {},
+  invalidateAlt: () => {},
+}));
+
+const fetchSolanaQuoteMock = vi.fn();
+vi.mock("../src/modules/swap/lifi.js", () => ({
+  fetchSolanaQuote: (...args: unknown[]) => fetchSolanaQuoteMock(...args),
+  SOLANA_WSOL_MINT: "So11111111111111111111111111111111111111112",
+  SOLANA_NATIVE_SENTINEL: "11111111111111111111111111111111",
+  LIFI_SOLANA_CHAIN_ID: 1151111081099710,
+}));
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: FAKE_BLOCKHASH,
+    authority: WALLET_KEYPAIR.publicKey,
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+/**
+ * Build a fake LiFi-shaped VersionedTransaction: single-signer (wallet
+ * as fee payer), one bridge-program ix carrying recognizable bytes, no
+ * ALTs. base64-encoded so it matches LiFi's wire shape.
+ */
+function makeFakeLifiTxBase64(opts?: {
+  feePayer?: PublicKey;
+  extraSignerKey?: PublicKey;
+  ixData?: Buffer;
+}): string {
+  const feePayer = opts?.feePayer ?? WALLET_KEYPAIR.publicKey;
+  const ixData = opts?.ixData ?? Buffer.from([0xab, 0xcd]);
+  const keys = [
+    { pubkey: feePayer, isSigner: true, isWritable: true },
+  ];
+  if (opts?.extraSignerKey) {
+    keys.push({
+      pubkey: opts.extraSignerKey,
+      isSigner: true,
+      isWritable: false,
+    });
+  }
+  const ix = new TransactionInstruction({
+    programId: FAKE_BRIDGE_PROGRAM,
+    keys,
+    data: ixData,
+  });
+  const message = new TransactionMessage({
+    payerKey: feePayer,
+    recentBlockhash: FAKE_BLOCKHASH,
+    instructions: [ix],
+  }).compileToV0Message();
+  const vt = new VersionedTransaction(message);
+  return Buffer.from(vt.serialize()).toString("base64");
+}
+
+function makeQuoteResponse(txDataBase64: string | string[] | undefined) {
+  return {
+    transactionRequest: txDataBase64 !== undefined ? { data: txDataBase64 } : undefined,
+    action: {
+      fromAmount: "1000000000",
+      fromToken: { symbol: "SOL", decimals: 9 },
+      toToken: { symbol: "USDC", decimals: 6 },
+      slippage: 0.005,
+    },
+    estimate: {
+      toAmount: "170000000",
+      toAmountMin: "169150000",
+    },
+    tool: "jupiter",
+    toolDetails: { name: "Jupiter" },
+  };
+}
+
+beforeEach(async () => {
+  connectionStub.getAccountInfo.mockReset();
+  connectionStub.getAddressLookupTable.mockReset();
+  fetchSolanaQuoteMock.mockReset();
+  resolveAltMock.mockReset();
+  resolveAltMock.mockResolvedValue([]); // default: no ALTs
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildLifiSolanaSwap — happy path", () => {
+  it("composes nonceAdvance + LiFi ix in order, with wallet as fee payer", async () => {
+    await setNoncePresent();
+    const lifiTxBase64 = makeFakeLifiTxBase64();
+    fetchSolanaQuoteMock.mockResolvedValue(makeQuoteResponse(lifiTxBase64));
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    const prepared = await buildLifiSolanaSwap({
+      wallet: WALLET,
+      fromMint: "native",
+      fromAmount: "1000000000",
+      toChain: "solana",
+      toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    });
+
+    expect(prepared.action).toBe("lifi_solana_swap");
+    expect(prepared.from).toBe(WALLET);
+    expect(prepared.description).toContain("LiFi swap");
+    expect(prepared.description).toContain("Jupiter");
+    expect(prepared.decoded.functionName).toBe("lifi.solana.swap");
+    expect(prepared.decoded.args.tool).toBe("Jupiter");
+    expect(prepared.decoded.args.toChain).toBe("solana");
+    expect(prepared.decoded.args.minOutput).toBe("169150000");
+
+    const { getSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    const draft = getSolanaDraft(prepared.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+
+    // ix[0] = SystemProgram.nonceAdvance, tag 0x04
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+
+    // ix[1] = the LiFi-returned bridge-program ix, preserved verbatim.
+    expect(draft.instructions.length).toBe(2);
+    expect(draft.instructions[1].programId.toBase58()).toBe(
+      FAKE_BRIDGE_PROGRAM.toBase58(),
+    );
+    expect(draft.instructions[1].data.toString("hex")).toBe("abcd");
+
+    expect(draft.payerKey.toBase58()).toBe(WALLET);
+    expect(draft.addressLookupTableAccounts).toEqual([]);
+    expect(draft.meta.action).toBe("lifi_solana_swap");
+    expect(draft.meta.nonce?.value).toBe(FAKE_BLOCKHASH);
+  });
+
+  it("labels the description as a bridge when toChain is an EVM chain", async () => {
+    await setNoncePresent();
+    fetchSolanaQuoteMock.mockResolvedValue(
+      makeQuoteResponse(makeFakeLifiTxBase64()),
+    );
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    const prepared = await buildLifiSolanaSwap({
+      wallet: WALLET,
+      fromMint: "native",
+      fromAmount: "1000000000",
+      toChain: "ethereum",
+      toToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      toAddress: "0x1111111111111111111111111111111111111111",
+    });
+    expect(prepared.description).toContain("LiFi bridge");
+    expect(prepared.description).toContain("ethereum");
+  });
+
+  it("forwards explicit slippage to the LiFi quote (bps → fraction)", async () => {
+    await setNoncePresent();
+    fetchSolanaQuoteMock.mockResolvedValue(
+      makeQuoteResponse(makeFakeLifiTxBase64()),
+    );
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await buildLifiSolanaSwap({
+      wallet: WALLET,
+      fromMint: "native",
+      fromAmount: "1000000000",
+      toChain: "solana",
+      toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      slippage: 0.01,
+    });
+    const quoteCall = fetchSolanaQuoteMock.mock.calls[0][0] as {
+      slippage?: number;
+    };
+    expect(quoteCall.slippage).toBe(0.01);
+  });
+});
+
+describe("buildLifiSolanaSwap — rejection paths", () => {
+  it("throws nonce-required when the wallet has no durable-nonce account", async () => {
+    await setNonceMissing();
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await expect(
+      buildLifiSolanaSwap({
+        wallet: WALLET,
+        fromMint: "native",
+        fromAmount: "1000000000",
+        toChain: "solana",
+        toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      }),
+    ).rejects.toThrow(/nonce account not initialized/i);
+  });
+
+  it("rejects multi-tx routes (transactionRequest.data is an array)", async () => {
+    await setNoncePresent();
+    const tx1 = makeFakeLifiTxBase64();
+    const tx2 = makeFakeLifiTxBase64();
+    fetchSolanaQuoteMock.mockResolvedValue(makeQuoteResponse([tx1, tx2]));
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await expect(
+      buildLifiSolanaSwap({
+        wallet: WALLET,
+        fromMint: "native",
+        fromAmount: "1000000000",
+        toChain: "ethereum",
+        toToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        toAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    ).rejects.toThrow(/2 transactions.*single-tx/);
+  });
+
+  it("rejects multi-signer routes (numRequiredSignatures > 1)", async () => {
+    await setNoncePresent();
+    const ephemeralKey = Keypair.generate().publicKey;
+    fetchSolanaQuoteMock.mockResolvedValue(
+      makeQuoteResponse(makeFakeLifiTxBase64({ extraSignerKey: ephemeralKey })),
+    );
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await expect(
+      buildLifiSolanaSwap({
+        wallet: WALLET,
+        fromMint: "native",
+        fromAmount: "1000000000",
+        toChain: "ethereum",
+        toToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        toAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    ).rejects.toThrow(/2 signers.*Ledger-only/);
+  });
+
+  it("rejects routes whose fee payer doesn't match the user wallet", async () => {
+    await setNoncePresent();
+    const otherWallet = Keypair.generate();
+    fetchSolanaQuoteMock.mockResolvedValue(
+      makeQuoteResponse(makeFakeLifiTxBase64({ feePayer: otherWallet.publicKey })),
+    );
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await expect(
+      buildLifiSolanaSwap({
+        wallet: WALLET,
+        fromMint: "native",
+        fromAmount: "1000000000",
+        toChain: "solana",
+        toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      }),
+    ).rejects.toThrow(/does not match the user wallet/);
+  });
+
+  it("rejects an empty quote (transactionRequest missing or no data)", async () => {
+    await setNoncePresent();
+    fetchSolanaQuoteMock.mockResolvedValue(makeQuoteResponse(undefined));
+
+    const { buildLifiSolanaSwap } = await import(
+      "../src/modules/solana/lifi-swap.js"
+    );
+    await expect(
+      buildLifiSolanaSwap({
+        wallet: WALLET,
+        fromMint: "native",
+        fromAmount: "1000000000",
+        toChain: "solana",
+        toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      }),
+    ).rejects.toThrow(/no transaction data/);
+  });
+});
+
+describe("renderSolanaAgentTaskBlock — lifi_solana_swap", () => {
+  it("treats it as blind-sign (Message Hash on-device, CHECK 2 runs)", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const { solanaLedgerMessageHash } = await import(
+      "../src/signing/verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "lifi_solana_swap" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: FAKE_BLOCKHASH,
+      description: "LiFi bridge — 1 SOL (Solana) → ~170 USDC on ethereum via Mayan",
+      decoded: {
+        functionName: "lifi.solana.swap",
+        args: {
+          fromMint: "native",
+          toChain: "ethereum",
+          tool: "Mayan",
+        },
+      },
+      nonce: { account: "NonceAcct1", authority: WALLET, value: FAKE_BLOCKHASH },
+    };
+    const expectedHash = solanaLedgerMessageHash(tx.messageBase64);
+    const block = renderSolanaAgentTaskBlock(tx);
+
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain(expectedHash);
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    expect(block).toContain("LiFi");
+    expect(block).toContain("durable-nonce-protected");
+  });
+});


### PR DESCRIPTION
## Summary

New tool `prepare_solana_lifi_swap`. Single surface covers two flows:

1. **In-chain swap** (`toChain: "solana"`) — LiFi internally routes through Jupiter / Orca / similar. The existing `prepare_solana_swap` (Jupiter direct) remains the more direct path for in-chain only.
2. **Cross-chain bridge** (`toChain: "ethereum" | "arbitrum" | …`) — LiFi aggregates Wormhole, deBridge, Mayan, Allbridge. The Solana source tx confirms first; destination delivery follows via the bridge protocol (typically 1-15 min).

Reverse direction (EVM → Solana) is **out of scope this PR** — needs extending `prepare_swap` (EVM-source) to accept a Solana destination address. Tracked as a follow-up.

## The load-bearing piece — tx-shape surgery

LiFi's API hands back a fully-formed `VersionedTransaction` (base64) in `quote.transactionRequest.data`. Unlike Jupiter (which exposes `/swap-instructions` so we can compose ixs cleanly), LiFi only ships the finished tx bytes. To put it through our durable-nonce pipeline (`ix[0] = nonceAdvance`) the builder:

1. Deserializes the v0 message.
2. **Validates**: `numRequiredSignatures === 1` AND `staticAccountKeys[0] === user wallet`. Multi-signer routes (some bridge variants use ephemeral keypairs LiFi normally provides via its wallet adapter) are rejected — Ledger-only signing can't supply the extra signers, same constraint that dropped Jito stake-pool from the staking roadmap.
3. Resolves any external ALTs the message references.
4. Decompiles the message → flat `TransactionInstruction[]`, preserving each ix's data + account refs.
5. Prepends `SystemProgram.nonceAdvance` at `ix[0]`. Reattaches the ALTs to `addressLookupTableAccounts` when `MessageV0` re-compiles at pin time.

Multi-tx routes (`transactionRequest.data` is an array) are rejected with a clear error pointing at `prepare_solana_swap` for in-chain alternatives. Multi-tx pipeline is roadmap #4 (deferred; Kamino scope-probe found it unneeded).

Treated as **blind-sign on Ledger** — same posture as Jupiter / MarginFi / Marinade.

## Test plan

- [x] 9 new unit tests cover: `nonceAdvance` ix[0] composition; LiFi ix preservation verbatim at ix[1+]; wallet=feePayer assertion; in-chain vs cross-chain description labels; explicit slippage forwarding; rejection paths (missing nonce, multi-tx, multi-signer, fee-payer mismatch, empty quote); blind-sign render branch
- [x] `npm run build` clean
- [x] `npx vitest run` — 896 tests, 73 files, all green
- [ ] Live mainnet smoke test on small SOL → USDC (in-chain) and SOL → USDC.e (Solana → Arbitrum bridge) — deferred to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)