### PR TITLE
fix(btc): detect P2WSH separately + tighten taproot regex (#182)

### DIFF
--- a/src/modules/btc/address.ts
+++ b/src/modules/btc/address.ts
@@ -31,23 +31,33 @@
 export type BitcoinAddressType =
   | "p2pkh" // Legacy `1...`
   | "p2sh" // P2SH-wrapped `3...`
-  | "p2wpkh" // Native segwit `bc1q...`
-  | "p2tr"; // Taproot `bc1p...`
+  | "p2wpkh" // Native segwit, 20-byte program (`bc1q…`, 42 chars)
+  | "p2wsh" // Native segwit, 32-byte program (`bc1q…`, 62 chars — typically multisig)
+  | "p2tr"; // Taproot `bc1p…`
 
 // Legacy P2PKH: starts with `1`, 26-34 chars, base58 charset.
 const P2PKH_RE = /^1[1-9A-HJ-NP-Za-km-z]{25,33}$/;
 // P2SH (incl. P2SH-wrapped segwit): starts with `3`, 26-34 chars, base58.
 const P2SH_RE = /^3[1-9A-HJ-NP-Za-km-z]{25,33}$/;
-// Bech32 native segwit: `bc1q…` (witness version 0). Length 42 (P2WPKH)
-// or 62 (P2WSH); we accept the common range.
-const BECH32_SEGWIT_RE = /^bc1q[02-9ac-hj-np-z]{38,58}$/;
-// Bech32m taproot: `bc1p…` (witness version 1). Length 62.
-const BECH32_TAPROOT_RE = /^bc1p[02-9ac-hj-np-z]{38,58}$/;
+// Bech32 native segwit (witness version 0). BIP-141 disambiguates
+// solely by witness-program length:
+//   - 20-byte program → P2WPKH (`bc1q…`, 42 chars total = `bc1q` + 38)
+//   - 32-byte program → P2WSH  (`bc1q…`, 62 chars total = `bc1q` + 58)
+// Other lengths are invalid v0 scripts. Splitting these into two
+// regexes both gives the correct addressType label AND rejects the
+// previously-accepted impossible lengths in (38..58) (issue #182).
+const BECH32_P2WPKH_RE = /^bc1q[02-9ac-hj-np-z]{38}$/;
+const BECH32_P2WSH_RE = /^bc1q[02-9ac-hj-np-z]{58}$/;
+// Bech32m taproot (witness version 1). v1 SegWit is always a 32-byte
+// program → exactly 62 chars total. Tightened from the prior `{38,58}`
+// loose range that accepted impossible lengths (issue #182).
+const BECH32_TAPROOT_RE = /^bc1p[02-9ac-hj-np-z]{58}$/;
 
 export function detectBitcoinAddressType(addr: string): BitcoinAddressType | null {
   if (P2PKH_RE.test(addr)) return "p2pkh";
   if (P2SH_RE.test(addr)) return "p2sh";
-  if (BECH32_SEGWIT_RE.test(addr)) return "p2wpkh";
+  if (BECH32_P2WPKH_RE.test(addr)) return "p2wpkh";
+  if (BECH32_P2WSH_RE.test(addr)) return "p2wsh";
   if (BECH32_TAPROOT_RE.test(addr)) return "p2tr";
   return null;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -669,7 +669,7 @@ export interface BitcoinPortfolioSlice {
    */
   balances: Array<{
     address: string;
-    addressType: "p2pkh" | "p2sh" | "p2wpkh" | "p2tr";
+    addressType: "p2pkh" | "p2sh" | "p2wpkh" | "p2wsh" | "p2tr";
     confirmedSats: string;
     mempoolSats: string;
     totalSats: string;

--- a/test/btc-pr1.test.ts
+++ b/test/btc-pr1.test.ts
@@ -20,9 +20,11 @@ import { resetBitcoinIndexer } from "../src/modules/btc/indexer.js";
 // Real mainnet addresses, one per type (lengths must hit the regex bounds).
 const P2PKH_ADDR = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"; // Satoshi block 0 coinbase
 const P2SH_ADDR = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"; // BIP-13 example
-const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"; // BIP-173 P2WPKH example
+const P2WPKH_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"; // BIP-173 P2WPKH example, 42 chars
+const P2WSH_ADDR =
+  "bc1qwzrryqr3ja8w7hnja2spmkgfdcgvqwp5swz4af4ngsjecfz0w0pqud7k38"; // 62-char witness-script-hash, observed in issue #182
 const TAPROOT_ADDR =
-  "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg"; // Variable-length taproot from BIP-350
+  "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg"; // BIP-350 taproot, exactly 62 chars (v1 SegWit always carries a 32-byte program)
 const TESTNET_ADDR = "tb1qar0srrr7xfkvy5l643lydnw9re59gtzzwfllgu";
 
 describe("address validation", () => {
@@ -36,12 +38,38 @@ describe("address validation", () => {
     expect(detectBitcoinAddressType(P2SH_ADDR)).toBe("p2sh");
   });
 
-  it("detects native segwit (P2WPKH)", () => {
-    expect(detectBitcoinAddressType(SEGWIT_ADDR)).toBe("p2wpkh");
+  it("detects native segwit P2WPKH (42-char bc1q…, 20-byte program)", () => {
+    expect(detectBitcoinAddressType(P2WPKH_ADDR)).toBe("p2wpkh");
   });
 
-  it("detects taproot (P2TR)", () => {
+  it("detects native segwit P2WSH (62-char bc1q…, 32-byte program — issue #182)", () => {
+    // Pre-fix this returned "p2wpkh" silently; multisig addresses were
+    // labeled as single-sig.
+    expect(detectBitcoinAddressType(P2WSH_ADDR)).toBe("p2wsh");
+  });
+
+  it("detects taproot (P2TR, exactly 62 chars)", () => {
     expect(detectBitcoinAddressType(TAPROOT_ADDR)).toBe("p2tr");
+  });
+
+  it("rejects v0 bech32 with impossible witness-program length (issue #182)", () => {
+    // BIP-141 v0 SegWit only allows 20-byte (P2WPKH) or 32-byte (P2WSH)
+    // programs → 42 or 62 chars total. Anything in between (e.g. 50 chars
+    // of data → 54 total) is structurally invalid even if checksum-valid.
+    // Pre-fix the loose `{38,58}` range silently accepted these.
+    const tooShort = "bc1q" + "p".repeat(37); // 41 chars total
+    const inBetween = "bc1q" + "p".repeat(50); // 54 chars total
+    const tooLong = "bc1q" + "p".repeat(59); // 63 chars total
+    expect(detectBitcoinAddressType(tooShort)).toBeNull();
+    expect(detectBitcoinAddressType(inBetween)).toBeNull();
+    expect(detectBitcoinAddressType(tooLong)).toBeNull();
+  });
+
+  it("rejects taproot of impossible length (issue #182)", () => {
+    // v1 SegWit is always a 32-byte witness program → exactly 62 chars.
+    // Pre-fix the loose `{38,58}` range silently accepted shorter values.
+    const tooShort = "bc1p" + "p".repeat(38); // 42 chars total — pre-fix would have accepted
+    expect(detectBitcoinAddressType(tooShort)).toBeNull();
   });
 
   it("rejects testnet bech32 (tb1...) — Phase 1 is mainnet-only", () => {
@@ -385,14 +413,14 @@ describe("balances — getBitcoinBalance / getBitcoinBalances", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { getBitcoinBalances } = await import("../src/modules/btc/balances.js");
-    const results = await getBitcoinBalances([TAPROOT_ADDR, SEGWIT_ADDR]);
+    const results = await getBitcoinBalances([TAPROOT_ADDR, P2WPKH_ADDR]);
     expect(results.length).toBe(2);
     expect(results[0].ok).toBe(true);
     if (!results[0].ok) throw new Error("unreachable");
     expect(results[0].balance.confirmedSats).toBe(50_000n);
     expect(results[1].ok).toBe(false);
     if (results[1].ok) throw new Error("unreachable");
-    expect(results[1].address).toBe(SEGWIT_ADDR);
+    expect(results[1].address).toBe(P2WPKH_ADDR);
     expect(results[1].error).toMatch(/500/);
   });
 


### PR DESCRIPTION
Closes #182.

\`get_btc_balance\` returned \`addressType: \"p2wpkh\"\` for native-segwit addresses regardless of length. 62-char P2WSH addresses (multisig) were silently labeled as 42-char P2WPKH (single-sig). Observed in the field on \`bc1qwzrryqr3ja8w7hnja2spmkgfdcgvqwp5swz4af4ngsjecfz0w0pqud7k38\`.

## Root cause

Per BIP-141, v0 SegWit disambiguates solely by witness-program length: 20-byte → P2WPKH (42 chars total), 32-byte → P2WSH (62 chars total). The prior single regex \`/^bc1q[02-9ac-hj-np-z]{38,58}$/\` collapsed both onto \`p2wpkh\` AND silently accepted impossible witness-program lengths in (20, 32).

The taproot regex had the same loose-range bug — v1 SegWit is always 32-byte so it should be exactly 62 chars.

## Fix

- Split bech32-v0 into \`BECH32_P2WPKH_RE\` (exactly 42 chars) + \`BECH32_P2WSH_RE\` (exactly 62 chars).
- Add \`\"p2wsh\"\` to \`BitcoinAddressType\` and to \`BitcoinPortfolioSlice.balances[].addressType\`.
- Tighten \`BECH32_TAPROOT_RE\` to exactly 62 chars (was \`{38,58}\`).

## Downstream audit

- \`_isSendableAddressType\` in \`actions.ts\` switches on the *paired* address type (a different union: \`legacy | p2sh-segwit | segwit | taproot\` from \`pair_ledger_btc\`). Ledger BTC app never derives multisig P2WSH, so paired wallets are never P2WSH — no code change there.
- \`assertBitcoinAddress\` on send-side \`to\` recipients: a P2WSH destination flows through as an address string; PSBT addOutput resolves the scriptPubKey via bitcoinjs-lib. No behavior change.
- \`balances.ts\` is the only spot that surfaces the detector's label to users — this is the case the fix corrects.

## Tests

3 new cases in \`btc-pr1.test.ts\`:
- The field-observed P2WSH address resolves to \`\"p2wsh\"\`
- v0 bech32 with impossible witness-program length (42-62 char range, e.g. 54 chars) → rejected
- v1 taproot of impossible length (e.g. 42 chars) → rejected

Existing P2WPKH/P2TR cases keep their fixtures (both already on canonical 42 / 62 char lengths).

## Verification

- \`npm run build\` clean
- Full suite 1050/1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)