### PR TITLE
feat(tron): prepare_tron_trc20_approve — TRC-20 allowance for LiFi-on-TRON

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,7 @@ import { listTronWitnesses } from "./modules/tron/witnesses.js";
 import {
   buildTronNativeSend,
   buildTronTokenSend,
+  buildTronTrc20Approve,
   buildTronClaimRewards,
   buildTronFreeze,
   buildTronUnfreeze,
@@ -175,6 +176,7 @@ import {
   getTronStakingInput,
   prepareTronNativeSendInput,
   prepareTronTokenSendInput,
+  prepareTronTrc20ApproveInput,
   prepareTronClaimRewardsInput,
   prepareTronFreezeInput,
   prepareTronUnfreezeInput,
@@ -1630,8 +1632,9 @@ async function main() {
         "(TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) and the owner_address is the user's wallet, " +
         "(3) decodes the inner ABI calldata's BridgeData tuple and cross-checks " +
         "destinationChainId + receiver against the user's request — refuses on any " +
-        "mismatch. TRC-20 source flows REQUIRE a prior approve to the LiFi Diamond — this " +
-        "tool does NOT prepare the approve; insufficient allowance reverts on-chain. " +
+        "mismatch. TRC-20 source flows REQUIRE a prior approve to the LiFi Diamond — call " +
+        "`prepare_tron_trc20_approve` first with `spender: \"TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt\"` " +
+        "and the amount you intend to swap; insufficient allowance reverts the swap on-chain. " +
         "BLIND-SIGN on Ledger (LiFi Diamond not in TRON app's clear-sign allowlist) — " +
         "enable \"Allow blind signing\" in the on-device Solana app Settings; the device " +
         "shows the txID, which the user matches against the txID in the prepare receipt. " +
@@ -2059,6 +2062,18 @@ async function main() {
       inputSchema: prepareTronTokenSendInput.shape,
     },
     handler(buildTronTokenSend, { toolName: "prepare_tron_token_send" })
+  );
+
+  server.registerTool(
+    "prepare_tron_trc20_approve",
+    {
+      description:
+        "Build an unsigned TRC-20 approve(spender, amount) tx — sets allowance so a third party can pull tokens via transferFrom. Primary use: authorize the LiFi Diamond on TRON (TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) before running prepare_tron_lifi_swap with a TRC-20 source token (LiFi's quote response assumes the approve already exists; insufficient allowance reverts the swap on-chain). " +
+        "Accepts ANY TRC-20 contract — not just the canonical set. Decimals are auto-resolved for canonical USDT/USDC/USDD/TUSD; for any other TRC-20 you MUST pass `decimals` explicitly. We REFUSE to default decimals on approve because an off-by-power-of-ten allowance silently authorizes a 10^12-fold larger spend than intended, with no UX recovery on a Ledger blind-sign flow. " +
+        "amount is a human decimal string (\"100\" = 100 tokens at the resolved decimals). \"max\" / unbounded approvals are NOT supported — pass exactly the amount you intend to swap. Returns a preview + opaque handle for `send_transaction`.",
+      inputSchema: prepareTronTrc20ApproveInput.shape,
+    },
+    handler(buildTronTrc20Approve, { toolName: "prepare_tron_trc20_approve" })
   );
 
   server.registerTool(

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -497,6 +497,145 @@ export async function buildTronTokenSend(
   return issueTronHandle(tx);
 }
 
+// ----- TRC-20 approve -----
+
+export interface BuildTronTrc20ApproveArgs {
+  from: string;
+  /** Base58 TRC-20 contract address. Any TRC-20 is accepted. */
+  token: string;
+  /** Base58 spender (typically the LiFi Diamond on TRON for prepare_tron_lifi_swap flows). */
+  spender: string;
+  amount: string;
+  /** Required when `token` is not in the canonical TRC-20 set. */
+  decimals?: number;
+  feeLimitTrx?: string;
+}
+
+/**
+ * Build a TRC-20 `approve(spender, amount)` call. Same TronGrid pipeline
+ * as `buildTronTokenSend` (triggersmartcontract → preflight constant call
+ * → bandwidth check → raw_data verify) but with selector `095ea7b3`
+ * instead of `a9059cbb`.
+ *
+ * Why this exists: `prepare_tron_lifi_swap` requires the user to have
+ * already approved the LiFi Diamond on TRON (TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt)
+ * to pull TRC-20 tokens. This builder lets the agent prepare that approve
+ * tx directly. We deliberately do NOT support `amount: "max"` /
+ * unbounded approvals — those are a known TRC-20 griefing vector
+ * (allowance survives across versions of the spender contract; a
+ * later upgrade could authorize new behaviors against the unbounded
+ * grant). Pass exactly the amount you intend to swap.
+ */
+export async function buildTronTrc20Approve(
+  args: BuildTronTrc20ApproveArgs,
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.from)) {
+    throw new Error(`"from" is not a valid TRON mainnet address: ${args.from}`);
+  }
+  if (!isTronAddress(args.token)) {
+    throw new Error(`"token" is not a valid TRC-20 base58 address: ${args.token}`);
+  }
+  if (!isTronAddress(args.spender)) {
+    throw new Error(`"spender" is not a valid TRON base58 address: ${args.spender}`);
+  }
+
+  // Decimals: canonical lookup OR caller-supplied. We REFUSE to default —
+  // an off-by-power-of-ten allowance would silently authorize a
+  // 10^12-fold larger spend than intended, and there's no UX recovery
+  // from that on a Ledger blind-sign flow.
+  const canonicalSymbol = SYMBOL_BY_CONTRACT[args.token];
+  let decimals: number;
+  let symbolForDescription: string;
+  if (canonicalSymbol) {
+    decimals = TOKEN_DECIMALS[canonicalSymbol];
+    symbolForDescription = canonicalSymbol;
+  } else {
+    if (args.decimals === undefined) {
+      throw new Error(
+        `Token ${args.token} is not in the canonical TRC-20 set (USDT/USDC/USDD/TUSD). ` +
+          `Pass an explicit \`decimals\` argument — we refuse to guess decimals on approve ` +
+          `because an off-by-power-of-ten allowance silently authorizes a vastly larger ` +
+          `spend than intended.`,
+      );
+    }
+    decimals = args.decimals;
+    symbolForDescription = `TRC-20 ${args.token}`;
+  }
+
+  const amountBase = parseUnits(args.amount, decimals);
+  if (amountBase <= 0n) {
+    throw new Error(`Amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const feeLimitSun = args.feeLimitTrx
+    ? parseUnits(args.feeLimitTrx, TRX_DECIMALS)
+    : DEFAULT_FEE_LIMIT_SUN;
+
+  // approve(address spender, uint256 amount) — same param shape as
+  // transfer, so the existing encoder works without any change.
+  const parameter = encodeTrc20TransferParam(args.spender, amountBase);
+  const body = {
+    owner_address: args.from,
+    contract_address: args.token,
+    function_selector: "approve(address,uint256)",
+    parameter,
+    fee_limit: Number(feeLimitSun),
+    call_value: 0,
+    visible: true,
+  };
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const { energyUsed } = await preflightConstantContract(body, apiKey);
+  const estimatedEnergySun = energyUsed * ENERGY_PRICE_SUN;
+  const res = await trongridPost<TrongridTriggerResponse>(
+    "/wallet/triggersmartcontract",
+    body,
+    apiKey,
+  );
+  if (!res.result?.result) {
+    throw new Error(
+      `TronGrid triggersmartcontract failed: ${res.result?.message ?? "unknown error"}`,
+    );
+  }
+  const ttx = res.transaction;
+  if (!ttx?.txID || !ttx.raw_data_hex) {
+    throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
+  }
+
+  assertTronRawDataMatches(ttx.raw_data_hex, {
+    kind: "trc20_approve",
+    from: args.from,
+    contract: args.token,
+    parameterHex: parameter,
+    feeLimitSun,
+    callValue: 0n,
+  });
+  await assertBandwidthSufficient(args.from, ttx.raw_data_hex, apiKey);
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "trc20_approve",
+    from: args.from,
+    txID: ttx.txID,
+    rawData: ttx.raw_data,
+    rawDataHex: ttx.raw_data_hex,
+    description: `Approve ${args.amount} ${symbolForDescription} for spender ${args.spender}`,
+    decoded: {
+      functionName: "approve(address,uint256)",
+      args: {
+        spender: args.spender,
+        amount: args.amount,
+        symbol: symbolForDescription,
+        contract: args.token,
+        decimals: String(decimals),
+      },
+    },
+    feeLimitSun: feeLimitSun.toString(),
+    estimatedEnergyUsed: energyUsed.toString(),
+    estimatedEnergyCostSun: estimatedEnergySun.toString(),
+  };
+  return issueTronHandle(tx);
+}
+
 // ----- VoteWitness (cast/replace all votes atomically) -----
 
 export interface TronVoteEntry {

--- a/src/modules/tron/schemas.ts
+++ b/src/modules/tron/schemas.ts
@@ -41,6 +41,45 @@ export const prepareTronTokenSendInput = z.object({
 
 export type PrepareTronTokenSendArgs = z.infer<typeof prepareTronTokenSendInput>;
 
+/**
+ * TRC-20 `approve(spender, amount)` — sets ERC-20-style allowance on a
+ * TRC-20 contract so a third-party (typically the LiFi Diamond on TRON
+ * for `prepare_tron_lifi_swap` flows) can pull tokens via transferFrom.
+ *
+ * Unlike `prepare_tron_token_send`, this tool accepts ANY TRC-20 contract
+ * — not just the canonical set — because LiFi's routing graph covers
+ * many tokens we don't list canonically. When the token isn't in the
+ * canonical table, `decimals` MUST be passed; otherwise the builder
+ * rejects (we won't fall back to assuming 6 or 18 — silent decimals
+ * mismatch would mean an off-by-orders-of-magnitude allowance).
+ */
+export const prepareTronTrc20ApproveInput = z.object({
+  from: tronAddress.describe("Base58 TRON owner address — the wallet that holds the tokens."),
+  token: tronAddress.describe(
+    "Base58 TRC-20 contract address. Any TRC-20 is accepted; non-canonical tokens require `decimals`."
+  ),
+  spender: tronAddress.describe(
+    "Base58 TRON address authorized to pull tokens via transferFrom. Typical use: the LiFi Diamond on TRON (TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) for `prepare_tron_lifi_swap` flows."
+  ),
+  amount: amountString.describe(
+    "Allowance amount as a human-readable decimal string. Pass exactly the amount you intend to swap, NOT \"max\" / unbounded — TRC-20 unbounded approvals are a known griefing vector and we don't expose them by default."
+  ),
+  decimals: z
+    .number()
+    .int()
+    .min(0)
+    .max(36)
+    .optional()
+    .describe(
+      "Token decimals. OPTIONAL when `token` is in the canonical TRC-20 set (USDT/USDC=6, USDD/TUSD=18 — auto-resolved). REQUIRED for any other TRC-20 contract; we refuse to guess decimals when an off-by-power-of-ten allowance could authorize a 10^12-fold larger spend than intended."
+    ),
+  feeLimitTrx: amountString
+    .optional()
+    .describe("Optional fee-limit override in TRX. Defaults to 100 TRX (TronLink/Ledger Live standard)."),
+});
+
+export type PrepareTronTrc20ApproveArgs = z.infer<typeof prepareTronTrc20ApproveInput>;
+
 export const prepareTronClaimRewardsInput = z.object({
   from: tronAddress.describe(
     "Base58 TRON address to claim accumulated voting rewards for. TRON enforces a 24h cooldown between claims."

--- a/src/modules/tron/verify-raw-data.ts
+++ b/src/modules/tron/verify-raw-data.ts
@@ -149,6 +149,14 @@ export type TronRawDataExpectation =
       callValue?: bigint;
     }
   | {
+      kind: "trc20_approve";
+      from: string;
+      contract: string;
+      parameterHex: string;
+      feeLimitSun?: bigint;
+      callValue?: bigint;
+    }
+  | {
       kind: "vote";
       from: string;
       votes: ReadonlyArray<{ address: string; count: number }>;
@@ -216,7 +224,23 @@ export function assertTronRawDataMatches(
     case "native_send":
       return verifyTransfer(type, inner, expected);
     case "trc20_send":
-      return verifyTriggerSmartContract(type, inner, expected, feeLimit);
+      return verifyTriggerSmartContract(
+        type,
+        inner,
+        expected,
+        feeLimit,
+        "a9059cbb",
+        "transfer(address,uint256)",
+      );
+    case "trc20_approve":
+      return verifyTriggerSmartContract(
+        type,
+        inner,
+        expected,
+        feeLimit,
+        "095ea7b3",
+        "approve(address,uint256)",
+      );
     case "vote":
       return verifyVote(type, inner, expected);
     case "freeze":
@@ -284,8 +308,10 @@ function verifyTransfer(
 function verifyTriggerSmartContract(
   type: number,
   inner: FieldMap,
-  e: Extract<TronRawDataExpectation, { kind: "trc20_send" }>,
-  actualFeeLimit: bigint
+  e: Extract<TronRawDataExpectation, { kind: "trc20_send" | "trc20_approve" }>,
+  actualFeeLimit: bigint,
+  expectedSelector: string,
+  selectorLabel: string,
 ): void {
   expectType(type, CONTRACT_TYPE.TriggerSmartContract, "TriggerSmartContract");
   expectAddress(
@@ -310,15 +336,15 @@ function verifyTriggerSmartContract(
   const dataBytes = optionalBytes(inner, 4) ?? new Uint8Array();
   const dataHex = toHex(dataBytes).toLowerCase();
   // Builder's `parameterHex` is the ABI param payload WITHOUT the 4-byte
-  // selector. TronGrid prepends `a9059cbb` (transfer(address,uint256)) to
-  // produce the full calldata. Compare on the suffix.
+  // selector. TronGrid prepends the function selector to produce the full
+  // calldata. Compare on selector + suffix to catch BOTH selector swap
+  // (transfer ↔ approve) and parameter tampering.
   const expectedParam = e.parameterHex.toLowerCase();
-  const transferSelector = "a9059cbb";
-  const expectedFullData = transferSelector + expectedParam;
+  const expectedFullData = expectedSelector + expectedParam;
   if (dataHex !== expectedFullData) {
     throw new Error(
-      `TRON rawData verify: TriggerSmartContract.data mismatch — got 0x${dataHex}, ` +
-        `expected 0x${expectedFullData}. Refusing to sign.`
+      `TRON rawData verify: TriggerSmartContract.data mismatch (expected ${selectorLabel}) — ` +
+        `got 0x${dataHex}, expected 0x${expectedFullData}. Refusing to sign.`
     );
   }
   if (e.feeLimitSun !== undefined && actualFeeLimit !== e.feeLimitSun) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -694,6 +694,7 @@ export interface UnsignedTronTx {
   action:
     | "native_send"
     | "trc20_send"
+    | "trc20_approve"
     | "claim_rewards"
     | "freeze"
     | "unfreeze"

--- a/test/tron-trc20-approve.test.ts
+++ b/test/tron-trc20-approve.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TRON_TOKENS } from "../src/config/tron.js";
+import { buildTronTrc20Approve } from "../src/modules/tron/actions.js";
+import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+import { encodeTriggerSmartContractRawData } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
+
+/**
+ * `prepare_tron_trc20_approve` builder tests. Mirrors the test pattern of
+ * `prepare_tron_token_send` (TronGrid POST body shape, raw_data verify,
+ * handle issuance, validation) but with two new invariants specific to
+ * approve:
+ *   - selector is `095ea7b3` (approve), not `a9059cbb` (transfer)
+ *   - canonical-token decimals are auto-resolved; non-canonical tokens
+ *     REQUIRE explicit `decimals` (we refuse to default — off-by-power-
+ *     of-ten allowance is too dangerous to silently fix up)
+ */
+
+const ADDR_USDT = TRON_TOKENS.USDT;
+const ADDR_FROM = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const TRON_LIFI_DIAMOND = "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt";
+const APPROVE_SELECTOR = "095ea7b3";
+
+function trongridFetchMock(opts: {
+  expected: {
+    selector: string;
+    contract: string;
+    feeLimitSun: number;
+  };
+  energyUsed?: number;
+}) {
+  return async (url: string, init?: RequestInit) => {
+    const preflight = maybeTronBandwidthResponse(url);
+    if (preflight) return preflight;
+    if (url === "https://api.trongrid.io/wallet/triggerconstantcontract") {
+      return new Response(
+        JSON.stringify({
+          result: { result: true },
+          energy_used: opts.energyUsed ?? 14_650,
+          constant_result: [""],
+        }),
+        { status: 200 },
+      );
+    }
+    expect(url).toBe("https://api.trongrid.io/wallet/triggersmartcontract");
+    const body = JSON.parse(init!.body as string);
+    expect(body.contract_address).toBe(opts.expected.contract);
+    expect(body.function_selector).toBe(opts.expected.selector);
+    expect(body.fee_limit).toBe(opts.expected.feeLimitSun);
+    return new Response(
+      JSON.stringify({
+        result: { result: true },
+        transaction: {
+          txID: "deadbeef".repeat(8),
+          raw_data: { expiration: 0 },
+          raw_data_hex: encodeTriggerSmartContractRawData({
+            from: ADDR_FROM,
+            contract: opts.expected.contract,
+            dataHex: APPROVE_SELECTOR + body.parameter,
+            feeLimitSun: BigInt(body.fee_limit),
+          }),
+          visible: true,
+        },
+      }),
+      { status: 200 },
+    );
+  };
+}
+
+describe("buildTronTrc20Approve — happy path", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          expected: {
+            selector: "approve(address,uint256)",
+            contract: ADDR_USDT,
+            feeLimitSun: 100_000_000,
+          },
+        }),
+      ),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("builds an approve to the LiFi Diamond for canonical USDT (6-decimal auto-resolve)", async () => {
+    const tx = await buildTronTrc20Approve({
+      from: ADDR_FROM,
+      token: ADDR_USDT,
+      spender: TRON_LIFI_DIAMOND,
+      amount: "10",
+    });
+
+    expect(tx.action).toBe("trc20_approve");
+    expect(tx.from).toBe(ADDR_FROM);
+    expect(tx.txID).toBe("deadbeef".repeat(8));
+    expect(tx.description).toBe(`Approve 10 USDT for spender ${TRON_LIFI_DIAMOND}`);
+    expect(tx.decoded.functionName).toBe("approve(address,uint256)");
+    expect(tx.decoded.args.spender).toBe(TRON_LIFI_DIAMOND);
+    expect(tx.decoded.args.symbol).toBe("USDT");
+    expect(tx.decoded.args.contract).toBe(ADDR_USDT);
+    expect(tx.decoded.args.decimals).toBe("6");
+    expect(tx.feeLimitSun).toBe("100000000");
+    expect(tx.estimatedEnergyUsed).toBe("14650");
+    expect(tx.handle).toBeDefined();
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+  });
+
+  it("encodes the approve param with spender as the address word, amount as the uint256 word", async () => {
+    let capturedParameter: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const preflight = maybeTronBandwidthResponse(url);
+        if (preflight) return preflight;
+        if (url === "https://api.trongrid.io/wallet/triggerconstantcontract") {
+          return new Response(
+            JSON.stringify({ result: { result: true }, energy_used: 14_650, constant_result: [""] }),
+            { status: 200 },
+          );
+        }
+        const body = JSON.parse(init!.body as string);
+        capturedParameter = body.parameter;
+        return new Response(
+          JSON.stringify({
+            result: { result: true },
+            transaction: {
+              txID: "abcd".repeat(16),
+              raw_data: { expiration: 0 },
+              raw_data_hex: encodeTriggerSmartContractRawData({
+                from: ADDR_FROM,
+                contract: ADDR_USDT,
+                dataHex: APPROVE_SELECTOR + body.parameter,
+                feeLimitSun: BigInt(body.fee_limit),
+              }),
+              visible: true,
+            },
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+    await buildTronTrc20Approve({
+      from: ADDR_FROM,
+      token: ADDR_USDT,
+      spender: TRON_LIFI_DIAMOND,
+      amount: "10",
+    });
+    expect(capturedParameter).toBeDefined();
+    expect(capturedParameter!.length).toBe(128);
+    // Second word = 10 USDT in base units = 10_000_000.
+    expect(capturedParameter!.slice(64)).toBe(
+      (10_000_000n).toString(16).padStart(64, "0"),
+    );
+    // First word = padded spender address (drop 0x41 TRON prefix).
+    // Don't recompute base58→hex here; just assert the last 40 chars
+    // (= 20-byte address form) appear in the address word.
+    expect(capturedParameter!.slice(0, 64).slice(0, 24)).toBe("0".repeat(24));
+  });
+
+  it("accepts a non-canonical TRC-20 contract when explicit decimals is passed", async () => {
+    const NON_CANONICAL_CONTRACT = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7"; // any valid TRON addr
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          expected: {
+            selector: "approve(address,uint256)",
+            contract: NON_CANONICAL_CONTRACT,
+            feeLimitSun: 100_000_000,
+          },
+        }),
+      ),
+    );
+    const tx = await buildTronTrc20Approve({
+      from: ADDR_FROM,
+      token: NON_CANONICAL_CONTRACT,
+      spender: TRON_LIFI_DIAMOND,
+      amount: "5",
+      decimals: 8,
+    });
+    expect(tx.action).toBe("trc20_approve");
+    expect(tx.decoded.args.decimals).toBe("8");
+    // Non-canonical token: description uses the contract address as the
+    // symbol fallback rather than guessing.
+    expect(tx.description).toContain("TRC-20");
+    expect(tx.description).toContain(NON_CANONICAL_CONTRACT);
+  });
+
+  it("honours an explicit feeLimitTrx override", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          expected: {
+            selector: "approve(address,uint256)",
+            contract: ADDR_USDT,
+            feeLimitSun: 50_000_000, // 50 TRX
+          },
+        }),
+      ),
+    );
+    const tx = await buildTronTrc20Approve({
+      from: ADDR_FROM,
+      token: ADDR_USDT,
+      spender: TRON_LIFI_DIAMOND,
+      amount: "10",
+      feeLimitTrx: "50",
+    });
+    expect(tx.feeLimitSun).toBe("50000000");
+  });
+});
+
+describe("buildTronTrc20Approve — rejection paths", () => {
+  it("rejects a non-TRON wallet", async () => {
+    await expect(
+      buildTronTrc20Approve({
+        from: "0xnotvalidtron",
+        token: ADDR_USDT,
+        spender: TRON_LIFI_DIAMOND,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/"from" is not a valid TRON/);
+  });
+
+  it("rejects a non-TRON token contract", async () => {
+    await expect(
+      buildTronTrc20Approve({
+        from: ADDR_FROM,
+        token: "0xnotvalidtron",
+        spender: TRON_LIFI_DIAMOND,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/"token" is not a valid TRC-20 base58/);
+  });
+
+  it("rejects a non-TRON spender", async () => {
+    await expect(
+      buildTronTrc20Approve({
+        from: ADDR_FROM,
+        token: ADDR_USDT,
+        spender: "0xnotvalidtron",
+        amount: "10",
+      }),
+    ).rejects.toThrow(/"spender" is not a valid TRON/);
+  });
+
+  it("REFUSES to default decimals on a non-canonical token", async () => {
+    const NON_CANONICAL_CONTRACT = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+    await expect(
+      buildTronTrc20Approve({
+        from: ADDR_FROM,
+        token: NON_CANONICAL_CONTRACT,
+        spender: TRON_LIFI_DIAMOND,
+        amount: "10",
+        // decimals omitted
+      }),
+    ).rejects.toThrow(
+      /not in the canonical TRC-20 set.*explicit `decimals`.*off-by-power-of-ten/,
+    );
+  });
+
+  it("rejects zero / negative amounts", async () => {
+    await expect(
+      buildTronTrc20Approve({
+        from: ADDR_FROM,
+        token: ADDR_USDT,
+        spender: TRON_LIFI_DIAMOND,
+        amount: "0",
+      }),
+    ).rejects.toThrow(/Amount must be greater than 0/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the follow-up flagged in #164. TRC-20-source LiFi flows (`prepare_tron_lifi_swap` with a TRC-20 fromToken) require the user to have approved the LiFi Diamond on TRON (`TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt`) to pull tokens via transferFrom. This tool prepares that approve directly.

## Why a separate tool (not extending `prepare_tron_token_send`)

- Different selector (`095ea7b3` vs `a9059cbb`) — the `verify-raw-data` cross-check needs to see the right selector + the right param payload; an MCP swapping selector while keeping the expected params would slip past a shared-kind verifier.
- Approve takes **any** TRC-20, not just the canonical set. LiFi covers tokens we don't list canonically, so locking approve behind the canonical-only allowlist would defeat the purpose. Send keeps the canonical constraint to preserve its known-token UX.

## Decimals-required guard for non-canonical tokens

The builder **refuses to default decimals** when the token is outside the canonical USDT/USDC/USDD/TUSD set. Pass `decimals` explicitly. Reason: on `transfer`, an off-by-power-of-ten amount is recoverable (the wrong-amount balance is in your own wallet). On `approve`, an off-by-power-of-ten allowance silently authorizes a 10^12-fold larger spend; once a malicious/compromised spender pulls those tokens, they're gone. We also don't expose unbounded (\"max\") approvals — known TRC-20 griefing vector that survives spender-contract upgrades.

## Verifier refactor

`verifyTriggerSmartContract` now takes `expectedSelector` + `selectorLabel` parameters; `assertTronRawDataMatches` switches on the new `kind: \"trc20_approve\"` and passes `095ea7b3` / `approve(address,uint256)` for the comparison. Same semantics as the existing `trc20_send` path; the selector swap means an attacker can't get an approve through by setting up params that look like a transfer or vice versa.

## Test plan

- [x] 9 new tests in `test/tron-trc20-approve.test.ts` covering: USDT canonical happy path; param encoding (spender word + amount word); non-canonical token with explicit decimals; feeLimitTrx override; rejections (bad wallet/token/spender, missing decimals for non-canonical, zero amount)
- [x] Existing TRON tests stay green (verifier refactor preserves the `trc20_send` selector path verbatim)
- [x] `npm run build` clean
- [x] `npx vitest run` — 963 tests, 80 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)