### PR TITLE
feat(btc): pair_ledger_btc + USB-HID signer + get_ledger_status BTC section (Phase 1 PR2)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,3 +17,35 @@ ignore:
           dependency.
         created: 2026-04-23T00:00:00.000Z
         expires: 2027-04-23T00:00:00.000Z
+  SNYK-JS-ELLIPTIC-14908844:
+    - '*':
+        reason: >-
+          CVE-2025-14505 / GHSA-848j-6mx2-7j84. The CVE is in elliptic's
+          ECDSA sign() implementation: when an interim k value has
+          leading zeros, the byte-length is mis-computed, faulty
+          signatures leak, and an attacker who collects both faulty +
+          correct signatures over the same input can recover the
+          private key. No upstream fix exists at any elliptic version
+          (advisory says "<= 6.6.1" with no first_patched_version);
+          npm's audit-fix suggestion downgrades @ledgerhq/hw-app-btc to
+          v6.7.0, which predates the modern PSBT API the BTC plan
+          (claude-work/plan-bitcoin-ledger-phase1.md) is built around.
+
+          The vulnerable code path is NOT REACHABLE in our deployment.
+          User keys live on the Ledger Secure Element; every BTC
+          ECDSA signature is produced by the device via APDU. The
+          host's elliptic dep is pulled in transitively
+          (@ledgerhq/hw-app-btc → bitcoinjs-lib@5 → tiny-secp256k1@1 →
+          elliptic) for ADDRESS DERIVATION (point operations only, no
+          signing), pubkey decompression, and tx-hash computation. None
+          of these call elliptic.ec.sign() against a private key, so
+          the faulty-k path the CVE exploits cannot fire in our flow.
+
+          Re-evaluate when (a) elliptic ships a patched release, or (b)
+          @ledgerhq/hw-app-btc upgrades to bitcoinjs-lib@6 (which uses
+          @noble/curves instead of elliptic) and we can take that
+          version, or (c) we override tiny-secp256k1 to v2 (the
+          @noble-backed major bump) without breaking the SDK's v5
+          bitcoinjs-lib expectations.
+        created: 2026-04-25T00:00:00.000Z
+        expires: 2027-04-25T00:00:00.000Z

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@kamino-finance/klend-sdk": "^7.3.22",
+        "@ledgerhq/hw-app-btc": "^10.21.1",
         "@ledgerhq/hw-app-solana": "^7.10.1",
         "@ledgerhq/hw-app-trx": "^6.34.1",
         "@ledgerhq/hw-transport-node-hid": "^6.32.1",
