### PR TITLE
fix(decode): treat LiFi bridge partial decode as opt-out of 4byte name cross-check

### DIFF
--- a/src/signing/decode-calldata.ts
+++ b/src/signing/decode-calldata.ts
@@ -304,7 +304,14 @@ function decodeLifiBridge(
     functionName: "lifiBridge",
     signature: `lifiBridge(BridgeData) — facet: ${bridgeData.bridge}`,
     args,
-    source: "local-abi",
+    // Partial because the LiFi Diamond ships dozens of bridge-facet selectors
+    // (startBridgeTokensViaAcrossV4, swapAndStartBridgeTokensViaWormhole, …)
+    // and our local ABI doesn't enumerate them — we only decode the universal
+    // first `BridgeData` tuple. The `lifiBridge` label is synthetic; 4byte
+    // resolves the same selector to the canonical facet name. Marking this
+    // as partial tells the cross-check to NOT compare names (would always
+    // mismatch by design); arg-level corroboration via re-encode still runs.
+    source: "local-abi-partial",
   };
 }
 

--- a/src/signing/verify-decode.ts
+++ b/src/signing/verify-decode.ts
@@ -166,9 +166,13 @@ export async function verifyEvmCalldata(
     };
   }
   const localDecode = tx.verification?.humanDecode;
+  // Only `"local-abi"` carries a canonical function name that's safe to
+  // compare against 4byte. `"local-abi-partial"` (LiFi bridge facets) ships
+  // a synthetic label by design — name-equality would always fail.
   const localFunctionName =
     localDecode && localDecode.source === "local-abi" ? localDecode.functionName : undefined;
   const localSignature = localDecode?.signature;
