### PR TITLE
feat(btc): indexer abstraction + balances + fee estimates + tx history (Phase 1 PR1)

### DIFF
--- a/src/config/btc.ts
+++ b/src/config/btc.ts
@@ -1,0 +1,26 @@
+/**
+ * Bitcoin mainnet configuration.
+ *
+ * Bitcoin is UTXO-based (not account-based), addresses are base58/bech32
+ * (no `0x` prefix), no smart contracts on L1. The server treats Bitcoin
+ * as strictly additive — existing EVM modules never see Bitcoin, and the
+ * Bitcoin code lives in `src/modules/btc/`.
+ */
+
+/**
+ * Default indexer endpoint — mempool.space's free public API. No API key
+ * needed for personal-volume usage. Per-IP soft rate limit, generous in
+ * practice. Override via `BITCOIN_INDEXER_URL` env var or
+ * `userConfig.bitcoinIndexerUrl` (set up in PR1; the env var is read at
+ * indexer construction time).
+ *
+ * For self-hosted Esplora / Electrs the URL just needs to expose the same
+ * REST surface — mempool.space's API is a fork of Blockstream Esplora's,
+ * which is what the indexer abstraction is modeled on.
+ */
+export const BITCOIN_DEFAULT_INDEXER_URL = "https://mempool.space/api";
+
+/** Native asset metadata. */
+export const BTC_DECIMALS = 8; // 1 BTC = 100_000_000 satoshis
+export const BTC_SYMBOL = "BTC";
+export const SATS_PER_BTC = 100_000_000n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,10 @@ import {
   prepareKaminoWithdraw,
   prepareKaminoRepay,
   getKaminoPositions,
+  getBitcoinBalance,
+  getBitcoinBalances,
+  getBitcoinFeeEstimates,
+  getBitcoinTxHistory,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -134,6 +138,10 @@ import {
   prepareKaminoWithdrawInput,
   prepareKaminoRepayInput,
   getKaminoPositionsInput,
+  getBitcoinBalanceInput,
+  getBitcoinBalancesInput,
+  getBitcoinFeeEstimatesInput,
+  getBitcoinTxHistoryInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -1722,6 +1730,64 @@ async function main() {
       inputSchema: getKaminoPositionsInput.shape,
     },
     handler(getKaminoPositions)
+  );
+
+  // ---- Module: Bitcoin (Phase 1 — read-only) ----
+  server.registerTool(
+    "get_btc_balance",
+    {
+      description:
+        "READ-ONLY — fetch the confirmed + mempool balance for a single Bitcoin mainnet " +
+        "address. Returns sats (raw) and BTC (formatted), separated into confirmed and " +
+        "mempool components, plus the address type (legacy / P2SH / native segwit / taproot) " +
+        "and a tx count. Backed by mempool.space's public API by default; configurable via " +
+        "`BITCOIN_INDEXER_URL` env var or `userConfig.bitcoinIndexerUrl` for self-hosted " +
+        "Esplora / Electrs. Phase 1 is mainnet-only (testnet/signet rejected).",
+      inputSchema: getBitcoinBalanceInput.shape,
+    },
+    handler(getBitcoinBalance)
+  );
+
+  server.registerTool(
+    "get_btc_balances",
+    {
+      description:
+        "READ-ONLY — multi-address Bitcoin balance fetch (1-20 addresses). Per-address " +
+        "indexer errors are surfaced as `errored` entries instead of failing the whole " +
+        "call (mirrors how EVM portfolio enumeration handles flaky RPCs). Each successful " +
+        "entry has the same shape as `get_btc_balance`'s output.",
+      inputSchema: getBitcoinBalancesInput.shape,
+    },
+    handler(getBitcoinBalances)
+  );
+
+  server.registerTool(
+    "get_btc_fee_estimates",
+    {
+      description:
+        "READ-ONLY — current Bitcoin fee-rate recommendations in sat/vB. Returns five " +
+        "labels: `fastestFee` (~next block), `halfHourFee` (~3 blocks), `hourFee` (~6 " +
+        "blocks), `economyFee` (~144 blocks / 1 day), and `minimumFee` (mempool floor). " +
+        "Sourced from mempool.space's `/v1/fees/recommended` endpoint when available; " +
+        "falls back to per-target estimates from the standard Esplora `/fee-estimates` " +
+        "for self-hosted indexers.",
+      inputSchema: getBitcoinFeeEstimatesInput.shape,
+    },
+    handler(getBitcoinFeeEstimates)
+  );
+
+  server.registerTool(
+    "get_btc_tx_history",
+    {
+      description:
+        "READ-ONLY — recent Bitcoin transaction history for a single address (newest-" +
+        "first). Each entry surfaces txid, received/sent sats from this address's " +
+        "perspective, the network fee, block height + time (when confirmed), and an " +
+        "RBF-eligible flag (sequence < 0xFFFFFFFE on at least one input). Default 25 " +
+        "txs, capped at 50 (one Esplora page); pagination beyond is a follow-up.",
+      inputSchema: getBitcoinTxHistoryInput.shape,
+    },
+    handler(getBitcoinTxHistory)
   );
 
   server.registerTool(

--- a/src/modules/btc/address.ts
+++ b/src/modules/btc/address.ts
@@ -1,0 +1,69 @@
+/**
+ * Bitcoin mainnet address validation. Local format checks (regex + base58/
+ * bech32 charset constraints) — does NOT verify on-chain existence or
+ * checksum-validate the address (a fully-correct base58check or bech32m
+ * checksum verifier would pull `bitcoinjs-lib` into the read-only PR1
+ * surface, which we don't need yet).
+ *
+ * What we DO catch:
+ *   - Wrong network (testnet `tb1…`, signet `sb1…`, regtest `bcrt1…`) →
+ *     refused since this server is mainnet-only in Phase 1.
+ *   - Wrong character set (e.g. `0`, `O`, `I`, `l` in base58 — those are
+ *     ambiguous and not used).
+ *   - Wrong length (legacy/P2SH must be 26-35 chars; bech32 is 42-62).
+ *
+ * What we DON'T catch (deferred to bitcoinjs-lib in PR3 when we build
+ * PSBTs):
+ *   - Bad base58check checksum (typo flips the address — would still
+ *     parse here but would fail at PSBT-build time).
+ *   - Bad bech32m checksum (taproot addresses).
+ *
+ * For PR1 this is good enough: an indexer query against a typo'd address
+ * just returns an empty balance, which is recoverable. PSBT signing has
+ * stricter validation when it matters.
+ */
+
+/**
+ * Discriminated union of mainnet address types we recognize. `unknown`
+ * never returns from the validator — the validator throws — but the
+ * type is useful for downstream switches.
+ */
+export type BitcoinAddressType =
+  | "p2pkh" // Legacy `1...`
+  | "p2sh" // P2SH-wrapped `3...`
+  | "p2wpkh" // Native segwit `bc1q...`
+  | "p2tr"; // Taproot `bc1p...`
+
+// Legacy P2PKH: starts with `1`, 26-34 chars, base58 charset.
+const P2PKH_RE = /^1[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+// P2SH (incl. P2SH-wrapped segwit): starts with `3`, 26-34 chars, base58.
+const P2SH_RE = /^3[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+// Bech32 native segwit: `bc1q…` (witness version 0). Length 42 (P2WPKH)
+// or 62 (P2WSH); we accept the common range.
+const BECH32_SEGWIT_RE = /^bc1q[02-9ac-hj-np-z]{38,58}$/;
+// Bech32m taproot: `bc1p…` (witness version 1). Length 62.
+const BECH32_TAPROOT_RE = /^bc1p[02-9ac-hj-np-z]{38,58}$/;
+
+export function detectBitcoinAddressType(addr: string): BitcoinAddressType | null {
+  if (P2PKH_RE.test(addr)) return "p2pkh";
+  if (P2SH_RE.test(addr)) return "p2sh";
+  if (BECH32_SEGWIT_RE.test(addr)) return "p2wpkh";
+  if (BECH32_TAPROOT_RE.test(addr)) return "p2tr";
+  return null;
+}
+
+export function isBitcoinAddress(addr: string): boolean {
+  return detectBitcoinAddressType(addr) !== null;
+}
+
+export function assertBitcoinAddress(addr: string): BitcoinAddressType {
+  const type = detectBitcoinAddressType(addr);
+  if (!type) {
+    throw new Error(
+      `"${addr}" is not a valid Bitcoin mainnet address. Expected one of: ` +
+        `legacy (1...), P2SH (3...), native segwit (bc1q...), or taproot (bc1p...). ` +
+        `Testnet/signet addresses (tb1.../sb1...) are not supported in Phase 1.`,
+    );
+  }
+  return type;
+}

--- a/src/modules/btc/balances.ts
+++ b/src/modules/btc/balances.ts
@@ -1,0 +1,112 @@
+import { assertBitcoinAddress, type BitcoinAddressType } from "./address.js";
+import {
+  getBitcoinIndexer,
+  type BitcoinAddressBalance,
+} from "./indexer.js";
+import { BTC_DECIMALS, BTC_SYMBOL, SATS_PER_BTC } from "../../config/btc.js";
+
+/**
+ * Bitcoin balance reader. Single + multi-address surface; multi fans out
+ * via Promise.allSettled so one failed indexer call doesn't drop the
+ * other addresses. The portfolio aggregator and the standalone
+ * `get_btc_balance` tool both call into this module.
+ *
+ * Pricing is intentionally NOT done here — same separation as the EVM /
+ * TRON / Solana balance readers: this module returns sat-denominated
+ * raw + formatted-BTC strings, and the caller layers USD on top via
+ * the price service. Keeps the module pure (no network besides the
+ * indexer call) and lets higher-level callers reuse the price cache.
+ */
+
+/**
+ * Per-address balance projection. Carries the indexer's confirmed +
+ * mempool split, the address-type tag (so callers can hint UX about
+ * legacy vs taproot), and human-readable BTC amounts derived from sats.
+ */
+export interface BitcoinBalance {
+  address: string;
+  addressType: BitcoinAddressType;
+  /** Confirmed balance in sats. */
+  confirmedSats: bigint;
+  /** Mempool delta in sats (can be negative). */
+  mempoolSats: bigint;
+  /** Confirmed + mempool. */
+  totalSats: bigint;
+  /** Confirmed-balance BTC as a human-readable decimal string (8 decimals). */
+  confirmedBtc: string;
+  /** Total (confirmed + mempool) BTC as a human-readable decimal string. */
+  totalBtc: string;
+  /** Symbol — always "BTC" on mainnet. Surfaced for UX symmetry with the EVM TokenAmount shape. */
+  symbol: typeof BTC_SYMBOL;
+  decimals: typeof BTC_DECIMALS;
+  /** Number of total tx (confirmed + mempool) the address has been involved in. */
+  txCount: number;
+}
+
+/**
+ * Format sats as a BTC decimal string, padding fractional digits to 8.
+ * Avoids floating-point — the integer is split into whole/frac parts and
+ * recombined as a string.
+ */
+function satsToBtcString(sats: bigint): string {
+  const negative = sats < 0n;
+  const abs = negative ? -sats : sats;
+  const whole = abs / SATS_PER_BTC;
+  const frac = abs - whole * SATS_PER_BTC;
+  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "") || "0";
+  const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+  return negative ? `-${body}` : body;
+}
+
+function projectBalance(
+  raw: BitcoinAddressBalance,
+  addressType: BitcoinAddressType,
+): BitcoinBalance {
+  return {
+    address: raw.address,
+    addressType,
+    confirmedSats: raw.confirmedSats,
+    mempoolSats: raw.mempoolSats,
+    totalSats: raw.totalSats,
+    confirmedBtc: satsToBtcString(raw.confirmedSats),
+    totalBtc: satsToBtcString(raw.totalSats),
+    symbol: BTC_SYMBOL,
+    decimals: BTC_DECIMALS,
+    txCount: raw.txCount,
+  };
+}
+
+export async function getBitcoinBalance(address: string): Promise<BitcoinBalance> {
+  const addressType = assertBitcoinAddress(address);
+  const raw = await getBitcoinIndexer().getBalance(address);
+  return projectBalance(raw, addressType);
+}
+
+/**
+ * Multi-address fan-out. Errors per-address are surfaced as `errored`
+ * entries rather than failing the whole call — mirrors how EVM
+ * portfolio enumeration handles flaky RPCs (one bad chain doesn't
+ * tank the whole summary).
+ */
+export type MultiBitcoinBalance =
+  | { ok: true; balance: BitcoinBalance }
+  | { ok: false; address: string; error: string };
+
+export async function getBitcoinBalances(
+  addresses: string[],
+): Promise<MultiBitcoinBalance[]> {
+  // Validate all addresses up-front; bail on the first malformed entry
+  // because mixing valid + invalid addresses in a single call is almost
+  // always a typo, not a deliberate query.
+  for (const a of addresses) assertBitcoinAddress(a);
+
+  const settled = await Promise.allSettled(addresses.map((a) => getBitcoinBalance(a)));
+  return settled.map((r, i) => {
+    if (r.status === "fulfilled") return { ok: true as const, balance: r.value };
+    return {
+      ok: false as const,
+      address: addresses[i],
+      error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+    };
+  });
+}

--- a/src/modules/btc/indexer.ts
+++ b/src/modules/btc/indexer.ts
@@ -1,0 +1,286 @@
+import { fetchWithTimeout } from "../../data/http.js";
+import { BITCOIN_DEFAULT_INDEXER_URL } from "../../config/btc.js";
+import { readUserConfig } from "../../config/user-config.js";
+
+/**
+ * Bitcoin indexer abstraction. Single interface, mempool.space (default)
+ * + any Esplora-compatible endpoint as the impl. Self-hosted Esplora /
+ * Electrs all expose the same REST surface — mempool.space's API is a
+ * fork of Blockstream Esplora's, with a few additions (fee
+ * recommendations, mempool stats) that we use.
+ *
+ * URL resolution priority (highest first):
+ *   1. `BITCOIN_INDEXER_URL` env var
+ *   2. `userConfig.bitcoinIndexerUrl`
+ *   3. `BITCOIN_DEFAULT_INDEXER_URL` (mempool.space)
+ *
+ * Phase 1 scope: read-only. PR3 adds `getUtxos` + `getRawTx` for
+ * coin-selection and PSBT input population, plus `broadcastTx` for the
+ * send path.
+ */
+
+/**
+ * Esplora address-stats payload. Both confirmed and mempool stats are
+ * present; we sum them to surface a "total balance" alongside the
+ * confirmed-only number. mempool.space prefers `chain_stats` /
+ * `mempool_stats` field naming (forked from Blockstream).
+ */
+interface EsploraAddressStats {
+  /** Address — echoed back. */
+  address: string;
+  /** Confirmed: funds that have at least 1 confirmation. */
+  chain_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+  /** Unconfirmed: funds in mempool, not yet mined. */
+  mempool_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+}
+
+/**
+ * Bitcoin balance for a single address. Confirmed + unconfirmed reported
+ * separately so the caller can decide UX (typically: show confirmed as
+ * the headline, surface unconfirmed only when non-zero).
+ */
+export interface BitcoinAddressBalance {
+  address: string;
+  /** Confirmed funded - confirmed spent, in sats. Always ≥ 0. */
+  confirmedSats: bigint;
+  /** Mempool funded - mempool spent, in sats. Can be negative when funds are in-flight as spent. */
+  mempoolSats: bigint;
+  /** Confirmed + mempool. Convenience field. */
+  totalSats: bigint;
+  /** Total tx count this address has been involved in (confirmed + mempool). */
+  txCount: number;
+}
+
+/**
+ * Fee-rate estimates in sat/vB. Returned by mempool.space's
+ * `/v1/fees/recommended` endpoint — these match the labels the mempool.space
+ * UI shows ("High Priority" / "Medium Priority" / etc.) so users see
+ * familiar terminology.
+ */
+export interface BitcoinFeeEstimates {
+  /** ~next-block target. */
+  fastestFee: number;
+  /** ~3 blocks (~30 min). */
+  halfHourFee: number;
+  /** ~6 blocks (~1 hour). */
+  hourFee: number;
+  /** Lowest fee miners are still including. */
+  economyFee: number;
+  /** Floor below which a tx is unlikely to ever confirm. */
+  minimumFee: number;
+}
+
+/**
+ * Tx history entry. Subset of the Esplora `/address/<addr>/txs` payload
+ * we surface — enough for portfolio history rendering without forcing
+ * callers to learn the full SAT/RBF/witness shape.
+ */
+export interface BitcoinTxHistoryEntry {
+  txid: string;
+  /** Sum of vouts that pay this address (the funding side). Sats. */
+  receivedSats: bigint;
+  /** Sum of vins that come from this address (the spending side). Sats. */
+  sentSats: bigint;
+  /** Tx fee from the Esplora payload (sats). Useful UX context. */
+  feeSats: bigint;
+  /** Block height — undefined when still in mempool. */
+  blockHeight?: number;
+  /** Unix timestamp of the block — undefined for mempool. */
+  blockTime?: number;
+  /** True when sequence < 0xFFFFFFFE on at least one input (BIP-125). */
+  rbfEligible: boolean;
+}
+
+/**
+ * Esplora vin/vout shapes we destructure. Trimmed to fields we read.
+ */
+interface EsploraVin {
+  txid: string;
+  vout: number;
+  prevout?: { scriptpubkey_address?: string; value?: number };
+  sequence?: number;
+}
+
+interface EsploraVout {
+  scriptpubkey_address?: string;
+  value?: number;
+}
+
+interface EsploraTx {
+  txid: string;
+  vin: EsploraVin[];
+  vout: EsploraVout[];
+  fee?: number;
+  status?: { confirmed?: boolean; block_height?: number; block_time?: number };
+}
+
+export interface BitcoinIndexer {
+  getBalance(address: string): Promise<BitcoinAddressBalance>;
+  getFeeEstimates(): Promise<BitcoinFeeEstimates>;
+  /**
+   * Fetch the tx history for an address. `limit` clamps how many entries
+   * to walk (we paginate via the Esplora `/txs/chain/<last_seen>` cursor
+   * pattern; mempool.space honors the same convention). Returns only
+   * confirmed + mempool txs, oldest-first within each segment.
+   */
+  getAddressTxs(
+    address: string,
+    opts?: { limit?: number },
+  ): Promise<BitcoinTxHistoryEntry[]>;
+}
+
+/**
+ * Resolve the indexer base URL via env > config > default.
+ */
+function resolveIndexerUrl(): string {
+  const fromEnv = process.env.BITCOIN_INDEXER_URL;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim();
+  const cfg = readUserConfig();
+  if (cfg && cfg.bitcoinIndexerUrl && cfg.bitcoinIndexerUrl.trim().length > 0) {
+    return cfg.bitcoinIndexerUrl.trim();
+  }
+  return BITCOIN_DEFAULT_INDEXER_URL;
+}
+
+/**
+ * Convert an Esplora tx + the address it's queried for into our thin
+ * history shape. The fee comes from the API directly; received/sent are
+ * derived by walking vin/vout for entries that match the address.
+ */
+function summarizeTx(tx: EsploraTx, address: string): BitcoinTxHistoryEntry {
+  let receivedSats = 0n;
+  let sentSats = 0n;
+  let rbfEligible = false;
+  for (const v of tx.vin) {
+    const seq = typeof v.sequence === "number" ? v.sequence : 0xffffffff;
+    if (seq < 0xfffffffe) rbfEligible = true;
+    if (v.prevout?.scriptpubkey_address === address && v.prevout.value !== undefined) {
+      sentSats += BigInt(v.prevout.value);
+    }
+  }
+  for (const v of tx.vout) {
+    if (v.scriptpubkey_address === address && v.value !== undefined) {
+      receivedSats += BigInt(v.value);
+    }
+  }
+  return {
+    txid: tx.txid,
+    receivedSats,
+    sentSats,
+    feeSats: tx.fee !== undefined ? BigInt(tx.fee) : 0n,
+    ...(tx.status?.block_height !== undefined ? { blockHeight: tx.status.block_height } : {}),
+    ...(tx.status?.block_time !== undefined ? { blockTime: tx.status.block_time } : {}),
+    rbfEligible,
+  };
+}
+
+class EsploraIndexer implements BitcoinIndexer {
+  constructor(private readonly baseUrl: string) {}
+
+  private async getJson<T>(path: string): Promise<T> {
+    const res = await fetchWithTimeout(`${this.baseUrl}${path}`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Bitcoin indexer ${path} returned ${res.status} ${res.statusText}`,
+      );
+    }
+    return (await res.json()) as T;
+  }
+
+  async getBalance(address: string): Promise<BitcoinAddressBalance> {
+    const stats = await this.getJson<EsploraAddressStats>(`/address/${address}`);
+    const confirmedSats =
+      BigInt(stats.chain_stats.funded_txo_sum) -
+      BigInt(stats.chain_stats.spent_txo_sum);
+    const mempoolSats =
+      BigInt(stats.mempool_stats.funded_txo_sum) -
+      BigInt(stats.mempool_stats.spent_txo_sum);
+    return {
+      address,
+      confirmedSats,
+      mempoolSats,
+      totalSats: confirmedSats + mempoolSats,
+      txCount: stats.chain_stats.tx_count + stats.mempool_stats.tx_count,
+    };
+  }
+
+  async getFeeEstimates(): Promise<BitcoinFeeEstimates> {
+    // mempool.space's recommended-fees endpoint lives under `/v1/`. Self-
+    // hosted Esplora-only deployments may not have it; for those, the
+    // per-block-target endpoint at `/fee-estimates` is the fallback. We
+    // try the recommended-fees endpoint first (rich labels) and fall
+    // back to deriving the four labels from the per-target map.
+    try {
+      const r = await this.getJson<BitcoinFeeEstimates>("/v1/fees/recommended");
+      // Defensive: ensure the fields are numbers (some Esplora forks may
+      // return strings or omit fields; clamp to the floor in that case).
+      const num = (n: unknown) => (typeof n === "number" && Number.isFinite(n) ? n : 1);
+      return {
+        fastestFee: num(r.fastestFee),
+        halfHourFee: num(r.halfHourFee),
+        hourFee: num(r.hourFee),
+        economyFee: num(r.economyFee),
+        minimumFee: num(r.minimumFee),
+      };
+    } catch {
+      // Esplora fallback: per-target map keyed by block-count.
+      const map = await this.getJson<Record<string, number>>("/fee-estimates");
+      const at = (k: string, fallback: number) =>
+        typeof map[k] === "number" && Number.isFinite(map[k]) ? map[k] : fallback;
+      return {
+        fastestFee: at("1", 20),
+        halfHourFee: at("3", 10),
+        hourFee: at("6", 5),
+        economyFee: at("144", 2),
+        minimumFee: at("1008", 1),
+      };
+    }
+  }
+
+  async getAddressTxs(
+    address: string,
+    opts: { limit?: number } = {},
+  ): Promise<BitcoinTxHistoryEntry[]> {
+    const limit = opts.limit ?? 25;
+    // Esplora returns 50 confirmed txs per page (newest-first) +
+    // mempool txs at the start. For a single page that's enough for
+    // portfolio history rendering. Pagination cursor is `/txs/chain/<last_seen>`
+    // — we don't paginate in PR1.
+    const txs = await this.getJson<EsploraTx[]>(`/address/${address}/txs`);
+    return txs.slice(0, limit).map((tx) => summarizeTx(tx, address));
+  }
+}
+
+let cached: { url: string; impl: BitcoinIndexer } | undefined;
+
+/**
+ * Get the singleton indexer. Re-resolved if the URL has changed (env or
+ * config swap). Lazy — env vars / config files are read on first call.
+ */
+export function getBitcoinIndexer(): BitcoinIndexer {
+  const url = resolveIndexerUrl();
+  if (!cached || cached.url !== url) {
+    cached = { url, impl: new EsploraIndexer(url) };
+  }
+  return cached.impl;
+}
+
+/** Test-only — drop the cached indexer so a fresh URL resolution runs. */
+export function resetBitcoinIndexer(): void {
+  cached = undefined;
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -111,6 +111,10 @@ import type {
   PrepareKaminoWithdrawArgs,
   PrepareKaminoRepayArgs,
   GetKaminoPositionsArgs,
+  GetBitcoinBalanceArgs,
+  GetBitcoinBalancesArgs,
+  GetBitcoinFeeEstimatesArgs,
+  GetBitcoinTxHistoryArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -547,6 +551,36 @@ export async function getKaminoPositions(args: GetKaminoPositionsArgs) {
   );
   const conn = getSolanaConnection();
   return { positions: await reader(conn, args.wallet) };
+}
+
+export async function getBitcoinBalance(args: GetBitcoinBalanceArgs) {
+  const { getBitcoinBalance: reader } = await import(
+    "../btc/balances.js"
+  );
+  return reader(args.address);
+}
+
+export async function getBitcoinBalances(args: GetBitcoinBalancesArgs) {
+  const { getBitcoinBalances: reader } = await import(
+    "../btc/balances.js"
+  );
+  return { balances: await reader(args.addresses) };
+}
+
+export async function getBitcoinFeeEstimates(_args: GetBitcoinFeeEstimatesArgs) {
+  void _args;
+  const { getBitcoinIndexer } = await import("../btc/indexer.js");
+  return getBitcoinIndexer().getFeeEstimates();
+}
+
+export async function getBitcoinTxHistory(args: GetBitcoinTxHistoryArgs) {
+  const { getBitcoinIndexer } = await import("../btc/indexer.js");
+  const { assertBitcoinAddress } = await import("../btc/address.js");
+  assertBitcoinAddress(args.address);
+  const txs = await getBitcoinIndexer().getAddressTxs(args.address, {
+    ...(args.limit !== undefined ? { limit: args.limit } : {}),
+  });
+  return { address: args.address, txs };
 }
 
 export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -975,5 +975,59 @@ export type PrepareKaminoBorrowArgs = z.infer<typeof prepareKaminoBorrowInput>;
 export type PrepareKaminoWithdrawArgs = z.infer<typeof prepareKaminoWithdrawInput>;
 export type PrepareKaminoRepayArgs = z.infer<typeof prepareKaminoRepayInput>;
 export type GetKaminoPositionsArgs = z.infer<typeof getKaminoPositionsInput>;
+
+/**
+ * Bitcoin (Phase 1) — read-only schemas.
+ *
+ * Address validation is deliberately a string-with-format-check rather
+ * than a tight regex schema: Bitcoin has 4 distinct mainnet address
+ * shapes (P2PKH `1...`, P2SH `3...`, native segwit `bc1q...`, taproot
+ * `bc1p...`) of varying lengths, so the runtime validator in
+ * `src/modules/btc/address.ts` is the source of truth.
+ */
+const bitcoinAddressSchema = z
+  .string()
+  .min(26)
+  .max(64)
+  .describe(
+    "Bitcoin mainnet address. Accepts legacy (1...), P2SH (3...), native " +
+      "segwit (bc1q...), and taproot (bc1p...). Testnet/signet not supported."
+  );
+
+export const getBitcoinBalanceInput = z.object({
+  address: bitcoinAddressSchema,
+});
+
+export const getBitcoinBalancesInput = z.object({
+  addresses: z
+    .array(bitcoinAddressSchema)
+    .min(1)
+    .max(20)
+    .describe(
+      "1-20 Bitcoin addresses to fetch in parallel. Per-address errors are " +
+        "surfaced as `errored` entries rather than failing the whole call."
+    ),
+});
+
+export const getBitcoinFeeEstimatesInput = z.object({});
+
+export const getBitcoinTxHistoryInput = z.object({
+  address: bitcoinAddressSchema,
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe(
+      "Max number of txs to return (newest-first). Default 25; capped at 50 " +
+        "(one Esplora page). Pagination beyond this is a follow-up."
+    ),
+});
+
+export type GetBitcoinBalanceArgs = z.infer<typeof getBitcoinBalanceInput>;
+export type GetBitcoinBalancesArgs = z.infer<typeof getBitcoinBalancesInput>;
+export type GetBitcoinFeeEstimatesArgs = z.infer<typeof getBitcoinFeeEstimatesInput>;
+export type GetBitcoinTxHistoryArgs = z.infer<typeof getBitcoinTxHistoryInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1100,6 +1100,14 @@ export interface UserConfig {
    * takes priority over this field.
    */
   solanaRpcUrl?: string;
+  /**
+   * Bitcoin indexer base URL (Esplora-compatible REST API). Defaults to
+   * mempool.space's free public API; override here when running against a
+   * self-hosted Esplora / Electrs / Mempool.space instance, or any
+   * privacy-preserving relay. Env var `BITCOIN_INDEXER_URL` takes priority
+   * over this field.
+   */
+  bitcoinIndexerUrl?: string;
   walletConnect?: {
     projectId?: string;
     /** Topic of the active WC session (so we can resume after restart). */

--- a/test/btc-pr1.test.ts
+++ b/test/btc-pr1.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  assertBitcoinAddress,
+  detectBitcoinAddressType,
+  isBitcoinAddress,
+} from "../src/modules/btc/address.js";
+import { resetBitcoinIndexer } from "../src/modules/btc/indexer.js";
+
+/**
+ * Bitcoin PR1 — address validation, indexer abstraction, balances + fee
+ * estimates + tx history. All HTTP IO mocked via vi.stubGlobal("fetch")
+ * so tests don't touch mempool.space.
+ *
+ * Address fixtures are real mainnet addresses (Satoshi's first P2PKH,
+ * SatoshiNakamoto.com's well-known taproot, etc.) — using real
+ * addresses catches typos in the regex bounds without needing a
+ * checksum verifier.
+ */
+
+// Real mainnet addresses, one per type (lengths must hit the regex bounds).
+const P2PKH_ADDR = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"; // Satoshi block 0 coinbase
+const P2SH_ADDR = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"; // BIP-13 example
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"; // BIP-173 P2WPKH example
+const TAPROOT_ADDR =
+  "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg"; // Variable-length taproot from BIP-350
+const TESTNET_ADDR = "tb1qar0srrr7xfkvy5l643lydnw9re59gtzzwfllgu";
+
+describe("address validation", () => {
+  it("detects P2PKH legacy addresses", () => {
+    expect(detectBitcoinAddressType(P2PKH_ADDR)).toBe("p2pkh");
+    expect(isBitcoinAddress(P2PKH_ADDR)).toBe(true);
+    expect(assertBitcoinAddress(P2PKH_ADDR)).toBe("p2pkh");
+  });
+
+  it("detects P2SH addresses", () => {
+    expect(detectBitcoinAddressType(P2SH_ADDR)).toBe("p2sh");
+  });
+
+  it("detects native segwit (P2WPKH)", () => {
+    expect(detectBitcoinAddressType(SEGWIT_ADDR)).toBe("p2wpkh");
+  });
+
+  it("detects taproot (P2TR)", () => {
+    expect(detectBitcoinAddressType(TAPROOT_ADDR)).toBe("p2tr");
+  });
+
+  it("rejects testnet bech32 (tb1...) — Phase 1 is mainnet-only", () => {
+    expect(detectBitcoinAddressType(TESTNET_ADDR)).toBeNull();
+    expect(() => assertBitcoinAddress(TESTNET_ADDR)).toThrow(/Testnet\/signet/);
+  });
+
+  it("rejects garbage strings", () => {
+    expect(detectBitcoinAddressType("0xnotvalidbtc")).toBeNull();
+    expect(detectBitcoinAddressType("not-a-btc-address")).toBeNull();
+    expect(detectBitcoinAddressType("")).toBeNull();
+    expect(() => assertBitcoinAddress("0xnotvalidbtc")).toThrow(
+      /not a valid Bitcoin mainnet address/,
+    );
+  });
+
+  it("rejects bech32 with banned base32 chars (1, b, i, o)", () => {
+    // Inject `o` (banned) into the data part — should be rejected.
+    const bad = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5moq";
+    expect(detectBitcoinAddressType(bad)).toBeNull();
+  });
+});
+
+describe("indexer — getBalance", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+  });
+
+  it("returns confirmed + mempool + total sats from Esplora address-stats", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(`https://mempool.space/api/address/${TAPROOT_ADDR}`);
+      return new Response(
+        JSON.stringify({
+          address: TAPROOT_ADDR,
+          chain_stats: {
+            funded_txo_count: 5,
+            funded_txo_sum: 250_000_000, // 2.5 BTC funded
+            spent_txo_count: 2,
+            spent_txo_sum: 100_000_000, // 1.0 BTC spent
+            tx_count: 7,
+          },
+          mempool_stats: {
+            funded_txo_count: 1,
+            funded_txo_sum: 5_000_000, // 0.05 BTC inbound, mempool
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 1,
+          },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const indexer = getBitcoinIndexer();
+    const bal = await indexer.getBalance(TAPROOT_ADDR);
+    expect(bal.address).toBe(TAPROOT_ADDR);
+    expect(bal.confirmedSats).toBe(150_000_000n); // 2.5 - 1.0 = 1.5 BTC
+    expect(bal.mempoolSats).toBe(5_000_000n);
+    expect(bal.totalSats).toBe(155_000_000n);
+    expect(bal.txCount).toBe(8);
+  });
+
+  it("throws on indexer HTTP failure", async () => {
+    const fetchMock = vi.fn(async () => new Response("Bad Gateway", { status: 502, statusText: "Bad Gateway" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    await expect(getBitcoinIndexer().getBalance(TAPROOT_ADDR)).rejects.toThrow(
+      /returned 502/,
+    );
+  });
+});
+
+describe("indexer — getFeeEstimates", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+  });
+
+  it("returns the five fee labels from mempool.space's recommended-fees endpoint", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://mempool.space/api/v1/fees/recommended");
+      return new Response(
+        JSON.stringify({
+          fastestFee: 25,
+          halfHourFee: 18,
+          hourFee: 12,
+          economyFee: 5,
+          minimumFee: 1,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const fees = await getBitcoinIndexer().getFeeEstimates();
+    expect(fees).toEqual({
+      fastestFee: 25,
+      halfHourFee: 18,
+      hourFee: 12,
+      economyFee: 5,
+      minimumFee: 1,
+    });
+  });
+
+  it("falls back to /fee-estimates when /v1/fees/recommended is unavailable", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      call++;
+      if (call === 1) {
+        expect(url).toBe("https://mempool.space/api/v1/fees/recommended");
+        return new Response("Not Found", { status: 404, statusText: "Not Found" });
+      }
+      // Second call: /fee-estimates
+      expect(url).toBe("https://mempool.space/api/fee-estimates");
+      return new Response(
+        JSON.stringify({
+          "1": 25,
+          "3": 18,
+          "6": 12,
+          "144": 5,
+          "1008": 1,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const fees = await getBitcoinIndexer().getFeeEstimates();
+    expect(fees.fastestFee).toBe(25);
+    expect(fees.halfHourFee).toBe(18);
+    expect(fees.hourFee).toBe(12);
+    expect(fees.economyFee).toBe(5);
+    expect(fees.minimumFee).toBe(1);
+  });
+});
+
+describe("indexer — getAddressTxs", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+  });
+
+  it("summarizes received / sent / fee + RBF flag from Esplora payload", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify([
+          {
+            txid: "aa".repeat(32),
+            vin: [
+              {
+                txid: "bb".repeat(32),
+                vout: 0,
+                prevout: { scriptpubkey_address: TAPROOT_ADDR, value: 200_000 },
+                sequence: 0xfffffffd, // RBF-eligible
+              },
+            ],
+            vout: [
+              { scriptpubkey_address: "1Recipient...", value: 150_000 },
+              { scriptpubkey_address: TAPROOT_ADDR, value: 49_000 }, // change
+            ],
+            fee: 1_000,
+            status: { confirmed: true, block_height: 800_000, block_time: 1_700_000_000 },
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const txs = await getBitcoinIndexer().getAddressTxs(TAPROOT_ADDR);
+    expect(txs.length).toBe(1);
+    const t = txs[0];
+    expect(t.txid).toBe("aa".repeat(32));
+    expect(t.sentSats).toBe(200_000n);
+    expect(t.receivedSats).toBe(49_000n);
+    expect(t.feeSats).toBe(1_000n);
+    expect(t.blockHeight).toBe(800_000);
+    expect(t.blockTime).toBe(1_700_000_000);
+    expect(t.rbfEligible).toBe(true);
+  });
+
+  it("clamps the result to the requested limit", async () => {
+    const fakeTx = (txid: string) => ({
+      txid,
+      vin: [],
+      vout: [],
+      fee: 0,
+      status: { confirmed: true, block_height: 1, block_time: 0 },
+    });
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify([fakeTx("aa"), fakeTx("bb"), fakeTx("cc")]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const txs = await getBitcoinIndexer().getAddressTxs(TAPROOT_ADDR, { limit: 2 });
+    expect(txs.length).toBe(2);
+  });
+});
+
+describe("indexer URL resolution", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+    delete process.env.BITCOIN_INDEXER_URL;
+  });
+
+  it("respects BITCOIN_INDEXER_URL env var", async () => {
+    process.env.BITCOIN_INDEXER_URL = "https://my-esplora.example/api";
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url.startsWith("https://my-esplora.example/api/")).toBe(true);
+      return new Response(
+        JSON.stringify({
+          address: P2PKH_ADDR,
+          chain_stats: { funded_txo_count: 0, funded_txo_sum: 0, spent_txo_count: 0, spent_txo_sum: 0, tx_count: 0 },
+          mempool_stats: { funded_txo_count: 0, funded_txo_sum: 0, spent_txo_count: 0, spent_txo_sum: 0, tx_count: 0 },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    await getBitcoinIndexer().getBalance(P2PKH_ADDR);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
+describe("balances — getBitcoinBalance / getBitcoinBalances", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+  });
+
+  it("formats sats as BTC decimal strings (8 decimal places, trailing zeros stripped)", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          address: TAPROOT_ADDR,
+          chain_stats: {
+            funded_txo_count: 1,
+            funded_txo_sum: 123_456_789, // 1.23456789 BTC
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 1,
+          },
+          mempool_stats: {
+            funded_txo_count: 0,
+            funded_txo_sum: 0,
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 0,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinBalance } = await import("../src/modules/btc/balances.js");
+    const bal = await getBitcoinBalance(TAPROOT_ADDR);
+    expect(bal.confirmedSats).toBe(123_456_789n);
+    expect(bal.confirmedBtc).toBe("1.23456789");
+    expect(bal.totalBtc).toBe("1.23456789");
+    expect(bal.addressType).toBe("p2tr");
+    expect(bal.symbol).toBe("BTC");
+    expect(bal.decimals).toBe(8);
+  });
+
+  it("formats whole BTC without trailing fractional dust", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          address: TAPROOT_ADDR,
+          chain_stats: {
+            funded_txo_count: 1,
+            funded_txo_sum: 100_000_000, // exactly 1 BTC
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 1,
+          },
+          mempool_stats: {
+            funded_txo_count: 0,
+            funded_txo_sum: 0,
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 0,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinBalance } = await import("../src/modules/btc/balances.js");
+    const bal = await getBitcoinBalance(TAPROOT_ADDR);
+    expect(bal.confirmedBtc).toBe("1");
+  });
+
+  it("multi-address fan-out: one ok, one errored — both surface", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            address: TAPROOT_ADDR,
+            chain_stats: { funded_txo_count: 1, funded_txo_sum: 50_000, spent_txo_count: 0, spent_txo_sum: 0, tx_count: 1 },
+            mempool_stats: { funded_txo_count: 0, funded_txo_sum: 0, spent_txo_count: 0, spent_txo_sum: 0, tx_count: 0 },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("Server Error", { status: 500, statusText: "Server Error" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinBalances } = await import("../src/modules/btc/balances.js");
+    const results = await getBitcoinBalances([TAPROOT_ADDR, SEGWIT_ADDR]);
+    expect(results.length).toBe(2);
+    expect(results[0].ok).toBe(true);
+    if (!results[0].ok) throw new Error("unreachable");
+    expect(results[0].balance.confirmedSats).toBe(50_000n);
+    expect(results[1].ok).toBe(false);
+    if (results[1].ok) throw new Error("unreachable");
+    expect(results[1].address).toBe(SEGWIT_ADDR);
+    expect(results[1].error).toMatch(/500/);
+  });
+
+  it("rejects malformed addresses up-front before any fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { getBitcoinBalances } = await import("../src/modules/btc/balances.js");
+    await expect(
+      getBitcoinBalances([TAPROOT_ADDR, "0xnotbtc"]),
+    ).rejects.toThrow(/not a valid Bitcoin mainnet address/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

First step of Bitcoin support per `claude-work/plan-bitcoin-ledger-phase1.md`. Read-only — pairing, signing, sends ship in PR2/3/4.

## What ships

Four new tools, all read-only:

```
get_btc_balance(address)
get_btc_balances(addresses[])
get_btc_fee_estimates
get_btc_tx_history(address, limit?)
```

Plus the foundation pieces every later PR will reuse:
- `src/config/btc.ts` — BTC_DECIMALS, SATS_PER_BTC, default indexer URL
- `src/modules/btc/address.ts` — mainnet validator with P2PKH / P2SH / P2WPKH / P2TR discriminator
- `src/modules/btc/indexer.ts` — Esplora-compatible REST surface, mempool.space as default
- `src/modules/btc/balances.ts` — TokenAmount-flavored projection with formatted-BTC strings

## Design notes

**Indexer URL resolution** — env (`BITCOIN_INDEXER_URL`) > config (`bitcoinIndexerUrl`) > mempool.space default. Same pattern as `SOLANA_RPC_URL`. Self-hosted Esplora / Electrs work as drop-in replacements (mempool.space's API is a fork of Blockstream Esplora's).

**Fee estimates with fallback** — tries `/v1/fees/recommended` first (mempool.space's labeled endpoint); falls back to standard Esplora `/fee-estimates` (per-block-target map) when unavailable. Fallback maps block targets 1/3/6/144/1008 onto the five labels.

**Address validation scope** — format-only (regex + charset). Catches wrong network (testnet/signet), wrong charset, wrong length. Doesn't catch typos that flip a checksum but stay in the right charset. For read-only PR1 an indexer query against a typo'd address just returns an empty balance — recoverable. PSBT signing in PR3 will pull in `bitcoinjs-lib` for strict validation.

**Multi-address fan-out** — pre-validates all inputs (single bad address fails the whole call); per-address indexer errors surface as `errored` entries in the result array rather than failing.

**sats → BTC formatting** — integer arithmetic only, no float precision loss. Whole BTC renders as `\"1\"` (not `\"1.00000000\"`); fractional values strip trailing zeros.

## Out of scope this PR (deferred to PR2/3/4)

- `pair_ledger_btc` flow
- PSBT construction + Ledger signing
- `prepare_btc_send` + `send_transaction` BTC branch
- Portfolio integration
- `sign_message_btc`
- `bitcoinjs-lib` + `coinselect` + `@ledgerhq/hw-app-btc` deps (none needed for read-only)

## Test plan

- [x] 18 new tests cover: address validation per type + rejection paths; indexer balance + HTTP-error; fee estimates happy + fallback; tx history derivation + limit clamp; URL env override; balances formatting (whole + fractional + zero-strip); multi-address fan-out (mixed ok/error); pre-validation rejects before fetch
- [x] `npm run build` clean
- [x] `npx vitest run` — 1009 tests, 83 files, all green

## Roadmap status

|  | Bitcoin Phase 1 |
|---|---|
| **PR1** | ✅ **this — indexer + balances + fees + tx history** |
| PR2 | 🚧 pair_ledger_btc + USB-HID signer + get_ledger_status ext |
| PR3 | 🚧 prepare_btc_send (coin-selection + PSBT) + send_transaction |
| PR4 | 🚧 portfolio integration + sign_message_btc |

🤖 Generated with [Claude Code](https://claude.com/claude-code)