### PR TITLE
fix(release): bump server.json to 0.7.0 + idempotent npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,20 @@ jobs:
       - name: Publish to npm
         # Node 22 ships npm 10.x; Trusted Publisher OIDC token exchange
         # needs npm >= 11.5.1, so invoke latest npm via npx just for this step.
-        run: npx --yes npm@latest publish --provenance --access public
+        #
+        # Idempotent guard: if the version is already on npm we no-op
+        # rather than failing. This matters when publish.yml is re-run
+        # via workflow_dispatch after a failure in a downstream step
+        # (e.g. MCP Registry publish failing on a stale server.json) —
+        # the npm side is already done, no point retrying it.
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          REMOTE_VERSION=$(npm view vaultpilot-mcp@${LOCAL_VERSION} version 2>/dev/null || echo "")
+          if [ "$LOCAL_VERSION" = "$REMOTE_VERSION" ]; then
+            echo "vaultpilot-mcp@${LOCAL_VERSION} already on npm — skipping publish."
+          else
+            npx --yes npm@latest publish --provenance --access public
+          fi
 
       - name: Install mcp-publisher
         run: |

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary
\`publish.yml\` failed at the MCP Registry step on v0.7.0:

\`\`\`
Error: publish failed: server returned status 400: {"detail":"Failed to publish server","errors":[{"message":"invalid version: cannot publish duplicate version"}]}
\`\`\`

Root cause: \`server.json\` was still pinned to \`0.6.1\` (npm version \`--no-git-tag-version\` only touches \`package.json\` + \`package-lock.json\`, not \`server.json\`). The MCP registry correctly rejected the duplicate submission since v0.6.1 was already pushed earlier today.

## Fixes
1. **\`server.json\` 0.6.1 → 0.7.0** — both top-level and the npm package entry. The actual fix.
2. **Idempotent npm publish step** — checks \`npm view vaultpilot-mcp@<local>\` before publishing; skips if the version already exists. Otherwise re-running publish.yml after fixing server.json would choke on "you cannot publish over the previously published versions 0.7.0" before reaching the registry step that we actually need to re-run.

## After-merge follow-up
Run \`publish.yml\` via \`workflow_dispatch\` (no inputs) to push v0.7.0 to the MCP registry. The npm step will skip (already at 0.7.0), the registry step will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)