+  const isPartialLocal = localDecode?.source === "local-abi-partial";
 
   let signatures: string[];
   try {
@@ -309,6 +313,16 @@ export async function verifyEvmCalldata(
       `swiss-knife decoder link (rendered in the VERIFY block above) is the out-of-band browser-side check ` +
       `for that threat. For all other threat models 4byte's independent data provenance is a legitimate ` +
       `selector→name anchor — it's specifically WHY this cross-check exists.`
+    : isPartialLocal
+    ? `✓ Cross-check passed via 4byte.directory. The local ABI surfaced a PARTIAL decode (a positional ` +
+      `decode of a known shared sub-tuple — e.g. LiFi's universal BridgeData — because the specific ` +
+      `selector / facet ABI isn't in the server's registry); the canonical name is 4byte's "${chosen.signature}". ` +
+      `Name-equality is intentionally skipped here (the local label is synthetic and would always disagree), ` +
+      `but the re-encode check still anchors the args: 4byte's signature decoded these calldata bytes and ` +
+      `re-encoded them back losslessly, so the LOCAL decode's surfaced fields above (bridge name, receiver, ` +
+      `sendingAssetId, minAmount, destinationChainId for a LiFi bridge) faithfully describe the bytes that ` +
+      `will be signed. Compromised-MCP caveat: same as the full-decode case — use the swiss-knife decoder ` +
+      `link in the VERIFY block above for an out-of-band browser-side check.`
     : `✓ Cross-check passed via 4byte.directory. 4byte is a public selector registry built from unrelated ` +
       `on-chain traffic — a DATA SOURCE separate from the server's local ABI (though the server fetched ` +
       `the registry via HTTP). The calldata decodes cleanly against signature "${chosen.signature}", and ` +

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -928,8 +928,13 @@ export interface HumanDecode {
   /** Full signature like `supply(address,uint256,address,uint16)`. */
   signature?: string;
   args: DecodedArg[];
-  /** `"local-abi"` when decoded from our ABI registry, `"native"` for pure ETH sends, `"none"` when unknown destination. */
-  source: "local-abi" | "native" | "none";
+  /**
+   * - `"local-abi"`: full decode against an ABI in our static registry — `functionName` is the canonical on-chain name and is corroborable against 4byte.directory's selector→name mapping.
+   * - `"local-abi-partial"`: the destination is in our registry but the specific selector/facet isn't (e.g. LiFi Diamond bridge facets) — we surfaced a positional decode of a known shared sub-tuple, but `functionName` is synthetic and MUST NOT be cross-checked against 4byte (a name-equality check would always fail by design).
+   * - `"native"`: pure native-value transfer, no calldata.
+   * - `"none"`: unknown destination, no decode possible.
+   */
+  source: "local-abi" | "local-abi-partial" | "native" | "none";
 }
 
 /**

--- a/test/lifi-bridge-decode.test.ts
+++ b/test/lifi-bridge-decode.test.ts
@@ -75,7 +75,7 @@ describe("decodeCalldata — LiFi bridge fallback", () => {
     const data = makeBridgeCalldata(bd);
 
     const out = decodeCalldata("ethereum", LIFI_DIAMOND, data, "0");
-    expect(out.source).toBe("local-abi");
+    expect(out.source).toBe("local-abi-partial");
     expect(out.functionName).toBe("lifiBridge");
     expect(out.signature).toBe("lifiBridge(BridgeData) — facet: across");
 
@@ -107,7 +107,7 @@ describe("decodeCalldata — LiFi bridge fallback", () => {
     const data = makeBridgeCalldata(bd);
 
     const out = decodeCalldata("ethereum", LIFI_DIAMOND, data, "0");
-    expect(out.source).toBe("local-abi");
+    expect(out.source).toBe("local-abi-partial");
 
     const named = Object.fromEntries(out.args.map((a) => [a.name, a]));
     expect(named.bridge.value).toBe("wormhole");
@@ -164,7 +164,7 @@ describe("decodeCalldata — LiFi bridge fallback", () => {
     // decode succeeds for "valid" first to guard against test infrastructure
     // confusion.
     const out = decodeCalldata("ethereum", LIFI_DIAMOND, makeBridgeCalldata(bd), "0");
-    expect(out.source).toBe("local-abi");
+    expect(out.source).toBe("local-abi-partial");
     expect(out.functionName).toBe("lifiBridge");
   });
 

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -917,6 +917,45 @@ describe("verifyEvmCalldata — independent cross-check via 4byte.directory", ()
     expect(result.independentSignature).toBe("transfer(address,uint256)");
     expect(result.independentFunctionName).toBe("transfer");
   });
+
+  it("treats source='local-abi-partial' as opt-out of the function-name comparison (fixes LiFi bridge false-positive mismatch)", async () => {
+    // The LiFi Diamond ships dozens of bridge facets (across, wormhole,
+    // mayan, …) keyed by per-facet selectors that aren't in our local ABI.
+    // We surface a positional decode of the universal BridgeData tuple and
+    // mark it `source: "local-abi-partial"` with a synthetic
+    // `functionName: "lifiBridge"`. 4byte resolves the same selector to the
+    // canonical facet name (e.g. `swapAndStartBridgeTokensViaAcrossV4`).
+    // Pre-fix: cross-check reported MISMATCH because names differ —
+    // refused legitimate bridge calldata. Fix: name-equality is intentionally
+    // skipped for partial sources; re-encode lossless still anchors the args.
+    const { verifyEvmCalldata } = await import("../src/signing/verify-decode.js");
+    const tx = issueHandles(usdcTransferTx(1_000_000n));
+    const partialTx = {
+      ...tx,
+      verification: {
+        ...tx.verification!,
+        humanDecode: {
+          ...tx.verification!.humanDecode,
+          functionName: "lifiBridge",
+          signature: "lifiBridge(BridgeData) — facet: across",
+          source: "local-abi-partial" as const,
+        },
+      },
+    };
+    const result = await verifyEvmCalldata(
+      partialTx,
+      // 4byte's canonical name for the selector; deliberately != "lifiBridge".
+      mockFetch(["transfer(address,uint256)"]),
+    );
+    expect(result.status).toBe("match");
+    expect(result.localFunctionName).toBeUndefined();
+    expect(result.independentFunctionName).toBe("transfer");
+    expect(result.summary).toMatch(/PARTIAL decode/);
+    expect(result.summary).toMatch(/Name-equality is intentionally skipped/);
+    expect(result.summary).toMatch(/swiss-knife/);
+    expect(result.summary).not.toMatch(/MISMATCH/);
+    expect(result.summary).not.toMatch(/DO NOT SEND/);
+  });
 });
 
 describe("verifyTxDecode (MCP handler) — routes by handle origin", () => {


### PR DESCRIPTION
## Summary

Fix a false-positive ✗ MISMATCH in the agent-side cross-check that refuses **every** LiFi bridge calldata (intra-EVM, EVM→Solana, EVM→TRON) at prepare time — discovered live during an EVM→Solana \`prepare_swap\` for 100 USDC, where the cross-check refused to send despite the BridgeData decoding cleanly into semantically correct fields.

## Root cause

The LiFi Diamond ships dozens of bridge facets — Across V4, Wormhole, Mayan, deBridge, Allbridge, Squid, Stargate, … — one selector per facet. Our local ABI doesn't enumerate them; we decode only the universal \`BridgeData\` tuple shared across all of them via \`decodeLifiBridge\` (PR #157), and label the result with a synthetic \`functionName: "lifiBridge"\`.

The independent cross-check in \`verifyEvmCalldata\` (\`src/signing/verify-decode.ts\`) compares the local \`functionName\` against 4byte.directory's canonical name for the same selector. 4byte resolves \`0x1794958f\` to \`swapAndStartBridgeTokensViaAcrossV4\`, not \`lifiBridge\` — names disagree by design, so every bridge calldata produced a hard \`✗ CROSS-CHECK MISMATCH — DO NOT SEND\`.

## Fix

New \`HumanDecode.source\` variant **\`"local-abi-partial"\`** with documented semantics: "I parsed a known shared sub-tuple, but I don't know the canonical function name — don't compare it." Returned by \`decodeLifiBridge\` instead of \`"local-abi"\`.

The cross-check already extracts \`localFunctionName\` only when \`source === "local-abi"\`, so the name-equality branch is naturally skipped for partial decodes; the lossless re-encode check still anchors the args (proves 4byte's signature describes these bytes losslessly, so the bridge name / receiver / minAmount / destinationChainId surfaced in the local decode faithfully describe what will be signed).

A new partial-aware success summary explains the situation and points at the swiss-knife browser check for the compromised-MCP threat — preserves the existing trust-model framing without the false positive.

## Behavioral matrix

| Source | localFunctionName extracted | Name-equality check | Re-encode check | Summary branch |
|---|---|---|---|---|
| \`"local-abi"\` (full decode) | yes | yes (mismatch on disagreement) | yes | original ✓ |
| **\`"local-abi-partial"\`** (NEW — LiFi bridge) | **no** | **skipped** | **yes** | **new partial-aware ✓** |
| \`"native"\` | no | n/a | n/a | n/a |
| \`"none"\` (unknown destination) | no | skipped | yes | existing fallback ✓ |

\`"local-abi"\` behavior is unchanged; this is purely additive.

## Files

- \`src/types/index.ts\` — extend \`HumanDecode.source\` union with \`"local-abi-partial"\` + per-variant docs
- \`src/signing/decode-calldata.ts\` — \`decodeLifiBridge\` returns the partial source (one-line change + explanatory comment)
- \`src/signing/verify-decode.ts\` — \`isPartialLocal\` flag + new partial-aware success summary branch
- \`test/lifi-bridge-decode.test.ts\` — three existing assertions updated from \`"local-abi"\` to \`"local-abi-partial"\`
- \`test/verification.test.ts\` — new regression test: partial source + 4byte returning a different name → \`status: "match"\`, summary contains "PARTIAL decode" / "Name-equality is intentionally skipped", no MISMATCH / DO NOT SEND text

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run\` — 976 / 976 passing across 81 files (full suite, no regressions)
- [x] New regression test reproduces the live false-positive and confirms it now resolves to a clean \`✓\`
- [ ] Live retry of the EVM→Solana bridge (100 USDC) after merge + MCP restart — should now produce a clean \`✓ Cross-check passed\` and proceed to \`preview_send\`

## Out of scope

Per-facet ABI enumeration in the local registry. Would replace the partial decode with a full one across all LiFi facets, but the upstream Diamond ships new facets often (Across V4 was a 2024 addition); the maintenance load isn't worth it when the BridgeData-tuple decode already surfaces every field that matters.