### PR TITLE
feat(solana): auto-bundle nonce-init into first native/SPL send

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1240,7 +1240,7 @@ async function main() {
     "prepare_solana_native_send",
     {
       description:
-        "Build an unsigned SOL native-transfer DRAFT via SystemProgram.transfer. Returns a compact preview + opaque handle — but does NOT yet serialize the message or fetch a blockhash (those happen in `preview_solana_send`, called right before `send_transaction`, to keep the ~60s blockhash validity window from being burned during user review). Run `pair_ledger_solana` once per session first so the Solana app is open and the device address is verified. Amount is in SOL (e.g. \"0.5\") or \"max\" for full balance minus fee + safety buffer. Priority fee is added dynamically only when `getRecentPrioritizationFees` p50 is above the congestion threshold. The Ledger Solana app clear-signs SystemProgram.transfer (shows recipient + amount on device); `preview_solana_send` still runs to pin a fresh blockhash — just without a blind-sign hash-match step on the user's side.",
+        "Build an unsigned SOL native-transfer DRAFT via SystemProgram.transfer. Returns a compact preview + opaque handle — but does NOT yet serialize the message or fetch a blockhash (those happen in `preview_solana_send`, called right before `send_transaction`, to keep the ~60s blockhash validity window from being burned during user review). Run `pair_ledger_solana` once per session first so the Solana app is open and the device address is verified. Amount is in SOL (e.g. \"0.5\") or \"max\" for full balance minus fee + safety buffer. Priority fee is added dynamically only when `getRecentPrioritizationFees` p50 is above the congestion threshold. AUTO NONCE SETUP: if the wallet has no durable-nonce account yet (first Solana send), this tool transparently bundles createAccountWithSeed + nonceInitialize ahead of the transfer in a single tx — costs an extra ~0.00144 SOL rent (reclaimable via `prepare_solana_nonce_close`), surfaced in the response (`firstTimeNonceSetup: \"true\"`, `rentLamports`, description suffix). Subsequent sends are durable-nonce-protected and stay valid indefinitely on the device. The Ledger Solana app clear-signs SystemProgram.transfer + nonce-account ops (no blind-sign hash-match step needed for native sends).",
       inputSchema: prepareSolanaNativeSendInput.shape,
     },
     handler(prepareSolanaNativeSend)
@@ -1250,7 +1250,7 @@ async function main() {
     "prepare_solana_spl_send",
     {
       description:
-        "Build an unsigned SPL token transfer DRAFT via Token.TransferChecked. Returns a compact preview + opaque handle — but does NOT yet serialize the message or fetch a blockhash. When the user says 'send', call `preview_solana_send(handle)` to pin a fresh blockhash, compute the Message Hash, and emit the CHECKS agent-task block, then call `send_transaction`. Run `pair_ledger_solana` first. Pass the base58 SPL mint address (canonical decimals resolved for USDC, USDT, JUP, BONK, JTO, mSOL, jitoSOL; otherwise read from chain). If the recipient does NOT yet have an Associated Token Account for this mint, the draft automatically includes a `createAssociatedTokenAccount` instruction — the sender pays ~0.00204 SOL rent, disclosed explicitly (`rentLamports` + `description`). DURABLE NONCE REQUIRED: every send tx is protected by a per-wallet durable-nonce account (ix[0] = SystemProgram.nonceAdvance), so the ~90s blockhash window no longer bounds Ledger review time. If the wallet hasn't run `prepare_solana_nonce_init` yet, this tool errors with a clear pointer to do so — that's a one-time setup costing ~0.00144 SOL (reclaimable via `prepare_solana_nonce_close`). BLIND-SIGN REQUIRED: the Ledger Solana app does NOT auto clear-sign TransferChecked — its parser requires a signed 'Trusted Name' TLV descriptor that only Ledger Live supplies, so the device drops into blind-sign and shows a 'Message Hash' (base58(sha256(messageBytes))). The user must (1) enable 'Allow blind signing' in Solana app → Settings, and (2) match the Message Hash surfaced by `preview_solana_send` against the on-device value before approving.",
+        "Build an unsigned SPL token transfer DRAFT via Token.TransferChecked. Returns a compact preview + opaque handle — but does NOT yet serialize the message or fetch a blockhash. When the user says 'send', call `preview_solana_send(handle)` to pin a fresh blockhash, compute the Message Hash, and emit the CHECKS agent-task block, then call `send_transaction`. Run `pair_ledger_solana` first. Pass the base58 SPL mint address (canonical decimals resolved for USDC, USDT, JUP, BONK, JTO, mSOL, jitoSOL; otherwise read from chain). If the recipient does NOT yet have an Associated Token Account for this mint, the draft automatically includes a `createAssociatedTokenAccount` instruction — the sender pays ~0.00204 SOL rent, disclosed explicitly (`rentLamports` + `description`). AUTO NONCE SETUP: if the wallet has no durable-nonce account yet, this tool transparently bundles createAccountWithSeed + nonceInitialize ahead of the SPL transfer (legacy blockhash; subsequent SPL sends use the durable-nonce path). Surfaced as `firstTimeNonceSetup: \"true\"` + ~0.00144 SOL rent in the description. BLIND-SIGN REQUIRED: the Ledger Solana app does NOT auto clear-sign TransferChecked — its parser requires a signed 'Trusted Name' TLV descriptor that only Ledger Live supplies, so the device drops into blind-sign and shows a 'Message Hash' (base58(sha256(messageBytes))). The user must (1) enable 'Allow blind signing' in Solana app → Settings, and (2) match the Message Hash surfaced by `preview_solana_send` against the on-device value before approving.",
       inputSchema: prepareSolanaSplSendInput.shape,
     },
     handler(prepareSolanaSplSend)
@@ -1260,17 +1260,16 @@ async function main() {
     "prepare_solana_nonce_init",
     {
       description:
-        "One-time setup: build a tx that creates a per-wallet durable-nonce account at the deterministic PDA " +
-        "`PublicKey.createWithSeed(wallet, 'vaultpilot-nonce-v1', SystemProgram.programId)`. After this runs " +
-        "and broadcasts, every subsequent `prepare_solana_native_send` / `prepare_solana_spl_send` for this " +
-        "wallet will prepend `SystemProgram.nonceAdvance` as ix[0] and use the nonce value in place of a " +
-        "recentBlockhash — eliminating the ~90s window that was causing Ledger blind-sign SPL txs to expire " +
-        "during user review. Costs ~0.00144 SOL rent-exempt seed + ~0.000005 SOL tx fee; the rent is " +
-        "returned to the main wallet via `prepare_solana_nonce_close`. The user's main wallet stays exactly " +
-        "as is — funds do NOT move; a small deposit is parked in the new account. Run this once per wallet. " +
-        "Refuses if a nonce account already exists at the derived PDA (re-init would brick in-flight txs). " +
-        "This init tx itself uses a regular recent blockhash (one-time exception — there's no nonce to use " +
-        "yet).",
+        "Explicit one-time setup of a per-wallet durable-nonce account at the deterministic PDA " +
+        "`PublicKey.createWithSeed(wallet, 'vaultpilot-nonce-v1', SystemProgram.programId)`. " +
+        "MOST USERS DO NOT NEED TO CALL THIS DIRECTLY — `prepare_solana_native_send` / " +
+        "`prepare_solana_spl_send` auto-bundle the same setup into the user's first send. Use this " +
+        "tool when the user wants the setup standalone (e.g. before a Jupiter swap or MarginFi " +
+        "action, which can't safely auto-bundle due to size + ALT constraints), or to re-init after " +
+        "a `prepare_solana_nonce_close`. Costs ~0.00144 SOL rent-exempt seed + ~0.000005 SOL tx fee; " +
+        "the rent is fully reclaimable via `prepare_solana_nonce_close`. Refuses if a nonce account " +
+        "already exists at the derived PDA. This init tx uses a regular recent blockhash (no nonce " +
+        "to use yet — same constraint that makes auto-bundling possible inside native/SPL sends).",
       inputSchema: prepareSolanaNonceInitInput.shape,
     },
     handler(prepareSolanaNonceInit)

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -138,29 +138,45 @@ export interface PreparedSolanaTx {
 }
 
 /**
- * Structured error thrown by `buildSolanaNativeSend` / `buildSolanaSplSend`
- * when the wallet hasn't initialized a durable-nonce account yet. The agent
- * relays the message verbatim to the user, who then runs
- * `prepare_solana_nonce_init` before retrying the send.
+ * Structured error thrown by builders that can't safely auto-bundle the
+ * one-time nonce-init step into their tx (Jupiter swaps + MarginFi actions
+ * are already large v0+ALT messages where appending two more ixs risks
+ * blowing past size limits). Points the user at the simplest fix: do any
+ * tiny `prepare_solana_native_send` first — that builder auto-bundles
+ * nonce-init when missing — or call `prepare_solana_nonce_init` explicitly.
  */
 export function throwNonceRequired(wallet: string): never {
   throw new Error(
-    `Solana nonce account not initialized for ${wallet}. Durable-nonce protection is required ` +
-      `for all Solana sends in this server — the ~90s recentBlockhash window was eating into the ` +
-      `Ledger blind-sign review time and causing intermittent failures. ` +
-      `Run prepare_solana_nonce_init first (one-time setup, ~0.00144 SOL rent-exempt seed, fully ` +
-      `reclaimable via prepare_solana_nonce_close) and then retry this send.`,
+    `Solana durable-nonce account not initialized for ${wallet}. This builder ` +
+      `can't safely auto-bundle the setup into a swap/lending tx (size + ALT ` +
+      `constraints), so you have two options: (1) easiest — do any tiny ` +
+      `prepare_solana_native_send (e.g. 0.001 SOL to yourself); that builder ` +
+      `auto-includes the one-time ~0.00144 SOL nonce setup, or (2) call ` +
+      `prepare_solana_nonce_init directly. Either way, retry this action ` +
+      `afterwards. The rent is fully reclaimable via prepare_solana_nonce_close.`,
   );
 }
 
 /**
- * Build a native SOL transfer. One `SystemProgram.transfer` instruction,
- * preceded by `SystemProgram.nonceAdvance` (ix[0], required — Agave
- * detects durable-nonce txs via ix[0] only) and optionally a `ComputeBudget`
- * pair when the network is congested. Pre-flight: refuses if the wallet is
- * short OR if the nonce account doesn't exist yet. Returns a DRAFT
- * (handle + metadata) — the nonce value is pinned later by
- * `preview_solana_send`.
+ * Build a native SOL transfer.
+ *
+ * Two shapes depending on whether the wallet has a durable-nonce account yet:
+ *
+ *   - **Steady state** (nonce exists): one `SystemProgram.transfer` preceded
+ *     by `SystemProgram.nonceAdvance` (ix[0], required — Agave detects
+ *     durable-nonce txs via ix[0] only) and optionally a `ComputeBudget`
+ *     pair when the network is congested. Tx is durable-nonce-protected and
+ *     stays valid indefinitely on the device.
+ *
+ *   - **First send** (nonce missing): same tx auto-bundles the one-time
+ *     create+initialize of the nonce PDA at ix[0..1], then optional compute-
+ *     budget, then the transfer. This run is legacy-blockhash mode (the
+ *     nonce account doesn't exist yet to advance), so the ~60s blockhash
+ *     window applies — but every subsequent send is durable-nonce-protected.
+ *     Eliminates the visible `prepare_solana_nonce_init` pre-step.
+ *
+ * Returns a DRAFT (handle + metadata); the blockhash / nonce value is pinned
+ * later by `preview_solana_send`.
  */
 export async function buildSolanaNativeSend(
   p: SolanaNativeSendParams,
@@ -169,12 +185,14 @@ export async function buildSolanaNativeSend(
   const toPubkey = assertSolanaAddress(p.to);
   const conn = getSolanaConnection();
 
-  // Durable-nonce preflight: refuse if the user hasn't initialized yet.
-  // The nonce PDA is deterministic — same seed + base → same pubkey — so
-  // no lookup table is needed, just derive and check on-chain presence.
+  // Derive the deterministic nonce PDA. Existence determines the tx shape.
   const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
   const nonceState = await getNonceAccountValue(conn, noncePubkey);
-  if (!nonceState) throwNonceRequired(p.wallet);
+  const firstTimeSetup = !nonceState;
+  // Rent for the nonce account, only fetched when we need to bundle init.
+  const nonceRentLamports = firstTimeSetup
+    ? await conn.getMinimumBalanceForRentExemption(NONCE_ACCOUNT_LENGTH)
+    : 0;
 
   // Priority-fee decision BEFORE resolving "max" — the fee is baked into
   // the amount we're willing to hand back to the user on "max".
@@ -183,18 +201,27 @@ export async function buildSolanaNativeSend(
     ? Math.ceil((pfee.microLamportsPerCu * pfee.computeUnitLimit) / 1_000_000)
     : 0;
   const totalFee = SOLANA_BASE_FEE_LAMPORTS + priorityFeeLamports;
+  // On the first-time path, rent for the nonce PDA is reserved BEFORE we
+  // decide how much SOL the user can send; "max" must leave the rent on the
+  // nonce account, not hand it to the recipient.
+  const reservedForNonceRent = BigInt(nonceRentLamports);
 
   let lamports: bigint;
   let displayAmount: string;
   if (p.amount === "max") {
     const balanceLamports = BigInt(await conn.getBalance(fromPubkey, "confirmed"));
-    const reserved = BigInt(totalFee + SOL_SAFETY_BUFFER_LAMPORTS);
+    const reserved =
+      BigInt(totalFee + SOL_SAFETY_BUFFER_LAMPORTS) + reservedForNonceRent;
     if (balanceLamports <= reserved) {
       throw new Error(
         `Cannot "max": wallet ${p.wallet} balance ${formatSol(balanceLamports)} SOL is at or below ` +
           `the reserve (${formatSol(reserved)} SOL = tx fee + ${formatSol(
             BigInt(SOL_SAFETY_BUFFER_LAMPORTS),
-          )} SOL safety buffer).`,
+          )} SOL safety buffer` +
+          (firstTimeSetup
+            ? ` + ${formatSol(reservedForNonceRent)} SOL one-time durable-nonce account rent`
+            : "") +
+          `).`,
       );
     }
     lamports = balanceLamports - reserved;
@@ -202,22 +229,35 @@ export async function buildSolanaNativeSend(
   } else {
     lamports = parseSolAmount(p.amount);
     const balanceLamports = BigInt(await conn.getBalance(fromPubkey, "confirmed"));
-    if (balanceLamports < lamports + BigInt(totalFee)) {
+    const needed = lamports + BigInt(totalFee) + reservedForNonceRent;
+    if (balanceLamports < needed) {
       throw new Error(
         `Insufficient SOL: wallet ${p.wallet} has ${formatSol(balanceLamports)} SOL, ` +
-          `requested ${p.amount} + ${formatSol(BigInt(totalFee))} SOL fee = ` +
-          `${formatSol(lamports + BigInt(totalFee))} SOL. Reduce the amount or top up.`,
+          `requested ${p.amount} + ${formatSol(BigInt(totalFee))} SOL fee` +
+          (firstTimeSetup
+            ? ` + ${formatSol(reservedForNonceRent)} SOL one-time durable-nonce account rent`
+            : "") +
+          ` = ${formatSol(needed)} SOL. Reduce the amount or top up.`,
       );
     }
     displayAmount = p.amount;
   }
 
-  // Build the draft tx. ix[0] MUST be nonceAdvance — that's the signal
-  // Agave uses to detect durable-nonce txs and skip the blockhash validity
-  // window check. Everything else (compute-budget, payload) stacks after.
+  // Build the draft tx.
+  //   - Steady state: ix[0] = nonceAdvance, then compute-budget, then transfer.
+  //   - First-time setup: ix[0..1] = createAccountWithSeed + nonceInitialize,
+  //     then compute-budget, then transfer. This bundle uses a regular recent
+  //     blockhash because the nonce doesn't exist yet to advance — but it's
+  //     a one-time path; subsequent sends take the steady-state branch.
   const draftTx = new Transaction();
   draftTx.feePayer = fromPubkey;
-  draftTx.add(buildAdvanceNonceIx(noncePubkey, fromPubkey));
+  if (firstTimeSetup) {
+    for (const ix of buildInitNonceIxs(fromPubkey, noncePubkey, nonceRentLamports)) {
+      draftTx.add(ix);
+    }
+  } else {
+    draftTx.add(buildAdvanceNonceIx(noncePubkey, fromPubkey));
+  }
   if (pfee) {
     draftTx.add(
       ComputeBudgetProgram.setComputeUnitLimit({ units: pfee.computeUnitLimit }),
@@ -235,35 +275,56 @@ export async function buildSolanaNativeSend(
   );
 
   const nonceAccountStr = noncePubkey.toBase58();
+  const setupSuffix = firstTimeSetup
+    ? ` (+ one-time durable-nonce account setup, ${formatSol(reservedForNonceRent)} SOL rent reclaimable later via prepare_solana_nonce_close)`
+    : "";
+  const estimatedFeeLamportsTotal = totalFee + nonceRentLamports;
   const draft: SolanaTxDraft = {
     kind: "legacy",
     draftTx,
     meta: {
       action: "native_send",
       from: p.wallet,
-      description: `Send ${displayAmount} SOL to ${p.to}`,
+      description: `Send ${displayAmount} SOL to ${p.to}${setupSuffix}`,
       decoded: {
-        functionName: "solana.system.transfer",
+        functionName: firstTimeSetup
+          ? "solana.system.transfer+createNonceAccount"
+          : "solana.system.transfer",
         args: {
           from: p.wallet,
           to: p.to,
           amount: `${displayAmount} SOL`,
           lamports: lamports.toString(),
           nonceAccount: nonceAccountStr,
+          ...(firstTimeSetup
+            ? {
+                firstTimeNonceSetup: "true",
+                nonceSetupRentLamports: nonceRentLamports.toString(),
+                nonceSetupRentSol: formatSol(reservedForNonceRent),
+              }
+            : {}),
         },
       },
+      ...(firstTimeSetup ? { rentLamports: nonceRentLamports } : {}),
       ...(pfee
         ? {
             priorityFeeMicroLamports: pfee.microLamportsPerCu,
             computeUnitLimit: pfee.computeUnitLimit,
           }
         : {}),
-      estimatedFeeLamports: totalFee,
-      nonce: {
-        account: nonceAccountStr,
-        authority: fromPubkey.toBase58(),
-        value: nonceState.nonce,
-      },
+      estimatedFeeLamports: estimatedFeeLamportsTotal,
+      // Steady-state sends self-protect via durable nonce; record the meta
+      // so preview re-fetches the on-chain nonce value at pin time. The
+      // first-time bundle uses a legacy blockhash (no nonce to advance yet).
+      ...(firstTimeSetup
+        ? {}
+        : {
+            nonce: {
+              account: nonceAccountStr,
+              authority: fromPubkey.toBase58(),
+              value: nonceState!.nonce,
+            },
+          }),
     },
   };
   const { handle } = issueSolanaDraftHandle(draft);
@@ -274,6 +335,9 @@ export async function buildSolanaNativeSend(
     from: p.wallet,
     description: draft.meta.description,
     decoded: draft.meta.decoded,
+    ...(draft.meta.rentLamports !== undefined
+      ? { rentLamports: draft.meta.rentLamports }
+      : {}),
     ...(draft.meta.priorityFeeMicroLamports !== undefined
       ? { priorityFeeMicroLamports: draft.meta.priorityFeeMicroLamports }
       : {}),
@@ -297,11 +361,21 @@ export interface SolanaSplSendParams {
 }
 
 /**
- * Build an SPL token transfer. ix[0] is `SystemProgram.nonceAdvance` (required
- * for durable-nonce protection — see the module docs in `nonce.ts`), followed
- * by optional ComputeBudget ixs, optional createAssociatedTokenAccount, and
- * finally `Token.TransferChecked`. TransferChecked makes the Ledger Solana
- * app clear-sign the mint + decimals + amount.
+ * Build an SPL token transfer.
+ *
+ * Two shapes depending on whether the wallet has a durable-nonce account yet:
+ *
+ *   - **Steady state** (nonce exists): ix[0] = `SystemProgram.nonceAdvance`,
+ *     then optional ComputeBudget, then optional `createAssociatedTokenAccount`,
+ *     then `Token.TransferChecked`. Tx is durable-nonce-protected.
+ *
+ *   - **First send** (nonce missing): ix[0..1] = createAccountWithSeed +
+ *     nonceInitialize, then optional CB, optional createATA, then
+ *     TransferChecked. Legacy-blockhash one-shot — same auto-bundle pattern
+ *     as `buildSolanaNativeSend`.
+ *
+ * TransferChecked makes the Ledger Solana app clear-sign the mint + decimals
+ * + amount (when paired with a Trusted Name TLV; otherwise blind-sign).
  */
 export async function buildSolanaSplSend(
   p: SolanaSplSendParams,
@@ -311,10 +385,14 @@ export async function buildSolanaSplSend(
   const mintPubkey = assertSolanaAddress(p.mint);
   const conn = getSolanaConnection();
 
-  // Durable-nonce preflight — same gate as buildSolanaNativeSend.
+  // Durable-nonce check — auto-bundle init when missing (same pattern as
+  // buildSolanaNativeSend). Subsequent SPL sends take the steady-state path.
   const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
   const nonceState = await getNonceAccountValue(conn, noncePubkey);
-  if (!nonceState) throwNonceRequired(p.wallet);
+  const firstTimeSetup = !nonceState;
+  const nonceRentLamports = firstTimeSetup
+    ? await conn.getMinimumBalanceForRentExemption(NONCE_ACCOUNT_LENGTH)
+    : 0;
 
   // Resolve decimals + symbol. Canonical mints (USDC/USDT/JUP/...) use the
   // static table; unknown mints hit the chain via getTokenSupply.
@@ -356,14 +434,15 @@ export async function buildSolanaSplSend(
   // Recipient ATA — may need to be created. Sender pays the rent if so.
   const recipient = await resolveRecipientAta(conn, mintPubkey, toPubkey);
 
-  // Pre-flight: ensure the wallet has enough SOL for tx fee + ATA rent.
+  // Pre-flight: ensure the wallet has enough SOL for tx fee + ATA rent
+  // (+ one-time durable-nonce account rent on the first SPL send).
   const pfee = await computePriorityFee(conn, [senderAta, recipient.ataAddress]);
   const priorityFeeLamports = pfee
     ? Math.ceil((pfee.microLamportsPerCu * pfee.computeUnitLimit) / 1_000_000)
     : 0;
   const totalFee = SOLANA_BASE_FEE_LAMPORTS + priorityFeeLamports;
-  const totalLamportsNeeded =
-    totalFee + (recipient.needsCreation ? SPL_TOKEN_ACCOUNT_RENT_LAMPORTS : 0);
+  const ataRent = recipient.needsCreation ? SPL_TOKEN_ACCOUNT_RENT_LAMPORTS : 0;
+  const totalLamportsNeeded = totalFee + ataRent + nonceRentLamports;
   const solBalance = BigInt(await conn.getBalance(fromPubkey, "confirmed"));
   if (solBalance < BigInt(totalLamportsNeeded)) {
     throw new Error(
@@ -372,15 +451,27 @@ export async function buildSolanaSplSend(
         (recipient.needsCreation
           ? ` + ${formatSol(BigInt(SPL_TOKEN_ACCOUNT_RENT_LAMPORTS))} SOL to create the recipient's ${symbol} account`
           : "") +
+        (firstTimeSetup
+          ? ` + ${formatSol(BigInt(nonceRentLamports))} SOL one-time durable-nonce account rent`
+          : "") +
         `). Top up and retry.`,
     );
   }
 
-  // Build the draft tx. ix[0] = nonceAdvance (required); then compute-budget,
-  // then optional ATA-create, then the SPL transfer.
+  // Build the draft tx.
+  //   - Steady state: ix[0] = nonceAdvance, then compute-budget, then optional
+  //     ATA-create, then TransferChecked.
+  //   - First-time setup: ix[0..1] = createAccountWithSeed + nonceInitialize,
+  //     then compute-budget, then optional ATA-create, then TransferChecked.
   const draftTx = new Transaction();
   draftTx.feePayer = fromPubkey;
-  draftTx.add(buildAdvanceNonceIx(noncePubkey, fromPubkey));
+  if (firstTimeSetup) {
+    for (const ix of buildInitNonceIxs(fromPubkey, noncePubkey, nonceRentLamports)) {
+      draftTx.add(ix);
+    }
+  } else {
+    draftTx.add(buildAdvanceNonceIx(noncePubkey, fromPubkey));
+  }
   if (pfee) {
     draftTx.add(
       ComputeBudgetProgram.setComputeUnitLimit({ units: pfee.computeUnitLimit }),
@@ -410,11 +501,16 @@ export async function buildSolanaSplSend(
     ),
   );
 
-  const descSuffix = recipient.needsCreation
+  const ataSuffix = recipient.needsCreation
     ? ` (+ create recipient ${symbol} account, costs ${formatSol(BigInt(SPL_TOKEN_ACCOUNT_RENT_LAMPORTS))} SOL rent)`
     : "";
-  const estimatedFeeLamports =
-    totalFee + (recipient.needsCreation ? SPL_TOKEN_ACCOUNT_RENT_LAMPORTS : 0);
+  const setupSuffix = firstTimeSetup
+    ? ` (+ one-time durable-nonce account setup, ${formatSol(BigInt(nonceRentLamports))} SOL rent reclaimable later via prepare_solana_nonce_close)`
+    : "";
+  const estimatedFeeLamports = totalFee + ataRent + nonceRentLamports;
+  // Combine rent components into a single number; surfaces the user's total
+  // rent obligation (ATA rent + nonce rent) on the prepared result.
+  const totalRentLamports = ataRent + nonceRentLamports;
   const nonceAccountStr = noncePubkey.toBase58();
   const draft: SolanaTxDraft = {
     kind: "legacy",
@@ -422,9 +518,11 @@ export async function buildSolanaSplSend(
     meta: {
       action: "spl_send",
       from: p.wallet,
-      description: `Send ${p.amount} ${symbol} to ${p.to}${descSuffix}`,
+      description: `Send ${p.amount} ${symbol} to ${p.to}${ataSuffix}${setupSuffix}`,
       decoded: {
-        functionName: "solana.spl.transferChecked",
+        functionName: firstTimeSetup
+          ? "solana.spl.transferChecked+createNonceAccount"
+          : "solana.spl.transferChecked",
         args: {
           from: p.wallet,
           to: p.to,
@@ -437,9 +535,16 @@ export async function buildSolanaSplSend(
           ...(recipient.needsCreation
             ? { createsRecipientAta: "true", rentSol: formatSol(BigInt(SPL_TOKEN_ACCOUNT_RENT_LAMPORTS)) }
             : {}),
+          ...(firstTimeSetup
+            ? {
+                firstTimeNonceSetup: "true",
+                nonceSetupRentLamports: nonceRentLamports.toString(),
+                nonceSetupRentSol: formatSol(BigInt(nonceRentLamports)),
+              }
+            : {}),
         },
       },
-      ...(recipient.needsCreation ? { rentLamports: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS } : {}),
+      ...(totalRentLamports > 0 ? { rentLamports: totalRentLamports } : {}),
       ...(pfee
         ? {
             priorityFeeMicroLamports: pfee.microLamportsPerCu,
@@ -447,11 +552,17 @@ export async function buildSolanaSplSend(
           }
         : {}),
       estimatedFeeLamports,
-      nonce: {
-        account: nonceAccountStr,
-        authority: fromPubkey.toBase58(),
-        value: nonceState.nonce,
-      },
+      // Steady-state SPL sends self-protect via durable nonce; the first-time
+      // bundle uses a legacy blockhash (no nonce to advance yet).
+      ...(firstTimeSetup
+        ? {}
+        : {
+            nonce: {
+              account: nonceAccountStr,
+              authority: fromPubkey.toBase58(),
+              value: nonceState!.nonce,
+            },
+          }),
     },
   };
   const { handle } = issueSolanaDraftHandle(draft);

--- a/test/solana-jupiter.test.ts
+++ b/test/solana-jupiter.test.ts
@@ -179,7 +179,7 @@ describe("buildJupiterSwap", () => {
     );
     await expect(
       buildJupiterSwap({ wallet: WALLET, quote: SAMPLE_QUOTE as never }),
-    ).rejects.toThrow(/prepare_solana_nonce_init first/);
+    ).rejects.toThrow(/durable-nonce account not initialized/);
   });
 
   it("composes the v0 ix list with nonceAdvance first + resolves ALTs + stashes everything on a v0 draft", async () => {

--- a/test/solana-prepare.test.ts
+++ b/test/solana-prepare.test.ts
@@ -246,22 +246,80 @@ describe("buildSolanaSplSend", () => {
 });
 
 describe("durable-nonce preflight", () => {
-  it("buildSolanaNativeSend refuses with structured error when nonce account missing", async () => {
+  it("buildSolanaNativeSend auto-bundles createNonce + initNonce + transfer when nonce account missing", async () => {
     await setNonceMissing();
     connectionStub.getBalance.mockResolvedValue(5_000_000_000);
     const { buildSolanaNativeSend } = await import("../src/modules/solana/actions.js");
-    await expect(
-      buildSolanaNativeSend({ wallet: WALLET, to: RECIPIENT, amount: "1" }),
-    ).rejects.toThrow(/prepare_solana_nonce_init first/);
+    const tx = await buildSolanaNativeSend({
+      wallet: WALLET,
+      to: RECIPIENT,
+      amount: "1",
+    });
+    expect(tx.action).toBe("native_send");
+    expect(tx.decoded.args.firstTimeNonceSetup).toBe("true");
+    expect(tx.decoded.functionName).toBe(
+      "solana.system.transfer+createNonceAccount",
+    );
+    expect(tx.description).toMatch(/one-time durable-nonce account setup/);
+    // Rent surfaced on the result so the agent can show it.
+    expect(tx.rentLamports).toBe(1_500_000);
+
+    const { getSolanaDraft } = await import("../src/signing/solana-tx-store.js");
+    const draft = getSolanaDraft(tx.handle);
+    // ix[0] = createAccountWithSeed (SystemInstruction tag 3, u32 LE)
+    expect(draft.draftTx.instructions[0].programId.toBase58()).toBe(
+      "11111111111111111111111111111111",
+    );
+    expect(draft.draftTx.instructions[0].data.readUInt32LE(0)).toBe(3);
+    // ix[1] = nonceInitialize (SystemInstruction tag 6)
+    expect(draft.draftTx.instructions[1].programId.toBase58()).toBe(
+      "11111111111111111111111111111111",
+    );
+    expect(draft.draftTx.instructions[1].data.readUInt32LE(0)).toBe(6);
+    // No durable-nonce meta — preview pins via getLatestBlockhash on this run.
+    expect(draft.meta.nonce).toBeUndefined();
   });
 
-  it("buildSolanaSplSend refuses with the same structured error when nonce account missing", async () => {
+  it("buildSolanaSplSend auto-bundles createNonce + initNonce + transferChecked when nonce account missing", async () => {
     await setNonceMissing();
     connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getAccountInfo
+      // sender ATA exists
+      .mockResolvedValueOnce({ data: Buffer.alloc(165), owner: new PublicKey(WALLET) })
+      // recipient ATA exists too
+      .mockResolvedValueOnce({ data: Buffer.alloc(165), owner: new PublicKey(RECIPIENT) });
+    connectionStub.getTokenAccountBalance.mockResolvedValue({
+      value: { amount: "100000000", decimals: 6, uiAmount: 100, uiAmountString: "100" },
+    });
     const { buildSolanaSplSend } = await import("../src/modules/solana/actions.js");
+    const tx = await buildSolanaSplSend({
+      wallet: WALLET,
+      mint: USDC_MINT,
+      to: RECIPIENT,
+      amount: "1",
+    });
+    expect(tx.decoded.args.firstTimeNonceSetup).toBe("true");
+    expect(tx.decoded.functionName).toBe(
+      "solana.spl.transferChecked+createNonceAccount",
+    );
+    expect(tx.description).toMatch(/one-time durable-nonce account setup/);
+    expect(tx.rentLamports).toBe(1_500_000);
+
+    const { getSolanaDraft } = await import("../src/signing/solana-tx-store.js");
+    const draft = getSolanaDraft(tx.handle);
+    expect(draft.draftTx.instructions[0].data.readUInt32LE(0)).toBe(3); // createAccountWithSeed
+    expect(draft.draftTx.instructions[1].data.readUInt32LE(0)).toBe(6); // nonceInitialize
+    expect(draft.meta.nonce).toBeUndefined();
+  });
+
+  it("first-time native_send refuses when balance can't cover amount + fee + nonce rent", async () => {
+    await setNonceMissing();
+    // 1 SOL balance, asking to send 1 SOL — leaves no room for the 0.0015 SOL nonce rent + fee.
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    const { buildSolanaNativeSend } = await import("../src/modules/solana/actions.js");
     await expect(
-      buildSolanaSplSend({ wallet: WALLET, mint: USDC_MINT, to: RECIPIENT, amount: "1" }),
-    ).rejects.toThrow(/prepare_solana_nonce_init first/);
+      buildSolanaNativeSend({ wallet: WALLET, to: RECIPIENT, amount: "1" }),
+    ).rejects.toThrow(/one-time durable-nonce account rent/);
   });
 
   it("buildSolanaNativeSend prepends AdvanceNonceAccount as ix[0] when nonce is present", async () => {


### PR DESCRIPTION
## Summary
- Implements item **3.2** of `claude-work/HIGH-plan-broad-audience-onboarding.md` — eliminates the visible `prepare_solana_nonce_init` pre-step for the common entry points.
- `prepare_solana_native_send` / `prepare_solana_spl_send`: when the wallet has no durable-nonce PDA, builds a single legacy-blockhash tx that bundles `createAccountWithSeed + nonceInitialize` ahead of the transfer. Subsequent sends fall back to the steady-state durable-nonce path.
- Jupiter / MarginFi keep the explicit-init requirement (size + ALT constraints make auto-splicing risky), but the error now points users at the easiest fix: do any tiny `prepare_solana_native_send` first.

## UX surface
- `decoded.args.firstTimeNonceSetup = \"true\"` on the prepared result
- `decoded.functionName = \"solana.system.transfer+createNonceAccount\"` (or `solana.spl.transferChecked+createNonceAccount`)
- `description` suffix: *(+ one-time durable-nonce account setup, ~0.00144 SOL rent reclaimable later via prepare_solana_nonce_close)*
- `rentLamports` populated on the prepared result
- Balance preflight messages mention the rent obligation explicitly

## Test plan
- [x] `npm test` — 888 tests pass (3 new in `test/solana-prepare.test.ts`)
- [x] `npm run build` — clean TS
- [ ] Live: fresh Solana wallet → `prepare_solana_native_send` 0.001 SOL → device shows createAccount + nonceInit + transfer → after broadcast, immediate second send takes the steady-state path (durable-nonce-protected, no rent).
- [ ] Live: fresh wallet → `prepare_solana_swap` → expect the new pointer error mentioning the auto-bundle path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)