### PR TITLE
feat(kamino): borrow / withdraw / repay + get_kamino_positions + portfolio integration (roadmap #5 PR3+PR4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,10 @@ import {
   prepareTronLifiSwap,
   prepareKaminoInitUser,
   prepareKaminoSupply,
+  prepareKaminoBorrow,
+  prepareKaminoWithdraw,
+  prepareKaminoRepay,
+  getKaminoPositions,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -126,6 +130,10 @@ import {
   prepareTronLifiSwapInput,
   prepareKaminoInitUserInput,
   prepareKaminoSupplyInput,
+  prepareKaminoBorrowInput,
+  prepareKaminoWithdrawInput,
+  prepareKaminoRepayInput,
+  getKaminoPositionsInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1655,6 +1663,65 @@ async function main() {
       inputSchema: prepareKaminoSupplyInput.shape,
     },
     handler(prepareKaminoSupply)
+  );
+
+  server.registerTool(
+    "prepare_kamino_borrow",
+    {
+      description:
+        "Build a Kamino borrow tx — pulls liquidity from a reserve as debt against the " +
+        "obligation's existing collateral. Refuses if the wallet hasn't run " +
+        "prepare_kamino_init_user; refuses if the mint isn't listed on Kamino's main market. " +
+        "On-chain LTV gate: borrow reverts if it would push the obligation over the " +
+        "reserve's `borrowLimit` (the simulation gate catches this before signing). " +
+        "DURABLE NONCE REQUIRED + same blind-sign treatment as prepare_kamino_supply.",
+      inputSchema: prepareKaminoBorrowInput.shape,
+    },
+    handler(prepareKaminoBorrow)
+  );
+
+  server.registerTool(
+    "prepare_kamino_withdraw",
+    {
+      description:
+        "Build a Kamino withdraw tx — pulls liquidity out of a previously-supplied reserve. " +
+        "Refuses with a clear error if the wallet has no deposit in the named reserve. " +
+        "Health-factor gated on-chain: withdraws that would leave the obligation under-" +
+        "collateralized for outstanding debt revert (caught by the simulation gate). " +
+        "DURABLE NONCE REQUIRED + same blind-sign treatment as prepare_kamino_supply.",
+      inputSchema: prepareKaminoWithdrawInput.shape,
+    },
+    handler(prepareKaminoWithdraw)
+  );
+
+  server.registerTool(
+    "prepare_kamino_repay",
+    {
+      description:
+        "Build a Kamino repay tx — pays down outstanding debt in the named reserve. " +
+        "Refuses with a clear error if the wallet has no debt in the reserve. The on-chain " +
+        "program clamps repayment at outstanding debt, so over-repaying just doesn't burn " +
+        "the excess (no funds lost). DURABLE NONCE REQUIRED + same blind-sign treatment " +
+        "as prepare_kamino_supply.",
+      inputSchema: prepareKaminoRepayInput.shape,
+    },
+    handler(prepareKaminoRepay)
+  );
+
+  server.registerTool(
+    "get_kamino_positions",
+    {
+      description:
+        "READ-ONLY — enumerate a Solana wallet's Kamino lending position on the main " +
+        "market. Returns the obligation PDA, per-reserve deposits + borrows (with USD " +
+        "values), totalSuppliedUsd / totalBorrowedUsd / netValueUsd, and a health factor " +
+        "(borrowLiquidationLimit / userTotalBorrowBorrowFactorAdjusted; >1 safe, <1 " +
+        "liquidatable, Infinity when no debt — same convention as Aave / MarginFi). " +
+        "Returns an empty list when the wallet has no Kamino userMetadata (= never used " +
+        "Kamino). Reserve-level pause / freeze flags surface in `warnings`.",
+      inputSchema: getKaminoPositionsInput.shape,
+    },
+    handler(getKaminoPositions)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -107,6 +107,10 @@ import type {
   PrepareTronLifiSwapArgs,
   PrepareKaminoInitUserArgs,
   PrepareKaminoSupplyArgs,
+  PrepareKaminoBorrowArgs,
+  PrepareKaminoWithdrawArgs,
+  PrepareKaminoRepayArgs,
+  GetKaminoPositionsArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -499,6 +503,50 @@ export async function prepareKaminoSupply(
     amount: args.amount,
   });
   return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareKaminoBorrow(
+  args: PrepareKaminoBorrowArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildKaminoBorrow } = await import("../solana/kamino-actions.js");
+  const prepared = await buildKaminoBorrow({
+    wallet: args.wallet,
+    mint: args.mint,
+    amount: args.amount,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareKaminoWithdraw(
+  args: PrepareKaminoWithdrawArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildKaminoWithdraw } = await import("../solana/kamino-actions.js");
+  const prepared = await buildKaminoWithdraw({
+    wallet: args.wallet,
+    mint: args.mint,
+    amount: args.amount,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareKaminoRepay(
+  args: PrepareKaminoRepayArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildKaminoRepay } = await import("../solana/kamino-actions.js");
+  const prepared = await buildKaminoRepay({
+    wallet: args.wallet,
+    mint: args.mint,
+    amount: args.amount,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function getKaminoPositions(args: GetKaminoPositionsArgs) {
+  const { getKaminoPositions: reader } = await import(
+    "../positions/kamino.js"
+  );
+  const conn = getSolanaConnection();
+  return { positions: await reader(conn, args.wallet) };
 }
 
 export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {
@@ -1894,7 +1942,10 @@ export interface SolanaVerificationArtifact {
     | "native_stake_withdraw"
     | "lifi_solana_swap"
     | "kamino_init_user"
-    | "kamino_supply";
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   from: string;
   messageBase64: string;
   recentBlockhash: string;
@@ -2016,6 +2067,9 @@ export function getVerificationArtifact(args: GetVerificationArtifactArgs): Veri
       "lifi_solana_swap",
       "kamino_init_user",
       "kamino_supply",
+      "kamino_borrow",
+      "kamino_withdraw",
+      "kamino_repay",
     ]);
     const ledgerMessageHash = blindSignActions.has(tx.action)
       ? solanaLedgerMessageHash(tx.messageBase64)

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -905,5 +905,75 @@ export const prepareKaminoSupplyInput = z.object({
 
 export type PrepareKaminoInitUserArgs = z.infer<typeof prepareKaminoInitUserInput>;
 export type PrepareKaminoSupplyArgs = z.infer<typeof prepareKaminoSupplyInput>;
+
+/**
+ * Kamino borrow / withdraw / repay share the same arg shape as supply
+ * (wallet + mint + amount); we keep them as separate schemas so the
+ * tool descriptions can document the per-action constraints (LTV gate,
+ * existing-deposit / existing-debt requirements, on-chain revert
+ * conditions) inline.
+ */
+export const prepareKaminoBorrowInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana base58 wallet — must already have Kamino userMetadata + obligation."
+  ),
+  mint: solanaAddressSchema.describe(
+    "Base58 SPL mint of the asset to borrow against the obligation's collateral."
+  ),
+  amount: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable amount to borrow (e.g. "100" for 100 USDC). Decimals are ' +
+        "resolved from the reserve's mint metadata. The on-chain program enforces " +
+        "the borrow LTV gate; if the borrow would push the obligation over the " +
+        "liquidation limit, the tx reverts (caught by the simulation gate)."
+    ),
+});
+
+export const prepareKaminoWithdrawInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana base58 wallet — must already have a Kamino deposit in the named reserve."
+  ),
+  mint: solanaAddressSchema,
+  amount: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable amount to withdraw. The reserve must have an active deposit ' +
+        "from this wallet — the builder refuses with a clear error otherwise. " +
+        "Health-factor gated on-chain: a withdraw that would leave the obligation " +
+        "under-collateralized for outstanding debt reverts."
+    ),
+});
+
+export const prepareKaminoRepayInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana base58 wallet — must already have outstanding debt in the named reserve."
+  ),
+  mint: solanaAddressSchema,
+  amount: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable amount to repay. The on-chain program clamps repayment at ' +
+        "outstanding debt; over-repaying just doesn't burn the excess (no funds " +
+        "lost). Refuses with a clear error if the wallet has no debt in the reserve."
+    ),
+});
+
+export const getKaminoPositionsInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana base58 wallet to enumerate Kamino positions for. Returns the wallet's " +
+      "obligation on Kamino's main market, with per-reserve deposits + borrows + " +
+      "USD valuations + health factor. Returns an empty list when the wallet has " +
+      "no Kamino userMetadata (= never used Kamino)."
+  ),
+});
+
+export type PrepareKaminoBorrowArgs = z.infer<typeof prepareKaminoBorrowInput>;
+export type PrepareKaminoWithdrawArgs = z.infer<typeof prepareKaminoWithdrawInput>;
+export type PrepareKaminoRepayArgs = z.infer<typeof prepareKaminoRepayInput>;
+export type GetKaminoPositionsArgs = z.infer<typeof getKaminoPositionsInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -13,6 +13,7 @@ import { getTronBalances } from "../tron/balances.js";
 import { getTronStaking } from "../tron/staking.js";
 import { getSolanaBalances } from "../solana/balances.js";
 import { getMarginfiPositions as readMarginfiPositions } from "../positions/marginfi.js";