@@ -1195,6 +1196,86 @@
       "integrity": "sha512-l16K56FzPoXBMT5J4EpnIBmRLTYkpSyYj3z4er+rmbwq0t9dDG/UaRvFeBpwB2gqGcYWcue14qF9Wkuos/43eA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@ledgerhq/hw-app-btc": {
+      "version": "10.21.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-btc/-/hw-app-btc-10.21.1.tgz",
+      "integrity": "sha512-zLn5WYtli0B/QwBRoPCrd1ZhQ6rcv0w7Ggv0eyqe6gM0fnfyymheSVybdDloKkBxYoM1W1ziUCXMJ70oohtGCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "6.35.1",
+        "@ledgerhq/logs": "^6.17.0",
+        "@ledgerhq/psbtv2": "^0.4.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^5.2.0",
+        "bs58": "^4.0.1",
+        "bs58check": "^2.1.2",
+        "invariant": "^2.2.4",
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/bip174": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/bitcoinjs-lib": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+      "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bech32": "^1.1.2",
+        "bip174": "^2.0.1",
+        "bip32": "^2.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "tiny-secp256k1": "^1.1.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/@ledgerhq/hw-app-solana": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-solana/-/hw-app-solana-7.10.1.tgz",
@@ -1261,6 +1342,77 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
       "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/psbtv2": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/psbtv2/-/psbtv2-0.4.0.tgz",
+      "integrity": "sha512-pjkS8dcGe+rA0GeZAdPZCbycDm8I/W5tdk84jUcl/IbTHztp9WQCE2JBeymZqZnJt1vL6OJZ0gunIT+JcpV3jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bitcoinjs-lib": "^5.2.0",
+        "varuint-bitcoin": "1.1.2"
+      }
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/bip174": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/bitcoinjs-lib": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+      "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bech32": "^1.1.2",
+        "bip174": "^2.0.1",
+        "bip32": "^2.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "tiny-secp256k1": "^1.1.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "node_modules/@lifi/sdk": {
       "version": "3.16.3",
@@ -3847,21 +3999,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -4366,6 +4503,21 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axios": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
@@ -4578,10 +4730,60 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/bip32": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
+      "integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.3",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bip32-path": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/bip32-path/-/bip32-path-0.4.2.tgz",
       "integrity": "sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ==",
+      "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
       "license": "MIT"
     },
     "node_modules/bitcoinjs-lib": {
@@ -4704,6 +4906,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
     "node_modules/bs58": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
@@ -4783,7 +4991,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4898,6 +5105,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5008,7 +5229,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5026,6 +5246,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "node_modules/cross-fetch": {
@@ -5135,7 +5382,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5302,6 +5548,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -5656,13 +5923,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5749,6 +6009,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -5987,7 +6262,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -6023,6 +6297,73 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -6033,6 +6374,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hono": {
@@ -6154,6 +6506,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -6179,6 +6540,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -6238,6 +6611,21 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -6255,7 +6643,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6335,21 +6722,6 @@
         "ws": "*"
       }
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6415,7 +6787,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6810,6 +7181,18 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -6853,6 +7236,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -6873,6 +7267,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merkle-lib": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+      "integrity": "sha512-XrNQvUbn1DL5hKNe46Ccs+Tu3/PYOlrcZILuGUhb95oKBPjc/nmIC8D462PQkipVDGKRvwhn+QFg2cCdIvmDJA==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6937,6 +7337,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -7012,6 +7424,12 @@
         "once": "^1.4.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7485,6 +7903,15 @@
       "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
       "license": "MIT"
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -7561,7 +7988,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-warning": {
@@ -7646,6 +8072,15 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -7680,6 +8115,15 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -7804,6 +8248,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rolldown": {
@@ -8005,7 +8462,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -8024,6 +8480,26 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8510,6 +8986,29 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8562,6 +9061,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/to-regex-range": {
@@ -8650,10 +9163,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9259,6 +9793,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -9274,6 +9829,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "<3.0.0"
+      }
+    },
+    "node_modules/wif/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   "license": "MIT",
   "dependencies": {
     "@kamino-finance/klend-sdk": "^7.3.22",
+    "@ledgerhq/hw-app-btc": "^10.21.1",
     "@ledgerhq/hw-app-solana": "^7.10.1",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport-node-hid": "^6.32.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
   pairLedgerLive,
   pairLedgerTron,
   pairLedgerSolana,
+  pairLedgerBitcoin,
   prepareSolanaNativeSend,
   prepareSolanaSplSend,
   prepareSolanaNonceInit,
@@ -114,6 +115,7 @@ import {
   pairLedgerLiveInput,
   pairLedgerTronInput,
   pairLedgerSolanaInput,
+  pairLedgerBitcoinInput,
   prepareSolanaNativeSendInput,
   prepareSolanaSplSendInput,
   prepareSolanaNonceInitInput,
@@ -1358,6 +1360,21 @@ async function main() {
       inputSchema: pairLedgerSolanaInput.shape,
     },
     handler(pairLedgerSolana)
+  );
+
+  server.registerTool(
+    "pair_ledger_btc",
+    {
+      description:
+        "Pair the host's directly-connected Ledger device for Bitcoin signing. REQUIREMENTS: Ledger plugged in over USB, device unlocked, the 'Bitcoin' app open on-screen. Ledger Live's WalletConnect relay does NOT expose `bip122` accounts to dApps, so Bitcoin signing goes over USB HID via `@ledgerhq/hw-app-btc` (same USB path as Solana / TRON). " +
+        "ONE CALL ENUMERATES ALL FOUR ADDRESS TYPES for the requested `accountIndex` (default 0): " +
+        "legacy P2PKH (`44'/0'/<n>'/0/0` → `1...`), P2SH-wrapped segwit (`49'/0'/<n>'/0/0` → `3...`), " +
+        "native segwit P2WPKH (`84'/0'/<n>'/0/0` → `bc1q...`), and taproot P2TR (`86'/0'/<n>'/0/0` → `bc1p...`). " +
+        "All four are cached so `get_ledger_status` can report them under the `bitcoin: [...]` section. " +
+        "Call again with a different `accountIndex` to expose additional accounts. Read-only on the device — the Ledger BTC app does not prompt during `getWalletPublicKey` by default. Phase 1 is mainnet-only.",
+      inputSchema: pairLedgerBitcoinInput.shape,
+    },
+    handler(pairLedgerBitcoin)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -77,6 +77,7 @@ import { getTokenPrice } from "../../data/prices.js";
 import type {
   PairLedgerTronArgs,
   PairLedgerSolanaArgs,
+  PairLedgerBitcoinArgs,
   PrepareAaveSupplyArgs,
   PrepareAaveWithdrawArgs,
   PrepareAaveBorrowArgs,
@@ -233,6 +234,75 @@ export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
  * device address at path `44'/501'/<accountIndex>'` (default 0 = first
  * Ledger Live Solana account).
  */
+/**
+ * Pair the host's directly-connected Ledger device for Bitcoin signing.
+ * Same USB-HID rationale as `pair_ledger_solana` and `pair_ledger_tron`:
+ * Ledger Live's WalletConnect relay does not expose `bip122` accounts
+ * to dApps, so Bitcoin signing happens over USB HID. The Ledger must be
+ * plugged in, unlocked, with the Bitcoin app open.
+ *
+ * One call enumerates ALL FOUR address types (legacy / p2sh-segwit /
+ * segwit / taproot) for the given account index — the user sees their
+ * full footprint per Ledger Live Bitcoin account in a single round-trip.
+ * Each derivation is just `getWalletPublicKey` (read-only); no on-device
+ * confirmation is requested by default. Subsequent calls with different
+ * `accountIndex` values expose more accounts.
+ */
+export async function pairLedgerBitcoin(args: PairLedgerBitcoinArgs = {}): Promise<{
+  accountIndex: number;
+  appVersion: string;
+  addresses: Array<{
+    addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+    address: string;
+    path: string;
+  }>;
+  instructions: string;
+}> {
+  const accountIndex = args.accountIndex ?? 0;
+  const { deriveBtcLedgerAccount, setPairedBtcAddress } = await import(
+    "../../signing/btc-usb-signer.js"
+  );
+  let derived;
+  try {
+    derived = await deriveBtcLedgerAccount(accountIndex);
+  } catch (e) {
+    // Same enrichment pattern as pairLedgerTron / pairLedgerSolana —
+    // probe which app is currently open so the agent can tell the user
+    // to switch to Bitcoin.
+    const hint = await getDeviceStateHint("Bitcoin");
+    if (hint && e instanceof Error) {
+      throw new Error(`${e.message} ${hint}`, { cause: e });
+    }
+    throw e;
+  }
+  for (const entry of derived.entries) {
+    setPairedBtcAddress({
+      address: entry.address,
+      publicKey: entry.publicKey,
+      path: entry.path,
+      appVersion: entry.appVersion,
+      addressType: entry.addressType,
+      accountIndex: entry.accountIndex,
+    });
+  }
+  return {
+    accountIndex,
+    appVersion: derived.appVersion,
+    addresses: derived.entries.map((e) => ({
+      addressType: e.addressType,
+      address: e.address,
+      path: e.path,
+    })),
+    instructions:
+      "Bitcoin account paired. All four standard mainnet address types " +
+      "(legacy / p2sh-segwit / segwit / taproot) for this index are now cached. " +
+      "Use `get_btc_balance` / `get_btc_balances` / `get_btc_tx_history` against " +
+      "any of the four addresses. Send + message-signing flows ship in Phase 1 PR3/PR4. " +
+      "Keep the Ledger plugged in with the Bitcoin app open — every device call " +
+      "re-opens USB and re-verifies the path → address mapping.",
+  };
+}
+
 export async function pairLedgerSolana(
   args: PairLedgerSolanaArgs = {},
 ): Promise<{

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -40,6 +40,23 @@ export const pairLedgerSolanaInput = z.object({
     ),
 });
 
+export const pairLedgerBitcoinInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "Ledger Bitcoin account slot. One call enumerates ALL FOUR address types " +
+        "for the given index (legacy at `44'/0'/<n>'/0/0`, p2sh-segwit at " +
+        "`49'/0'/<n>'/0/0`, native segwit at `84'/0'/<n>'/0/0`, taproot at " +
+        "`86'/0'/<n>'/0/0`) so the user sees their full footprint per Ledger Live " +
+        "Bitcoin account. 0 = first Bitcoin account, 1 = second, etc. Omit for the " +
+        "default (index 0). Call again with a different index to expose more accounts."
+    ),
+});
+
 const solanaAddressSchema = z
   .string()
   .regex(SOLANA_ADDRESS)
