### PR TITLE
chore(release): bump 0.8.0 → 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Patch release rolling up the three post-0.8.0 issues:

- **#181** (#184) — \`pair_ledger_btc\` crashed with \`base58.decode is not a function\` on clean 0.8.0 installs. Scoped \`@ledgerhq/hw-app-btc → bs58: ^5.0.0\` override.
- **#182** (#185) — \`detectBitcoinAddressType\` mislabeled P2WSH (62-char \`bc1q…\`) as P2WPKH. Split regex per BIP-141 + added \`p2wsh\` to the type union + tightened taproot regex to canonical 62 chars.
- **#183** (#186) — new \`get_btc_block_tip\` read-only tool: latest block height / hash / timestamp / age via the configured indexer.

## Verification

- \`npm run build\` clean
- Full suite 1055/1055
- All three version files (package.json / server.json / package-lock.json) consistent at 0.8.1

## Test plan

- [ ] CI green
- [ ] Merge → tag \`v0.8.1\` → create GitHub Release. \`publish.yml\` (npm) + \`release-binaries.yml\` (4-OS binaries) fire on \`release.published\`.

#181 unblocks anyone on the freshly-released 0.8.0 — recommend cutting the release ASAP after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)