### PR TITLE
feat(wc): detect Ledger Live version + multi-path pairing hints

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -147,12 +147,21 @@ export async function pairLedgerLive(): Promise<{
   approval.catch(() => {
     // WalletConnect will surface any error on the next call.
   });
+  // If this is a re-pair (prior session exists on disk), surface the
+  // cached peer version so the generated instructions lead with the UI
+  // path that matched last time. Fresh first-ever pairs have no cached
+  // session → version is undefined → instructions fall back to listing
+  // both common UI paths.
+  const { getCurrentSession } = await import("../../signing/walletconnect.js");
+  const { parseLedgerLiveVersion, ledgerLivePairingInstructions } = await import(
+    "../../signing/session.js"
+  );
+  const cached = getCurrentSession();
+  const cachedVersion = parseLedgerLiveVersion(cached?.peer?.metadata);
   return {
     uri,
     qr,
-    instructions:
-      "Open Ledger Live → Discover → WalletConnect, paste this URI (or scan the QR) to pair. " +
-      "Once pairing completes, the session is persisted; you can call `send_transaction` without re-pairing.",
+    instructions: ledgerLivePairingInstructions(cachedVersion),
     waitingForApproval: true,
   };
 }

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -34,6 +34,21 @@ export interface SessionStatus {
   /** Peer-advertised description. Self-reported — NOT a trusted identity. */
   peerDescription?: string;
   /**
+   * Best-effort version string parsed from peer metadata (e.g. "2.80.0").
+   * Self-reported by the peer just like `wallet` / `peerUrl` — not trusted
+   * for any security decision, only used to tailor pairing instructions
+   * for re-pair flows. Absent when no semver token could be found.
+   */
+  peerVersion?: string;
+  /**
+   * Tailored pairing instructions — emitted only when the session is
+   * unreachable (re-pair likely needed) or unpaired. The string covers
+   * both common Ledger Live UI paths (Discover vs Settings → Connected
+   * Apps) so it works across 2.x branches; `peerVersion` adds a "try this
+   * first" hint when available. Absent on healthy paired sessions.
+   */
+  pairingInstructions?: string;
+  /**
    * Only set when the paired peer's URL host is NOT on the Ledger-first-party
    * allowlist (see `isKnownLedgerPeer`). The common case — pairing with Ledger
    * Live, which advertises a `ledger.com` host — produces no warning, so the
@@ -109,6 +124,67 @@ export const PEER_UNREACHABLE_GUIDANCE =
   "Only call pair_ledger_live on explicit confirmation. Do NOT auto-re-pair on read-only requests.";
 
 /**
+ * Best-effort Ledger Live version extraction from WalletConnect peer
+ * metadata. The peer's `name`, `description`, and `url` fields are self-
+ * reported and the shape varies across Ledger Live releases — sometimes the
+ * version lands in `name` ("Ledger Live 2.80.0"), sometimes only in
+ * `description`, sometimes absent entirely. We look for the first
+ * semver-shaped token across all three fields; any match is returned
+ * verbatim. Returns `undefined` when nothing looks like a version.
+ *
+ * This is intentionally a UX hint, not load-bearing: mismatched or
+ * missing versions never affect signing — they only tailor the pairing
+ * instructions we emit for re-pair flows.
+ */
+export function parseLedgerLiveVersion(meta: {
+  name?: string;
+  description?: string;
+  url?: string;
+} | undefined): string | undefined {
+  if (!meta) return undefined;
+  const haystack = [meta.name, meta.description, meta.url]
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .join(" ");
+  // Lookbehind/ahead for "not a digit and not a dot" so we don't start the
+  // match mid-version (e.g. "v2.90.1" → "2.90.1", not "90.1") and don't
+  // truncate the middle-component of a three-part semver. `\b` alone was
+  // insufficient because `\b` sees `v` as a word char adjacent to `2`.
+  const match = haystack.match(/(?<![\d.])(\d+\.\d+(?:\.\d+)?)(?![\d.])/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Produce a tailored pairing-instructions string for Ledger Live's
+ * WalletConnect flow. The WC entry point moved around across Ledger Live
+ * 2.x branches — older builds surfaced it under **Discover**, newer builds
+ * under **Settings → Connected Apps** (sometimes nested further). Rather
+ * than hard-code a single path (which rots with every Ledger Live release),
+ * we emit BOTH common paths and, when we have a detected version, add a
+ * best-effort "try this first" nudge. Unknown version → no nudge, both
+ * paths listed so the user can find whichever applies.
+ *
+ * Exported so `pair_ledger_live` and `get_ledger_status` share the same
+ * copy — otherwise the two surfaces would drift.
+ */
+export function ledgerLivePairingInstructions(
+  detectedVersion: string | undefined,
+): string {
+  const lead = detectedVersion
+    ? `Detected Ledger Live ${detectedVersion} on your last pairing. `
+    : "";
+  return (
+    `${lead}Open Ledger Live, find the WalletConnect entry, and paste the URI ` +
+    `(or scan the QR) to pair. The entry point moved across Ledger Live 2.x ` +
+    `branches — try these in order: ` +
+    `(1) Discover → WalletConnect (older builds), ` +
+    `(2) Settings → Connected Apps → WalletConnect (newer builds), ` +
+    `(3) search "WalletConnect" in Ledger Live's search bar. ` +
+    `Once pairing completes, the session is persisted and this server can ` +
+    `reuse it across tool calls without re-pairing.`
+  );
+}
+
+/**
  * Hosts the server treats as first-party Ledger WC peers. Exact match or any
  * subdomain of `ledger.com` (so `wc.apps.ledger.com`, `ledger.com`, etc. all
  * pass). Everything else trips `peerTrustWarning`.
@@ -155,6 +231,8 @@ export async function getSessionStatus(): Promise<SessionStatus> {
       paired: false,
       accounts: [],
       accountDetails: [],
+      // Unpaired: no peerVersion yet, so instructions are fully generic.
+      pairingInstructions: ledgerLivePairingInstructions(undefined),
       ...tronSection,
       ...solanaSection,
     };
@@ -163,6 +241,7 @@ export async function getSessionStatus(): Promise<SessionStatus> {
   const meta = session.peer?.metadata;
   const unreachable = isPeerUnreachable();
   const warnPeer = !isKnownLedgerPeer(meta?.url);
+  const version = parseLedgerLiveVersion(meta);
   return {
     paired: true,
     accounts,
@@ -172,9 +251,16 @@ export async function getSessionStatus(): Promise<SessionStatus> {
     ...(meta?.name ? { wallet: meta.name } : {}),
     ...(meta?.url ? { peerUrl: meta.url } : {}),
     ...(meta?.description ? { peerDescription: meta.description } : {}),
+    ...(version ? { peerVersion: version } : {}),
     ...(warnPeer ? { peerTrustWarning: PEER_TRUST_WARNING } : {}),
     ...(unreachable
-      ? { peerUnreachable: true, peerUnreachableGuidance: PEER_UNREACHABLE_GUIDANCE }
+      ? {
+          peerUnreachable: true,
+          peerUnreachableGuidance: PEER_UNREACHABLE_GUIDANCE,
+          // Emit re-pair instructions on the unreachable path — the
+          // healthy-paired case doesn't need them cluttering responses.
+          pairingInstructions: ledgerLivePairingInstructions(version),
+        }
       : {}),
     ...tronSection,
     ...solanaSection,

--- a/test/ledger-live-version-hints.test.ts
+++ b/test/ledger-live-version-hints.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the Ledger Live version hint + pairing-instructions
+ * helpers in `src/signing/session.ts`. Pure functions — no WC, no FS, no
+ * network. The live-session integration (session-status exposes
+ * `peerVersion`) is covered indirectly wherever callers mock a session
+ * struct.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseLedgerLiveVersion,
+  ledgerLivePairingInstructions,
+} from "../src/signing/session.js";
+
+describe("parseLedgerLiveVersion", () => {
+  it("returns undefined when metadata is missing", () => {
+    expect(parseLedgerLiveVersion(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when metadata has no version-shaped token", () => {
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live",
+        description: "Ledger's self-custody app",
+        url: "https://ledger.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("extracts a three-part semver embedded in `name`", () => {
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live 2.80.0",
+        description: "",
+        url: "https://ledger.com",
+      }),
+    ).toBe("2.80.0");
+  });
+
+  it("extracts a two-part version when that's all the peer reports", () => {
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live",
+        description: "v2.78",
+        url: "",
+      }),
+    ).toBe("2.78");
+  });
+
+  it("falls through to description / url when name has no version", () => {
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live",
+        description: "self-custody wallet",
+        url: "https://apps.ledger.com/v2.90.1/walletconnect",
+      }),
+    ).toBe("2.90.1");
+  });
+
+  it("returns the FIRST version it sees (predictable + cheap)", () => {
+    // A peer reporting multiple semver tokens shouldn't confuse the caller.
+    // First-match is fine; the hint is advisory.
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live 2.80.0 (build 3.0.1)",
+        description: "",
+        url: "",
+      }),
+    ).toBe("2.80.0");
+  });
+
+  it("ignores non-versiony numbers (single integers)", () => {
+    expect(
+      parseLedgerLiveVersion({
+        name: "Ledger Live 5",
+        description: "",
+        url: "",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("ledgerLivePairingInstructions", () => {
+  it("emits both UI paths when no version is known (generic fallback)", () => {
+    const out = ledgerLivePairingInstructions(undefined);
+    expect(out).toMatch(/Discover.*WalletConnect/);
+    expect(out).toMatch(/Settings.*Connected Apps.*WalletConnect/);
+    expect(out).not.toMatch(/Detected Ledger Live/);
+  });
+
+  it("leads with a 'Detected' hint when a version is known", () => {
+    const out = ledgerLivePairingInstructions("2.80.0");
+    expect(out).toMatch(/^Detected Ledger Live 2\.80\.0/);
+    // But STILL lists both paths — the version string alone isn't
+    // authoritative enough to drop one, since the actual cutover point
+    // between the two menus varies.
+    expect(out).toMatch(/Discover/);
+    expect(out).toMatch(/Settings.*Connected Apps/);
+  });
+
+  it("mentions the search-bar fallback so the user always has a way to find it", () => {
+    expect(ledgerLivePairingInstructions(undefined)).toMatch(/search.*"WalletConnect"/);
+    expect(ledgerLivePairingInstructions("2.99.0")).toMatch(/search.*"WalletConnect"/);
+  });
+
+  it("tells the user the session persists after pairing", () => {
+    expect(ledgerLivePairingInstructions(undefined)).toMatch(
+      /session is persisted/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Implements item **3.3** of `claude-work/HIGH-plan-broad-audience-onboarding.md`. The WC entry point in Ledger Live moved across 2.x branches — older builds have it under **Discover → WalletConnect**, newer builds under **Settings → Connected Apps → WalletConnect**. Hardcoding one path was wrong for roughly half of users on any given day.
- `pair_ledger_live` now emits copy that lists **both** common UI paths + a search-bar fallback. When a cached session exists (re-pair case), the copy leads with a "Detected Ledger Live X.Y.Z" hint so the user sees the version they already successfully paired with.
- `get_ledger_status` exposes `peerVersion?` (best-effort semver extraction from WC peer metadata) + emits `pairingInstructions?` on the unpaired and peer-unreachable paths.

## Security note
Peer metadata is self-reported — any app can claim to be "Ledger Live 2.80.0". The new fields are UX hints only and never affect signing decisions. The on-device signing check remains the authoritative defense.

## Test plan
- [x] `npm test` — 932 tests pass (11 new for version extraction + instruction shape)
- [x] `npm run build` — clean TS
- [ ] Live: `pair_ledger_live` against current Ledger Live build, verify instructions surface both menu paths
- [ ] Live: re-pair after a session is established — verify "Detected Ledger Live X.Y.Z" hint leads

🤖 Generated with [Claude Code](https://claude.com/claude-code)