@@ -817,6 +834,7 @@ export const getVerificationArtifactInput = z.object({
 
 export type PairLedgerTronArgs = z.infer<typeof pairLedgerTronInput>;
 export type PairLedgerSolanaArgs = z.infer<typeof pairLedgerSolanaInput>;
+export type PairLedgerBitcoinArgs = z.infer<typeof pairLedgerBitcoinInput>;
 export type PrepareSolanaNativeSendArgs = z.infer<typeof prepareSolanaNativeSendInput>;
 export type PrepareSolanaSplSendArgs = z.infer<typeof prepareSolanaSplSendInput>;
 export type PrepareSolanaNonceInitArgs = z.infer<typeof prepareSolanaNonceInitInput>;

--- a/src/signing/btc-usb-loader.ts
+++ b/src/signing/btc-usb-loader.ts
@@ -1,0 +1,90 @@
+import { createRequire } from "node:module";
+
+/**
+ * Thin loader that brings the Ledger Bitcoin packages in via CommonJS.
+ * Same ESM/CJS-interop reason as `solana-usb-loader.ts` /
+ * `tron-usb-loader.ts`: `@ledgerhq/hw-transport-node-hid` ships an ESM
+ * build whose imports omit `.js` extensions, which Node's ESM loader
+ * rejects. The CJS build resolves cleanly.
+ *
+ * Isolating the `require()` here lets tests
+ * `vi.mock("../signing/btc-usb-loader.js")` with a fake `openLedger()` and
+ * avoid touching the Ledger SDK entirely.
+ */
+
+export type BtcAddressFormat = "legacy" | "p2sh" | "bech32" | "bech32m";
+
+export interface BtcLedgerTransport {
+  close(): Promise<void>;
+}
+
+export interface BtcLedgerApp {
+  /**
+   * Returns the public key + address at the BIP-32 path for the given
+   * address format. Pass `verify: true` to have the Ledger show the
+   * address on-screen for user confirmation (used during pairing).
+   *
+   * `bitcoinAddress` is encoded for the requested format:
+   *   - `legacy`   → P2PKH (`1...`)
+   *   - `p2sh`     → P2SH-wrapped segwit (`3...`)
+   *   - `bech32`   → native segwit P2WPKH (`bc1q...`)
+   *   - `bech32m`  → taproot P2TR (`bc1p...`)
+   */
+  getWalletPublicKey(
+    path: string,
+    opts?: { verify?: boolean; format?: BtcAddressFormat },
+  ): Promise<{
+    publicKey: string;
+    bitcoinAddress: string;
+    chainCode: string;
+  }>;
+  /**
+   * Sign a Bitcoin Signed Message (BIP-137 for legacy, BIP-322 for
+   * segwit/taproot — the Ledger BTC app picks the right shape based on
+   * the path's purpose). Used by `sign_message_btc` (PR4).
+   */
+  signMessage(
+    path: string,
+    messageHex: string,
+  ): Promise<{ v: number; r: string; s: string }>;
+}
+
+export interface BtcAppAndVersion {
+  name: string;
+  version: string;
+}
+
+const requireCjs = createRequire(import.meta.url);
+
+export async function openLedger(): Promise<{
+  app: BtcLedgerApp;
+  transport: BtcLedgerTransport;
+  // The bare transport is needed for `getAppAndVersion` (a standalone
+  // function in the SDK that talks the dashboard CLA, not a Btc-class method).
+  rawTransport: unknown;
+}> {
+  const TransportNodeHid = requireCjs("@ledgerhq/hw-transport-node-hid").default;
+  const Btc = requireCjs("@ledgerhq/hw-app-btc").default;
+  const transport = (await TransportNodeHid.open("")) as BtcLedgerTransport & {
+    close(): Promise<void>;
+  };
+  // Newer hw-app-btc constructor takes `{ transport, currency }`. The
+  // legacy single-arg form (just `transport`) still works in v10 but is
+  // deprecated; use the object form.
+  const app = new Btc({ transport, currency: "bitcoin" }) as BtcLedgerApp;
+  return { app, transport, rawTransport: transport };
+}
+
+/**
+ * Surface the open app's name + version. Standalone function in the SDK
+ * (talks the dashboard CLA APDU); reused so the pairing flow can stamp
+ * `appVersion` on the cached entry.
+ */
+export async function getAppAndVersion(
+  rawTransport: unknown,
+): Promise<BtcAppAndVersion> {
+  const mod = requireCjs("@ledgerhq/hw-app-btc/lib/getAppAndVersion");
+  const fn = mod.getAppAndVersion;
+  const out = await fn(rawTransport as never);
+  return { name: out.name, version: out.version };
+}

--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -1,0 +1,282 @@
+import { existsSync } from "node:fs";
+import {
+  openLedger,
+  getAppAndVersion,
+  type BtcAddressFormat,
+  type BtcLedgerTransport,
+} from "./btc-usb-loader.js";
+import { getConfigPath, patchUserConfig, readUserConfig } from "../config/user-config.js";
+import type { PairedBitcoinEntry } from "../types/index.js";
+
+export type { PairedBitcoinEntry };
+
+/**
+ * Bitcoin BIP-44/49/84/86 paths — one purpose per address format. Per
+ * SLIP-44 + the relevant BIPs:
+ *
+ *   - BIP-44 (legacy P2PKH):              `44'/0'/<account>'/0/0`
+ *   - BIP-49 (P2SH-wrapped segwit):       `49'/0'/<account>'/0/0`
+ *   - BIP-84 (native segwit P2WPKH):      `84'/0'/<account>'/0/0`
+ *   - BIP-86 (taproot P2TR):              `86'/0'/<account>'/0/0`
+ *
+ * Path layout matches Ledger Live's so account-index 0 in this server
+ * corresponds to the first Bitcoin account in Ledger Live for each
+ * address type.
+ *
+ * The 5-segment shape (`<purpose>'/0'/<account>'/0/0`) drills all the way
+ * to the first receive address (`change=0, index=0`). The Ledger BTC app
+ * accepts any prefix (down to `m/<purpose>'/0'/<account>'`) for the
+ * account-level xpub; for our pair-and-cache flow we ask for the leaf
+ * receive address directly so the user sees a concrete `bc1p…` value
+ * during pairing rather than an xpub.
+ */
+const MAX_BTC_ACCOUNT_INDEX = 100;
+
+export const BTC_ADDRESS_TYPES = [
+  "legacy",
+  "p2sh-segwit",
+  "segwit",
+  "taproot",
+] as const;
+
+export type BtcAddressType = (typeof BTC_ADDRESS_TYPES)[number];
+
+/**
+ * Map our address-type label → Ledger BTC app's `format` enum + the
+ * BIP-44 purpose number. Single source of truth so paths and formats
+ * never drift.
+ */
+const TYPE_META: Record<
+  BtcAddressType,
+  { purpose: number; format: BtcAddressFormat }
+> = {
+  legacy: { purpose: 44, format: "legacy" },
+  "p2sh-segwit": { purpose: 49, format: "p2sh" },
+  segwit: { purpose: 84, format: "bech32" },
+  taproot: { purpose: 86, format: "bech32m" },
+};
+
+export function btcPathForAccountIndex(
+  accountIndex: number,
+  addressType: BtcAddressType,
+): string {
+  if (
+    !Number.isInteger(accountIndex) ||
+    accountIndex < 0 ||
+    accountIndex > MAX_BTC_ACCOUNT_INDEX
+  ) {
+    throw new Error(
+      `Invalid Bitcoin accountIndex ${accountIndex} — must be an integer in [0, ${MAX_BTC_ACCOUNT_INDEX}].`,
+    );
+  }
+  const { purpose } = TYPE_META[addressType];
+  return `${purpose}'/0'/${accountIndex}'/0/0`;
+}
+
+const BTC_PATH_RE = /^(44|49|84|86)'\/0'\/(\d+)'\/0\/0$/;
+
+/**
+ * Parse the address type + account index out of a BTC BIP-44 path.
+ * Returns null when the path doesn't match the standard 5-segment
+ * `<purpose>'/0'/<account>'/0/0` shape — a custom path we'd cache but
+ * couldn't index.
+ */
+export function parseBtcPath(
+  path: string,
+): { addressType: BtcAddressType; accountIndex: number } | null {
+  const m = BTC_PATH_RE.exec(path);
+  if (!m) return null;
+  const purpose = Number(m[1]);
+  const accountIndex = Number(m[2]);
+  if (!Number.isInteger(accountIndex)) return null;
+  for (const t of BTC_ADDRESS_TYPES) {
+    if (TYPE_META[t].purpose === purpose) {
+      return { addressType: t, accountIndex };
+    }
+  }
+  return null;
+}
+
+/**
+ * Module-local serialization for HID transport calls. USB-HID is
+ * single-tenant — opening a second transport while the first is in
+ * flight throws "device busy". Same primitive Solana / TRON signers use.
+ */
+let usbLock: Promise<void> = Promise.resolve();
+export async function withBtcUsbLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = usbLock;
+  let release!: () => void;
+  usbLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+interface DerivedAddress {
+  address: string;
+  publicKey: string;
+  path: string;
+  appVersion: string;
+  addressType: BtcAddressType;
+  accountIndex: number;
+}
+
+/**
+ * Open the BTC app, derive the address at `path` for `addressType`, and
+ * close. Single round-trip per call. The caller is responsible for
+ * batching when deriving multiple paths — `pair_ledger_btc` reuses the
+ * same transport for all four BIP-44 / BIP-49 / BIP-84 / BIP-86 paths.
+ */
+export async function getBtcLedgerAddress(
+  path: string,
+  addressType: BtcAddressType,
+): Promise<DerivedAddress> {
+  return withBtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Bitcoin" &&
+        appVer.name !== "Bitcoin Test" &&
+        appVer.name !== "BTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Bitcoin is required. ` +
+            `Open the Bitcoin app on your device and retry.`,
+        );
+      }
+      const { format } = TYPE_META[addressType];
+      const out = await app.getWalletPublicKey(path, { format });
+      const parsed = parseBtcPath(path);
+      const accountIndex = parsed?.accountIndex ?? 0;
+      return {
+        address: out.bitcoinAddress,
+        publicKey: out.publicKey,
+        path,
+        appVersion: appVer.version,
+        addressType,
+        accountIndex,
+      };
+    } finally {
+      await (transport as BtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * Derive ALL four address types for one account index in a single
+ * USB-HID session. Reuses the open transport so the user only sees one
+ * "approve on device" prompt per type if they have `display: true`
+ * configured (we don't pass it in pairing — Ledger's BTC app shows the
+ * derivation on-screen on signing, not on derivation by default).
+ */
+export async function deriveBtcLedgerAccount(
+  accountIndex: number,
+): Promise<{ appVersion: string; entries: DerivedAddress[] }> {
+  return withBtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Bitcoin" &&
+        appVer.name !== "Bitcoin Test" &&
+        appVer.name !== "BTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Bitcoin is required. ` +
+            `Open the Bitcoin app on your device and retry.`,
+        );
+      }
+      const entries: DerivedAddress[] = [];
+      for (const addressType of BTC_ADDRESS_TYPES) {
+        const path = btcPathForAccountIndex(accountIndex, addressType);
+        const { format } = TYPE_META[addressType];
+        const out = await app.getWalletPublicKey(path, { format });
+        entries.push({
+          address: out.bitcoinAddress,
+          publicKey: out.publicKey,
+          path,
+          appVersion: appVer.version,
+          addressType,
+          accountIndex,
+        });
+      }
+      return { appVersion: appVer.version, entries };
+    } finally {
+      await (transport as BtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+// --- Pairing cache --------------------------------------------------------
+
+const pairedBtcByPath = new Map<string, PairedBitcoinEntry>();
+let pairedBtcHydrated = false;
+
+function ensurePairedBtcHydrated(): void {
+  if (pairedBtcHydrated) return;
+  pairedBtcHydrated = true;
+  const persisted = readUserConfig()?.pairings?.bitcoin ?? [];
+  for (const entry of persisted) {
+    pairedBtcByPath.set(entry.path, entry);
+  }
+}
+
+function persistPairedBtc(): void {
+  patchUserConfig({
+    pairings: { bitcoin: Array.from(pairedBtcByPath.values()) },
+  });
+}
+
+export function getPairedBtcAddresses(): PairedBitcoinEntry[] {
+  ensurePairedBtcHydrated();
+  return Array.from(pairedBtcByPath.values()).sort((a, b) => {
+    // Sort by accountIndex first, then by purpose so each account's four
+    // address types appear together (legacy → p2sh-segwit → segwit →
+    // taproot, the BIP-44 purpose order).
+    if (a.accountIndex !== b.accountIndex) {
+      if (a.accountIndex === null) return 1;
+      if (b.accountIndex === null) return -1;
+      return a.accountIndex - b.accountIndex;
+    }
+    return BTC_ADDRESS_TYPES.indexOf(a.addressType) - BTC_ADDRESS_TYPES.indexOf(b.addressType);
+  });
+}
+
+export function getPairedBtcByAddress(address: string): PairedBitcoinEntry | null {
+  ensurePairedBtcHydrated();
+  for (const entry of pairedBtcByPath.values()) {
+    if (entry.address === address) return entry;
+  }
+  return null;
+}
+
+export function setPairedBtcAddress(
+  entry: Omit<PairedBitcoinEntry, "accountIndex"> & { accountIndex: number | null },
+): PairedBitcoinEntry {
+  ensurePairedBtcHydrated();
+  const full: PairedBitcoinEntry = {
+    address: entry.address,
+    publicKey: entry.publicKey,
+    path: entry.path,
+    appVersion: entry.appVersion,
+    addressType: entry.addressType,
+    accountIndex: entry.accountIndex,
+  };
+  pairedBtcByPath.set(entry.path, full);
+  persistPairedBtc();
+  return full;
+}
+
+export function clearPairedBtcAddresses(): void {
+  pairedBtcByPath.clear();
+  pairedBtcHydrated = false;
+  if (existsSync(getConfigPath())) {
+    patchUserConfig({ pairings: { bitcoin: [] } });
+  }
+}

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -6,6 +6,7 @@ import {
 } from "./walletconnect.js";
 import { getPairedTronAddresses } from "./tron-usb-signer.js";
 import { getPairedSolanaAddresses } from "./solana-usb-signer.js";
+import { getPairedBtcAddresses } from "./btc-usb-signer.js";
 import type { SupportedChain } from "../types/index.js";
 
 export interface SessionAccount {
@@ -106,6 +107,22 @@ export interface SessionStatus {
     path: string;
     appVersion: string;
     /** Null when the path is not in the standard `44'/501'/<n>'` layout. */
+    accountIndex: number | null;
+  }>;
+  /**
+   * Bitcoin pairings — typically four entries per accountIndex, one per
+   * address type (legacy / p2sh-segwit / segwit / taproot). Same
+   * USB-HID rationale as Solana / TRON: Ledger Live's WalletConnect
+   * relay doesn't expose `bip122`. Ordered by accountIndex then by
+   * address-type purpose. Absent/empty → agent should call
+   * `pair_ledger_btc` before any Bitcoin tool.
+   */
+  bitcoin?: Array<{
+    address: string;
+    path: string;
+    appVersion: string;
+    addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+    /** Null when the path doesn't match the standard 5-segment layout. */
     accountIndex: number | null;
   }>;
 }
@@ -226,6 +243,19 @@ export async function getSessionStatus(): Promise<SessionStatus> {
           })),
         }
       : {};
