### PR TITLE
feat(btc): add get_btc_block_tip read-only tool (#183)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import {
   getBitcoinBalance,
   getBitcoinBalances,
   getBitcoinFeeEstimates,
+  getBitcoinBlockTip,
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   signBtcMessage,
@@ -145,6 +146,7 @@ import {
   getBitcoinBalanceInput,
   getBitcoinBalancesInput,
   getBitcoinFeeEstimatesInput,
+  getBitcoinBlockTipInput,
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   signBtcMessageInput,
@@ -1814,6 +1816,25 @@ async function main() {
       inputSchema: getBitcoinFeeEstimatesInput.shape,
     },
     handler(getBitcoinFeeEstimates)
+  );
+
+  server.registerTool(
+    "get_btc_block_tip",
+    {
+      description:
+        "READ-ONLY — current Bitcoin mainnet chain tip. Returns block height, " +
+        "64-hex block hash, header timestamp (unix seconds), server-computed " +
+        "`ageSeconds` (now − timestamp), and — when the indexer exposes them — " +
+        "BIP-113 median time past + difficulty. Backed by the configured " +
+        "indexer (mempool.space default; `BITCOIN_INDEXER_URL` env var or " +
+        "`bitcoinIndexerUrl` user-config override for self-hosted Esplora). " +
+        "Useful for: latest-hash lookups, block-age UX context (Bitcoin block " +
+        "intervals are Poisson — a 40-min gap is normal but worth surfacing), " +
+        "indexer-freshness sanity checks before quoting balances, confirmation-" +
+        "depth math against `get_btc_tx_history` entries.",
+      inputSchema: getBitcoinBlockTipInput.shape,
+    },
+    handler(getBitcoinBlockTip)
   );
 
   server.registerTool(

--- a/src/modules/btc/indexer.ts
+++ b/src/modules/btc/indexer.ts
@@ -182,6 +182,38 @@ export interface BitcoinIndexer {
     blockHeight?: number;
     confirmations?: number;
   } | null>;
+  /**
+   * Fetch the current Bitcoin chain tip — height, block hash, header
+   * timestamp, etc. Two HTTP calls under the hood: `/blocks/tip/hash`
+   * for the latest hash, then `/block/<hash>` for the full header
+   * details. Both endpoints are aggressively cached at the indexer
+   * (mempool.space + standard Esplora share the same shape).
+   */
+  getBlockTip(): Promise<BitcoinBlockTip>;
+}
+
+/**
+ * Latest mainnet block as the indexer reports it. Carries the height,
+ * the 64-hex block hash, the header timestamp (unix seconds), and a
+ * server-computed `ageSeconds` for UX convenience (the agent doesn't
+ * need to grab system time and subtract). `medianTimePast` and
+ * `difficulty` are surfaced when the indexer exposes them — both are
+ * standard Esplora fields but we tolerate their absence for self-
+ * hosted forks that strip them.
+ */
+export interface BitcoinBlockTip {
+  /** Block height — e.g. 946598. */
+  height: number;
+  /** 64-hex block hash. */
+  hash: string;
+  /** Block header timestamp, unix seconds. */
+  timestamp: number;
+  /** Server-computed `now - timestamp` at fetch time, in seconds. */
+  ageSeconds: number;
+  /** BIP-113 median time past, when the indexer exposes it. */
+  medianTimePast?: number;
+  /** Block difficulty, when the indexer exposes it. */
+  difficulty?: number;
 }
 
 /**
@@ -404,6 +436,56 @@ class EsploraIndexer implements BitcoinIndexer {
     return {
       confirmed: true,
       ...(status.block_height !== undefined ? { blockHeight: status.block_height } : {}),
+    };
+  }
+
+  async getBlockTip(): Promise<BitcoinBlockTip> {
+    // Esplora exposes the chain tip via two endpoints:
+    //   GET /blocks/tip/hash  → plain-text 64-hex hash
+    //   GET /block/<hash>     → JSON with height, timestamp, mediantime, difficulty
+    // Both are aggressively cached at the indexer (mempool.space caches
+    // for ~10s; self-hosted Esplora similar), so the two-call shape is
+    // cheap. Esplora-pure deployments without `/blocks/tip` (the
+    // alternate single-call shape mempool.space exposes) still work via
+    // this path.
+    const hashRes = await fetchWithTimeout(`${this.baseUrl}/blocks/tip/hash`, {
+      method: "GET",
+    });
+    if (!hashRes.ok) {
+      throw new Error(
+        `Bitcoin indexer /blocks/tip/hash returned ${hashRes.status} ${hashRes.statusText}`,
+      );
+    }
+    const hash = (await hashRes.text()).trim();
+    if (!/^[0-9a-fA-F]{64}$/.test(hash)) {
+      throw new Error(
+        `Bitcoin indexer /blocks/tip/hash returned an unexpected response (not a 64-hex block hash): "${hash.slice(0, 80)}"`,
+      );
+    }
+    interface EsploraBlock {
+      id?: string;
+      height?: number;
+      timestamp?: number;
+      // BIP-113 median time past — Esplora exposes as `mediantime`.
+      mediantime?: number;
+      difficulty?: number;
+    }
+    const block = await this.getJson<EsploraBlock>(`/block/${hash}`);
+    if (typeof block.height !== "number" || typeof block.timestamp !== "number") {
+      throw new Error(
+        `Bitcoin indexer /block/${hash} response missing required fields ` +
+          `(height: ${block.height}, timestamp: ${block.timestamp}). The indexer ` +
+          `may not be Esplora-compatible — check the URL.`,
+      );
+    }
+    const ageSeconds = Math.max(0, Math.floor(Date.now() / 1000) - block.timestamp);
+    return {
+      height: block.height,
+      hash,
+      timestamp: block.timestamp,
+      ageSeconds,
+      ...(typeof block.mediantime === "number" ? { medianTimePast: block.mediantime } : {}),
+      ...(typeof block.difficulty === "number" ? { difficulty: block.difficulty } : {}),
     };
   }
 }

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -124,6 +124,7 @@ import type {
   GetBitcoinBalanceArgs,
   GetBitcoinBalancesArgs,
   GetBitcoinFeeEstimatesArgs,
+  GetBitcoinBlockTipArgs,
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   SignBtcMessageArgs,
@@ -652,6 +653,12 @@ export async function getBitcoinFeeEstimates(_args: GetBitcoinFeeEstimatesArgs) 
   void _args;
   const { getBitcoinIndexer } = await import("../btc/indexer.js");
   return getBitcoinIndexer().getFeeEstimates();
+}
+
+export async function getBitcoinBlockTip(_args: GetBitcoinBlockTipArgs) {
+  void _args;
+  const { getBitcoinIndexer } = await import("../btc/indexer.js");
+  return getBitcoinIndexer().getBlockTip();
 }
 
 export async function getBitcoinTxHistory(args: GetBitcoinTxHistoryArgs) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1033,6 +1033,8 @@ export const getBitcoinBalancesInput = z.object({
 
 export const getBitcoinFeeEstimatesInput = z.object({});
 
+export const getBitcoinBlockTipInput = z.object({});
+
 export const prepareBitcoinNativeSendInput = z.object({
   wallet: bitcoinAddressSchema.describe(
     "Paired Bitcoin source address. Must already be in `pairings.bitcoin` " +
@@ -1099,6 +1101,7 @@ export const getBitcoinTxHistoryInput = z.object({
 export type GetBitcoinBalanceArgs = z.infer<typeof getBitcoinBalanceInput>;
 export type GetBitcoinBalancesArgs = z.infer<typeof getBitcoinBalancesInput>;
 export type GetBitcoinFeeEstimatesArgs = z.infer<typeof getBitcoinFeeEstimatesInput>;
+export type GetBitcoinBlockTipArgs = z.infer<typeof getBitcoinBlockTipInput>;
 export const signBtcMessageInput = z.object({
   wallet: bitcoinAddressSchema.describe(
     "Paired Bitcoin source address. Must already be in `pairings.bitcoin` " +

--- a/test/btc-pr1.test.ts
+++ b/test/btc-pr1.test.ts
@@ -261,6 +261,96 @@ describe("indexer — getAddressTxs", () => {
   });
 });
 
+describe("indexer — getBlockTip (issue #183)", () => {
+  beforeEach(() => {
+    resetBitcoinIndexer();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBitcoinIndexer();
+  });
+
+  it("returns height + hash + timestamp + ageSeconds + optional fields", async () => {
+    const fixedHash =
+      "0000000000000000000123456789abcdef0123456789abcdef0123456789abcd";
+    const blockTime = Math.floor(Date.now() / 1000) - 600; // ~10 min ago
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/blocks/tip/hash")) {
+        return new Response(fixedHash, { status: 200 });
+      }
+      if (url.endsWith(`/block/${fixedHash}`)) {
+        return new Response(
+          JSON.stringify({
+            id: fixedHash,
+            height: 946_598,
+            timestamp: blockTime,
+            mediantime: blockTime - 300,
+            difficulty: 110_568_428_300_421.94,
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const tip = await getBitcoinIndexer().getBlockTip();
+    expect(tip.height).toBe(946_598);
+    expect(tip.hash).toBe(fixedHash);
+    expect(tip.timestamp).toBe(blockTime);
+    expect(tip.medianTimePast).toBe(blockTime - 300);
+    expect(tip.difficulty).toBe(110_568_428_300_421.94);
+    // ageSeconds: server-side computed; allow ±2s for test wall-clock drift.
+    expect(tip.ageSeconds).toBeGreaterThanOrEqual(599);
+    expect(tip.ageSeconds).toBeLessThanOrEqual(602);
+  });
+
+  it("omits medianTimePast/difficulty when the indexer doesn't expose them", async () => {
+    const fixedHash =
+      "0000000000000000000abcdef0123456789abcdef0123456789abcdef0123456";
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/blocks/tip/hash")) {
+        return new Response(fixedHash, { status: 200 });
+      }
+      // Esplora-pure stripped to just height/timestamp.
+      return new Response(
+        JSON.stringify({ height: 100, timestamp: 1_700_000_000 }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    const tip = await getBitcoinIndexer().getBlockTip();
+    expect(tip.height).toBe(100);
+    expect(tip.medianTimePast).toBeUndefined();
+    expect(tip.difficulty).toBeUndefined();
+  });
+
+  it("rejects a malformed tip-hash response (sanity check on the indexer URL)", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response("<html>404</html>", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    await expect(getBitcoinIndexer().getBlockTip()).rejects.toThrow(
+      /not a 64-hex block hash/,
+    );
+  });
+
+  it("throws on indexer HTTP failure", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("Bad Gateway", { status: 502, statusText: "Bad Gateway" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { getBitcoinIndexer } = await import("../src/modules/btc/indexer.js");
+    await expect(getBitcoinIndexer().getBlockTip()).rejects.toThrow(
+      /returned 502/,
+    );
+  });
+});
+
 describe("indexer URL resolution", () => {
   beforeEach(() => {
     resetBitcoinIndexer();


### PR DESCRIPTION
Closes #183.

Exposes the current Bitcoin mainnet chain tip via the configured indexer. Today's BTC read surface (\`get_btc_balance\` / \`get_btc_balances\` / \`get_btc_fee_estimates\` / \`get_btc_tx_history\`) has no way to ask \"what's the latest block?\" Agents end up shelling out to \`curl https://mempool.space/api/blocks/tip/...\`, which bypasses the configurable \`BITCOIN_INDEXER_URL\` (self-hosted Esplora users can't keep their queries on their own indexer).

## Returned shape

\`\`\`ts
{
  height: number;            // e.g. 946598
  hash: string;              // 64-hex block hash
  timestamp: number;         // header time, unix seconds
  ageSeconds: number;        // server-computed `now - timestamp`
  medianTimePast?: number;   // BIP-113, when indexer exposes it
  difficulty?: number;       // when indexer exposes it
}
\`\`\`

The server-computed \`ageSeconds\` saves the agent from grabbing system time and subtracting — keeps clock semantics consistent with the indexer's reported timestamp.

## Implementation

Two HTTP calls under the hood:
- \`/blocks/tip/hash\` → plain-text 64-hex hash
- \`/block/<hash>\` → JSON with height / timestamp / mediantime / difficulty

Both endpoints are aggressively cached at the indexer (mempool.space ~10s; self-hosted Esplora similar). The two-call shape works for Esplora-pure deployments (which don't have mempool.space's \`/blocks/tip\` single-call alternative). Validates the hash response is 64-hex before issuing the second call so a misconfigured indexer URL fails fast with a clear error instead of a JSON-parse stack trace.

## Tests

4 new cases in \`btc-pr1.test.ts\`:
- Full-fields happy path with mocked Esplora response (height + hash + timestamp + medianTimePast + difficulty + computed ageSeconds within ±2s wall-clock tolerance)
- Optional fields stripped (Esplora-pure shape — only height + timestamp)
- Malformed tip-hash response → clear error
- HTTP 502 failure → throws

## Verification

- \`npm run build\` clean
- Full suite 1051/1051

## Out of scope (per the issue)

- \`get_btc_block(heightOrHash)\` for arbitrary lookups (confirmation-depth math, historical reorg checks)
- Multi-chain extension (EVM \`eth_blockNumber\` per chainId, Solana \`getSlot\`, TRON \`wallet/getnowblock\`) — flagged in issue #183 but explicitly deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)