### PR TITLE
fix(btc): nest bs58@5 under @ledgerhq/hw-app-btc subtree (#181)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1276,6 +1276,12 @@
         "semver": "7.7.3"
       }
     },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
     "node_modules/@ledgerhq/hw-app-btc/node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -1306,6 +1312,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-btc/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/@ledgerhq/hw-app-btc/node_modules/bs58check": {
@@ -1396,6 +1411,12 @@
         "varuint-bitcoin": "1.1.2"
       }
     },
+    "node_modules/@ledgerhq/psbtv2/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
     "node_modules/@ledgerhq/psbtv2/node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -1426,6 +1447,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/psbtv2/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/@ledgerhq/psbtv2/node_modules/bs58check": {
@@ -4917,6 +4947,21 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
       "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
       "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
     },
     "node_modules/bip32/node_modules/bs58check": {
       "version": "2.1.2",
@@ -10013,6 +10058,21 @@
       "license": "MIT",
       "dependencies": {
         "bs58check": "<3.0.0"
+      }
+    },
+    "node_modules/wif/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/wif/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/wif/node_modules/bs58check": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,9 @@
       "@coral-xyz/anchor": "^0.28.0",
       "@coral-xyz/borsh": "^0.28.0",
       "bs58": "^5.0.0"
+    },
+    "@ledgerhq/hw-app-btc": {
+      "bs58": "^5.0.0"
     }
   },
   "engines": {

--- a/test/btc-bs58-override.test.ts
+++ b/test/btc-bs58-override.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+/**
+ * Regression test for issue #181 ("`base58.decode is not a function`"
+ * during `pair_ledger_btc`).
+ *
+ * The root `package.json` overrides block forces `bs58: ^6.0.0` for
+ * every nested dep so the Solana / Anchor side gets the modern shape.
+ * `bs58@6` is ESM-default-export; loading it from a CJS consumer
+ * yields `{ default: { decode, encode, ... } }`, with the decode/encode
+ * methods NOT present on the module root.
+ *
+ * `@ledgerhq/hw-app-btc@10.21.1` transitively pulls `bs58check@2.1.2`,
+ * a CJS package that does `require('bs58').decode(...)`. Under bs58@6
+ * that throws synchronously, breaking `pair_ledger_btc` before the
+ * Ledger device is ever reached.
+ *
+ * Fix: a scoped `@ledgerhq/hw-app-btc → bs58: ^5.0.0` override (mirrors
+ * the existing Marinade carve-out) keeps the BTC subtree on bs58@5
+ * (CJS named exports) while the rest of the tree stays on bs58@6.
+ *
+ * This test reaches into the hw-app-btc subtree's resolved bs58check
+ * and confirms `decode` is callable. If the scoped override is ever
+ * dropped or bs58check@2 disappears from the tree (e.g. hw-app-btc
+ * upgrades to bitcoinjs-lib@7+), this test surfaces the change at CI
+ * time so we can re-evaluate before users hit a runtime crash.
+ */
+describe("@ledgerhq/hw-app-btc bs58 subtree (issue #181)", () => {
+  it("loads bs58check.decode as a callable function from the BTC subtree", () => {
+    // Resolve bs58check the same way hw-app-btc's CJS code does at
+    // runtime — anchored at hw-app-btc's package.json so the require
+    // walks the BTC subtree, not the top-level node_modules.
+    const r = createRequire(import.meta.url);
+    const btcRequire = createRequire(r.resolve("@ledgerhq/hw-app-btc/package.json"));
+    const bs58check = btcRequire("bs58check") as {
+      encode: (b: Uint8Array) => string;
+      decode: (s: string) => Uint8Array;
+    };
+
+    expect(typeof bs58check.decode).toBe("function");
+    expect(typeof bs58check.encode).toBe("function");
+
+    // Round-trip a known mainnet P2PKH address so we know decode is
+    // not just present but functional. Genesis-block address.
+    const decoded = bs58check.decode("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa");
+    // 1-byte version + 20-byte hash160 = 21 bytes (no checksum — bs58check strips it).
+    expect(decoded.length).toBe(21);
+  });
+});


### PR DESCRIPTION
Closes #181.

\`pair_ledger_btc\` crashes on a clean 0.8.0 install with \`base58.decode is not a function\` before the Ledger device is ever reached.

## Root cause

Root \`overrides\` forces \`bs58: ^6.0.0\` globally so the Solana / Anchor side gets the modern shape. \`bs58@6\` is ESM-default-export; loaded from a CJS consumer it yields \`{ default: { decode, encode, ... } }\` — the named methods aren't on the module root.

\`@ledgerhq/hw-app-btc@10.21.1\` transitively pulls \`bs58check@2.1.2\` (via \`bitcoinjs-lib@5 → bip32 / wif\`), which is CJS and calls \`require('bs58').decode(...)\` directly. Under bs58@6 that throws synchronously.

## Fix

Scoped \`@ledgerhq/hw-app-btc → bs58: ^5.0.0\` override mirroring the existing Marinade carve-out:

\`\`\`json
\"@ledgerhq/hw-app-btc\": {
  \"bs58\": \"^5.0.0\"
}
\`\`\`

\`npm ls bs58\` after the change:

\`\`\`
@ledgerhq/hw-app-btc → bs58check@2.1.2 → bs58@5.0.0 (overridden)
rest of tree (Anchor / Kamino / LiFi / our BTC send code) → bs58@6.0.0
\`\`\`

## Regression test

\`test/btc-bs58-override.test.ts\` reaches into the hw-app-btc subtree's resolved bs58check, asserts \`decode\` is callable, and round-trips a known mainnet P2PKH address (genesis-block address). If the scoped override is dropped, or hw-app-btc upgrades off bitcoinjs-lib@5 (changing the bs58check pin), CI surfaces the change before users hit it.

## Verification

- \`npm run build\` clean
- Full suite 1048/1048 (1047 + the new regression test)
- Manual: live \`pair_ledger_btc\` would now pass the \`base58.decode\` step (separate runtime check; no Ledger device available in this environment)

## Test plan

- [ ] CI green
- [ ] Manual: plug in a Ledger, run \`pair_ledger_btc\` — expect 4 cached addresses returned, not the \`base58.decode\` throw
- [ ] Cut \`v0.8.1\` once merged so users on 0.8.0 get unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)