### PR TITLE
chore(release): group binary assets by platform + bump 0.7.0 → 0.7.1

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -51,23 +51,29 @@ jobs:
         # dynamic import under pkg's ESM→CJS transformer. Two binaries
         # keeps both users (MCP runtime, first-run wizard) on the
         # zero-node-install path with no fragile dispatching.
+        # Asset names follow `vaultpilot-mcp-<platform>-<arch>-<role>` so
+        # the GitHub Releases page (which sorts assets alphabetically)
+        # shows the server + setup binaries for each platform adjacent
+        # to each other rather than scattered. The previous shape put
+        # `setup` BETWEEN platforms when sorted, which made the page
+        # harder to scan for users picking one platform.
         include:
           - target: node22-linux-x64
             runner: ubuntu-latest
-            server_asset: vaultpilot-mcp-linux-x64
-            setup_asset: vaultpilot-mcp-setup-linux-x64
+            server_asset: vaultpilot-mcp-linux-x64-server
+            setup_asset: vaultpilot-mcp-linux-x64-setup
           - target: node22-macos-x64
             runner: macos-13
-            server_asset: vaultpilot-mcp-macos-x64
-            setup_asset: vaultpilot-mcp-setup-macos-x64
+            server_asset: vaultpilot-mcp-macos-x64-server
+            setup_asset: vaultpilot-mcp-macos-x64-setup
           - target: node22-macos-arm64
             runner: macos-14
-            server_asset: vaultpilot-mcp-macos-arm64
-            setup_asset: vaultpilot-mcp-setup-macos-arm64
+            server_asset: vaultpilot-mcp-macos-arm64-server
+            setup_asset: vaultpilot-mcp-macos-arm64-setup
           - target: node22-win-x64
             runner: windows-latest
-            server_asset: vaultpilot-mcp-windows-x64.exe
-            setup_asset: vaultpilot-mcp-setup-windows-x64.exe
+            server_asset: vaultpilot-mcp-windows-x64-server.exe
+            setup_asset: vaultpilot-mcp-windows-x64-setup.exe
 
     steps:
       - name: Checkout

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,10 +22,10 @@ and download **two** files for your platform:
 
 | Platform | Server binary | Setup wizard |
 |---|---|---|
-| Linux x64 | `vaultpilot-mcp-linux-x64` | `vaultpilot-mcp-setup-linux-x64` |
-| macOS Apple silicon (M1/M2/M3) | `vaultpilot-mcp-macos-arm64` | `vaultpilot-mcp-setup-macos-arm64` |
-| macOS Intel | `vaultpilot-mcp-macos-x64` | `vaultpilot-mcp-setup-macos-x64` |
-| Windows x64 | `vaultpilot-mcp-windows-x64.exe` | `vaultpilot-mcp-setup-windows-x64.exe` |
+| Linux x64 | `vaultpilot-mcp-linux-x64-server` | `vaultpilot-mcp-linux-x64-setup` |
+| macOS Apple silicon (M1/M2/M3) | `vaultpilot-mcp-macos-arm64-server` | `vaultpilot-mcp-macos-arm64-setup` |
+| macOS Intel | `vaultpilot-mcp-macos-x64-server` | `vaultpilot-mcp-macos-x64-setup` |
+| Windows x64 | `vaultpilot-mcp-windows-x64-server.exe` | `vaultpilot-mcp-windows-x64-setup.exe` |
 
 Move both files into a stable location — somewhere they will live
 permanently and your MCP client can reach them. Suggested paths:
@@ -46,9 +46,8 @@ get past it:
 **Option A — strip the quarantine attribute (one-time, command-line)**
 
 ```bash
-chmod +x ~/.local/bin/vaultpilot-mcp-macos-* ~/.local/bin/vaultpilot-mcp-setup-macos-*
+chmod +x ~/.local/bin/vaultpilot-mcp-macos-*
 xattr -d com.apple.quarantine ~/.local/bin/vaultpilot-mcp-macos-* 2>/dev/null
-xattr -d com.apple.quarantine ~/.local/bin/vaultpilot-mcp-setup-macos-* 2>/dev/null
 ```
 
 **Option B — Finder right-click → Open**
