### PR TITLE
chore(release): bump 0.7.1 → 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
The \`0.7.1\` bump landed back in 3fe9f81 but was never tagged + released. In the meantime BTC Phase 1 completed across #172 / #176 / #177 plus two production Marinade fixes (#179 + the nested-anchor 0.28 override). \`0.7.1\` undersells the scope; a minor bump (0.7 → 0.8) reflects it more honestly.

## What 0.8.0 ships vs the released 0.7.0

**BTC Phase 1 — complete**
- \`pair_ledger_btc\` — pairs all 4 mainnet address types (legacy / P2SH / segwit / taproot) for one Ledger account
- \`prepare_btc_send\` — segwit + taproot sends with PSBT v0, RBF on by default, fee-cap guard
- \`send_transaction\` BTC branch — Ledger BTC app clear-signs every output + fee
- \`get_transaction_status\` BTC branch — confirmation count via mempool.space
- \`get_btc_balance\` / \`get_btc_balances\` / \`get_btc_fee_estimates\` / \`get_btc_tx_history\` — read-side
- \`get_portfolio_summary\` — \`bitcoinAddress\` / \`bitcoinAddresses\` fold BTC × USD into the same total
- \`sign_message_btc\` — BIP-137 (taproot refused, BIP-322 not yet exposed by Ledger)

**Release plumbing**
- Bundled binaries grouped by platform via filename order
- Snyk SNYK-JS-ELLIPTIC-14908844 suppressed with reachability justification
- server.json bumped + idempotent npm publish

**Bug fixes**
- Marinade BN named-export resolution under Node ESM-CJS interop (#178)
- Marinade nested anchor 0.28 override for marinade-ts-sdk subtree

## Verification

- \`npm run build\` clean
- Full suite 1047/1047 (one flaky-under-parallelism test pre-existing, passes on retry — not introduced here)
- All three version files (package.json, server.json, package-lock.json) consistent at 0.8.0

## Test plan

- [ ] CI green
- [ ] After merge, tag \`v0.8.0\` and create the GitHub Release — \`publish.yml\` (npm) + \`release-binaries.yml\` (4-OS binaries) fire on \`release.published\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)