### PR TITLE
feat(lifi): TRON destination + bridge-intent cross-check decoding defense

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1174,7 +1174,7 @@ async function main() {
     {
       description:
         "Get a LiFi aggregator quote for a token swap (same-chain) or bridge (cross-chain). Returns expected output, fees, execution time, and the underlying tool selected. Default is exact-in (`amount` = fromToken); set `amountSide: \"to\"` for exact-out quotes (`amount` = target toToken output). " +
-        "Source chain is always EVM. Destination can be any EVM chain OR Solana — pass `toChain: \"solana\"` + an explicit `toAddress` (Solana base58); the bridge protocol delivers SPL tokens after the EVM source tx confirms (typically 1-15 min). Exact-out is not supported for cross-chain bridges to Solana. For Solana-source swaps and bridges (the reverse direction) use `prepare_solana_lifi_swap`. " +
+        "Source chain is always EVM. Destination can be any EVM chain, Solana, or TRON — pass `toChain: \"solana\"` / `toChain: \"tron\"` + an explicit `toAddress` (Solana base58 / TRON T-prefixed base58); the bridge protocol delivers tokens on the destination chain after the EVM source tx confirms (typically 1-15 min). Exact-out is not supported for cross-chain bridges to Solana or TRON. For Solana-source swaps and bridges (the reverse direction) use `prepare_solana_lifi_swap`. TRON-source LiFi is not yet wired. " +
         "No transaction is built by this tool.",
       inputSchema: getSwapQuoteInput.shape,
     },
@@ -1186,7 +1186,8 @@ async function main() {
     {
       description:
         "Prepare an unsigned swap or bridge transaction via LiFi aggregator. Same-chain swaps use the best DEX route; cross-chain swaps use a bridge + DEX combo. Default is exact-in (`amount` = fromToken); set `amountSide: \"to\"` for exact-out (`amount` = target toToken output, e.g. \"I want 100 USDC out\"). " +
-        "Source chain is always EVM. Destination can be any EVM chain OR Solana — pass `toChain: \"solana\"` + an explicit `toAddress` (Solana base58); the user signs an EVM tx and the bridge protocol delivers SPL tokens to the Solana address after confirmation. The destination-side decimals cross-check is dropped for Solana destinations (we can't read SPL via EVM RPC); LiFi's reported decimals are the source of truth there. Exact-out is not supported for cross-chain-to-Solana. For Solana-source swaps and bridges use `prepare_solana_lifi_swap`. " +
+        "Source chain is always EVM. Destination can be any EVM chain, Solana, or TRON. For non-EVM destinations pass `toChain: \"solana\"` / `\"tron\"` + an explicit `toAddress` in the destination chain's format; the user signs an EVM tx and the bridge protocol delivers tokens to the destination after confirmation. The destination-side decimals cross-check is dropped for non-EVM destinations (we can't read SPL/TRC-20 via EVM RPC); LiFi's reported decimals are the source of truth there. Exact-out is not supported for cross-chain-to-non-EVM. For Solana-source swaps and bridges use `prepare_solana_lifi_swap`. TRON-source LiFi is not yet wired. " +
+        "DECODING DEFENSE: every cross-chain bridge calldata is parsed into its `BridgeData` tuple and the encoded `destinationChainId` + `receiver` are cross-checked against what the user requested — refuses on mismatch. Catches a compromised MCP that returns calldata routing to a different chain or recipient than the prepare receipt advertises. " +
         "The returned tx can be sent via `send_transaction`.",
       inputSchema: prepareSwapInput.shape,
     },

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -1,12 +1,38 @@
-import { parseUnits, formatUnits, encodeFunctionData } from "viem";
+import { parseUnits, formatUnits, encodeFunctionData, getAddress } from "viem";
 import { fetchQuote, fetchStatus } from "./lifi.js";
 import { fetchOneInchQuote } from "./oneinch.js";
 import type { GetSwapQuoteArgs, PrepareSwapArgs } from "./schemas.js";
 import { getClient } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
 import { readUserConfig, resolveOneInchApiKey } from "../../config/user-config.js";
-import { SOLANA_ADDRESS } from "../../shared/address-patterns.js";
+import { SOLANA_ADDRESS, TRON_ADDRESS } from "../../shared/address-patterns.js";
+import {
+  tryDecodeLifiBridgeData,
+  type DecodedLifiBridgeData,
+} from "../../signing/decode-calldata.js";
+import { NON_EVM_RECEIVER_SENTINEL } from "../../abis/lifi-diamond.js";
 import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+
+/**
+ * LiFi-internal numeric chain IDs for non-EVM destinations. Source: the
+ * chain IDs returned by `https://li.quest/v1/chains` (also surfaced as
+ * the `ChainId` enum in `@lifi/types`). Hardcoding here avoids a
+ * cross-module import for what is, conceptually, a small lookup table
+ * specific to bridge-intent verification.
+ *
+ * Same constants are duplicated in `decode-calldata.describeBridgeChainId` —
+ * those tables stay in lockstep manually; the test
+ * `swap-evm-to-solana.test.ts` pins both via the LiFi public chain ID.
+ */
+const LIFI_CHAIN_ID: Record<SupportedChain | "solana" | "tron", number> = {
+  ethereum: 1,
+  arbitrum: 42161,
+  polygon: 137,
+  base: 8453,
+  optimism: 10,
+  solana: 1151111081099710,
+  tron: 728126428,
+};
 
 /**
  * Validate destination addressing for cross-chain-type bridges. The schema
@@ -29,22 +55,32 @@ function assertCrossChainAddressing(
   args: GetSwapQuoteArgs | PrepareSwapArgs,
 ): void {
   const toIsSolana = args.toChain === "solana";
-  if (toIsSolana) {
+  const toIsTron = args.toChain === "tron";
+  const toIsNonEvm = toIsSolana || toIsTron;
+  if (toIsNonEvm) {
     if (!args.toAddress) {
       throw new Error(
-        `toAddress is required when toChain === "solana" — the source EVM wallet ` +
-          `is not a valid Solana recipient. Pass an explicit base58 destination address.`,
+        `toAddress is required when toChain === "${args.toChain}" — the source EVM wallet ` +
+          `is not a valid recipient on a non-EVM chain. Pass an explicit destination ` +
+          `address (Solana base58 for "solana", T-prefixed base58 for "tron").`,
       );
     }
-    if (!SOLANA_ADDRESS.test(args.toAddress)) {
+    if (toIsSolana && !SOLANA_ADDRESS.test(args.toAddress)) {
       throw new Error(
         `toAddress "${args.toAddress}" is not a valid Solana base58 address ` +
           `(expected 43-44 chars). Refusing to prepare a bridge to an unparseable destination.`,
       );
     }
+    if (toIsTron && !TRON_ADDRESS.test(args.toAddress)) {
+      throw new Error(
+        `toAddress "${args.toAddress}" is not a valid TRON base58 address ` +
+          `(expected T-prefixed, 34 chars total). Refusing to prepare a bridge to an ` +
+          `unparseable destination.`,
+      );
+    }
     if (args.amountSide === "to") {
       throw new Error(
-        `Exact-out (amountSide: "to") is not supported for cross-chain bridges to Solana. ` +
+        `Exact-out (amountSide: "to") is not supported for cross-chain bridges to ${args.toChain}. ` +
           `LiFi's quote API has no reliable exact-out for cross-chain routes; the bridge ` +
           `protocol's delivery side adds fee drift the quote can't account for. Use ` +
           `amountSide: "from" (default) and inspect the quote's toAmountMin.`,
@@ -59,6 +95,91 @@ function assertCrossChainAddressing(
           `or omit toAddress to default to the source wallet.`,
       );
     }
+  }
+}
+
+/**
+ * Cross-check the LiFi quote's encoded bridge intent against what the user
+ * asked for. Catches a compromised MCP that swaps `toChain` or `toAddress`
+ * between the prepare call and the calldata it returns — even though the
+ * prepare receipt would still print the user-requested fields, the bytes
+ * that go to Ledger would carry the attacker's destination.
+ *
+ * Decode strategy is the same as `decode-calldata.tryDecodeLifiBridgeData`:
+ * positional decode of the universal `BridgeData` tuple, ignoring the
+ * facet-specific second arg. Returns silently when the calldata is NOT
+ * bridge-shaped (e.g. intra-EVM swap-facet calls — those don't carry a
+ * BridgeData tuple, and the existing source-side guards already cover them).
+ *
+ * Asserts:
+ *   1. `BridgeData.destinationChainId` matches LiFi's chain ID for the
+ *      requested `args.toChain`. Catches a `toChain` swap.
+ *   2. `BridgeData.receiver`:
+ *      - For EVM destinations: equals `args.toAddress` (or, if omitted,
+ *        the source wallet — LiFi default behavior).
+ *      - For non-EVM destinations: is the LiFi non-EVM sentinel. The
+ *        actual non-EVM address lives in the bridge-specific second arg
+ *        (Wormhole-style `bytes32`, etc.) which we don't decode; the
+ *        user's prepare receipt + Etherscan + the destinationChainId
+ *        invariant above are the layered defenses there.
+ */
+function verifyLifiBridgeIntent(
+  args: PrepareSwapArgs,
+  data: `0x${string}`,
+): void {
+  const decoded = tryDecodeLifiBridgeData(data);
+  const isCrossChain = args.fromChain !== args.toChain;
+  if (!decoded) {
+    // No BridgeData → swap-facet calldata. Legitimate for same-chain
+    // swaps; suspicious for cross-chain asks (a same-chain swap disguised
+    // as a bridge would execute on-chain as a swap, leaving the user's
+    // funds in the source wallet as the "to" token rather than delivering
+    // them to the destination chain — funds aren't stealable but the
+    // user's intent is undermined).
+    if (isCrossChain) {
+      throw new Error(
+        `LiFi quote returned swap-facet calldata for a cross-chain request ` +
+          `(${args.fromChain} → ${args.toChain}) — expected bridge-facet ` +
+          `calldata carrying a BridgeData tuple. Refusing to return calldata; ` +
+          `re-run get_swap_quote.`,
+      );
+    }
+    return;
+  }
+  const expectedChainId = BigInt(LIFI_CHAIN_ID[args.toChain as keyof typeof LIFI_CHAIN_ID]);
+  if (decoded.destinationChainId !== expectedChainId) {
+    throw new Error(
+      `LiFi bridge calldata destinationChainId mismatch: encoded ${decoded.destinationChainId.toString()} ` +
+        `but user requested toChain="${args.toChain}" (= ${expectedChainId.toString()}). ` +
+        `Refusing to return calldata — this would route funds to the wrong chain. Re-run get_swap_quote.`,
+    );
+  }
+
+  const toIsNonEvm = args.toChain === "solana" || args.toChain === "tron";
+  if (toIsNonEvm) {
+    if (decoded.receiver.toLowerCase() !== NON_EVM_RECEIVER_SENTINEL) {
+      throw new Error(
+        `LiFi bridge calldata receiver mismatch for non-EVM destination ${args.toChain}: ` +
+          `expected the LiFi non-EVM sentinel (${NON_EVM_RECEIVER_SENTINEL}), got ${decoded.receiver.toLowerCase()}. ` +
+          `Refusing to return calldata. The actual ${args.toChain} destination is encoded in ` +
+          `the bridge-specific data; the sentinel is how LiFi marks this is a non-EVM route.`,
+      );
+    }
+    return;
+  }
+
+  // EVM destination — receiver must match either explicit toAddress or
+  // (when toAddress omitted) the source wallet.
+  const expectedReceiver = (args.toAddress ?? args.wallet) as `0x${string}`;
+  if (
+    getAddress(decoded.receiver) !== getAddress(expectedReceiver)
+  ) {
+    throw new Error(
+      `LiFi bridge calldata receiver mismatch: encoded ${getAddress(decoded.receiver)} but ` +
+        `user requested ${getAddress(expectedReceiver)}. Refusing to return calldata — ` +
+        `this would route funds to a different recipient than the prepare receipt shows. ` +
+        `Re-run get_swap_quote.`,
+    );
   }
 }
 
@@ -348,12 +469,13 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
   assertCrossChainAddressing(args);
   const chain = args.fromChain as SupportedChain;
   const toIsSolana = args.toChain === "solana";
+  const toIsTron = args.toChain === "tron";
+  const toIsNonEvm = toIsSolana || toIsTron;
   const amountSide = args.amountSide ?? "from";
   const isExactOut = amountSide === "to";
 
-  // Same exact-out branch story as getSwapQuote — exact-out is rejected
-  // for Solana destinations, so the cast to SupportedChain in that branch
-  // is safe.
+  // Exact-out is rejected for non-EVM destinations in
+  // assertCrossChainAddressing, so the cast in this branch is safe.
   const sideDecimals = isExactOut
     ? await resolveDecimals(
         args.toChain as SupportedChain,
@@ -365,7 +487,9 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
 
   const lifiReq = {
     fromChain: chain,
-    toChain: toIsSolana ? "solana" : (args.toChain as SupportedChain),
+    toChain: toIsNonEvm
+      ? (args.toChain as "solana" | "tron")
+      : (args.toChain as SupportedChain),
     fromToken: args.fromToken as `0x${string}` | "native",
     toToken: args.toToken as `0x${string}` | "native",
     fromAddress: args.wallet as `0x${string}`,
@@ -380,19 +504,30 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
     throw new Error("LiFi did not return a transactionRequest for this quote.");
   }
 
+  // Bridge-intent cross-check. For routes whose calldata embeds a LiFi
+  // BridgeData tuple (= every cross-chain bridge facet), assert the encoded
+  // destinationChainId + receiver match what the user requested. Closes the
+  // attack vector where a compromised MCP returns calldata that bridges to
+  // a different chain or address than the prepare receipt advertises.
+  // Intra-EVM swap facets don't carry BridgeData and the helper returns null
+  // there — no false positives on the existing same-chain swap path.
+  verifyLifiBridgeIntent(args, txRequest.data as `0x${string}`);
+
   // Cross-check LiFi's reported token decimals against on-chain reads. A mismatch
   // would mean either LiFi has stale metadata or the route targets a token different
   // from what we asked for — in either case, the formatted expectedOut/minOut shown
   // to the user would be wrong, so refuse. Native assets are skipped (no contract).
   //
-  // Solana destination (cross-chain bridge): we cannot read SPL decimals via EVM
-  // RPC. The user's signature only authorizes the EVM-side action; the bridge
-  // protocol delivers SPL on Solana with whatever decimals LiFi reports. The
-  // destination cross-check is dropped here — the source-side check (which is
-  // what the user's signed bytes pull) still fires.
+  // Non-EVM destination (Solana / TRON cross-chain bridge): we cannot read SPL
+  // or TRC-20 decimals via EVM RPC. The user's signature only authorizes the
+  // EVM-side action; the bridge protocol delivers tokens on the destination
+  // chain with whatever decimals LiFi reports. The destination cross-check is
+  // dropped here — the source-side check (what the user's signed bytes pull)
+  // still fires, and `verifyLifiBridgeIntent` below cross-checks the encoded
+  // destination chain ID + receiver against the user's request.
   const fromToken = args.fromToken as `0x${string}` | "native";
   const fromDecimalsOnchain = await readOnchainDecimals(chain, fromToken);
-  const toDecimalsOnchain = toIsSolana
+  const toDecimalsOnchain = toIsNonEvm
     ? undefined
     : await readOnchainDecimals(
         args.toChain as SupportedChain,

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -22,6 +22,14 @@ export function initLifi(): void {
  */
 export const LIFI_SOLANA_CHAIN_ID = 1151111081099710 as const;
 
+/**
+ * LiFi numeric chain ID for TRON. Same value as TRON's standard chain ID
+ * (728126428), since TRON uses an EVM-compatible chain ID — but LiFi's
+ * routing graph still labels it as a TVM chain (chainType: "TVM"). Probe:
+ * GET https://li.quest/v1/chains?chainTypes=TVM returns id=728126428.
+ */
+export const LIFI_TRON_CHAIN_ID = 728126428 as const;
+
 /** Map our chain name to LiFi's numeric chain ID. */
 function toLifiChain(chain: SupportedChain): number {
   return CHAIN_IDS[chain];
@@ -30,26 +38,28 @@ function toLifiChain(chain: SupportedChain): number {
 interface LifiQuoteRequestBase {
   fromChain: SupportedChain;
   /**
-   * Destination chain. Either a known EVM `SupportedChain` (existing
-   * intra-EVM and EVM-EVM-cross flows) or `"solana"` (cross-chain bridge
-   * landing on Solana). LiFi's API itself accepts any numeric chain ID;
-   * we constrain to chains we've validated end-to-end in this server.
+   * Destination chain. EVM `SupportedChain` (intra-EVM + EVM-cross), or
+   * `"solana"` / `"tron"` (cross-chain bridge to a non-EVM chain). LiFi's
+   * API itself accepts any numeric chain ID; we constrain to chains we've
+   * validated end-to-end in this server.
    */
-  toChain: SupportedChain | "solana";
+  toChain: SupportedChain | "solana" | "tron";
   /** Use "native" or "0x0000000000000000000000000000000000000000" for native token. */
   fromToken: `0x${string}` | "native";
   /**
    * Destination token. EVM hex when `toChain` is EVM; SPL mint (base58)
-   * when `toChain === "solana"`. `"native"` resolves to the chain's
-   * native sentinel (`0x0…0` for EVM, wSOL mint for Solana — handled
-   * inside `fetchQuote`).
+   * when `toChain === "solana"`; TRC-20 contract address (T-prefixed
+   * base58) when `toChain === "tron"`. `"native"` resolves to the chain's
+   * native sentinel (`0x0…0` for EVM, wSOL mint for Solana, TRX
+   * contract address for TRON — handled inside `fetchQuote`).
    */
   toToken: string | "native";
   fromAddress: `0x${string}`;
   /**
    * Destination wallet. Defaults to `fromAddress` for intra-EVM swaps
-   * (LiFi behavior). REQUIRED when `toChain === "solana"` because the
-   * source EVM hex wallet isn't a valid Solana recipient.
+   * (LiFi behavior). REQUIRED when `toChain` is `"solana"` or `"tron"`
+   * because the source EVM hex wallet isn't a valid recipient on those
+   * chains.
    */
   toAddress?: string;
   /** Optional slippage override — LiFi default is 0.5% (0.005). */
@@ -70,22 +80,32 @@ export type LifiQuoteRequest =
 
 const NATIVE = "0x0000000000000000000000000000000000000000";
 
+// LiFi's canonical native-token handles per non-EVM chain. Source: the
+// `nativeToken.address` field in `https://li.quest/v1/chains` for each chain.
+const SOLANA_WSOL_NATIVE = "So11111111111111111111111111111111111111112";
+const TRON_NATIVE = "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb";
+
 export async function fetchQuote(req: LifiQuoteRequest) {
   initLifi();
   const fromChain = toLifiChain(req.fromChain);
   const toIsSolana = req.toChain === "solana";
+  const toIsTron = req.toChain === "tron";
   const toChain = toIsSolana
     ? LIFI_SOLANA_CHAIN_ID
-    : toLifiChain(req.toChain as SupportedChain);
+    : toIsTron
+      ? LIFI_TRON_CHAIN_ID
+      : toLifiChain(req.toChain as SupportedChain);
   const fromToken = req.fromToken === "native" ? NATIVE : req.fromToken;
   // Destination native sentinel depends on the chain family — wSOL for
-  // Solana, 0x0…0 for EVM. LiFi's routing graph treats both as the
-  // canonical native handle.
+  // Solana, TRX contract for TRON, 0x0…0 for EVM. LiFi's routing graph
+  // treats each of these as the canonical native handle for that chain.
   const toToken =
     req.toToken === "native"
       ? toIsSolana
-        ? "So11111111111111111111111111111111111111112"
-        : NATIVE
+        ? SOLANA_WSOL_NATIVE
+        : toIsTron
+          ? TRON_NATIVE
+          : NATIVE
       : req.toToken;
 
   if (req.toAmount !== undefined) {

--- a/src/modules/swap/schemas.ts
+++ b/src/modules/swap/schemas.ts
@@ -1,17 +1,20 @@
 import { z } from "zod";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
-import { EVM_ADDRESS, SOLANA_ADDRESS } from "../../shared/address-patterns.js";
+import { EVM_ADDRESS, SOLANA_ADDRESS, TRON_ADDRESS } from "../../shared/address-patterns.js";
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 /**
- * Destination-chain enum: EVM chains plus Solana. Used for cross-chain
- * bridging where the user signs an EVM tx and the bridge protocol delivers
- * SPL tokens on Solana. Source chain stays EVM-only (this tool does not
- * sign Solana txs — that's `prepare_solana_lifi_swap`).
+ * Destination-chain enum: EVM chains plus Solana and TRON. Used for cross-
+ * chain bridging where the user signs an EVM tx and the bridge protocol
+ * delivers tokens on the destination chain. Source chain stays EVM-only
+ * (Solana-source goes through `prepare_solana_lifi_swap`; TRON-source LiFi
+ * is not yet wired — tracked as a follow-up that needs raw_data
+ * reconstruction).
  */
 const toChainEnum = z.enum([
   ...(SUPPORTED_CHAINS as unknown as [string, ...string[]]),
   "solana",
+  "tron",
 ]);
 const walletSchema = z.string().regex(EVM_ADDRESS);
 const tokenSchema = z.union([
@@ -20,14 +23,18 @@ const tokenSchema = z.union([
 ]);
 /**
  * Destination token: EVM hex when `toChain` is EVM, base58 SPL mint when
- * `toChain === "solana"`. Format-validated per-chain in the resolver
+ * `toChain === "solana"`, base58 TRC-20 contract address (T-prefixed)
+ * when `toChain === "tron"`. Format-validated per-chain in the resolver
  * (`assertCrossChainAddressing`) since zod can't cross-reference fields
- * within `union` cleanly.
+ * within `union` cleanly. `TRON_ADDRESS` is a strict subset of
+ * `SOLANA_ADDRESS` (TRON is exactly 34 chars + T prefix; Solana is 43-44
+ * chars), so the union-with-regex works cleanly.
  */
 const toTokenSchema = z.union([
   z.literal("native"),
   z.string().regex(EVM_ADDRESS),
   z.string().regex(SOLANA_ADDRESS),
+  z.string().regex(TRON_ADDRESS),
 ]);
 
 const baseSwapSchema = z.object({
@@ -42,10 +49,11 @@ const baseSwapSchema = z.object({
     .optional()
     .describe(
       "Destination wallet. OMIT for same-chain-type swaps (defaults to the source " +
-        "wallet — LiFi behavior). REQUIRED when `toChain === \"solana\"` because " +
-        "the source EVM hex wallet isn't a valid Solana recipient. Format must " +
-        "match the destination chain (Solana base58 for `toChain: \"solana\"`, " +
-        "EVM hex for EVM destinations)."
+        "wallet — LiFi behavior). REQUIRED when `toChain` is `\"solana\"` or " +
+        "`\"tron\"` because the source EVM hex wallet isn't a valid recipient on " +
+        "those chains. Format must match the destination chain (Solana base58 " +
+        "for `\"solana\"`, TRON base58 with T-prefix for `\"tron\"`, EVM hex " +
+        "otherwise)."
     ),
   amount: z
     .string()

--- a/src/signing/decode-calldata.ts
+++ b/src/signing/decode-calldata.ts
@@ -156,6 +156,8 @@ function describeBridgeChainId(id: bigint): string {
       return "gnosis (100)";
     case 1151111081099710n:
       return "solana (1151111081099710)";
+    case 728126428n:
+      return "tron (728126428)";
     case 20000000000001n:
       return "bitcoin (20000000000001)";
     case 9270000000000000n:
@@ -170,7 +172,7 @@ function describeBridgeChainId(id: bigint): string {
  * mirror of `LIFI_BRIDGE_DATA_TUPLE`. Returned only when decode succeeds —
  * caller falls back to `source: "none"` on parse failure.
  */
-interface DecodedLifiBridgeData {
+export interface DecodedLifiBridgeData {
   transactionId: `0x${string}`;
   bridge: string;
   integrator: string;
@@ -198,7 +200,7 @@ interface DecodedLifiBridgeData {
  * matching parameter at the start of the buffer and ignores trailing bytes,
  * so we don't need to know the bridge-specific second argument's shape.
  */
-function tryDecodeLifiBridgeData(
+export function tryDecodeLifiBridgeData(
   data: `0x${string}`,
 ): DecodedLifiBridgeData | null {
   // Selector + at least one offset word (= bridge data offset). We don't

--- a/test/swap-evm-to-solana.test.ts
+++ b/test/swap-evm-to-solana.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { parseUnits } from "viem";
+import { encodeAbiParameters, parseUnits } from "viem";
+import {
+  LIFI_BRIDGE_DATA_TUPLE,
+  NON_EVM_RECEIVER_SENTINEL,
+} from "../src/abis/lifi-diamond.js";
 
 /**
  * EVM → Solana bridge via the existing `prepare_swap` / `get_swap_quote`
@@ -50,6 +54,33 @@ vi.mock("../src/config/user-config.js", () => ({
   resolveOneInchApiKey: () => undefined,
 }));
 
+/**
+ * Build proper bridge-shaped calldata so the new `verifyLifiBridgeIntent`
+ * cross-check has a BridgeData tuple to inspect. Tests that don't care
+ * about specific fields can override `bridgeData` with the defaults shown.
+ */
+function makeBridgeCalldata(): `0x${string}` {
+  const argsHex = encodeAbiParameters(
+    [LIFI_BRIDGE_DATA_TUPLE, { type: "bytes", name: "_facetData" }],
+    [
+      {
+        transactionId: ("0x" + "11".repeat(32)) as `0x${string}`,
+        bridge: "mayan",
+        integrator: "vaultpilot-mcp",
+        referrer: "0x0000000000000000000000000000000000000000",
+        sendingAssetId: ETH_USDC_MAINNET.toLowerCase() as `0x${string}`,
+        receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+        minAmount: 9_900_000n,
+        destinationChainId: 1151111081099710n, // Solana
+        hasSourceSwaps: false,
+        hasDestinationCall: false,
+      },
+      "0xc0de",
+    ],
+  );
+  return ("0xdeadbeef" + argsHex.slice(2)) as `0x${string}`;
+}
+
 function makeEvmToSolQuote(overrides?: { fromAmount?: string; toAmount?: string }) {
   return {
     action: {
@@ -77,7 +108,7 @@ function makeEvmToSolQuote(overrides?: { fromAmount?: string; toAmount?: string 
     },
     transactionRequest: {
       to: LIFI_DIAMOND,
-      data: "0xdeadbeef",
+      data: makeBridgeCalldata(),
       value: "0",
       gasLimit: "500000",
     },
@@ -166,7 +197,7 @@ describe("getSwapQuote — EVM → Solana", () => {
         amount: "10",
         amountSide: "to",
       }),
-    ).rejects.toThrow(/Exact-out.*not supported for cross-chain bridges to Solana/);
+    ).rejects.toThrow(/Exact-out.*not supported for cross-chain bridges to solana/);
   });
 });
 
@@ -198,7 +229,7 @@ describe("prepareSwap — EVM → Solana", () => {
 
     expect(tx.chain).toBe("ethereum"); // source chain — that's what the user signs
     expect(tx.to).toBe(LIFI_DIAMOND);
-    expect(tx.data).toBe("0xdeadbeef");
+    expect(tx.data.startsWith("0xdeadbeef")).toBe(true);
     expect(tx.description).toContain("Bridge");
     expect(tx.description).toContain("solana");
 

--- a/test/swap-evm-to-tron.test.ts
+++ b/test/swap-evm-to-tron.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { encodeAbiParameters, parseUnits } from "viem";
+import {
+  LIFI_BRIDGE_DATA_TUPLE,
+  NON_EVM_RECEIVER_SENTINEL,
+} from "../src/abis/lifi-diamond.js";
+
+/**
+ * EVM → TRON bridge via the existing `prepare_swap` / `get_swap_quote`
+ * tools, plus the new `verifyLifiBridgeIntent` cross-check that fires on
+ * EVERY bridge route (Solana + TRON + EVM-to-EVM cross). The check decodes
+ * the LiFi BridgeData tuple from the calldata and asserts:
+ *   - `destinationChainId` matches LiFi's chain ID for the requested
+ *     toChain
+ *   - For non-EVM destinations: receiver is the LiFi non-EVM sentinel
+ *   - For EVM destinations: receiver matches the user-requested toAddress
+ *     (or wallet, when toAddress omitted)
+ */
+
+const EVM_WALLET = "0x1111111111111111111111111111111111111111";
+const TRON_RECIPIENT = "TQn9Y2khEsLJW1ChVWFMSMeRDow5KcbLSE";
+const SOL_RECIPIENT = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+const ETH_USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const TRON_USDT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const SOL_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const LIFI_DIAMOND = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
+const ARB_RECIPIENT = "0x2222222222222222222222222222222222222222";
+
+const fetchQuoteMock = vi.fn();
+vi.mock("../src/modules/swap/lifi.js", () => ({
+  fetchQuote: (...args: unknown[]) => fetchQuoteMock(...args),
+  fetchStatus: vi.fn(),
+  initLifi: () => {},
+  LIFI_SOLANA_CHAIN_ID: 1151111081099710,
+  LIFI_TRON_CHAIN_ID: 728126428,
+  fetchSolanaQuote: vi.fn(),
+}));
+
+vi.mock("../src/modules/swap/oneinch.js", () => ({
+  fetchOneInchQuote: vi.fn(),
+}));
+
+const evmClientStub = {
+  readContract: vi.fn(),
+  multicall: vi.fn(),
+};
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => evmClientStub,
+  resetClients: () => {},
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/config/user-config.js", () => ({
+  readUserConfig: () => ({}),
+  resolveOneInchApiKey: () => undefined,
+}));
+
+interface BridgeDataInput {
+  transactionId: `0x${string}`;
+  bridge: string;
+  integrator: string;
+  referrer: `0x${string}`;
+  sendingAssetId: `0x${string}`;
+  receiver: `0x${string}`;
+  minAmount: bigint;
+  destinationChainId: bigint;
+  hasSourceSwaps: boolean;
+  hasDestinationCall: boolean;
+}
+
+/** Build a fake LiFi-Diamond bridge calldata with the given BridgeData. */
+function makeBridgeCalldata(
+  bd: BridgeDataInput,
+  selector: `0x${string}` = "0xdeadbeef",
+  facetSpecificData: `0x${string}` = "0xc0de",
+): `0x${string}` {
+  const argsHex = encodeAbiParameters(
+    [LIFI_BRIDGE_DATA_TUPLE, { type: "bytes", name: "_facetData" }],
+    [bd, facetSpecificData],
+  );
+  return (selector + argsHex.slice(2)) as `0x${string}`;
+}
+
+function makeBridgeQuote(
+  options: {
+    bridgeData: BridgeDataInput;
+    fromAmount?: string;
+    fromChainId?: number;
+    toChainId?: number;
+    fromAsset?: { address: string; symbol: string; decimals: number; priceUSD?: string };
+    toAsset?: { address: string; symbol: string; decimals: number; priceUSD?: string };
+  },
+) {
+  return {
+    action: {
+      fromToken: options.fromAsset ?? {
+        address: ETH_USDT,
+        symbol: "USDT",
+        decimals: 6,
+        priceUSD: "1",
+      },
+      toToken: options.toAsset ?? {
+        address: TRON_USDT,
+        symbol: "USDT",
+        decimals: 6,
+        priceUSD: "1",
+      },
+      fromAmount: options.fromAmount ?? "10000000",
+    },
+    estimate: {
+      toAmount: "9950000",
+      toAmountMin: "9900000",
+      executionDuration: 60,
+      feeCosts: [],
+      gasCosts: [],
+      approvalAddress: LIFI_DIAMOND,
+    },
+    transactionRequest: {
+      to: LIFI_DIAMOND,
+      data: makeBridgeCalldata(options.bridgeData),
+      value: "0",
+      gasLimit: "500000",
+    },
+    tool: options.bridgeData.bridge,
+  };
+}
+
+beforeEach(() => {
+  fetchQuoteMock.mockReset();
+  evmClientStub.readContract.mockReset();
+  evmClientStub.multicall.mockReset();
+  evmClientStub.readContract.mockImplementation(
+    async (req: { functionName: string }) => {
+      if (req.functionName === "allowance") return parseUnits("1000", 6);
+      return 6;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getSwapQuote — EVM → TRON", () => {
+  it("requires toAddress when toChain === 'tron'", async () => {
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/toAddress is required.*tron/);
+  });
+
+  it("rejects toAddress not in TRON base58 format", async () => {
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: SOL_RECIPIENT, // Solana base58, not TRON
+        amount: "10",
+      }),
+    ).rejects.toThrow(/not a valid TRON base58 address/);
+  });
+
+  it("rejects exact-out for cross-chain to TRON", async () => {
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: TRON_RECIPIENT,
+        amount: "10",
+        amountSide: "to",
+      }),
+    ).rejects.toThrow(/Exact-out.*tron/);
+  });
+
+  it("forwards toChain and toAddress to LiFi for a TRON-destination quote", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "11".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 728126428n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    const out = await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "tron",
+      fromToken: ETH_USDT,
+      toToken: TRON_USDT,
+      toAddress: TRON_RECIPIENT,
+      amount: "10",
+    });
+    expect(out.crossChain).toBe(true);
+    expect(out.toChain).toBe("tron");
+
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.toChain).toBe("tron");
+    expect(lifiCall.toAddress).toBe(TRON_RECIPIENT);
+  });
+});
+
+describe("prepareSwap — EVM → TRON", () => {
+  it("returns an EVM UnsignedTx for a TRON-destination bridge after the intent cross-check", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "22".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 728126428n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "tron",
+      fromToken: ETH_USDT,
+      toToken: TRON_USDT,
+      toAddress: TRON_RECIPIENT,
+      amount: "10",
+    });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to).toBe(LIFI_DIAMOND);
+    expect(tx.description).toContain("tron");
+
+    // Destination decimals read MUST NOT have fired against TRC-20 contract.
+    const calls = evmClientStub.readContract.mock.calls as Array<
+      [{ address?: string }]
+    >;
+    const dstTrcCall = calls.find((c) => c[0].address === TRON_USDT);
+    expect(dstTrcCall).toBeUndefined();
+  });
+});
+
+describe("verifyLifiBridgeIntent — chain-id swap detection", () => {
+  it("refuses calldata whose destinationChainId disagrees with toChain (Solana → TRON swap attack)", async () => {
+    // User asks for Solana destination. Calldata claims to bridge to TRON.
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "33".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 728126428n, // TRON, but user wants Solana
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "solana",
+        fromToken: ETH_USDT,
+        toToken: SOL_USDC_MINT,
+        toAddress: SOL_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/destinationChainId mismatch.*encoded 728126428.*toChain="solana"/);
+  });
+
+  it("refuses calldata whose receiver disagrees with toAddress on EVM destinations", async () => {
+    // User asks ethereum → arbitrum to ARB_RECIPIENT. Calldata routes to a
+    // different EVM recipient.
+    const attackerReceiver = "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead" as `0x${string}`;
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "44".repeat(32)) as `0x${string}`,
+          bridge: "across",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: attackerReceiver,
+          minAmount: 9_900_000n,
+          destinationChainId: 42161n, // arbitrum (correct chain)
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+        fromChainId: 1,
+        toChainId: 42161,
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "arbitrum",
+        fromToken: ETH_USDT,
+        toToken: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", // arb USDT
+        toAddress: ARB_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/receiver mismatch.*encoded 0xDead.*requested.*0x2222/i);
+  });
+
+  it("refuses calldata whose receiver is NOT the non-EVM sentinel for a non-EVM destination", async () => {
+    // User asks for TRON destination. Calldata's receiver is a real EVM
+    // address (= the bridge protocol forgot the sentinel, or attacker is
+    // routing to an EVM account using a TRON-labeled chain ID).
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "55".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: ARB_RECIPIENT as `0x${string}`, // an EVM address, not the sentinel
+          minAmount: 9_900_000n,
+          destinationChainId: 728126428n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: TRON_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/receiver mismatch for non-EVM destination tron.*expected the LiFi non-EVM sentinel/);
+  });
+
+  it("accepts intra-EVM same-chain swap calldata (no BridgeData → check skipped)", async () => {
+    // For intra-EVM same-chain swaps, the calldata uses the swap-facet ABI
+    // and tryDecodeLifiBridgeData returns null. The intent check skips
+    // silently — no false positive on the existing same-chain path.
+    fetchQuoteMock.mockResolvedValue({
+      action: {
+        fromToken: { address: ETH_USDT, symbol: "USDT", decimals: 6, priceUSD: "1" },
+        toToken: {
+          address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          symbol: "WETH",
+          decimals: 18,
+          priceUSD: "3000",
+        },
+        fromAmount: parseUnits("10", 6).toString(),
+      },
+      estimate: {
+        toAmount: parseUnits("0.0033", 18).toString(),
+        toAmountMin: parseUnits("0.0032", 18).toString(),
+        executionDuration: 30,
+        feeCosts: [],
+        gasCosts: [],
+        approvalAddress: LIFI_DIAMOND,
+      },
+      transactionRequest: {
+        to: LIFI_DIAMOND,
+        // Use a swap-facet selector (swapTokensSingleV3ERC20ToERC20) plus
+        // garbage args — the key invariant is that
+        // tryDecodeLifiBridgeData fails to extract a tuple (so the intent
+        // check skips), not that prepareSwap's other guards happen to pass.
+        data: ("0x4666fc80" + "00".repeat(32)) as `0x${string}`,
+        value: "0",
+        gasLimit: "200000",
+      },
+      tool: "lifi-dex-aggregator",
+    });
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    // The swap path itself may still throw on the malformed data — the
+    // assertion here is that it does NOT throw the bridge-intent
+    // mismatch error. (It'd be unusual for a real LiFi quote to ship
+    // malformed calldata; the test is structured around the scenario
+    // where the bridge-intent check correctly bypasses non-bridge calls.)
+    let bridgeIntentErr: unknown = null;
+    try {
+      await prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: ETH_USDT,
+        toToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        amount: "10",
+      });
+    } catch (err) {
+      bridgeIntentErr = err;
+    }
+    if (bridgeIntentErr instanceof Error) {
+      expect(bridgeIntentErr.message).not.toMatch(/destinationChainId mismatch/);
+      expect(bridgeIntentErr.message).not.toMatch(/receiver mismatch/);
+    }
+  });
+
+  it("accepts a happy-path EVM-to-EVM bridge whose receiver matches toAddress", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "66".repeat(32)) as `0x${string}`,
+          bridge: "across",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: ARB_RECIPIENT as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 42161n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "arbitrum",
+      fromToken: ETH_USDT,
+      toToken: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      toAddress: ARB_RECIPIENT,
+      amount: "10",
+    });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.description).toContain("Bridge");
+  });
+});


