### PR TITLE
feat(lifi): prepare_tron_lifi_swap — TRON-source bridge to EVM and Solana

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import {
   prepareNativeStakeDeactivate,
   prepareNativeStakeWithdraw,
   prepareSolanaLifiSwap,
+  prepareTronLifiSwap,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -120,6 +121,7 @@ import {
   prepareNativeStakeDeactivateInput,
   prepareNativeStakeWithdrawInput,
   prepareSolanaLifiSwapInput,
+  prepareTronLifiSwapInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1520,6 +1522,32 @@ async function main() {
       inputSchema: prepareSolanaLifiSwapInput.shape,
     },
     handler(prepareSolanaLifiSwap)
+  );
+
+  server.registerTool(
+    "prepare_tron_lifi_swap",
+    {
+      description:
+        "Build an unsigned LiFi-routed cross-chain bridge with TRON as the source chain. " +
+        "User signs a TRON tx via Ledger over USB; the bridge protocol delivers tokens on " +
+        "the destination (any EVM chain or Solana) after the source confirms (typically " +
+        "1-15 min). LiFi aggregates NearIntents, Wormhole, Allbridge, etc. The builder " +
+        "(1) decodes the TRON protobuf to extract the TriggerSmartContract envelope, " +
+        "(2) asserts the contract_address is the LiFi Diamond on TRON " +
+        "(TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) and the owner_address is the user's wallet, " +
+        "(3) decodes the inner ABI calldata's BridgeData tuple and cross-checks " +
+        "destinationChainId + receiver against the user's request — refuses on any " +
+        "mismatch. TRC-20 source flows REQUIRE a prior approve to the LiFi Diamond — this " +
+        "tool does NOT prepare the approve; insufficient allowance reverts on-chain. " +
+        "BLIND-SIGN on Ledger (LiFi Diamond not in TRON app's clear-sign allowlist) — " +
+        "enable \"Allow blind signing\" in the on-device Solana app Settings; the device " +
+        "shows the txID, which the user matches against the txID in the prepare receipt. " +
+        "Pair the Ledger via `pair_ledger_tron` first. Broadcast goes via TronGrid's " +
+        "`/wallet/broadcasthex` endpoint (LiFi gives us only raw_data_hex, not the " +
+        "deserialized JSON shape `/wallet/broadcasttransaction` requires).",
+      inputSchema: prepareTronLifiSwapInput.shape,
+    },
+    handler(prepareTronLifiSwap, { toolName: "prepare_tron_lifi_swap" })
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -104,6 +104,7 @@ import type {
   PrepareNativeStakeDeactivateArgs,
   PrepareNativeStakeWithdrawArgs,
   PrepareSolanaLifiSwapArgs,
+  PrepareTronLifiSwapArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -450,6 +451,23 @@ export async function prepareSolanaLifiSwap(
     ...(slippage !== undefined ? { slippage } : {}),
   });
   return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareTronLifiSwap(
+  args: PrepareTronLifiSwapArgs,
+): Promise<UnsignedTronTx> {
+  const { buildTronLifiSwap } = await import("../tron/lifi-swap.js");
+  const slippage =
+    args.slippageBps !== undefined ? args.slippageBps / 10_000 : undefined;
+  return buildTronLifiSwap({
+    wallet: args.wallet,
+    fromToken: args.fromToken,
+    fromAmount: args.fromAmount,
+    toChain: args.toChain as Parameters<typeof buildTronLifiSwap>[0]["toChain"],
+    toToken: args.toToken,
+    toAddress: args.toAddress,
+    ...(slippage !== undefined ? { slippage } : {}),
+  });
 }
 
 export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 import { approvalCapSchema } from "../shared/approval.js";
-import { EVM_ADDRESS, SOLANA_ADDRESS } from "../../shared/address-patterns.js";
+import { EVM_ADDRESS, SOLANA_ADDRESS, TRON_ADDRESS } from "../../shared/address-patterns.js";
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 const walletSchema = z.string().regex(EVM_ADDRESS);
@@ -453,6 +453,82 @@ export const prepareSolanaLifiSwapInput = z.object({
 });
 
 /**
+ * TRON-source LiFi swap / bridge. User signs a TRON tx via Ledger over
+ * USB; the bridge protocol delivers tokens on the destination chain
+ * (any EVM chain or Solana) after the source tx confirms.
+ *
+ * BLIND-SIGN on Ledger — the LiFi Diamond on TRON is not in the TRON
+ * app's clear-sign allowlist. User must enable "Allow blind signing" in
+ * the on-device Settings; the device then displays the txID (sha256 of
+ * raw_data_hex), which the user matches against the txID printed in the
+ * prepare receipt. TRC-20 source flows require a prior approve — this
+ * tool does not prepare it; insufficient allowance reverts on-chain.
+ */
+export const prepareTronLifiSwapInput = z.object({
+  wallet: z
+    .string()
+    .regex(TRON_ADDRESS)
+    .describe(
+      "TRON base58 wallet (T-prefixed, 34 chars) — funds the swap and signs " +
+        "the source tx on Ledger via USB. Pair via `pair_ledger_tron` first."
+    ),
+  fromToken: z
+    .string()
+    .max(50)
+    .describe(
+      "Source token. T-prefixed TRC-20 contract address OR the literal string " +
+        "\"native\" for TRX (LiFi maps \"native\" to TRX's contract address " +
+        "internally). TRC-20 source REQUIRES a prior approve to the LiFi " +
+        "Diamond on TRON (TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) — this tool " +
+        "does not prepare the approve; insufficient allowance reverts on-chain."
+    ),
+  fromAmount: z
+    .string()
+    .max(50)
+    .regex(/^\d+$/)
+    .describe(
+      "Raw integer amount in base units (NOT decimal-adjusted). For TRX (6 decimals) " +
+        "1 TRX = '1000000'; for TRC-20 USDT (6 decimals) 10 USDT = '10000000'."
+    ),
+  toChain: z
+    .enum([
+      ...(SUPPORTED_CHAINS as unknown as [string, ...string[]]),
+      "solana",
+    ])
+    .describe(
+      "Destination chain. Any EVM chain (cross-chain bridge to EVM) or \"solana\" " +
+        "(cross-chain bridge to Solana). LiFi internally picks the best bridge " +
+        "protocol (NearIntents, Wormhole, Allbridge, etc.)."
+    ),
+  toToken: z
+    .string()
+    .max(80)
+    .describe(
+      "Destination token. 0x-prefixed EVM token when toChain is EVM; SPL mint base58 " +
+        "when toChain=\"solana\". \"native\" works on both (resolves to the chain's " +
+        "conventional native sentinel)."
+    ),
+  toAddress: z
+    .string()
+    .max(80)
+    .describe(
+      "Destination wallet — REQUIRED. EVM hex when toChain is EVM; Solana base58 " +
+        "when toChain=\"solana\". The TRON source wallet isn't a valid recipient on " +
+        "either destination chain family."
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(10_000)
+    .optional()
+    .describe(
+      "Slippage tolerance in basis points (50 = 0.5%). Omit for LiFi's default " +
+        "(0.5%). Cross-chain bridges may impose their own minimums above this."
+    ),
+});
+
+/**
  * No args — `get_vaultpilot_config_status` returns a structured snapshot of
  * the local server config, intended for diagnostic / onboarding flows.
  * The output deliberately never echoes any secret values (API keys, RPC
@@ -784,5 +860,6 @@ export type GetMarginfiPositionsArgs = z.infer<typeof getMarginfiPositionsInput>
 export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPositionsInput>;
 export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;
 export type PrepareSolanaLifiSwapArgs = z.infer<typeof prepareSolanaLifiSwapInput>;
+export type PrepareTronLifiSwapArgs = z.infer<typeof prepareTronLifiSwapInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -36,7 +36,13 @@ function toLifiChain(chain: SupportedChain): number {
 }
 
 interface LifiQuoteRequestBase {
-  fromChain: SupportedChain;
+  /**
+   * Source chain. EVM `SupportedChain` for the existing `prepare_swap`
+   * flow, or `"tron"` for the LiFi-on-TRON flow (`prepare_tron_lifi_swap`)
+   * that signs a TRON tx. Solana-source has its own quote shape
+   * (`fetchSolanaQuote`) — it doesn't share this type.
+   */
+  fromChain: SupportedChain | "tron";
   /**
    * Destination chain. EVM `SupportedChain` (intra-EVM + EVM-cross), or
    * `"solana"` / `"tron"` (cross-chain bridge to a non-EVM chain). LiFi's
@@ -54,7 +60,12 @@ interface LifiQuoteRequestBase {
    * contract address for TRON — handled inside `fetchQuote`).
    */
   toToken: string | "native";
-  fromAddress: `0x${string}`;
+  /**
+   * Source wallet. EVM hex when `fromChain` is EVM; TRON base58 when
+   * `fromChain === "tron"`. LiFi's API accepts either — typed as the
+   * narrow EVM-hex string for legacy callers; TRON callers cast through.
+   */
+  fromAddress: `0x${string}` | string;
   /**
    * Destination wallet. Defaults to `fromAddress` for intra-EVM swaps
    * (LiFi behavior). REQUIRED when `toChain` is `"solana"` or `"tron"`
@@ -87,7 +98,10 @@ const TRON_NATIVE = "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb";
 
 export async function fetchQuote(req: LifiQuoteRequest) {
   initLifi();
-  const fromChain = toLifiChain(req.fromChain);
+  const fromIsTron = req.fromChain === "tron";
+  const fromChain = fromIsTron
+    ? LIFI_TRON_CHAIN_ID
+    : toLifiChain(req.fromChain as SupportedChain);
   const toIsSolana = req.toChain === "solana";
   const toIsTron = req.toChain === "tron";
   const toChain = toIsSolana

--- a/src/modules/tron/broadcast.ts
+++ b/src/modules/tron/broadcast.ts
@@ -27,11 +27,63 @@ function decodeHexMessage(hex: string): string {
 }
 
 /**
+ * Encode a base-128 varint per protobuf wire format. TRON's Transaction
+ * envelope uses one for each length-delimited field. ~4 bytes max for the
+ * sizes we encode (raw_data is hundreds-of-bytes, signature is exactly 65).
+ */
+function encodeVarintHex(n: number): string {
+  if (n < 0) throw new Error("varint underflow");
+  let hex = "";
+  let value = n;
+  while (value > 0x7f) {
+    hex += (0x80 | (value & 0x7f)).toString(16).padStart(2, "0");
+    value >>>= 7;
+  }
+  hex += value.toString(16).padStart(2, "0");
+  return hex;
+}
+
+/**
+ * Build the full hex of a signed TRON `Transaction` protobuf message from
+ * its two parts:
+ *
+ *   message Transaction {
+ *     Transaction.raw raw_data = 1;     // tag 0x0a, length-delimited
+ *     bytes signature = 2;              // tag 0x12, length-delimited (repeated; single entry for our flow)
+ *   }
+ *
+ * `/wallet/broadcasthex` takes this assembled envelope and accepts no
+ * other shape. Used for LiFi-on-TRON broadcasts where we don't have the
+ * deserialized `raw_data` JSON object — only the wire-form raw_data_hex.
+ */
+function buildSignedTransactionHex(rawDataHex: string, signatureHex: string): string {
+  const rawData = rawDataHex.startsWith("0x") ? rawDataHex.slice(2) : rawDataHex;
+  const sig = signatureHex.startsWith("0x") ? signatureHex.slice(2) : signatureHex;
+  if (!/^[0-9a-fA-F]*$/.test(rawData) || rawData.length % 2 !== 0) {
+    throw new Error("buildSignedTransactionHex: raw_data_hex is not valid hex");
+  }
+  if (!/^[0-9a-fA-F]+$/.test(sig) || sig.length % 2 !== 0) {
+    throw new Error("buildSignedTransactionHex: signature is not valid hex");
+  }
+  const rawLen = rawData.length / 2;
+  const sigLen = sig.length / 2;
+  return "0a" + encodeVarintHex(rawLen) + rawData + "12" + encodeVarintHex(sigLen) + sig;
+}
+
+/**
  * Broadcast a signed TRON transaction via TronGrid.
  *
  * The signature is appended to the raw tx envelope in the `signature[]`
  * field. TronGrid multi-sig would use multiple entries; for single-sig
  * (the only flow we support) it's always exactly one.
+ *
+ * Two endpoint paths:
+ *   - `/wallet/broadcasttransaction` — used when `tx.rawData` (the
+ *     deserialized JSON) is present. Standard TronGrid-built txs from
+ *     `prepare_tron_*` actions.
+ *   - `/wallet/broadcasthex` — used when `tx.rawData` is absent (LiFi-
+ *     routed flows). We encode the Transaction envelope ourselves from
+ *     `raw_data_hex` + `signature` and post the assembled hex.
  *
  * Returns the on-chain txID on success. Throws with the decoded error
  * message on validation / signature failures.
@@ -43,6 +95,32 @@ export async function broadcastTronTx(
   const apiKey = resolveTronApiKey(readUserConfig());
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+
+  // No deserialized raw_data → use the broadcasthex endpoint instead. The
+  // LiFi quote response for TRON-source flows returns only
+  // raw_data_hex; reconstructing the JSON object from the protobuf would
+  // need a per-contract-type deserializer (TriggerSmartContract /
+  // TransferContract / FreezeBalanceV2 / ...) which is a parallel
+  // codebase to verify-raw-data.ts. /broadcasthex sidesteps that work.
+  if (tx.rawData === undefined) {
+    const fullHex = buildSignedTransactionHex(tx.rawDataHex, signatureHex);
+    const res = await fetchWithTimeout(`${TRONGRID_BASE_URL}/wallet/broadcasthex`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ transaction: fullHex }),
+    });
+    if (!res.ok) {
+      throw new Error(`TronGrid /wallet/broadcasthex returned ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as BroadcastResponse;
+    if (data.result === true) {
+      return { txID: data.txid ?? tx.txID };
+    }
+    const decoded = data.message ? decodeHexMessage(data.message) : "unknown error";
+    throw new Error(
+      `TronGrid /broadcasthex rejected the transaction: ${data.code ?? "unknown code"} — ${decoded}`,
+    );
+  }
 
   const body = {
     txID: tx.txID,
@@ -70,3 +148,7 @@ export async function broadcastTronTx(
     `TronGrid broadcast rejected the transaction: ${data.code ?? "unknown code"} — ${decoded}`
   );
 }
+
+// Internal export for tests. The signed-tx-hex builder is pure, no I/O,
+// and worth pinning given it's protobuf wire-format glue.
+export const __test_buildSignedTransactionHex = buildSignedTransactionHex;

--- a/src/modules/tron/lifi-swap.ts
+++ b/src/modules/tron/lifi-swap.ts
@@ -1,0 +1,318 @@
+import { createHash } from "node:crypto";
+import { fetchQuote } from "../swap/lifi.js";
+import { base58ToHex } from "./address.js";
+import { isTronAddress } from "../../config/tron.js";
+import { issueTronHandle } from "../../signing/tron-tx-store.js";
+import {
+  decodeTronTriggerSmartContract,
+  type DecodedTronTriggerSmartContract,
+} from "./verify-raw-data.js";
+import {
+  tryDecodeLifiBridgeData,
+  type DecodedLifiBridgeData,
+} from "../../signing/decode-calldata.js";
+import { NON_EVM_RECEIVER_SENTINEL } from "../../abis/lifi-diamond.js";
+import { SOLANA_ADDRESS } from "../../shared/address-patterns.js";
+import { getAddress } from "viem";
+import type { SupportedChain, UnsignedTronTx } from "../../types/index.js";
+
+/**
+ * TRON-source LiFi swap / bridge.
+ *
+ * Why this exists separately from `prepare_solana_lifi_swap` and
+ * `prepare_swap` (EVM-source): TRON's tx envelope is protobuf, signing is
+ * USB HID via `@ledgerhq/hw-app-trx`, and broadcast goes to TronGrid —
+ * none of that overlaps with the Solana or EVM flows. Sharing the
+ * cross-chain LiFi quote endpoint and the universal BridgeData decoder
+ * lets us reuse the security defenses, but the tx-shape work is
+ * TRON-specific.
+ *
+ * ## Tx-shape surgery
+ *
+ * LiFi returns a fully-formed TRON `Transaction.raw` protobuf in
+ * `quote.transactionRequest.data` (hex). Unlike Solana where we own the
+ * VersionedMessage compile step, TRON's raw_data is wrap-and-sign — we
+ * don't recompile, just validate + pass to Ledger. Validation:
+ *
+ *   1. Decode the protobuf to extract the inner `TriggerSmartContract`.
+ *   2. Assert the contract_address is the LiFi Diamond on TRON
+ *      (`TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt`).
+ *   3. Assert the owner_address is the user's wallet (catches a wallet
+ *      swap inside the protobuf even though `from` in the tx-store would
+ *      look correct).
+ *   4. Decode the inner ABI calldata (= the EVM-style call to the LiFi
+ *      Diamond) and run `verifyLifiBridgeIntent`-equivalent checks:
+ *        - destinationChainId matches user-requested toChain
+ *        - receiver matches toAddress (EVM dest) or is the LiFi
+ *          non-EVM sentinel (Solana dest)
+ *
+ * ## Broadcast path
+ *
+ * `tx.rawData` is left undefined — broadcast.ts branches on this and
+ * uses `/wallet/broadcasthex` instead of `/wallet/broadcasttransaction`,
+ * because we don't have the deserialized JSON shape that the latter
+ * requires.
+ *
+ * ## On-device review
+ *
+ * The Ledger TRON app does NOT clear-sign LiFi Diamond calls — its
+ * allowlist covers System contract types (Transfer, Vote, Freeze) and
+ * a small set of TRC-20 selectors (USDT/USDC `transfer`). User must
+ * enable "Allow blind signing" in the app's on-device Settings; the
+ * device then displays the txID (= sha256 of raw_data_hex), which the
+ * user matches against the txID in our prepare receipt.
+ *
+ * ## TRC-20 source flows
+ *
+ * If `fromToken` is a TRC-20 mint (not TRX-native), the LiFi Diamond
+ * needs prior `approve()` allowance. This builder does NOT check or
+ * prepare the approve — the on-chain swap will revert if allowance is
+ * insufficient. The agent should explain to the user that TRC-20
+ * sources require a prior approve, and either offer one via separate
+ * tooling (a `prepare_tron_trc20_approve` is not yet shipped) or
+ * confirm they've already approved sufficient allowance.
+ */
+
+/** TRON LiFi Diamond — same routing engine as EVM, deployed on TRON mainnet. */
+const TRON_LIFI_DIAMOND = "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt";
+
+/**
+ * Same chain-id table as `swap/index.ts:LIFI_CHAIN_ID`; copied here to
+ * avoid a cross-module import. The two MUST stay in sync; tests pin
+ * both via the LiFi public chain IDs.
+ */
+const LIFI_CHAIN_ID: Record<SupportedChain | "solana" | "tron", number> = {
+  ethereum: 1,
+  arbitrum: 42161,
+  polygon: 137,
+  base: 8453,
+  optimism: 10,
+  solana: 1151111081099710,
+  tron: 728126428,
+};
+
+export interface PrepareTronLifiSwapParams {
+  /** TRON base58 wallet — funds + signs. T-prefix, 34 chars. */
+  wallet: string;
+  /**
+   * Source token. T-prefixed base58 TRC-20 contract OR the literal
+   * string "native" for TRX. TRC-20 source requires prior approve to
+   * the LiFi Diamond — this builder does not prepare the approve;
+   * insufficient allowance will revert the on-chain swap.
+   */
+  fromToken: string | "native";
+  /** Raw integer base units to sell. */
+  fromAmount: string;
+  /**
+   * Destination chain. Any EVM chain (cross-chain bridge to EVM) or
+   * "solana" (cross-chain bridge to Solana). TRON-to-TRON is supported
+   * by LiFi (in-chain swap), but `prepare_swap`'s EVM-source surface
+   * doesn't quote to TRON either, so we keep the cross-chain-only
+   * scope on the TRON-source side too.
+   */
+  toChain: SupportedChain | "solana";
+  /** Destination token. EVM hex when toChain is EVM; SPL mint base58 for "solana". */
+  toToken: string | "native";
+  /**
+   * Destination wallet. REQUIRED — TRON base58 source wallet isn't a
+   * valid recipient on EVM or Solana destinations.
+   */
+  toAddress: string;
+  /** Slippage as fraction (0.005 = 50 bps). LiFi default 0.005. */
+  slippage?: number;
+}
+
+export interface PreparedTronLifiSwapTx {
+  handle: string;
+  action: "lifi_swap";
+  chain: "tron";
+  from: string;
+  txID: string;
+  rawDataHex: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  feeLimitSun?: string;
+}
+
+function sha256Hex(hex: string): string {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return createHash("sha256").update(Buffer.from(clean, "hex")).digest("hex");
+}
+
+function assertCrossChainAddressing(p: PrepareTronLifiSwapParams): void {
+  if (!isTronAddress(p.wallet)) {
+    throw new Error(
+      `wallet "${p.wallet}" is not a valid TRON base58 address (T-prefix, 34 chars).`,
+    );
+  }
+  if (p.toChain === "solana") {
+    if (!SOLANA_ADDRESS.test(p.toAddress)) {
+      throw new Error(
+        `toAddress "${p.toAddress}" is not a valid Solana base58 address. ` +
+          `Refusing to prepare a bridge to an unparseable destination.`,
+      );
+    }
+  } else {
+    // EVM destination — toAddress must be EVM hex.
+    if (!/^0x[a-fA-F0-9]{40}$/.test(p.toAddress)) {
+      throw new Error(
+        `toAddress "${p.toAddress}" is not a valid EVM address. For ` +
+          `toChain="${p.toChain}" pass a 0x-prefixed 40-hex-char address.`,
+      );
+    }
+  }
+}
+
+/**
+ * Cross-check the LiFi quote's bridge intent against the user's request.
+ * Identical asserts to `swap/index.ts:verifyLifiBridgeIntent`, but operating
+ * on TRON-source TriggerSmartContract calldata rather than EVM calldata.
+ */
+function verifyTronLifiBridgeIntent(
+  p: PrepareTronLifiSwapParams,
+  trigger: DecodedTronTriggerSmartContract,
+): DecodedLifiBridgeData {
+  // Owner address must be the user's wallet — catches a swap-and-replay
+  // where calldata was prepared for a different account.
+  const expectedOwnerHex = base58ToHex(p.wallet).toLowerCase();
+  if (trigger.ownerAddressHex.toLowerCase() !== expectedOwnerHex) {
+    throw new Error(
+      `LiFi TRON tx owner_address mismatch: encoded 0x${trigger.ownerAddressHex} ` +
+        `but user wallet is ${p.wallet} (0x${expectedOwnerHex}). Refusing to sign.`,
+    );
+  }
+
+  // Contract must be the LiFi Diamond on TRON.
+  const expectedDiamondHex = base58ToHex(TRON_LIFI_DIAMOND).toLowerCase();
+  if (trigger.contractAddressHex.toLowerCase() !== expectedDiamondHex) {
+    throw new Error(
+      `LiFi TRON tx contract_address mismatch: encoded 0x${trigger.contractAddressHex} ` +
+        `but expected the LiFi Diamond on TRON (${TRON_LIFI_DIAMOND}). ` +
+        `Refusing to sign — calldata targets a different contract.`,
+    );
+  }
+
+  // Decode BridgeData from the inner ABI calldata.
+  const decoded = tryDecodeLifiBridgeData(trigger.dataHex);
+  if (!decoded) {
+    throw new Error(
+      `LiFi TRON quote returned non-bridge calldata for a cross-chain request ` +
+        `(tron → ${p.toChain}) — expected calldata carrying a BridgeData tuple. ` +
+        `Refusing to return tx.`,
+    );
+  }
+
+  const expectedChainId = BigInt(LIFI_CHAIN_ID[p.toChain]);
+  if (decoded.destinationChainId !== expectedChainId) {
+    throw new Error(
+      `LiFi bridge calldata destinationChainId mismatch: encoded ` +
+        `${decoded.destinationChainId.toString()} but user requested toChain="${p.toChain}" ` +
+        `(= ${expectedChainId.toString()}). Refusing to sign.`,
+    );
+  }
+
+  if (p.toChain === "solana") {
+    if (decoded.receiver.toLowerCase() !== NON_EVM_RECEIVER_SENTINEL) {
+      throw new Error(
+        `LiFi bridge calldata receiver mismatch for non-EVM destination solana: ` +
+          `expected the LiFi non-EVM sentinel (${NON_EVM_RECEIVER_SENTINEL}), got ` +
+          `${decoded.receiver.toLowerCase()}. Refusing to sign.`,
+      );
+    }
+  } else {
+    // EVM destination — receiver must equal toAddress.
+    if (getAddress(decoded.receiver) !== getAddress(p.toAddress as `0x${string}`)) {
+      throw new Error(
+        `LiFi bridge calldata receiver mismatch: encoded ${getAddress(decoded.receiver)} ` +
+          `but user requested ${getAddress(p.toAddress as `0x${string}`)}. Refusing to sign.`,
+      );
+    }
+  }
+
+  return decoded;
+}
+
+export async function buildTronLifiSwap(
+  p: PrepareTronLifiSwapParams,
+): Promise<UnsignedTronTx> {
+  assertCrossChainAddressing(p);
+
+  // Hand off to LiFi. fetchQuote already supports `fromChain: "tron"` via
+  // the wrapper's chain-id resolution.
+  const quote = await fetchQuote({
+    fromChain: "tron" as unknown as SupportedChain,
+    toChain: p.toChain,
+    fromToken: p.fromToken === "native"
+      ? "native"
+      : (p.fromToken as `0x${string}`),
+    toToken: p.toToken === "native" ? "native" : (p.toToken as `0x${string}`),
+    fromAddress: p.wallet as `0x${string}`,
+    toAddress: p.toAddress,
+    fromAmount: p.fromAmount,
+    ...(p.slippage !== undefined ? { slippage: p.slippage } : {}),
+  });
+
+  const txReq = quote.transactionRequest;
+  if (!txReq || !txReq.data) {
+    throw new Error(
+      `LiFi quote returned no transactionRequest.data for TRON source. ` +
+        `The route may not be supported — try a different fromToken / toChain combination.`,
+    );
+  }
+
+  // Decode the TRON protobuf to extract TriggerSmartContract.
+  const rawDataHex = String(txReq.data).startsWith("0x")
+    ? String(txReq.data).slice(2)
+    : String(txReq.data);
+  const trigger = decodeTronTriggerSmartContract(rawDataHex);
+
+  // Cross-check bridge intent on the inner ABI calldata.
+  const bridgeData = verifyTronLifiBridgeIntent(p, trigger);
+
+  // Compute txID. Same convention TronGrid uses: sha256 of the raw_data
+  // protobuf bytes. Ledger TRON app displays this on-device when
+  // blind-signing; user matches against the prepare receipt.
+  const txID = sha256Hex(rawDataHex);
+
+  const fromSym =
+    p.fromToken === "native"
+      ? "TRX"
+      : quote.action.fromToken.symbol ?? p.fromToken;
+  const toSym = quote.action.toToken.symbol ?? p.toToken;
+  const tool = quote.toolDetails?.name ?? quote.tool ?? "lifi";
+  const description =
+    `LiFi bridge — ${quote.action.fromAmount} ${fromSym} (TRON) → ` +
+    `~${quote.estimate.toAmount} ${toSym} on ${p.toChain} via ${tool}`;
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "lifi_swap",
+    from: p.wallet,
+    txID,
+    // rawData intentionally absent — broadcast.ts uses /broadcasthex.
+    rawDataHex,
+    description,
+    decoded: {
+      functionName: "lifi.tron.bridge",
+      args: {
+        wallet: p.wallet,
+        fromToken: p.fromToken,
+        fromAmount: p.fromAmount,
+        toChain: p.toChain,
+        toToken: p.toToken,
+        toAddress: p.toAddress,
+        bridge: bridgeData.bridge,
+        minOutput: quote.estimate.toAmountMin,
+        tool: String(tool),
+        // TRON LiFi Diamond contract — included so the prepare receipt
+        // surfaces what contract the user is calling.
+        diamond: TRON_LIFI_DIAMOND,
+      },
+    },
+    ...(trigger.feeLimitSun > 0n
+      ? { feeLimitSun: trigger.feeLimitSun.toString() }
+      : {}),
+  };
+
+  return issueTronHandle(tx);
+}

--- a/src/modules/tron/verify-raw-data.ts
+++ b/src/modules/tron/verify-raw-data.ts
@@ -419,3 +419,79 @@ function verifyOwnerOnly(
   expectType(type, expectedType, label);
   expectAddress(requireBytes(inner, 1, `${label}.owner_address`), from, "owner_address");
 }
+
+// --- LiFi-specific extractor ----------------------------------------------
+
+/**
+ * Decode just enough of a TRON `raw_data_hex` to expose the
+ * `TriggerSmartContract` envelope. Used by the LiFi-on-TRON flow to
+ * cross-check that LiFi's response targets the LiFi Diamond contract on
+ * TRON and to extract the inner ABI calldata for the universal
+ * `BridgeData` decoder. Mirrors the structural assertions in
+ * `assertTronRawDataMatches` for `kind: "trc20_send"` but returns the
+ * raw fields to the caller rather than asserting against a fixed
+ * expectation.
+ *
+ * Throws if the contract type isn't TriggerSmartContract or the protobuf
+ * is malformed.
+ */
+export interface DecodedTronTriggerSmartContract {
+  /** Hex string (no 0x prefix) of the owner_address — 21 bytes including `41` TRON prefix. */
+  ownerAddressHex: string;
+  /** Hex string (no 0x prefix) of the contract_address — 21 bytes. */
+  contractAddressHex: string;
+  /** ABI calldata (selector + args) the call invokes on the contract. */
+  dataHex: `0x${string}`;
+  /** Native TRX value passed with the call (typically 0 for TRC-20 swaps; non-zero for TRX-source). */
+  callValueSun: bigint;
+  /** Fee limit in SUN — bound on the energy burn for this call. */
+  feeLimitSun: bigint;
+}
+
+export function decodeTronTriggerSmartContract(
+  rawDataHex: string,
+): DecodedTronTriggerSmartContract {
+  const buf = hexToBytes(rawDataHex);
+  const raw = parseProtobuf(buf);
+  const contracts = raw.get(11) ?? [];
+  if (contracts.length !== 1) {
+    throw new Error(
+      `TRON raw_data_hex must have exactly 1 contract, got ${contracts.length}. ` +
+        `LiFi-routed TRON txs are single-contract by design.`,
+    );
+  }
+  const contractBytes = contracts[0].bytes;
+  if (!contractBytes) {
+    throw new Error("TRON raw_data_hex: contract[0] not length-delimited");
+  }
+  const contract = parseProtobuf(contractBytes);
+  const typeField = contract.get(1)?.[0];
+  if (!typeField || typeField.varint === undefined) {
+    throw new Error("TRON raw_data_hex: contract.type missing");
+  }
+  const type = Number(typeField.varint);
+  if (type !== CONTRACT_TYPE.TriggerSmartContract) {
+    throw new Error(
+      `TRON raw_data_hex: expected TriggerSmartContract (${CONTRACT_TYPE.TriggerSmartContract}), got contract type ${type}. ` +
+        `LiFi-routed TRON txs are always smart-contract calls; refusing.`,
+    );
+  }
+  const parameterBytes = requireBytes(contract, 2, "contract.parameter");
+  const anyFields = parseProtobuf(parameterBytes);
+  const innerBytes = requireBytes(anyFields, 2, "Any.value");
+  const inner = parseProtobuf(innerBytes);
+
+  const ownerAddress = requireBytes(inner, 1, "TriggerSmartContract.owner_address");
+  const contractAddress = requireBytes(inner, 2, "TriggerSmartContract.contract_address");
+  const callValueSun = optionalVarint(inner, 3);
+  const dataBytes = optionalBytes(inner, 4) ?? new Uint8Array();
+  const feeLimitSun = optionalVarint(raw, 18);
+
+  return {
+    ownerAddressHex: toHex(ownerAddress),
+    contractAddressHex: toHex(contractAddress),
+    dataHex: ("0x" + toHex(dataBytes)) as `0x${string}`,
+    callValueSun,
+    feeLimitSun,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -698,13 +698,20 @@ export interface UnsignedTronTx {
     | "freeze"
     | "unfreeze"
     | "withdraw_expire_unfreeze"
-    | "vote";
+    | "vote"
+    | "lifi_swap";
   /** Base58 owner address (prefix T). */
   from: string;
   /** TronGrid-returned transaction ID (sha256 of raw_data_hex, hex string). */
   txID: string;
-  /** TronGrid's raw_data object — opaque to us; serialized in raw_data_hex. */
-  rawData: unknown;
+  /**
+   * TronGrid's raw_data object — opaque to us; serialized in raw_data_hex.
+   * Required for the standard `/wallet/broadcasttransaction` path. ABSENT
+   * for `lifi_swap` flows where we receive only `raw_data_hex` from LiFi
+   * and broadcast via `/wallet/broadcasthex` instead (broadcast.ts branches
+   * on this).
+   */
+  rawData?: unknown;
   /** Hex-encoded raw_data used by the signer. */
   rawDataHex: string;
   /** Human-readable description for the preview. */

--- a/test/tron-lifi-swap.test.ts
+++ b/test/tron-lifi-swap.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { encodeAbiParameters } from "viem";
+import {
+  LIFI_BRIDGE_DATA_TUPLE,
+  NON_EVM_RECEIVER_SENTINEL,
+} from "../src/abis/lifi-diamond.js";
+import { __test_buildSignedTransactionHex } from "../src/modules/tron/broadcast.js";
+import { base58ToHex } from "../src/modules/tron/address.js";
+
+/**
+ * TRON-source LiFi swap / bridge tests. The two load-bearing pieces:
+ *
+ *   1. The TRON protobuf decoder (`decodeTronTriggerSmartContract`) extracts
+ *      the inner ABI calldata so the BridgeData cross-check can run.
+ *   2. `buildSignedTransactionHex` assembles a signed Transaction envelope
+ *      hex from `raw_data_hex` + `signature` per protobuf wire format —
+ *      `/wallet/broadcasthex` accepts no other shape.
+ *
+ * Plus the end-to-end: synthetic LiFi quote → buildTronLifiSwap → assert the
+ * resulting UnsignedTronTx has the expected action / from / txID / decoded
+ * args, and that bridge-intent mismatches are refused.
+ */
+
+const TRON_WALLET = "TQn9Y2khEsLJW1ChVWFMSMeRDow5KcbLSE";
+const TRON_LIFI_DIAMOND = "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt";
+const TRON_USDT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const ETH_USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const SOL_USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SOL_RECIPIENT = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+const EVM_RECIPIENT = "0x1111111111111111111111111111111111111111";
+
+const fetchQuoteMock = vi.fn();
+vi.mock("../src/modules/swap/lifi.js", () => ({
+  fetchQuote: (...args: unknown[]) => fetchQuoteMock(...args),
+  fetchStatus: vi.fn(),
+  initLifi: () => {},
+  LIFI_SOLANA_CHAIN_ID: 1151111081099710,
+  LIFI_TRON_CHAIN_ID: 728126428,
+  fetchSolanaQuote: vi.fn(),
+}));
+
+interface BridgeDataInput {
+  transactionId: `0x${string}`;
+  bridge: string;
+  integrator: string;
+  referrer: `0x${string}`;
+  sendingAssetId: `0x${string}`;
+  receiver: `0x${string}`;
+  minAmount: bigint;
+  destinationChainId: bigint;
+  hasSourceSwaps: boolean;
+  hasDestinationCall: boolean;
+}
+
+function makeAbiCalldata(bd: BridgeDataInput): `0x${string}` {
+  const argsHex = encodeAbiParameters(
+    [LIFI_BRIDGE_DATA_TUPLE, { type: "bytes", name: "_facetData" }],
+    [bd, "0xc0de"],
+  );
+  return ("0xdeadbeef" + argsHex.slice(2)) as `0x${string}`;
+}
+
+/**
+ * Encode a fake TRON `Transaction.raw` protobuf wrapping a TriggerSmartContract
+ * that calls the LiFi Diamond on TRON with the given ABI calldata. Just
+ * enough wire-format to satisfy `decodeTronTriggerSmartContract`:
+ *
+ *   raw_data:
+ *     contract[0] (tag 11):
+ *       Contract:
+ *         type = TriggerSmartContract = 31
+ *         parameter (Any):
+ *           type_url (omitted — only `value` is required)
+ *           value:
+ *             owner_address = walletHex (21 bytes)
+ *             contract_address = diamondHex (21 bytes)
+ *             call_value = 0
+ *             data = abiCalldata
+ *     fee_limit (tag 18) = 100_000_000 (100 TRX)
+ */
+function encodeTronTriggerSmartContractRawData(
+  walletHex: string,
+  diamondHex: string,
+  abiCalldata: `0x${string}`,
+): string {
+  function varint(n: number): string {
+    let s = "";
+    let v = n;
+    while (v > 0x7f) {
+      s += (0x80 | (v & 0x7f)).toString(16).padStart(2, "0");
+      v >>>= 7;
+    }
+    s += v.toString(16).padStart(2, "0");
+    return s;
+  }
+  function tagBytes(tag: number, wireType: number): string {
+    // Tag itself is varint-encoded; for tag>=16 it needs multi-byte form.
+    return varint((tag << 3) | wireType);
+  }
+  function lenDelim(tag: number, payloadHex: string): string {
+    const len = payloadHex.length / 2;
+    return tagBytes(tag, 2) + varint(len) + payloadHex;
+  }
+  function tagVarint(tag: number, value: number): string {
+    return tagBytes(tag, 0) + varint(value);
+  }
+
+  // TriggerSmartContract.value fields:
+  //   1: owner_address (bytes)
+  //   2: contract_address (bytes)
+  //   3: call_value (varint, omitted = 0)
+  //   4: data (bytes)
+  const triggerInner =
+    lenDelim(1, walletHex) +
+    lenDelim(2, diamondHex) +
+    lenDelim(4, abiCalldata.slice(2));
+
+  // Any: { type_url (1, omitted), value (2, bytes) }
+  const anyMessage = lenDelim(2, triggerInner);
+
+  // Contract: { type (1, varint=31), parameter (2, Any) }
+  const contractInner = tagVarint(1, 31) + lenDelim(2, anyMessage);
+
+  // Transaction.raw: contract[0] (tag 11), fee_limit (tag 18, varint)
+  return lenDelim(11, contractInner) + tagVarint(18, 100_000_000);
+}
+
+function makeTronLifiQuote(opts: {
+  bridgeData: BridgeDataInput;
+  walletBase58?: string;
+  diamondBase58?: string;
+}) {
+  const walletHex = base58ToHex(opts.walletBase58 ?? TRON_WALLET);
+  const diamondHex = base58ToHex(opts.diamondBase58 ?? TRON_LIFI_DIAMOND);
+
+  const rawDataHex = encodeTronTriggerSmartContractRawData(
+    walletHex,
+    diamondHex,
+    makeAbiCalldata(opts.bridgeData),
+  );
+  return {
+    action: {
+      fromToken: {
+        address: TRON_USDT,
+        symbol: "USDT",
+        decimals: 6,
+        priceUSD: "1",
+      },
+      toToken: {
+        address: ETH_USDT,
+        symbol: "USDT",
+        decimals: 6,
+        priceUSD: "1",
+      },
+      fromAmount: "10000000",
+    },
+    estimate: {
+      toAmount: "9950000",
+      toAmountMin: "9900000",
+      executionDuration: 60,
+      feeCosts: [],
+      gasCosts: [],
+      approvalAddress: TRON_LIFI_DIAMOND,
+    },
+    transactionRequest: {
+      to: TRON_LIFI_DIAMOND,
+      data: ("0x" + rawDataHex) as `0x${string}`,
+      value: "0",
+      chainId: 728126428,
+    },
+    tool: opts.bridgeData.bridge,
+    toolDetails: { name: opts.bridgeData.bridge },
+  };
+}
+
+beforeEach(() => {
+  fetchQuoteMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildTronLifiSwap — happy path", () => {
+  it("returns an UnsignedTronTx with action=lifi_swap and the right decoded args (TRON → EVM)", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "11".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: EVM_RECIPIENT as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 1n, // ethereum
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    const tx = await buildTronLifiSwap({
+      wallet: TRON_WALLET,
+      fromToken: TRON_USDT,
+      fromAmount: "10000000",
+      toChain: "ethereum",
+      toToken: ETH_USDT,
+      toAddress: EVM_RECIPIENT,
+    });
+
+    expect(tx.chain).toBe("tron");
+    expect(tx.action).toBe("lifi_swap");
+    expect(tx.from).toBe(TRON_WALLET);
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
+    expect(tx.rawData).toBeUndefined(); // /broadcasthex path
+    expect(tx.rawDataHex).toMatch(/^[0-9a-f]+$/);
+    expect(tx.feeLimitSun).toBe("100000000");
+    expect(tx.description).toContain("LiFi bridge");
+    expect(tx.description).toContain("ethereum");
+    expect(tx.description).toContain("near");
+    expect(tx.decoded.functionName).toBe("lifi.tron.bridge");
+    expect(tx.decoded.args.toChain).toBe("ethereum");
+    expect(tx.decoded.args.toAddress).toBe(EVM_RECIPIENT);
+    expect(tx.decoded.args.diamond).toBe(TRON_LIFI_DIAMOND);
+    expect(tx.handle).toBeDefined(); // issueTronHandle stamps it
+  });
+
+  it("accepts Solana destination + non-EVM sentinel receiver", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "22".repeat(32)) as `0x${string}`,
+          bridge: "wormhole",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 1151111081099710n, // solana
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    const tx = await buildTronLifiSwap({
+      wallet: TRON_WALLET,
+      fromToken: TRON_USDT,
+      fromAmount: "10000000",
+      toChain: "solana",
+      toToken: SOL_USDC,
+      toAddress: SOL_RECIPIENT,
+    });
+    expect(tx.action).toBe("lifi_swap");
+    expect(tx.decoded.args.toChain).toBe("solana");
+    expect(tx.decoded.args.toAddress).toBe(SOL_RECIPIENT);
+  });
+});
+
+describe("buildTronLifiSwap — rejection paths", () => {
+  it("rejects malformed wallet (not TRON base58)", async () => {
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: "0xnotvalidtron",
+        fromToken: "native",
+        fromAmount: "1000000",
+        toChain: "ethereum",
+        toToken: ETH_USDT,
+        toAddress: EVM_RECIPIENT,
+      }),
+    ).rejects.toThrow(/not a valid TRON base58/);
+  });
+
+  it("rejects toAddress format mismatch (Solana base58 for EVM destination)", async () => {
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: TRON_WALLET,
+        fromToken: "native",
+        fromAmount: "1000000",
+        toChain: "ethereum",
+        toToken: ETH_USDT,
+        toAddress: SOL_RECIPIENT, // Solana base58 — wrong for ethereum dest
+      }),
+    ).rejects.toThrow(/not a valid EVM address/);
+  });
+
+  it("rejects calldata whose contract_address isn't the LiFi Diamond on TRON", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "33".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: EVM_RECIPIENT as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 1n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+        diamondBase58: TRON_USDT, // any valid TRON address that isn't the LiFi Diamond
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: TRON_WALLET,
+        fromToken: TRON_USDT,
+        fromAmount: "10000000",
+        toChain: "ethereum",
+        toToken: ETH_USDT,
+        toAddress: EVM_RECIPIENT,
+      }),
+    ).rejects.toThrow(/contract_address mismatch.*expected the LiFi Diamond/);
+  });
+
+  it("rejects destinationChainId mismatch (user asked Solana, calldata bridges to TRON)", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "44".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 728126428n, // tron, not solana
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: TRON_WALLET,
+        fromToken: TRON_USDT,
+        fromAmount: "10000000",
+        toChain: "solana",
+        toToken: SOL_USDC,
+        toAddress: SOL_RECIPIENT,
+      }),
+    ).rejects.toThrow(/destinationChainId mismatch.*encoded 728126428.*toChain="solana"/);
+  });
+
+  it("rejects EVM-destination calldata whose receiver doesn't match toAddress", async () => {
+    const attackerReceiver = "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead" as `0x${string}`;
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "55".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: attackerReceiver,
+          minAmount: 9_900_000n,
+          destinationChainId: 1n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: TRON_WALLET,
+        fromToken: TRON_USDT,
+        fromAmount: "10000000",
+        toChain: "ethereum",
+        toToken: ETH_USDT,
+        toAddress: EVM_RECIPIENT,
+      }),
+    ).rejects.toThrow(/receiver mismatch/);
+  });
+
+  it("rejects Solana-destination calldata whose receiver isn't the non-EVM sentinel", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeTronLifiQuote({
+        bridgeData: {
+          transactionId: ("0x" + "66".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: "0x0000000000000000000000000000000000000001",
+          receiver: EVM_RECIPIENT as `0x${string}`, // not the sentinel
+          minAmount: 9_900_000n,
+          destinationChainId: 1151111081099710n,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { buildTronLifiSwap } = await import(
+      "../src/modules/tron/lifi-swap.js"
+    );
+    await expect(
+      buildTronLifiSwap({
+        wallet: TRON_WALLET,
+        fromToken: TRON_USDT,
+        fromAmount: "10000000",
+        toChain: "solana",
+        toToken: SOL_USDC,
+        toAddress: SOL_RECIPIENT,
+      }),
+    ).rejects.toThrow(/receiver mismatch for non-EVM destination solana/);
+  });
+});
+
+describe("buildSignedTransactionHex — protobuf envelope encoder", () => {
+  it("wraps raw_data + signature into a Transaction protobuf hex", () => {
+    const rawData = "0a02583722"; // 5 bytes
+    const sig = "11".repeat(65); // 65-byte signature
+    const out = __test_buildSignedTransactionHex(rawData, sig);
+    // Field 1 (raw_data, length-delim): tag 0x0a + varint(5) + raw bytes
+    // Field 2 (signature, length-delim): tag 0x12 + varint(65) + sig bytes
+    expect(out).toBe("0a05" + rawData + "12" + "41" + sig);
+  });
+
+  it("encodes long-form varint length when raw_data exceeds 127 bytes", () => {
+    const rawData = "ab".repeat(200); // 200-byte raw_data
+    const sig = "11".repeat(65);
+    const out = __test_buildSignedTransactionHex(rawData, sig);
+    // varint(200) = 0xc8 0x01 (200 = 0x80 | 0x48, then 1)
+    expect(out.startsWith("0ac801" + rawData)).toBe(true);
+  });
+
+  it("strips 0x prefix from inputs", () => {
+    const rawData = "ab".repeat(5);
+    const sig = "11".repeat(65);
+    const withPrefix = __test_buildSignedTransactionHex("0x" + rawData, "0x" + sig);
+    const withoutPrefix = __test_buildSignedTransactionHex(rawData, sig);
+    expect(withPrefix).toBe(withoutPrefix);
+  });
+
+  it("rejects malformed hex inputs", () => {
+    expect(() => __test_buildSignedTransactionHex("notvalidhex", "11".repeat(65))).toThrow(
+      /not valid hex/,
+    );
+    expect(() => __test_buildSignedTransactionHex("ab".repeat(5), "notvalidhex")).toThrow(
+      /not valid hex/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes the deferred TRON-source piece flagged in #161. With this PR the LiFi cross-chain matrix is fully covered:

|  | → EVM | → Solana | → TRON |
|---|---|---|---|
| **EVM source** | existing | #155 | #161 |
| **Solana source** | #153 | #153 (in-chain via Jupiter) | not wired |
| **TRON source** | **this PR** | **this PR** | not wired |

Solana-source was already shipped in #153 (`prepare_solana_lifi_swap`) — heads-up since your message mentioned both. No changes there.

## Tx-shape surgery

LiFi returns a fully-formed TRON `Transaction.raw` protobuf in `quote.transactionRequest.data` (hex). The builder validates and hands it to Ledger:

1. Decode the protobuf → extract the inner `TriggerSmartContract`
2. Assert `contract_address` is the LiFi Diamond on TRON (`TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt`)
3. Assert `owner_address` is the user's wallet
4. Decode the inner ABI calldata's universal `BridgeData` tuple and run the same `destinationChainId` + `receiver` cross-check we apply to EVM-source bridges (#161). Refuses on mismatch.

## Broadcast path

LiFi gives us only `raw_data_hex` while TronGrid's `/wallet/broadcasttransaction` requires the deserialized `raw_data` JSON object too. Solved by using `/wallet/broadcasthex`: a small (~20-line) protobuf encoder assembles the full signed `Transaction` envelope (raw_data + signature) post-signing. `UnsignedTronTx.rawData` is now optional; broadcast.ts branches on its presence.

## On-device review

The Ledger TRON app does NOT clear-sign LiFi Diamond calls. User must enable **\"Allow blind signing\"** in the on-device Settings; the device displays the txID (sha256 of raw_data_hex), which the user matches against the txID in the prepare receipt.

## Out of scope this PR

TRC-20 source flows: LiFi's quote assumes the user has already approved the LiFi Diamond to spend the TRC-20 token. This builder does **not** prepare the approve; insufficient allowance reverts on-chain. The agent should explain this to TRC-20-source users. A `prepare_tron_trc20_approve` tool is a follow-up. TRX-source flows work without any approve dance.

## Test plan

- [x] 12 new tests in `test/tron-lifi-swap.test.ts` covering: happy paths (TRON → EVM, TRON → Solana); rejections (bad wallet, format-mismatched toAddress, wrong contract_address, destinationChainId mismatch, EVM-receiver mismatch, missing non-EVM sentinel); `buildSignedTransactionHex` protobuf envelope encoder edge cases
- [x] `npm run build` clean
- [x] `npx vitest run` — 933 tests, 77 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)