+  const btcPaired = getPairedBtcAddresses();
+  const btcSection =
+    btcPaired.length > 0
+      ? {
+          bitcoin: btcPaired.map((e) => ({
+            address: e.address,
+            path: e.path,
+            appVersion: e.appVersion,
+            addressType: e.addressType,
+            accountIndex: e.accountIndex,
+          })),
+        }
+      : {};
   if (!session)
     return {
       paired: false,
@@ -235,6 +265,7 @@ export async function getSessionStatus(): Promise<SessionStatus> {
       pairingInstructions: ledgerLivePairingInstructions(undefined),
       ...tronSection,
       ...solanaSection,
+      ...btcSection,
     };
   const accountDetails = await getConnectedAccountsDetailed();
   const accounts = accountDetails.map((a) => a.address);
@@ -264,5 +295,6 @@ export async function getSessionStatus(): Promise<SessionStatus> {
       : {}),
     ...tronSection,
     ...solanaSection,
+    ...btcSection,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1074,6 +1074,30 @@ export interface PairedTronEntry {
   accountIndex: number | null;
 }
 
+/**
+ * Bitcoin pairing entry. Bitcoin has 4 standard mainnet address types,
+ * each on its own BIP-44 purpose (BIP-44 / BIP-49 / BIP-84 / BIP-86),
+ * so a single account index produces 4 entries — one per type. The
+ * `addressType` discriminator tells callers which path generated this
+ * address without re-parsing the path.
+ */
+export interface PairedBitcoinEntry {
+  address: string;
+  publicKey: string;
+  path: string;
+  appVersion: string;
+  /**
+   * Discriminator for the four standard mainnet address shapes:
+   *   - "legacy"      → BIP-44 P2PKH (`1...`)
+   *   - "p2sh-segwit" → BIP-49 P2SH-wrapped segwit (`3...`)
+   *   - "segwit"      → BIP-84 native segwit P2WPKH (`bc1q...`)
+   *   - "taproot"     → BIP-86 P2TR (`bc1p...`)
+   */
+  addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+  /** Null when the path doesn't match the standard 5-segment layout. */
+  accountIndex: number | null;
+}
+
 export interface UserConfig {
   rpc: {
     provider: RpcProvider;
@@ -1125,5 +1149,11 @@ export interface UserConfig {
   pairings?: {
     solana?: PairedSolanaEntry[];
     tron?: PairedTronEntry[];
+    /**
+     * Bitcoin pairings — typically four entries per accountIndex, one
+     * per address type (legacy / p2sh-segwit / segwit / taproot). Same
+     * write-through-to-disk semantics as the Solana / TRON slices.
+     */
+    bitcoin?: PairedBitcoinEntry[];
   };
 }

--- a/test/btc-pair.test.ts
+++ b/test/btc-pair.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+/**
+ * Bitcoin USB-HID pairing tests (Phase 1 PR2). Mocks the Ledger BTC SDK
+ * via `vi.mock("../src/signing/btc-usb-loader.js")` so the test never
+ * touches real USB. Pairing entries persist to ~/.vaultpilot-mcp/config.json,
+ * so each test redirects the config dir to a fresh tmp dir.
+ */
+
+const LEGACY_ADDR = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const P2SH_ADDR = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const TAPROOT_ADDR =
+  "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg";
+const FAKE_PUBKEY = "0".repeat(66);
+const FAKE_CHAIN_CODE = "0".repeat(64);
+
+const getWalletPublicKeyMock = vi.fn();
+const signMessageMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+const getAppAndVersionMock = vi.fn();
+
+vi.mock("../src/signing/btc-usb-loader.js", () => ({
+  openLedger: async () => ({
+    app: {
+      getWalletPublicKey: getWalletPublicKeyMock,
+      signMessage: signMessageMock,
+    },
+    transport: { close: transportCloseMock },
+    rawTransport: {},
+  }),
+  getAppAndVersion: (rt: unknown) => getAppAndVersionMock(rt),
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-btc-pair-"));
+  setConfigDirForTesting(tmpHome);
+  getWalletPublicKeyMock.mockReset();
+  signMessageMock.mockReset();
+  transportCloseMock.mockClear();
+  getAppAndVersionMock.mockReset();
+  const { clearPairedBtcAddresses } = await import(
+    "../src/signing/btc-usb-signer.js"
+  );
+  clearPairedBtcAddresses();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("btcPathForAccountIndex", () => {
+  it("produces the standard 5-segment BIP-44/49/84/86 paths", async () => {
+    const { btcPathForAccountIndex } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    expect(btcPathForAccountIndex(0, "legacy")).toBe("44'/0'/0'/0/0");
+    expect(btcPathForAccountIndex(0, "p2sh-segwit")).toBe("49'/0'/0'/0/0");
+    expect(btcPathForAccountIndex(0, "segwit")).toBe("84'/0'/0'/0/0");
+    expect(btcPathForAccountIndex(0, "taproot")).toBe("86'/0'/0'/0/0");
+    expect(btcPathForAccountIndex(7, "taproot")).toBe("86'/0'/7'/0/0");
+  });
+
+  it("rejects invalid account indices", async () => {
+    const { btcPathForAccountIndex } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    expect(() => btcPathForAccountIndex(-1, "taproot")).toThrow(/Invalid Bitcoin accountIndex/);
+    expect(() => btcPathForAccountIndex(101, "taproot")).toThrow();
+    expect(() => btcPathForAccountIndex(1.5, "taproot")).toThrow();
+  });
+});
+
+describe("parseBtcPath", () => {
+  it("decodes standard paths back into address-type + accountIndex", async () => {
+    const { parseBtcPath } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    expect(parseBtcPath("44'/0'/0'/0/0")).toEqual({
+      addressType: "legacy",
+      accountIndex: 0,
+    });
+    expect(parseBtcPath("49'/0'/3'/0/0")).toEqual({
+      addressType: "p2sh-segwit",
+      accountIndex: 3,
+    });
+    expect(parseBtcPath("84'/0'/7'/0/0")).toEqual({
+      addressType: "segwit",
+      accountIndex: 7,
+    });
+    expect(parseBtcPath("86'/0'/12'/0/0")).toEqual({
+      addressType: "taproot",
+      accountIndex: 12,
+    });
+  });
+
+  it("returns null on non-standard paths", async () => {
+    const { parseBtcPath } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    // Wrong purpose (mainnet only — no testnet purpose=1).
+    expect(parseBtcPath("44'/1'/0'/0/0")).toBeNull();
+    // Wrong segment count (account-level xpub path, not leaf).
+    expect(parseBtcPath("84'/0'/0'")).toBeNull();
+    // Garbage.
+    expect(parseBtcPath("not-a-path")).toBeNull();
+  });
+});
+
+describe("pairLedgerBitcoin", () => {
+  it("derives all four address types in one call and persists each entry", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    // Ledger BTC app returns one address per format. Map by format string.
+    getWalletPublicKeyMock.mockImplementation(
+      async (_path: string, opts: { format: string }) => {
+        const addr =
+          opts.format === "legacy"
+            ? LEGACY_ADDR
+            : opts.format === "p2sh"
+              ? P2SH_ADDR
+              : opts.format === "bech32"
+                ? SEGWIT_ADDR
+                : TAPROOT_ADDR;
+        return { publicKey: FAKE_PUBKEY, bitcoinAddress: addr, chainCode: FAKE_CHAIN_CODE };
+      },
+    );
+
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await pairLedgerBitcoin({ accountIndex: 0 });
+
+    expect(out.accountIndex).toBe(0);
+    expect(out.appVersion).toBe("2.2.3");
+    expect(out.addresses).toHaveLength(4);
+    const byType = Object.fromEntries(out.addresses.map((a) => [a.addressType, a]));
+    expect(byType.legacy.address).toBe(LEGACY_ADDR);
+    expect(byType.legacy.path).toBe("44'/0'/0'/0/0");
+    expect(byType["p2sh-segwit"].address).toBe(P2SH_ADDR);
+    expect(byType["p2sh-segwit"].path).toBe("49'/0'/0'/0/0");
+    expect(byType.segwit.address).toBe(SEGWIT_ADDR);
+    expect(byType.segwit.path).toBe("84'/0'/0'/0/0");
+    expect(byType.taproot.address).toBe(TAPROOT_ADDR);
+    expect(byType.taproot.path).toBe("86'/0'/0'/0/0");
+
+    // Cached + persisted: get_ledger_status's btc section should now
+    // surface all four entries.
+    const { getPairedBtcAddresses } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const cached = getPairedBtcAddresses();
+    expect(cached).toHaveLength(4);
+    expect(cached.map((e) => e.addressType)).toEqual([
+      "legacy",
+      "p2sh-segwit",
+      "segwit",
+      "taproot",
+    ]);
+    expect(cached.every((e) => e.accountIndex === 0)).toBe(true);
+    expect(cached.every((e) => e.appVersion === "2.2.3")).toBe(true);
+
+    // Single transport open + close (deriveBtcLedgerAccount reuses it).
+    expect(transportCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses when the wrong app is open on-device", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Ethereum", version: "1.10.4" });
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(pairLedgerBitcoin({ accountIndex: 0 })).rejects.toThrow(
+      /open app as "Ethereum".*Bitcoin is required/,
+    );
+  });
+
+  it("survives multiple pairings at different account indices", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    let callCount = 0;
+    getWalletPublicKeyMock.mockImplementation(async (path: string) => {
+      callCount++;
+      // Synthesize a unique-looking address per call. Real validation
+      // happens in the regex; we just need the bench32m prefix for the
+      // taproot case below to round-trip.
+      const idx = callCount.toString().padStart(2, "0");
+      return {
+        publicKey: FAKE_PUBKEY,
+        bitcoinAddress: path.startsWith("44'")
+          ? `1FakeAddr${idx}vH1nADuVeoUaqcJBZ1Yp`
+          : path.startsWith("49'")
+            ? `3FakeAddr${idx}vH1nADuVeoUaqcJBZ1Yp`
+            : path.startsWith("84'")
+              ? `bc1qfakeaddr${idx}vh1naduveoaqcjbz1ypqsxz3yrm`
+              : `bc1pfakeaddr${idx}vh1naduveoaqcjbz1ypqsxz3yrm`,
+        chainCode: FAKE_CHAIN_CODE,
+      };
+    });
+
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await pairLedgerBitcoin({ accountIndex: 0 });
+    await pairLedgerBitcoin({ accountIndex: 1 });
+
+    const { getPairedBtcAddresses } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const cached = getPairedBtcAddresses();
+    expect(cached).toHaveLength(8); // 2 accounts × 4 types
+    // Sorted by accountIndex first, then by purpose order.
+    expect(cached.map((e) => e.accountIndex)).toEqual([0, 0, 0, 0, 1, 1, 1, 1]);
+    expect(cached.slice(0, 4).map((e) => e.addressType)).toEqual([
+      "legacy",
+      "p2sh-segwit",
+      "segwit",
+      "taproot",
+    ]);
+  });
+});
+
+describe("get_ledger_status — btc section", () => {
+  it("surfaces paired BTC entries when at least one is cached", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    getWalletPublicKeyMock.mockImplementation(
+      async (_path: string, opts: { format: string }) => ({
+        publicKey: FAKE_PUBKEY,
+        bitcoinAddress:
+          opts.format === "legacy"
+            ? LEGACY_ADDR
+            : opts.format === "p2sh"
+              ? P2SH_ADDR
+              : opts.format === "bech32"
+                ? SEGWIT_ADDR
+                : TAPROOT_ADDR,
+        chainCode: FAKE_CHAIN_CODE,
+      }),
+    );
+
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await pairLedgerBitcoin({ accountIndex: 0 });
+
+    const { getSessionStatus } = await import("../src/signing/session.js");
+    const status = await getSessionStatus();
+    expect(status.bitcoin).toBeDefined();
+    expect(status.bitcoin?.length).toBe(4);
+    const byType = Object.fromEntries(
+      (status.bitcoin ?? []).map((e) => [e.addressType, e]),
+    );
+    expect(byType.taproot.address).toBe(TAPROOT_ADDR);
+    expect(byType.segwit.path).toBe("84'/0'/0'/0/0");
+  });
+
+  it("omits the btc section when no Bitcoin pairings are cached", async () => {
+    const { getSessionStatus } = await import("../src/signing/session.js");
+    const status = await getSessionStatus();
+    expect(status.bitcoin).toBeUndefined();
+  });
+});

--- a/test/btc-pair.test.ts
+++ b/test/btc-pair.test.ts
@@ -226,6 +226,18 @@ describe("pairLedgerBitcoin", () => {
 
 describe("get_ledger_status — btc section", () => {
   it("surfaces paired BTC entries when at least one is cached", async () => {
+    // Reset the module cache + stub walletconnect so getSessionStatus's
+    // getSignClient() call doesn't try to resolve a WC project ID under
+    // CI (where WALLETCONNECT_PROJECT_ID is unset). Mirrors the TRON
+    // get-ledger-status test's pattern.
+    vi.resetModules();
+    vi.doMock("../src/signing/walletconnect.js", () => ({
+      getSignClient: async () => ({}),
+      getCurrentSession: () => null,
+      getConnectedAccountsDetailed: async () => [],
+      isPeerUnreachable: () => false,
+    }));
+
     getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
     getWalletPublicKeyMock.mockImplementation(
       async (_path: string, opts: { format: string }) => ({
@@ -259,6 +271,13 @@ describe("get_ledger_status — btc section", () => {
   });
 
   it("omits the btc section when no Bitcoin pairings are cached", async () => {
+    vi.resetModules();
+    vi.doMock("../src/signing/walletconnect.js", () => ({
+      getSignClient: async () => ({}),
+      getCurrentSession: () => null,
+      getConnectedAccountsDetailed: async () => [],
+      isPeerUnreachable: () => false,
+    }));
     const { getSessionStatus } = await import("../src/signing/session.js");
     const status = await getSessionStatus();
     expect(status.bitcoin).toBeUndefined();


### PR DESCRIPTION
## Summary

Second step of Bitcoin support per `claude-work/plan-bitcoin-ledger-phase1.md`. Adds pairing infrastructure; sends ship in PR3.

```
pair_ledger_btc(accountIndex?)  →  derives ALL FOUR address types
                                   (legacy / p2sh-segwit / segwit /
                                   taproot) for the index in one
                                   USB-HID round-trip
get_ledger_status              →  now surfaces a `bitcoin: [...]`
                                   section parallel to `tron:` and
                                   `solana:`
```

## USB-HID precedent

Same path Solana / TRON took (USB HID via `@ledgerhq/hw-app-btc`) for the same reason: Ledger Live's WalletConnect relay does **not** expose a `bip122` namespace to dApps. Foundation pieces mirror the solana-usb-loader.ts / solana-usb-signer.ts pair:

- `src/signing/btc-usb-loader.ts` (~70 LOC) — CommonJS-loaded SDK shim that lets tests `vi.mock` it cleanly
- `src/signing/btc-usb-signer.ts` (~250 LOC) — path mapping, cache, pairing flow, USB lock

`getAppAndVersion` is loaded as a standalone function from `@ledgerhq/hw-app-btc/lib/getAppAndVersion` (the dashboard CLA APDU, not a Btc-class method) so the loader stamps app version on each entry without speaking the BTC-specific protocol.

## BIP-44 path layout

```
44'/0'/<account>'/0/0  legacy P2PKH  (`1...`)
49'/0'/<account>'/0/0  P2SH-segwit   (`3...`)
84'/0'/<account>'/0/0  native segwit (`bc1q...`)
86'/0'/<account>'/0/0  taproot       (`bc1p...`)
```

Matches Ledger Live's layout so accountIndex 0 = first Bitcoin account in Ledger Live for each address type. 5-segment shape drills to the first receive address (`change=0, index=0`) so pairing surfaces a concrete address per type rather than an account-level xpub.

## Cache + persistence

`PairedBitcoinEntry` extends the Solana / TRON entry shape with an `addressType` discriminator. Same write-through-to-disk semantics: hydrated from `UserConfig.pairings.bitcoin` on first read; `persistPairedBtc` snapshots the in-memory Map to disk via `patchUserConfig` on every set.

## Out of scope this PR (deferred to PR3/PR4)

- PSBT construction + Ledger signing (`signPsbtBuffer`)
- `prepare_btc_send` + `send_transaction` BTC branch
- Coin selection (`coinselect` dep)
- `bitcoinjs-lib` (lands with PR3 PSBT building)
- Portfolio integration
- `sign_message_btc`

## Test plan

- [x] 9 new tests in `test/btc-pair.test.ts` cover: path mapping (4 BIP-44 purposes); path parser round-trip + null on non-standard; pair_ledger_btc happy path (4 derived addresses, formats + paths, persistence); wrong-app rejection; multi-account caching; get_ledger_status surfaces bitcoin section, omits when empty
- [x] `npm run build` clean
- [x] `npx vitest run` — 1018 tests, 84 files, all green

## Deps

Added `@ledgerhq/hw-app-btc@^10.21.1` (transport-node-hid was already present).

## Roadmap status

|  | Bitcoin Phase 1 |
|---|---|
| PR1 | ✅ indexer + balances + fees + tx history (#170) |
| **PR2** | ✅ **this — pair_ledger_btc + USB-HID signer + get_ledger_status ext** |
| PR3 | 🚧 prepare_btc_send (coin-selection + PSBT) + send_transaction |
| PR4 | 🚧 portfolio integration + sign_message_btc |

🤖 Generated with [Claude Code](https://claude.com/claude-code)