### PR TITLE
fix(release): cross-OS smoke test + bump 0.6.1 → 0.7.0

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -114,27 +114,18 @@ jobs:
         env:
           CI: "true"
 
-      - name: Smoke-test server binary (non-Windows)
+      - name: Mark server binary executable (non-Windows)
         if: runner.os != 'Windows'
-        # Pipe a `tools/list` JSON-RPC request into the binary — if it
-        # returns a JSON envelope with `result.tools[]`, the MCP is up.
-        # The `sleep 2` + timeout pattern gives the server time to
-        # respond before the parent closes stdin and we SIGTERM.
-        run: |
-          chmod +x ./release/${{ matrix.server_asset }}
-          (echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'; sleep 3) | \
-            timeout 20 ./release/${{ matrix.server_asset }} | \
-            node -e "const s=require('fs').readFileSync(0,'utf8'); const line=s.split('\n').find(l=>l.startsWith('{')) ?? '{}'; const j=JSON.parse(line); if(!j.result?.tools?.length) { console.error('no tools in response'); process.exit(1); } console.log('tools:', j.result.tools.length);"
+        run: chmod +x ./release/${{ matrix.server_asset }}
 
-      - name: Smoke-test server binary (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $out = '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | & "./release/${{ matrix.server_asset }}"
-          $line = $out -split "`n" | Where-Object { $_.StartsWith("{") } | Select-Object -First 1
-          $json = $line | ConvertFrom-Json
-          if (-not $json.result.tools) { Write-Error "no tools in response"; exit 1 }
-          Write-Host "tools: $($json.result.tools.Count)"
+      - name: Smoke-test server binary
+        # One Node script runs identically on Linux / macOS / Windows.
+        # The previous per-OS shell snippets relied on GNU `timeout`,
+        # which isn't present on macOS by default and would have
+        # required `brew install coreutils` — easier to handle process
+        # spawn + timeout in Node directly. See
+        # `scripts/smoke-test-binary.mjs` for the implementation.
+        run: node scripts/smoke-test-binary.mjs ./release/${{ matrix.server_asset }}
 
       - name: Upload assets to release
         if: github.event_name == 'release'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",

--- a/scripts/smoke-test-binary.mjs
+++ b/scripts/smoke-test-binary.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Cross-OS smoke test for a vaultpilot-mcp release binary.
+ *
+ * Spawns the binary, sends a `tools/list` JSON-RPC request on stdin,
+ * waits up to TIMEOUT_MS for a response that contains a non-empty
+ * `result.tools[]`, then kills the process and exits 0. Any failure
+ * (timeout, crash, missing tools field) exits 1.
+ *
+ * Replaces the previous per-OS shell snippets in
+ * `.github/workflows/release-binaries.yml`. Linux had GNU `timeout`
+ * available; macOS does not by default (would need
+ * `brew install coreutils`); Windows used a separate pwsh path. One
+ * Node script runs identically on all three.
+ *
+ * Usage:
+ *   node scripts/smoke-test-binary.mjs <path-to-binary>
+ */
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const binary = process.argv[2];
+if (!binary) {
+  console.error("usage: node scripts/smoke-test-binary.mjs <binary-path>");
+  process.exit(2);
+}
+
+const TIMEOUT_MS = 20_000;
+const REQUEST = '{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n';
+
+const proc = spawn(binary, [], { stdio: ["pipe", "pipe", "pipe"] });
+
+let buf = "";
+let done = false;
+
+const timer = setTimeout(() => {
+  if (done) return;
+  console.error(`smoke test timed out after ${TIMEOUT_MS}ms`);
+  proc.kill();
+  process.exit(1);
+}, TIMEOUT_MS);
+
+proc.stdout.on("data", (chunk) => {
+  if (done) return;
+  buf += chunk.toString("utf8");
+  // The binary may print warnings on stderr (handled below) and a JSON
+  // envelope on stdout. Walk completed lines until we find one parseable
+  // as a JSON-RPC result with a non-empty tools array.
+  const lines = buf.split("\n");
+  buf = lines.pop() ?? ""; // keep partial last line in buffer
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const j = JSON.parse(trimmed);
+      if (Array.isArray(j.result?.tools) && j.result.tools.length > 0) {
+        console.log(`tools: ${j.result.tools.length}`);
+        done = true;
+        clearTimeout(timer);
+        proc.kill();
+        process.exit(0);
+      }
+    } catch {
+      // Partial line or non-JSON; keep reading.
+    }
+  }
+});
+
+// Forward stderr so CI logs show any startup diagnostics from the binary.
+proc.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+proc.on("exit", (code, signal) => {
+  if (done) return;
+  console.error(
+    `binary exited before tools/list response (code=${code} signal=${signal})`,
+  );
+  clearTimeout(timer);
+  process.exit(1);
+});
+
+proc.on("error", (err) => {
+  console.error("failed to spawn binary:", err.message);
+  clearTimeout(timer);
+  process.exit(1);
+});
+
+// Drive the request.
+proc.stdin.write(REQUEST);


### PR DESCRIPTION
## Summary
Two changes bundled because they ship together — the workflow fix is what makes a v0.7.0 release actually work, so they belong on the same tag.

**1. Cross-OS smoke test (\`scripts/smoke-test-binary.mjs\`)**

The v0.6.1 release binary matrix produced uneven results: Linux + Windows uploaded their assets, macOS arm64 hit \`exit 1\` at the smoke test step (\`timeout\` binary isn't on macOS's default PATH; would have needed \`brew install coreutils\`), and macOS x64 was still queued on a slow macos-13 runner 26+ minutes in. This PR replaces the three per-OS shell snippets (Linux+macOS \`timeout\`-based, Windows pwsh-based) with one Node script that handles spawn + timeout + JSON parsing identically across all three.

Locally verified against \`./release/vaultpilot-mcp-linux-x64\` — returns \`tools: 91\`, exit 0.

**2. Bump 0.6.1 → 0.7.0**

v0.6.1 was published this morning as a placeholder while the binary matrix was being wired; only Linux + Windows assets actually landed. v0.7.0 is the first release where the bundled-binary distribution will be fully operational across all four target platforms — promoted to a minor bump to reflect that.

## Test plan
- [x] \`node scripts/smoke-test-binary.mjs ./release/vaultpilot-mcp-linux-x64\` → \`tools: 91\` exit 0
- [ ] After merge: tag \`v0.7.0\`, push tag → release-binaries matrix runs on all 4 OSes, 8 assets attached
- [ ] Live test: download macOS arm64 binary on a real Mac, run \`xattr -d com.apple.quarantine\`, smoke-test by piping a tools/list

🤖 Generated with [Claude Code](https://claude.com/claude-code)