### PR DESCRIPTION
## Summary

Two layered improvements on the LiFi cross-chain story.

### 1. TRON destination support

Mirrors EVM → Solana from #155. User signs an EVM tx; the bridge protocol delivers TRC-20 (or TRX) on TRON.

- `toChain` widened to include `\"tron\"`; `toToken` accepts T-prefixed base58
- `assertCrossChainAddressing` validates TRON addresses + rejects exact-out
- Destination on-chain decimals cross-check skipped for TRON (can't read TRC-20 via EVM RPC)
- `fetchQuote` resolves TRON to chain ID 728126428; `\"native\"` → TRON's TRX contract address (`T9yD…wb`)
- Decoder gets a `728126428 → \"tron\"` case
- Tool descriptions advertise TRON destination + flag TRON-source as not yet wired

TRON-source LiFi (user signs a TRON tx) deferred — LiFi gives us only `raw_data_hex` while our broadcast path needs TronGrid's deserialized `raw_data` object. Solvable via a small protobuf reconstructor or a `/broadcasthex` integration.

### 2. `verifyLifiBridgeIntent` — calldata cross-check (decoding defense)

Every cross-chain bridge calldata is parsed into its `BridgeData` tuple (via the universal-decoder helper from #157) and the encoded `destinationChainId` + `receiver` are cross-checked against what the user requested. Refuses on mismatch.

Closes the attack vector: a compromised MCP returns calldata routing to a different chain or recipient than the prepare receipt advertises.

Specific guards:
- **`destinationChainId` disagreement** → refuse (blocks \"user asked Solana, calldata bridges to TRON\")
- **EVM destinations**: encoded receiver must equal `toAddress` (or source wallet when omitted)
- **Non-EVM destinations**: encoded receiver must be the LiFi non-EVM sentinel; refuse otherwise (blocks \"calldata routes to a real EVM account using a non-EVM-labeled chain ID\")
- **Cross-chain ask + swap-facet calldata** (no BridgeData) → refuse (catches same-chain swap disguised as bridge)

Same-chain intra-EVM swaps: `tryDecodeLifiBridgeData` returns null, intent check skips, no false positives.

## Test plan

- [x] 10 new tests in `test/swap-evm-to-tron.test.ts` covering: TRON quote/prepare guards; bridge-intent chainId/receiver/sentinel refusals; intra-EVM bypass; happy-path EVM-to-EVM bridge
- [x] Updated `test/swap-evm-to-solana.test.ts` to use proper bridge-shaped calldata (the new strict guard refuses cross-chain asks with non-bridge-shaped calldata)
- [x] `npm run build` clean
- [x] `npx vitest run` — 921 tests, 76 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)