+import { getKaminoPositions as readKaminoPositions } from "../positions/kamino.js";
 import { getSolanaStakingPositions as readSolanaStakingPositions } from "../positions/solana-staking.js";
 import { getSolanaConnection } from "../solana/rpc.js";
 import type { GetPortfolioSummaryArgs } from "./schemas.js";
@@ -22,6 +23,7 @@ import type {
   PortfolioCoverage,
   PortfolioSummary,
   SolanaMarginfiPositionSlice,
+  SolanaKaminoPositionSlice,
   SolanaPortfolioSlice,
   SolanaStakingPositionSlice,
   SupportedChain,
@@ -310,6 +312,7 @@ async function buildWalletSummary(
     tronStaking: false,
     solana: false,
     marginfi: false,
+    kamino: false,
     solanaStaking: false,
   };
   // Per-market Compound V3 failure detail, populated when at least one market
@@ -349,6 +352,7 @@ async function buildWalletSummary(
     tronStakingSlice,
     solanaSlice,
     marginfiPositionsRaw,
+    kaminoPositionsRaw,
     solanaStakingRaw,
   ] = await Promise.all([
       Promise.all(
@@ -486,6 +490,17 @@ async function buildWalletSummary(
         : (Promise.resolve([]) as Promise<
             Awaited<ReturnType<typeof readMarginfiPositions>>
           >),
+      // Kamino positions ride the same gate. The reader short-circuits when
+      // the wallet has no Kamino userMetadata (1 RPC lookup, then return [])
+      // so the cost of the idle case is essentially free.
+      solanaAddress
+        ? readKaminoPositions(getSolanaConnection(), solanaAddress).catch(() => {
+            errors.kamino = true;
+            return [] as Awaited<ReturnType<typeof readKaminoPositions>>;
+          })
+        : (Promise.resolve([]) as Promise<
+            Awaited<ReturnType<typeof readKaminoPositions>>
+          >),
       // Solana staking rides the same gate. The consolidated reader fans
       // out to three sub-readers (Marinade SDK, Jito stake pool, native
       // stake-program enumeration) in parallel. A failure is independent
@@ -549,10 +564,34 @@ async function buildWalletSummary(
       warnings: pos.warnings,
     }),
   );
-  const solanaLendingUsd = marginfiSlices.reduce(
-    (s, p) => s + p.netValueUsd,
-    0,
+  // Project the Kamino reader's full KaminoPosition into the thin slice.
+  // Mirror of marginfiSlices: drop reserve/mint/obligation-internal fields
+  // that the portfolio JSON doesn't need.
+  const kaminoSlices: SolanaKaminoPositionSlice[] = kaminoPositionsRaw.map(
+    (pos) => ({
+      protocol: "kamino",
+      chain: "solana",
+      obligation: pos.obligation,
+      supplied: pos.supplied.map((b) => ({
+        symbol: b.symbol,
+        amount: b.amount,
+        valueUsd: b.valueUsd,
+      })),
+      borrowed: pos.borrowed.map((b) => ({
+        symbol: b.symbol,
+        amount: b.amount,
+        valueUsd: b.valueUsd,
+      })),
+      totalSuppliedUsd: pos.totalSuppliedUsd,
+      totalBorrowedUsd: pos.totalBorrowedUsd,
+      netValueUsd: pos.netValueUsd,
+      healthFactor: pos.healthFactor,
+      warnings: pos.warnings,
+    }),
   );
+  const solanaLendingUsd =
+    marginfiSlices.reduce((s, p) => s + p.netValueUsd, 0) +
+    kaminoSlices.reduce((s, p) => s + p.netValueUsd, 0);
 
   // Solana staking slice — shrink the consolidated reader's shape into the
   // portfolio's thin projection. Dropping the wallet/protocol/chain fields
@@ -743,6 +782,13 @@ async function buildWalletSummary(
                 note: "MarginFi position fetch failed — lending positions not included in totals. SDK or oracle RPC error; balances still loaded if coverage.solana is covered.",
               }
             : { covered: true },
+          kamino: errors.kamino
+            ? {
+                covered: false,
+                errored: true,
+                note: "Kamino position fetch failed — lending positions not included in totals. Kamino market load or obligation read failed; balances + MarginFi still loaded if their coverage flags are covered.",
+              }
+            : { covered: true },
           solanaStaking: errors.solanaStaking
             ? {
                 covered: false,
@@ -788,7 +834,7 @@ async function buildWalletSummary(
     ...(tronBreakdown ? { tronUsd: tronUsdTotal } : {}),
     ...(tronStakingSlice ? { tronStakingUsd: round(tronStakingUsd, 2) } : {}),
     ...(solanaSlice ? { solanaUsd: round(solanaBalancesUsd, 2) } : {}),
-    ...(marginfiSlices.length > 0
+    ...(marginfiSlices.length > 0 || kaminoSlices.length > 0
       ? { solanaLendingUsd: round(solanaLendingUsd, 2) }
       : {}),
     ...(solanaStakingSlice && solanaStakingSlice.totalSolEquivalent > 0
@@ -808,7 +854,19 @@ async function buildWalletSummary(
               ...(marginfiSlices.length > 0
                 ? {
                     marginfi: marginfiSlices,
-                    marginfiNetUsd: round(solanaLendingUsd, 2),
+                    marginfiNetUsd: round(
+                      marginfiSlices.reduce((s, p) => s + p.netValueUsd, 0),
+                      2,
+                    ),
+                  }
+                : {}),
+              ...(kaminoSlices.length > 0
+                ? {
+                    kamino: kaminoSlices,
+                    kaminoNetUsd: round(
+                      kaminoSlices.reduce((s, p) => s + p.netValueUsd, 0),
+                      2,
+                    ),
                   }
                 : {}),
               ...(solanaStakingSlice &&

--- a/src/modules/positions/kamino.ts
+++ b/src/modules/positions/kamino.ts
@@ -1,0 +1,190 @@
+import type { Connection } from "@solana/web3.js";
+import { assertSolanaAddress } from "../solana/address.js";
+import { loadKaminoMainMarket } from "../solana/kamino.js";
+
+/**
+ * Read-only Kamino position reader. Parallels `getMarginfiPositions` —
+ * enumerates one wallet's Kamino obligation, surfaces deposits + borrows
+ * with USD valuations, and derives a health factor.
+ *
+ * Health factor convention: matches Aave / MarginFi —
+ * `borrowLiquidationLimit / userTotalBorrowBorrowFactorAdjusted`. >1 safe,
+ * <1 liquidatable, Infinity when no debt. The Kamino SDK exposes
+ * `loanToValue` (current usage as fraction of liquidation limit) which is
+ * the inverse — we publish 1/loanToValue to keep the user-facing
+ * convention consistent across the lending bucket.
+ */
+
+export interface KaminoBalanceEntry {
+  /** Reserve PDA. */
+  reserve: string;
+  /** SPL mint of the reserve's liquidity asset. */
+  mint: string;
+  /** Token symbol from the reserve metadata; empty string when missing. */
+  symbol: string;
+  /** Human-readable decimal balance (already-decimals-applied). */
+  amount: string;
+  /** Refreshed market value in USD. */
+  valueUsd: number;
+}
+
+export interface KaminoPosition {
+  protocol: "kamino";
+  chain: "solana";
+  wallet: string;
+  /** Base58 obligation PDA — empty string when wallet has none on Kamino. */
+  obligation: string;
+  /** Per-reserve deposits with USD values. */
+  supplied: KaminoBalanceEntry[];
+  /** Per-reserve outstanding borrows with USD values. */
+  borrowed: KaminoBalanceEntry[];
+  totalSuppliedUsd: number;
+  totalBorrowedUsd: number;
+  /** Net = supplied − borrowed. */
+  netValueUsd: number;
+  /**
+   * `borrowLiquidationLimit / userTotalBorrowBorrowFactorAdjusted`.
+   * Infinity when no debt; matches Aave / MarginFi convention.
+   */
+  healthFactor: number;
+  /** Optional reserve-level pause / freeze flags — empty array when all healthy. */
+  warnings: string[];
+}
+
+/**
+ * Project the SDK's `Position` (per-reserve entry on the obligation) into
+ * our thin `KaminoBalanceEntry`. Decimal values are converted via
+ * `Decimal.toNumber()`; for obligations with extreme amounts that's lossy
+ * but acceptable for portfolio display (USD valuation already lost
+ * precision earlier in the price stack).
+ */
+function projectPosition(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pos: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reserve: any,
+): KaminoBalanceEntry {
+  // SDK's `Position.amount` is in lamports/base units; divide by mintFactor
+  // (= 10^decimals) to get the human amount.
+  const decimals = Number(reserve.state.liquidity.mintDecimals);
+  const factor = 10 ** decimals;
+  const humanAmount = Number(pos.amount.toString()) / factor;
+  return {
+    reserve: pos.reserveAddress.toString(),
+    mint: pos.mintAddress.toString(),
+    symbol: reserve.getTokenSymbol() ?? "",
+    amount: humanAmount.toString(),
+    valueUsd: Number(pos.marketValueRefreshed.toString()),
+  };
+}
+
+/**
+ * Read a single wallet's Kamino position on the main market. Returns an
+ * empty position (zero balances, no obligation) when the wallet has no
+ * userMetadata or obligation — never throws on the empty path. Rethrows
+ * any RPC / SDK error so the portfolio caller can mark coverage errored.
+ */
+export async function getKaminoPositions(
+  _conn: Connection,
+  wallet: string,
+): Promise<KaminoPosition[]> {
+  // The connection is unused; Kamino SDK uses its own kit-style RPC. We
+  // keep the conn parameter for signature parity with getMarginfiPositions
+  // (the portfolio aggregator passes it the same way).
+  void _conn;
+
+  assertSolanaAddress(wallet);
+
+  const market = await loadKaminoMainMarket();
+  if (!market) {
+    throw new Error("Kamino main market not found on-chain.");
+  }
+
+  const { address: toAddress } = await import("@solana/kit");
+  const { KaminoObligation, VanillaObligation } = await import(
+    "@kamino-finance/klend-sdk"
+  );
+
+  const ownerAddr = toAddress(wallet);
+
+  // No userMetadata = wallet has never used Kamino. Return empty array
+  // (= "no positions"), same convention as MarginFi for fresh wallets.
+  const [, userMetadataState] = await market.getUserMetadata(ownerAddr);
+  if (userMetadataState === null) {
+    return [];
+  }
+
+  const obligationKind = new VanillaObligation(market.programId);
+  const obligationPda = await obligationKind.toPda(market.getAddress(), ownerAddr);
+  const obligationState = await KaminoObligation.load(market, obligationPda);
+  if (!obligationState) {
+    // userMetadata exists but obligation doesn't — partial-init state. No
+    // position to surface; return empty.
+    return [];
+  }
+
+  const supplied: KaminoBalanceEntry[] = [];
+  for (const [reserveAddr, pos] of obligationState.deposits.entries()) {
+    void reserveAddr;
+    const reserve = market.getReserveByAddress(pos.reserveAddress);
+    if (!reserve) continue; // shouldn't happen on a healthy market
+    supplied.push(projectPosition(pos, reserve));
+  }
+
+  const borrowed: KaminoBalanceEntry[] = [];
+  for (const [reserveAddr, pos] of obligationState.borrows.entries()) {
+    void reserveAddr;
+    const reserve = market.getReserveByAddress(pos.reserveAddress);
+    if (!reserve) continue;
+    borrowed.push(projectPosition(pos, reserve));
+  }
+
+  const totalSuppliedUsd = supplied.reduce((s, b) => s + b.valueUsd, 0);
+  const totalBorrowedUsd = borrowed.reduce((s, b) => s + b.valueUsd, 0);
+
+  // Health factor: borrowLiquidationLimit / userTotalBorrowBorrowFactorAdjusted.
+  // Both are SDK Decimal; coerce via toNumber() for the user-facing ratio.
+  const stats = obligationState.refreshedStats;
+  const adjustedBorrow = Number(stats.userTotalBorrowBorrowFactorAdjusted.toString());
+  const liquidationLimit = Number(stats.borrowLiquidationLimit.toString());
+  const healthFactor =
+    adjustedBorrow > 0 ? liquidationLimit / adjustedBorrow : Number.POSITIVE_INFINITY;
+
+  // Reserve-level warnings: walk both deposits + borrows, surface if any
+  // touched reserve is paused/frozen via Kamino's risk-config flags. The
+  // SDK exposes `state.config.status` (0 = active, 1 = obsolete, 2 = hidden)
+  // — anything non-zero is worth flagging to the user even if the position
+  // still loads cleanly.
+  const warnings: string[] = [];
+  const touchedReserves = new Set<string>([
+    ...supplied.map((b) => b.reserve),
+    ...borrowed.map((b) => b.reserve),
+  ]);
+  for (const reserveAddr of touchedReserves) {
+    const reserve = market.getReserveByAddress(toAddress(reserveAddr));
+    if (!reserve) continue;
+    const status = Number(reserve.state.config.status);
+    if (status !== 0) {
+      const sym = reserve.getTokenSymbol() ?? reserveAddr;
+      warnings.push(
+        `Reserve ${sym} (${reserveAddr}) reports non-active status (${status}) — position may be illiquid for new ops.`,
+      );
+    }
+  }
+
+  return [
+    {
+      protocol: "kamino",
+      chain: "solana",
+      wallet,
+      obligation: obligationPda.toString(),
+      supplied,
+      borrowed,
+      totalSuppliedUsd,
+      totalBorrowedUsd,
+      netValueUsd: totalSuppliedUsd - totalBorrowedUsd,
+      healthFactor,
+      warnings,
+    },
+  ];
+}

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -127,7 +127,10 @@ export interface PreparedSolanaTx {
     | "native_stake_withdraw"
     | "lifi_solana_swap"
     | "kamino_init_user"
-    | "kamino_supply";
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   chain: "solana";
   from: string;
   description: string;

--- a/src/modules/solana/kamino-actions.ts
+++ b/src/modules/solana/kamino-actions.ts
@@ -85,7 +85,12 @@ function tokenBaseUnits(amountDecimal: string, decimals: number): bigint {
 function buildDraft(args: {
   ctx: NonceContext;
   walletStr: string;
-  action: "kamino_init_user" | "kamino_supply";
+  action:
+    | "kamino_init_user"
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
   actionIxs: TransactionInstruction[];
@@ -118,7 +123,12 @@ export interface PrepareKaminoInitUserParams {
 
 export interface PreparedKaminoTx {
   handle: string;
-  action: "kamino_init_user" | "kamino_supply";
+  action:
+    | "kamino_init_user"
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   chain: "solana";
   from: string;
   description: string;
@@ -397,6 +407,345 @@ export async function buildKaminoSupply(
     description,
     decoded: draft.meta.decoded,
     nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}
+
+/**
+ * Common preflight for borrow/withdraw/repay: load market, validate the
+ * mint, fetch the obligation, refuse if userMetadata or obligation are
+ * missing. Returns everything the three write builders need to call the
+ * matching `KaminoAction.build*Txns`.
+ */
+async function loadKaminoSupplyContext(p: {
+  wallet: string;
+  mint: string;
+  amount: string;
+}): Promise<{
+  ctx: NonceContext;
+  // Cast to `any` because the kit-typed SDK objects flow through this
+  // module without our local types layering on top — the SDK's
+  // KaminoMarket / KaminoReserve / KaminoObligation are the source of
+  // truth and any explicit typing here would just shadow them and rot.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  market: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  owner: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ownerAddr: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mintAddr: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reserve: any;
+  symbol: string;
+  decimals: number;
+  amountBaseUnits: bigint;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  obligationState: any;
+  obligationPda: string;
+}> {
+  const ctx = await loadNonceContext(p.wallet);
+  const market = await loadKaminoMainMarket();
+  if (!market) {
+    throw new Error("Kamino main market not found on-chain.");
+  }
+  const { createNoopSigner, address: toAddress } = await import("@solana/kit");
+  const { KaminoObligation, VanillaObligation } = await import(
+    "@kamino-finance/klend-sdk"
+  );
+
+  const ownerAddr = toAddress(p.wallet);
+  const owner = createNoopSigner(ownerAddr);
+  const mintAddr = toAddress(p.mint);
+
+  const reserve = market.getReserveByMint(mintAddr);
+  if (!reserve) {
+    throw new Error(
+      `Mint ${p.mint} is not listed on Kamino's main market. Confirm via the Kamino app's reserve list.`,
+    );
+  }
+  const decimals = Number(reserve.state.liquidity.mintDecimals);
+  const amountBaseUnits = tokenBaseUnits(p.amount, decimals);
+  const symbol = reserve.getTokenSymbol() ?? p.mint.slice(0, 6);
+
+  const [, userMetadataState] = await market.getUserMetadata(ownerAddr);
+  if (userMetadataState === null) {
+    throw new Error(
+      `Wallet ${p.wallet} has no Kamino userMetadata. Run prepare_kamino_init_user first.`,
+    );
+  }
+
+  const obligationKind = new VanillaObligation(market.programId);
+  const obligationPda = await obligationKind.toPda(market.getAddress(), ownerAddr);
+  const obligationState = await KaminoObligation.load(market, obligationPda);
+  if (!obligationState) {
+    throw new Error(
+      `Wallet ${p.wallet} has no Kamino obligation at ${obligationPda.toString()}. ` +
+        `Run prepare_kamino_init_user first.`,
+    );
+  }
+
+  return {
+    ctx,
+    market,
+    owner,
+    ownerAddr,
+    mintAddr,
+    reserve,
+    symbol,
+    decimals,
+    amountBaseUnits,
+    obligationState,
+    obligationPda: obligationPda.toString(),
+  };
+}
+
+export interface PrepareKaminoBorrowParams {
+  wallet: string;
+  mint: string;
+  amount: string;
+}
+
+/**
+ * Build a Kamino borrow tx. Pulls liquidity from the named reserve as
+ * debt against the obligation's collateral. Refuses if userMetadata /
+ * obligation aren't initialized; refuses if the mint isn't listed.
+ *
+ * The on-chain program enforces the borrow LTV gate — if the borrow
+ * would push the obligation over `borrowLimit`, the tx reverts. We don't
+ * pre-validate that here (the obligation's exact LTV depends on Scope's
+ * latest prices, which Kamino refreshes inside the tx itself); the
+ * pre-sign simulation gate at `simulatePinnedSolanaTx` catches it before
+ * the user signs.
+ */
+export async function buildKaminoBorrow(
+  p: PrepareKaminoBorrowParams,
+): Promise<PreparedKaminoTx> {
+  const c = await loadKaminoSupplyContext(p);
+  const { KaminoAction } = await import("@kamino-finance/klend-sdk");
+  const { none } = await import("@solana/kit");
+
+  const action = await KaminoAction.buildBorrowTxns(
+    c.market,
+    c.amountBaseUnits.toString(),
+    c.mintAddr,
+    c.owner,
+    c.obligationState,
+    true, // useV2Ixs
+    undefined, // scopeRefreshConfig
+    1_000_000, // extraComputeBudget
+    true, // includeAtaIxs
+    false, // requestElevationGroup
+    { skipInitialization: true, skipLutCreation: true },
+    none(),
+    0n,
+  );
+  const kitIxs = KaminoAction.actionToIxs(action);
+  const actionIxs = kitInstructionsToLegacy(kitIxs);
+
+  const description = `Kamino borrow: ${p.amount} ${c.symbol} from reserve ${c.reserve.address.toString()}`;
+  const draft = buildDraft({
+    ctx: c.ctx,
+    walletStr: p.wallet,
+    action: "kamino_borrow",
+    description,
+    decoded: {
+      functionName: "kamino.borrow",
+      args: {
+        wallet: p.wallet,
+        market: c.market.getAddress().toString(),
+        reserve: c.reserve.address.toString(),
+        mint: p.mint,
+        symbol: c.symbol,
+        amount: p.amount,
+        amountBaseUnits: c.amountBaseUnits.toString(),
+        obligation: c.obligationPda,
+        nonceAccount: c.ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "kamino_borrow",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: c.ctx.noncePubkey.toBase58(),
+  };
+}
+
+export interface PrepareKaminoWithdrawParams {
+  wallet: string;
+  mint: string;
+  amount: string;
+}
+
+/**
+ * Build a Kamino withdraw tx. Pulls liquidity out of a previously-supplied
+ * reserve. Refuses if the obligation has zero deposits in the reserve
+ * (the on-chain program would revert; surfacing the same condition with
+ * a clear error beats a confusing revert).
+ *
+ * Withdraws are health-factor-gated on-chain — if the withdraw would
+ * leave the obligation under-collateralized for its outstanding debt,
+ * the tx reverts. The simulation gate catches this before broadcast.
+ */
+export async function buildKaminoWithdraw(
+  p: PrepareKaminoWithdrawParams,
+): Promise<PreparedKaminoTx> {
+  const c = await loadKaminoSupplyContext(p);
+  const { KaminoAction } = await import("@kamino-finance/klend-sdk");
+  const { none } = await import("@solana/kit");
+
+  // Sanity check: refuse if the obligation has no deposit in this reserve.
+  // SDK error here is opaque ("reserve not in deposits"); preflight gives
+  // a clean message.
+  const hasDeposit = c.obligationState.deposits.has(c.reserve.address);
+  if (!hasDeposit) {
+    throw new Error(
+      `Wallet ${p.wallet} has no Kamino deposit in reserve ${c.reserve.address.toString()} (mint ${p.mint}). ` +
+        `Nothing to withdraw.`,
+    );
+  }
+
+  const action = await KaminoAction.buildWithdrawTxns(
+    c.market,
+    c.amountBaseUnits.toString(),
+    c.mintAddr,
+    c.owner,
+    c.obligationState,
+    true,
+    undefined,
+    1_000_000,
+    true,
+    false,
+    { skipInitialization: true, skipLutCreation: true },
+    none(),
+    0n,
+  );
+  const kitIxs = KaminoAction.actionToIxs(action);
+  const actionIxs = kitInstructionsToLegacy(kitIxs);
+
+  const description = `Kamino withdraw: ${p.amount} ${c.symbol} from reserve ${c.reserve.address.toString()}`;
+  const draft = buildDraft({
+    ctx: c.ctx,
+    walletStr: p.wallet,
+    action: "kamino_withdraw",
+    description,
+    decoded: {
+      functionName: "kamino.withdraw",
+      args: {
+        wallet: p.wallet,
+        market: c.market.getAddress().toString(),
+        reserve: c.reserve.address.toString(),
+        mint: p.mint,
+        symbol: c.symbol,
+        amount: p.amount,
+        amountBaseUnits: c.amountBaseUnits.toString(),
+        obligation: c.obligationPda,
+        nonceAccount: c.ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "kamino_withdraw",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: c.ctx.noncePubkey.toBase58(),
+  };
+}
+
+export interface PrepareKaminoRepayParams {
+  wallet: string;
+  mint: string;
+  amount: string;
+}
+
+/**
+ * Build a Kamino repay tx. Pays down outstanding debt in the named
+ * reserve. Refuses if the obligation has zero borrows in the reserve.
+ *
+ * "Repay all" is not surfaced as a separate flag here; the on-chain
+ * program clamps repayment at outstanding debt, so over-repaying just
+ * burns the excess back to the user's wallet (no funds lost). If
+ * over-repay UX matters later, we can add a `repayAll: true` shortcut
+ * that fetches the exact outstanding amount.
+ */
+export async function buildKaminoRepay(
+  p: PrepareKaminoRepayParams,
+): Promise<PreparedKaminoTx> {
+  const c = await loadKaminoSupplyContext(p);
+  const { KaminoAction } = await import("@kamino-finance/klend-sdk");
+  const { none } = await import("@solana/kit");
+
+  const hasBorrow = c.obligationState.borrows.has(c.reserve.address);
+  if (!hasBorrow) {
+    throw new Error(
+      `Wallet ${p.wallet} has no Kamino debt in reserve ${c.reserve.address.toString()} (mint ${p.mint}). ` +
+        `Nothing to repay.`,
+    );
+  }
+
+  const action = await KaminoAction.buildRepayTxns(
+    c.market,
+    c.amountBaseUnits.toString(),
+    c.mintAddr,
+    c.owner,
+    c.obligationState,
+    true,
+    undefined,
+    0n, // currentSlot (note: buildRepayTxns positional differs slightly — slot first, then defaults follow)
+    c.owner, // payer
+    1_000_000,
+    true,
+    false,
+    { skipInitialization: true, skipLutCreation: true },
+    none(),
+  );
+  const kitIxs = KaminoAction.actionToIxs(action);
+  const actionIxs = kitInstructionsToLegacy(kitIxs);
+
+  const description = `Kamino repay: ${p.amount} ${c.symbol} → reserve ${c.reserve.address.toString()}`;
+  const draft = buildDraft({
+    ctx: c.ctx,
+    walletStr: p.wallet,
+    action: "kamino_repay",
+    description,
+    decoded: {
+      functionName: "kamino.repay",
+      args: {
+        wallet: p.wallet,
+        market: c.market.getAddress().toString(),
+        reserve: c.reserve.address.toString(),
+        mint: p.mint,
+        symbol: c.symbol,
+        amount: p.amount,
+        amountBaseUnits: c.amountBaseUnits.toString(),
+        obligation: c.obligationPda,
+        nonceAccount: c.ctx.noncePubkey.toBase58(),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "kamino_repay",
+    chain: "solana",
+    from: p.wallet,
+    description,
+    decoded: draft.meta.decoded,
+    nonceAccount: c.ctx.noncePubkey.toBase58(),
   };
 }
 

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -900,7 +900,10 @@ export interface RenderableSolanaPrepareResult {
     | "native_stake_withdraw"
     | "lifi_solana_swap"
     | "kamino_init_user"
-    | "kamino_supply";
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   from: string;
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
@@ -954,6 +957,12 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "Kamino account init (create LUT + userMetadata + obligation)";
     case "kamino_supply":
       return "Kamino supply";
+    case "kamino_borrow":
+      return "Kamino borrow";
+    case "kamino_withdraw":
+      return "Kamino withdraw";
+    case "kamino_repay":
+      return "Kamino repay";
   }
 }
 
@@ -1351,7 +1360,11 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
     tx.action === "native_stake_withdraw";
   const isLifiSolana = tx.action === "lifi_solana_swap";
   const isKamino =
-    tx.action === "kamino_init_user" || tx.action === "kamino_supply";
+    tx.action === "kamino_init_user" ||
+    tx.action === "kamino_supply" ||
+    tx.action === "kamino_borrow" ||
+    tx.action === "kamino_withdraw" ||
+    tx.action === "kamino_repay";
   const marginfiActionLabel =
     tx.action === "marginfi_init"
       ? "account init"

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -57,7 +57,10 @@ export interface SolanaDraftMeta {
     | "native_stake_withdraw"
     | "lifi_solana_swap"
     | "kamino_init_user"
-    | "kamino_supply";
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   from: string;
   description: string;
   decoded: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,12 @@ export interface PortfolioCoverage {
    */
   marginfi?: CoverageStatus;
   /**
+   * Kamino position fetch coverage. Same separation rationale as `marginfi` —
+   * a Kamino-reader failure shouldn't mask a successful balance read. Absent
+   * when no Solana address was queried.
+   */
+  kamino?: CoverageStatus;
+  /**
    * Solana staking position fetch coverage (Marinade mSOL, Jito jitoSOL,
    * native stake accounts). Mirrors the `marginfi` split so a staking-
    * reader failure doesn't mask a successful balance read. Absent when no
@@ -364,6 +370,15 @@ export interface SolanaPortfolioSlice {
   /** MarginFi aggregate net USD (sum of netValueUsd across positions). */
   marginfiNetUsd?: number;
   /**
+   * Kamino lending positions on the main market. Present when the wallet
+   * has Kamino userMetadata + obligation with non-zero deposits or borrows.
+   * Empty/missing means no position; errored case surfaces through
+   * PortfolioCoverage.kamino.
+   */
+  kamino?: SolanaKaminoPositionSlice[];
+  /** Kamino aggregate net USD (sum of netValueUsd across positions). */
+  kaminoNetUsd?: number;
+  /**
    * Solana staking positions — Marinade mSOL, Jito jitoSOL, native stake
    * accounts. Present when any of the three sections is non-empty for
    * this wallet. Missing means nothing found (errored case surfaces
@@ -419,6 +434,25 @@ export interface SolanaMarginfiPositionSlice {
   protocol: "marginfi";
   chain: "solana";
   marginfiAccount: string;
+  supplied: Array<{ symbol: string; amount: string; valueUsd: number }>;
+  borrowed: Array<{ symbol: string; amount: string; valueUsd: number }>;
+  totalSuppliedUsd: number;
+  totalBorrowedUsd: number;
+  netValueUsd: number;
+  healthFactor: number;
+  warnings: string[];
+}
+
+/**
+ * Thin projection of the full `KaminoPosition` type exposed by
+ * `src/modules/positions/kamino.ts`. Same shape as MarginFi's slice; the
+ * `obligation` field is Kamino's per-(wallet, market, kind) state account
+ * (analogous to `marginfiAccount`).
+ */
+export interface SolanaKaminoPositionSlice {
+  protocol: "kamino";
+  chain: "solana";
+  obligation: string;
   supplied: Array<{ symbol: string; amount: string; valueUsd: number }>;
   borrowed: Array<{ symbol: string; amount: string; valueUsd: number }>;
   totalSuppliedUsd: number;
@@ -794,7 +828,10 @@ export interface UnsignedSolanaTx {
     | "native_stake_withdraw"
     | "lifi_solana_swap"
     | "kamino_init_user"
-    | "kamino_supply";
+    | "kamino_supply"
+    | "kamino_borrow"
+    | "kamino_withdraw"
+    | "kamino_repay";
   /** Base58 owner address (44-char ed25519 pubkey). */
   from: string;
   /**

--- a/test/solana-kamino-pr3-pr4.test.ts
+++ b/test/solana-kamino-pr3-pr4.test.ts
@@ -1,0 +1,541 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
+
+/**
+ * Kamino PR3 + PR4 — borrow/withdraw/repay write builders, the
+ * `getKaminoPositions` reader, and portfolio integration. Mocks the SDK +
+ * KaminoMarket at module boundary; the Solana RPC connection isn't reached
+ * by any of these paths under the mocks.
+ */
+
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const FAKE_BLOCKHASH = "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
+const WALLET_KP = Keypair.generate();
+const WALLET = WALLET_KP.publicKey.toBase58();
+const FAKE_MARKET_ADDR = Keypair.generate().publicKey.toBase58();
+const FAKE_PROGRAM_ID = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const FAKE_USDC_RESERVE = Keypair.generate().publicKey.toBase58();
+const FAKE_SOL_RESERVE = Keypair.generate().publicKey.toBase58();
+const FAKE_USER_METADATA_ADDR = Keypair.generate().publicKey.toBase58();
+const FAKE_USER_LUT_ADDR = Keypair.generate().publicKey.toBase58();
+const FAKE_OBLIGATION_ADDR = Keypair.generate().publicKey.toBase58();
+const FAKE_KAMINO_PROGRAM = Keypair.generate().publicKey;
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+  getSolanaRpcUrl: () => "https://test",
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+const fakeUsdcReserve = {
+  address: FAKE_USDC_RESERVE,
+  state: {
+    liquidity: { mintDecimals: 6n },
+    config: { status: 0 },
+  },
+  getTokenSymbol: () => "USDC",
+};
+const fakeSolReserve = {
+  address: FAKE_SOL_RESERVE,
+  state: {
+    liquidity: { mintDecimals: 9n },
+    config: { status: 0 },
+  },
+  getTokenSymbol: () => "SOL",
+};
+
+const fakeMarket = {
+  programId: FAKE_PROGRAM_ID,
+  getAddress: () => FAKE_MARKET_ADDR,
+  getUserMetadata: vi.fn(),
+  getReserveByMint: vi.fn(),
+  getReserveByAddress: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/kamino.js", () => ({
+  loadKaminoMainMarket: async () => fakeMarket,
+  KAMINO_MAIN_MARKET: FAKE_MARKET_ADDR,
+  RECENT_SLOT_DURATION_MS: 410,
+  createKaminoRpc: () => ({}),
+}));
+
+const KaminoActionBuildBorrowTxnsMock = vi.fn();
+const KaminoActionBuildWithdrawTxnsMock = vi.fn();
+const KaminoActionBuildRepayTxnsMock = vi.fn();
+const KaminoActionActionToIxsMock = vi.fn();
+const KaminoObligationLoadMock = vi.fn();
+const VanillaObligationToPdaMock = vi.fn();
+
+vi.mock("@kamino-finance/klend-sdk", () => {
+  class VanillaObligation {
+    constructor(public programId: unknown) {}
+    toArgs() {
+      return {
+        tag: 0,
+        id: 0,
+        seed1: SYSTEM_PROGRAM,
+        seed2: SYSTEM_PROGRAM,
+      };
+    }
+    toPda(market: unknown, user: unknown) {
+      return VanillaObligationToPdaMock(market, user);
+    }
+  }
+  class KaminoObligation {
+    static load(...args: unknown[]) {
+      return KaminoObligationLoadMock(...args);
+    }
+  }
+  class KaminoAction {
+    static buildBorrowTxns(...args: unknown[]) {
+      return KaminoActionBuildBorrowTxnsMock(...args);
+    }
+    static buildWithdrawTxns(...args: unknown[]) {
+      return KaminoActionBuildWithdrawTxnsMock(...args);
+    }
+    static buildRepayTxns(...args: unknown[]) {
+      return KaminoActionBuildRepayTxnsMock(...args);
+    }
+    static actionToIxs(...args: unknown[]) {
+      return KaminoActionActionToIxsMock(...args);
+    }
+    static buildDepositTxns() {
+      return null; // PR2 path; not exercised here
+    }
+  }
+  return {
+    KaminoMarket: class {},
+    KaminoAction,
+    KaminoObligation,
+    VanillaObligation,
+    initObligation: () => ({ programAddress: FAKE_KAMINO_PROGRAM.toBase58() }),
+    getUserLutAddressAndSetupIxs: () => Promise.resolve([FAKE_USER_LUT_ADDR, []]),
+  };
+});
+
+vi.mock("@solana/kit", () => ({
+  createNoopSigner: (addr: unknown) => ({ address: addr }),
+  address: (s: unknown) => s,
+  none: () => ({ __option: "none" }),
+  some: (v: unknown) => ({ __option: "some", value: v }),
+  isSome: (v: { __option?: string }) => v.__option === "some",
+  AccountRole: { READONLY: 0, WRITABLE: 1, READONLY_SIGNER: 2, WRITABLE_SIGNER: 3 },
+}));
+
+vi.mock("@solana/sysvars", () => ({
+  SYSVAR_RENT_ADDRESS: "SysvarRent111111111111111111111111111111111",
+}));
+
+vi.mock("@solana-program/system", () => ({
+  SYSTEM_PROGRAM_ADDRESS: "11111111111111111111111111111111",
+}));
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: FAKE_BLOCKHASH,
+    authority: WALLET_KP.publicKey,
+  });
+}
+
+function fakeKitInstruction(label: string) {
+  return {
+    programAddress: FAKE_KAMINO_PROGRAM.toBase58(),
+    accounts: [
+      { address: WALLET_KP.publicKey.toBase58(), role: 3 },
+    ],
+    data: new Uint8Array([0xab, 0xcd, label.charCodeAt(0)]),
+  };
+}
+
+function makeFakeObligation(opts: {
+  deposits?: { reserveAddress: string; mintAddress: string; amount: string; valueUsd: string }[];
+  borrows?: { reserveAddress: string; mintAddress: string; amount: string; valueUsd: string }[];
+  totalDepositUsd?: string;
+  totalBorrowAdjustedUsd?: string;
+  liquidationLimitUsd?: string;
+}) {
+  const depositsMap = new Map();
+  const borrowsMap = new Map();
+  const decimal = (s: string) => ({ toString: () => s });
+  for (const d of opts.deposits ?? []) {
+    depositsMap.set(d.reserveAddress, {
+      reserveAddress: d.reserveAddress,
+      mintAddress: d.mintAddress,
+      amount: decimal(d.amount),
+      marketValueRefreshed: decimal(d.valueUsd),
+    });
+  }
+  for (const b of opts.borrows ?? []) {
+    borrowsMap.set(b.reserveAddress, {
+      reserveAddress: b.reserveAddress,
+      mintAddress: b.mintAddress,
+      amount: decimal(b.amount),
+      marketValueRefreshed: decimal(b.valueUsd),
+    });
+  }
+  return {
+    obligationAddress: FAKE_OBLIGATION_ADDR,
+    deposits: depositsMap,
+    borrows: borrowsMap,
+    refreshedStats: {
+      userTotalBorrowBorrowFactorAdjusted: decimal(opts.totalBorrowAdjustedUsd ?? "0"),
+      borrowLiquidationLimit: decimal(opts.liquidationLimitUsd ?? "0"),
+    },
+  };
+}
+
+beforeEach(async () => {
+  fakeMarket.getUserMetadata.mockReset();
+  fakeMarket.getReserveByMint.mockReset();
+  fakeMarket.getReserveByAddress.mockReset();
+  KaminoActionBuildBorrowTxnsMock.mockReset();
+  KaminoActionBuildWithdrawTxnsMock.mockReset();
+  KaminoActionBuildRepayTxnsMock.mockReset();
+  KaminoActionActionToIxsMock.mockReset();
+  KaminoObligationLoadMock.mockReset();
+  VanillaObligationToPdaMock.mockReset();
+  VanillaObligationToPdaMock.mockResolvedValue(FAKE_OBLIGATION_ADDR);
+
+  const { getNonceAccountValue } = await import(
+    "../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildKaminoBorrow", () => {
+  it("builds a borrow tx with nonceAdvance + the SDK's ix list", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      deposits: [{ reserveAddress: FAKE_SOL_RESERVE, mintAddress: SOL_MINT, amount: "100000000000", valueUsd: "1500" }],
+    }));
+    KaminoActionBuildBorrowTxnsMock.mockResolvedValue({});
+    KaminoActionActionToIxsMock.mockReturnValue([fakeKitInstruction("B")]);
+
+    const { buildKaminoBorrow } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    const tx = await buildKaminoBorrow({
+      wallet: WALLET,
+      mint: USDC_MINT,
+      amount: "50",
+    });
+
+    expect(tx.action).toBe("kamino_borrow");
+    expect(tx.description).toContain("50 USDC");
+    expect(tx.decoded.functionName).toBe("kamino.borrow");
+    expect(tx.decoded.args.amount).toBe("50");
+    expect(tx.decoded.args.amountBaseUnits).toBe("50000000");
+    expect(tx.decoded.args.symbol).toBe("USDC");
+
+    const { getSolanaDraft } = await import("../src/signing/solana-tx-store.js");
+    const draft = getSolanaDraft(tx.handle);
+    if (draft.kind !== "v0") throw new Error("unreachable");
+    expect(draft.instructions[0].programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0].data.toString("hex")).toBe("04000000");
+    expect(draft.instructions.length).toBe(2);
+  });
+
+  it("refuses when userMetadata is missing", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([FAKE_USER_METADATA_ADDR, null]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+
+    const { buildKaminoBorrow } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    await expect(
+      buildKaminoBorrow({ wallet: WALLET, mint: USDC_MINT, amount: "10" }),
+    ).rejects.toThrow(/no Kamino userMetadata.*prepare_kamino_init_user/);
+  });
+});
+
+describe("buildKaminoWithdraw", () => {
+  it("builds a withdraw tx when the wallet has a deposit in the reserve", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      deposits: [{ reserveAddress: FAKE_USDC_RESERVE, mintAddress: USDC_MINT, amount: "100000000", valueUsd: "100" }],
+    }));
+    KaminoActionBuildWithdrawTxnsMock.mockResolvedValue({});
+    KaminoActionActionToIxsMock.mockReturnValue([fakeKitInstruction("W")]);
+
+    const { buildKaminoWithdraw } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    const tx = await buildKaminoWithdraw({
+      wallet: WALLET,
+      mint: USDC_MINT,
+      amount: "30",
+    });
+    expect(tx.action).toBe("kamino_withdraw");
+    expect(tx.decoded.functionName).toBe("kamino.withdraw");
+  });
+
+  it("refuses when the wallet has no deposit in the named reserve", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      // No USDC deposit; only SOL.
+      deposits: [{ reserveAddress: FAKE_SOL_RESERVE, mintAddress: SOL_MINT, amount: "1000000000", valueUsd: "150" }],
+    }));
+
+    const { buildKaminoWithdraw } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    await expect(
+      buildKaminoWithdraw({ wallet: WALLET, mint: USDC_MINT, amount: "10" }),
+    ).rejects.toThrow(/no Kamino deposit in reserve.*Nothing to withdraw/);
+  });
+});
+
+describe("buildKaminoRepay", () => {
+  it("builds a repay tx when the wallet has debt in the reserve", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      borrows: [{ reserveAddress: FAKE_USDC_RESERVE, mintAddress: USDC_MINT, amount: "50000000", valueUsd: "50" }],
+    }));
+    KaminoActionBuildRepayTxnsMock.mockResolvedValue({});
+    KaminoActionActionToIxsMock.mockReturnValue([fakeKitInstruction("R")]);
+
+    const { buildKaminoRepay } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    const tx = await buildKaminoRepay({
+      wallet: WALLET,
+      mint: USDC_MINT,
+      amount: "20",
+    });
+    expect(tx.action).toBe("kamino_repay");
+    expect(tx.decoded.functionName).toBe("kamino.repay");
+
+    // Sanity: repay's positional signature differs from supply
+    // (currentSlot before payer). Verify our handler passes them correctly.
+    const args = KaminoActionBuildRepayTxnsMock.mock.calls[0];
+    expect(args[7]).toBe(0n); // currentSlot
+    // payer (slot 8) should equal owner (slot 3) — same noopSigner.
+    expect(args[8]).toBe(args[3]);
+  });
+
+  it("refuses when the wallet has no debt in the reserve", async () => {
+    await setNoncePresent();
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    fakeMarket.getReserveByMint.mockReturnValue(fakeUsdcReserve);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({}));
+
+    const { buildKaminoRepay } = await import(
+      "../src/modules/solana/kamino-actions.js"
+    );
+    await expect(
+      buildKaminoRepay({ wallet: WALLET, mint: USDC_MINT, amount: "10" }),
+    ).rejects.toThrow(/no Kamino debt in reserve.*Nothing to repay/);
+  });
+});
+
+describe("getKaminoPositions reader", () => {
+  it("returns empty list when wallet has no userMetadata", async () => {
+    fakeMarket.getUserMetadata.mockResolvedValue([FAKE_USER_METADATA_ADDR, null]);
+    const { getKaminoPositions } = await import(
+      "../src/modules/positions/kamino.js"
+    );
+    const positions = await getKaminoPositions(connectionStub as never, WALLET);
+    expect(positions).toEqual([]);
+  });
+
+  it("returns empty list when userMetadata exists but obligation doesn't (partial init)", async () => {
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    KaminoObligationLoadMock.mockResolvedValue(null);
+    const { getKaminoPositions } = await import(
+      "../src/modules/positions/kamino.js"
+    );
+    const positions = await getKaminoPositions(connectionStub as never, WALLET);
+    expect(positions).toEqual([]);
+  });
+
+  it("projects deposits + borrows + healthFactor for an active obligation", async () => {
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      deposits: [
+        { reserveAddress: FAKE_SOL_RESERVE, mintAddress: SOL_MINT, amount: "10000000000", valueUsd: "1500" }, // 10 SOL @ $150
+      ],
+      borrows: [
+        { reserveAddress: FAKE_USDC_RESERVE, mintAddress: USDC_MINT, amount: "300000000", valueUsd: "300" }, // 300 USDC
+      ],
+      totalBorrowAdjustedUsd: "300",
+      liquidationLimitUsd: "1200", // 80% LTV → HF = 1200/300 = 4
+    }));
+    fakeMarket.getReserveByAddress.mockImplementation((addr: unknown) => {
+      if (addr === FAKE_SOL_RESERVE) return fakeSolReserve;
+      if (addr === FAKE_USDC_RESERVE) return fakeUsdcReserve;
+      return undefined;
+    });
+
+    const { getKaminoPositions } = await import(
+      "../src/modules/positions/kamino.js"
+    );
+    const positions = await getKaminoPositions(connectionStub as never, WALLET);
+    expect(positions).toHaveLength(1);
+    const p = positions[0];
+    expect(p.protocol).toBe("kamino");
+    expect(p.obligation).toBe(FAKE_OBLIGATION_ADDR);
+    expect(p.supplied).toHaveLength(1);
+    expect(p.supplied[0].symbol).toBe("SOL");
+    expect(p.supplied[0].amount).toBe("10"); // 10000000000 / 10^9
+    expect(p.supplied[0].valueUsd).toBe(1500);
+    expect(p.borrowed).toHaveLength(1);
+    expect(p.borrowed[0].symbol).toBe("USDC");
+    expect(p.borrowed[0].amount).toBe("300"); // 300000000 / 10^6
+    expect(p.totalSuppliedUsd).toBe(1500);
+    expect(p.totalBorrowedUsd).toBe(300);
+    expect(p.netValueUsd).toBe(1200);
+    expect(p.healthFactor).toBe(4); // 1200 / 300
+    expect(p.warnings).toEqual([]);
+  });
+
+  it("returns Infinity health factor when there's no debt", async () => {
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      deposits: [{ reserveAddress: FAKE_SOL_RESERVE, mintAddress: SOL_MINT, amount: "1000000000", valueUsd: "150" }],
+      totalBorrowAdjustedUsd: "0",
+      liquidationLimitUsd: "120",
+    }));
+    fakeMarket.getReserveByAddress.mockReturnValue(fakeSolReserve);
+
+    const { getKaminoPositions } = await import(
+      "../src/modules/positions/kamino.js"
+    );
+    const positions = await getKaminoPositions(connectionStub as never, WALLET);
+    expect(positions[0].healthFactor).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("flags reserves with non-active config status", async () => {
+    fakeMarket.getUserMetadata.mockResolvedValue([
+      FAKE_USER_METADATA_ADDR,
+      { userLookupTable: FAKE_USER_LUT_ADDR },
+    ]);
+    KaminoObligationLoadMock.mockResolvedValue(makeFakeObligation({
+      deposits: [{ reserveAddress: FAKE_SOL_RESERVE, mintAddress: SOL_MINT, amount: "1000000000", valueUsd: "150" }],
+    }));
+    fakeMarket.getReserveByAddress.mockReturnValue({
+      ...fakeSolReserve,
+      state: { ...fakeSolReserve.state, config: { status: 2 } }, // hidden
+    });
+
+    const { getKaminoPositions } = await import(
+      "../src/modules/positions/kamino.js"
+    );
+    const positions = await getKaminoPositions(connectionStub as never, WALLET);
+    expect(positions[0].warnings.length).toBe(1);
+    expect(positions[0].warnings[0]).toMatch(/non-active status \(2\)/);
+  });
+});
+
+describe("renderSolanaAgentTaskBlock — borrow / withdraw / repay", () => {
+  it("renders kamino_borrow as blind-sign with the right action label", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const { solanaLedgerMessageHash } = await import(
+      "../src/signing/verification.js"
+    );
+    const tx = {
+      chain: "solana" as const,
+      action: "kamino_borrow" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: FAKE_BLOCKHASH,
+      description: "Kamino borrow: 50 USDC",
+      decoded: {
+        functionName: "kamino.borrow",
+        args: { amount: "50", symbol: "USDC" },
+      },
+      nonce: { account: "NonceAcct1", authority: WALLET, value: FAKE_BLOCKHASH },
+    };
+    const expectedHash = solanaLedgerMessageHash(tx.messageBase64);
+    const block = renderSolanaAgentTaskBlock(tx);
+    expect(block).toContain("BLIND-SIGN");
+    expect(block).toContain(expectedHash);
+    expect(block).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    expect(block).toContain("durable-nonce-protected");
+  });
+
+  it("renders kamino_withdraw + kamino_repay as blind-sign", async () => {
+    const { renderSolanaAgentTaskBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const baseTx = {
+      chain: "solana" as const,
+      from: WALLET,
+      messageBase64: "AQAEBzA/m98Yce1Jt/hp+eAbCM3GPwfIAUQr0DAXVer+HYYg",
+      recentBlockhash: FAKE_BLOCKHASH,
+      nonce: { account: "NonceAcct1", authority: WALLET, value: FAKE_BLOCKHASH },
+    };
+    const withdraw = renderSolanaAgentTaskBlock({
+      ...baseTx,
+      action: "kamino_withdraw",
+      description: "Kamino withdraw: 30 USDC",
+      decoded: { functionName: "kamino.withdraw", args: {} },
+    });
+    expect(withdraw).toContain("BLIND-SIGN");
+    expect(withdraw).toContain("PAIR-CONSISTENCY LEDGER HASH");
+    const repay = renderSolanaAgentTaskBlock({
+      ...baseTx,
+      action: "kamino_repay",
+      description: "Kamino repay: 20 USDC",
+      decoded: { functionName: "kamino.repay", args: {} },
+    });
+    expect(repay).toContain("BLIND-SIGN");
+    expect(repay).toContain("PAIR-CONSISTENCY LEDGER HASH");
+  });
+});

--- a/test/solana-portfolio.test.ts
+++ b/test/solana-portfolio.test.ts
@@ -68,6 +68,15 @@ const SOL_WALLET = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
 // aggregator doesn't try to decode a real Marinade state or Jito pool.
 const marinadeStateStub = { mSolPrice: 1 };
 const getMarinadeStateMock = vi.fn(async () => marinadeStateStub);
+// Stub the Kamino position reader at module boundary so the portfolio
+// aggregator's Kamino fan-out never reaches into the real SDK (Kamino's
+// transitive zstddec dep loads a wasm via `fetch(...)` that breaks under
+// vitest's Response shim). Mirror the existing
+// `../src/modules/positions/index.js` mock pattern.
+vi.mock("../src/modules/positions/kamino.js", () => ({
+  getKaminoPositions: async () => [],
+}));
+
 vi.mock("@marinade.finance/marinade-ts-sdk", () => {
   class MarinadeConfig {}
   class Marinade {
@@ -294,5 +303,71 @@ describe("get_portfolio_summary with solanaAddress", () => {
     expect(res.coverage.solanaStaking?.covered).toBe(true);
     expect(res.breakdown.solana?.staking).toBeUndefined();
     expect(res.solanaStakingUsd).toBeUndefined();
+  });
+
+  it("folds Kamino positions into breakdown.solana.kamino + solanaLendingUsd when present", async () => {
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    // Override the default empty Kamino mock for this test only — return
+    // one synthetic position with $1500 supplied / $300 borrowed.
+    const kaminoMod = await import("../src/modules/positions/kamino.js");
+    vi.spyOn(kaminoMod, "getKaminoPositions").mockResolvedValue([
+      {
+        protocol: "kamino",
+        chain: "solana",
+        wallet: SOL_WALLET,
+        obligation: "ObligationFakeAddress11111111111111111111111",
+        supplied: [{ reserve: "ReserveSol", mint: "SolMint", symbol: "SOL", amount: "10", valueUsd: 1500 }],
+        borrowed: [{ reserve: "ReserveUsdc", mint: "UsdcMint", symbol: "USDC", amount: "300", valueUsd: 300 }],
+        totalSuppliedUsd: 1500,
+        totalBorrowedUsd: 300,
+        netValueUsd: 1200,
+        healthFactor: 4,
+        warnings: [],
+      },
+    ]);
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    const solana = res.breakdown.solana;
+    expect(solana?.kamino).toBeDefined();
+    expect(solana?.kamino?.length).toBe(1);
+    expect(solana?.kamino?.[0].protocol).toBe("kamino");
+    expect(solana?.kamino?.[0].netValueUsd).toBe(1200);
+    expect(solana?.kaminoNetUsd).toBe(1200);
+    expect(res.solanaLendingUsd).toBe(1200);
+    expect(res.coverage.kamino?.covered).toBe(true);
+    expect(res.coverage.kamino?.errored).toBeUndefined();
+  });
+
+  it("marks coverage.kamino as errored when the reader fails — balance + MarginFi coverage unaffected", async () => {
+    connectionStub.getBalance.mockResolvedValue(1_000_000_000);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+
+    const kaminoMod = await import("../src/modules/positions/kamino.js");
+    vi.spyOn(kaminoMod, "getKaminoPositions").mockRejectedValue(
+      new Error("Kamino market load failed"),
+    );
+
+    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
+    const res = await getPortfolioSummary({
+      wallet: EVM_WALLET,
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+
+    expect("breakdown" in res).toBe(true);
+    if (!("breakdown" in res)) return;
+    expect(res.coverage.kamino?.errored).toBe(true);
+    expect(res.coverage.solana?.covered).toBe(true); // balance fetch survived
+    expect(res.breakdown.solana?.kamino).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes Kamino lending. Roadmap #5 done. Three new write tools, one read tool, portfolio integration — combined into one PR per request.

```
prepare_kamino_borrow(wallet, mint, amount)
prepare_kamino_withdraw(wallet, mint, amount)
prepare_kamino_repay(wallet, mint, amount)
get_kamino_positions(wallet)
```

Plus: Kamino positions now fold into `get_portfolio_summary` Solana branch.

## Write builders

All three mirror `prepare_kamino_supply` (PR2): common preflight (load market, validate mint, fetch obligation, refuse on missing init), then `KaminoAction.build*Txns` with `skipInitialization: true`, then `actionToIxs` → kit-bridge → web3.js v1 → durable-nonce v0 tx.

Per-action specifics:
- **withdraw** — refuses with a clean error if no deposit in the named reserve (cleaner than the SDK's opaque \"reserve not in deposits\")
- **repay** — refuses if no debt in the named reserve; on-chain program clamps over-repays so excess just doesn't burn
- **borrow** — no extra preflight; on-chain LTV gate is the safety net (caught by `simulatePinnedSolanaTx`)

`buildRepayTxns` has a slightly different positional signature (currentSlot before payer); a test pins it.

## Position reader

Parallels `getMarginfiPositions`. Returns `[]` when wallet has no userMetadata (= never used Kamino) or partial-init state (userMetadata exists but obligation doesn't). For active obligations: per-reserve deposits + borrows + valueUsd, plus `healthFactor = borrowLiquidationLimit / userTotalBorrowBorrowFactorAdjusted` (Infinity for no debt). Reserve-level pause/freeze flags surface in `warnings`.

## Portfolio integration

- `coverage.kamino` flag (parallel to `coverage.marginfi`)
- `SolanaKaminoPositionSlice` thin type added
- `breakdown.solana.kamino` + `breakdown.solana.kaminoNetUsd` fields
- `solanaLendingUsd` (top-level) now sums BOTH marginfi + kamino contributions
- **Drive-by fix**: `breakdown.solana.marginfiNetUsd` was set to `solanaLendingUsd` in PR2 (only correct because Kamino wasn't there yet); corrected to sum just the marginfi component

## Test plan

- [x] 13 new tests in `test/solana-kamino-pr3-pr4.test.ts` — borrow/withdraw/repay happy paths, all rejection paths, reader (empty, partial-init, active, no-debt-Infinity-HF, non-active-status warnings), render branches
- [x] 2 new portfolio tests — Kamino folds in correctly, coverage marked errored on reader failure
- [x] **vitest-environment fix**: existing `solana-portfolio.test.ts` now mocks `../src/modules/positions/kamino.js` → `[]` so the aggregator's Kamino fan-out doesn't load the real SDK (Kamino's transitive zstddec dep loads a wasm via `fetch(...)` that breaks under vitest's Response shim — was an unhandled rejection that didn't fail tests but added noise)
- [x] `npm run build` clean
- [x] `npx vitest run` — 990 tests, 82 files, all green

## Roadmap status

Roadmap #5 (Kamino lending) closes:

|  | Roadmap #5 |
|---|---|
| PR1 | ✅ kit-bridge + market loader (#151) |
| PR2 | ✅ init_user + supply (#166) |
| **PR3+4** | ✅ **this — borrow/withdraw/repay + positions + portfolio** |

**Out of scope (deferred):** Kamino's repay-with-collateral / leverage / multiply flows. Those use flash loans + multi-tx pipelines (= roadmap #4, deferred), and are margin-trading-flavored. Scope here is vanilla-obligation supply/borrow/withdraw/repay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)