@@ -67,7 +66,7 @@ filenames. Code-signing is on the roadmap but not shipped yet.
 ### Linux
 
 ```bash
-chmod +x ~/.local/bin/vaultpilot-mcp-linux-x64 ~/.local/bin/vaultpilot-mcp-setup-linux-x64
+chmod +x ~/.local/bin/vaultpilot-mcp-linux-x64-*
 ```
 
 If you plan to use TRON or Solana hardware-signing flows, you also need
@@ -179,10 +178,10 @@ How you invoke the wizard depends on which install path you used:
 
 ```bash
 # Path A — bundled binary (macOS / Linux)
-~/.local/bin/vaultpilot-mcp-setup-<platform>
+~/.local/bin/vaultpilot-mcp-<platform>-<arch>-setup
 
 # Path A — bundled binary (Windows, PowerShell)
-& "$env:LOCALAPPDATA\Programs\vaultpilot-mcp\vaultpilot-mcp-setup-windows-x64.exe"
+& "$env:LOCALAPPDATA\Programs\vaultpilot-mcp\vaultpilot-mcp-windows-x64-setup.exe"
 
 # Path B — installed via npm
 vaultpilot-mcp-setup
@@ -227,7 +226,7 @@ request into stdin:
 ```bash
 # Path A — bundled binary
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | \
-  ~/.local/bin/vaultpilot-mcp-<platform> | head -c 200
+  ~/.local/bin/vaultpilot-mcp-<platform>-<arch>-server | head -c 200
 
 # Path B — installed via npm
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | \
@@ -251,7 +250,7 @@ slightly per install path:
 {
   "mcpServers": {
     "vaultpilot-mcp": {
-      "command": "/absolute/path/to/vaultpilot-mcp-<platform>"
+      "command": "/absolute/path/to/vaultpilot-mcp-<platform>-<arch>-server"
     }
   }
 }
@@ -346,7 +345,7 @@ across all three update paths.
 
 ```bash
 # Remove the binaries
-rm ~/.local/bin/vaultpilot-mcp-* ~/.local/bin/vaultpilot-mcp-setup-*
+rm ~/.local/bin/vaultpilot-mcp-*-server ~/.local/bin/vaultpilot-mcp-*-setup
 # (Windows: delete the files in %LOCALAPPDATA%\Programs\vaultpilot-mcp\)
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Why
GitHub Releases sorts assets alphabetically with no UI grouping option. The current filenames interleave server + setup binaries when sorted — looks like the screenshot. Renaming so each platform's pair stays adjacent.

## Naming
\`vaultpilot-mcp-<platform>-<arch>-<role>\` where role is \`server\` or \`setup\`.

**Before** (alphabetical):
- vaultpilot-mcp-linux-x64
- vaultpilot-mcp-macos-arm64
- vaultpilot-mcp-setup-linux-x64
- vaultpilot-mcp-setup-macos-arm64
- vaultpilot-mcp-setup-windows-x64.exe
- vaultpilot-mcp-windows-x64.exe

**After** (alphabetical, grouped by platform):
- vaultpilot-mcp-linux-x64-server
- vaultpilot-mcp-linux-x64-setup
- vaultpilot-mcp-macos-arm64-server
- vaultpilot-mcp-macos-arm64-setup
- vaultpilot-mcp-macos-x64-server
- vaultpilot-mcp-macos-x64-setup
- vaultpilot-mcp-windows-x64-server.exe
- vaultpilot-mcp-windows-x64-setup.exe

## Scope
- Workflow matrix \`server_asset\` / \`setup_asset\` keys updated
- \`INSTALL.md\` filename references updated (download table, PowerShell example, JSON-RPC verify, manual MCP wiring snippet, uninstall glob)

## v0.7.0
The v0.7.0 release keeps the old filenames since assets are already published and uploaded. The new naming takes effect from the next tag (v0.7.1+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)