### PR TITLE
feat(btc): BIP44 gap-limit scanning for pair_ledger_btc + get_btc_account_balance (#189)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ import {
   getBitcoinBalances,
   getBitcoinFeeEstimates,
   getBitcoinBlockTip,
+  getBitcoinAccountBalance,
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   signBtcMessage,
@@ -147,6 +148,7 @@ import {
   getBitcoinBalancesInput,
   getBitcoinFeeEstimatesInput,
   getBitcoinBlockTipInput,
+  getBitcoinAccountBalanceInput,
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   signBtcMessageInput,
@@ -1816,6 +1818,25 @@ async function main() {
       inputSchema: getBitcoinFeeEstimatesInput.shape,
     },
     handler(getBitcoinFeeEstimates)
+  );
+
+  server.registerTool(
+    "get_btc_account_balance",
+    {
+      description:
+        "READ-ONLY — sum the on-chain balance across every cached USED address " +
+        "(txCount > 0 at last scan) for one Ledger Bitcoin account index. " +
+        "Walks the pairing cache populated by `pair_ledger_btc`'s BIP44 gap-limit " +
+        "scan, fans out to the indexer for live balances, and returns both the " +
+        "rolled-up totals (confirmed + mempool + total sats / BTC) and a " +
+        "per-address breakdown including type, BIP-32 chain (0=receive, " +
+        "1=change), and addressIndex. Skips empty cached entries (the trailing " +
+        "fresh-receive addresses) to keep fan-out tight. Re-run `pair_ledger_btc` " +
+        "if you suspect the cache is stale (e.g. recent receive past the gap " +
+        "window).",
+      inputSchema: getBitcoinAccountBalanceInput.shape,
+    },
+    handler(getBitcoinAccountBalance)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -125,6 +125,7 @@ import type {
   GetBitcoinBalancesArgs,
   GetBitcoinFeeEstimatesArgs,
   GetBitcoinBlockTipArgs,
+  GetBitcoinAccountBalanceArgs,
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   SignBtcMessageArgs,
@@ -262,21 +263,49 @@ export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
  */
 export async function pairLedgerBitcoin(args: PairLedgerBitcoinArgs = {}): Promise<{
   accountIndex: number;
+  gapLimit: number;
   appVersion: string;
   addresses: Array<{
     addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
     address: string;
     path: string;
+    chain: 0 | 1;
+    addressIndex: number;
+    txCount: number;
   }>;
+  summary: {
+    totalDerived: number;
+    used: number;
+    unused: number;
+  };
   instructions: string;
 }> {
   const accountIndex = args.accountIndex ?? 0;
-  const { deriveBtcLedgerAccount, setPairedBtcAddress } = await import(
-    "../../signing/btc-usb-signer.js"
-  );
+  const {
+    scanBtcAccount,
+    setPairedBtcAddress,
+    clearPairedBtcAccount,
+    DEFAULT_BTC_GAP_LIMIT,
+  } = await import("../../signing/btc-usb-signer.js");
+  const gapLimit = args.gapLimit ?? DEFAULT_BTC_GAP_LIMIT;
+
+  // The indexer's getBalance() returns txCount alongside the balance —
+  // reuse it as the gap-limit probe so we don't add a second HTTP API
+  // surface. One round trip per derived address.
+  const { getBitcoinIndexer } = await import("../btc/indexer.js");
+  const indexer = getBitcoinIndexer();
+  const fetchTxCount = async (addr: string): Promise<number> => {
+    const bal = await indexer.getBalance(addr);
+    return bal.txCount;
+  };
+
   let derived;
   try {
-    derived = await deriveBtcLedgerAccount(accountIndex);
+    derived = await scanBtcAccount({
+      accountIndex,
+      gapLimit,
+      fetchTxCount,
+    });
   } catch (e) {
     // Same enrichment pattern as pairLedgerTron / pairLedgerSolana —
     // probe which app is currently open so the agent can tell the user
@@ -287,6 +316,11 @@ export async function pairLedgerBitcoin(args: PairLedgerBitcoinArgs = {}): Promi
     }
     throw e;
   }
+  // Drop any stale entries for this accountIndex BEFORE persisting the
+  // fresh scan — protects against the case where a prior scan walked
+  // further than this one (e.g. funds moved out, gap window now stops
+  // earlier) and would otherwise leave dangling cached paths.
+  clearPairedBtcAccount(accountIndex);
   for (const entry of derived.entries) {
     setPairedBtcAddress({
       address: entry.address,
@@ -295,23 +329,40 @@ export async function pairLedgerBitcoin(args: PairLedgerBitcoinArgs = {}): Promi
       appVersion: entry.appVersion,
       addressType: entry.addressType,
       accountIndex: entry.accountIndex,
+      chain: entry.chain,
+      addressIndex: entry.addressIndex,
+      txCount: entry.txCount,
     });
   }
+  const used = derived.entries.filter((e) => e.txCount > 0).length;
   return {
     accountIndex,
+    gapLimit,
     appVersion: derived.appVersion,
     addresses: derived.entries.map((e) => ({
       addressType: e.addressType,
       address: e.address,
       path: e.path,
+      chain: e.chain,
+      addressIndex: e.addressIndex,
+      txCount: e.txCount,
     })),
+    summary: {
+      totalDerived: derived.entries.length,
+      used,
+      unused: derived.entries.length - used,
+    },
     instructions:
-      "Bitcoin account paired. All four standard mainnet address types " +
-      "(legacy / p2sh-segwit / segwit / taproot) for this index are now cached. " +
-      "Use `get_btc_balance` / `get_btc_balances` / `get_btc_tx_history` against " +
-      "any of the four addresses. Send + message-signing flows ship in Phase 1 PR3/PR4. " +
-      "Keep the Ledger plugged in with the Bitcoin app open — every device call " +
-      "re-opens USB and re-verifies the path → address mapping.",
+      "Bitcoin account paired with BIP44 gap-limit scanning. Both the receive " +
+      "(/0/i) and change (/1/i) chains were walked across all four address types " +
+      "until " +
+      gapLimit +
+      " consecutive empty addresses were observed. Every address with on-chain " +
+      "history is cached, plus the next fresh receive address per chain. Use " +
+      "`get_btc_account_balance({ accountIndex })` to sum across the cached set " +
+      "for this account, or `get_btc_balance` against any single cached address. " +
+      "Re-run `pair_ledger_btc` to refresh the cache; previously-cached entries " +
+      "for this accountIndex are dropped before the new scan persists.",
   };
 }
 
@@ -659,6 +710,118 @@ export async function getBitcoinBlockTip(_args: GetBitcoinBlockTipArgs) {
   void _args;
   const { getBitcoinIndexer } = await import("../btc/indexer.js");
   return getBitcoinIndexer().getBlockTip();
+}
+
+/**
+ * Aggregate the on-chain balance across every CACHED used-address for
+ * one Ledger BTC account index. Walks the in-memory + persisted
+ * pairing cache (populated by `pair_ledger_btc`'s gap-limit scan),
+ * filters to entries with `txCount > 0` (skip the trailing fresh
+ * receive addresses to keep fan-out tight), fans out to the indexer's
+ * per-address `getBalance`, and surfaces both the rolled-up totals and
+ * the per-leg breakdown so the agent can show which addresses hold
+ * what.
+ */
+export async function getBitcoinAccountBalance(
+  args: GetBitcoinAccountBalanceArgs,
+) {
+  const { getPairedBtcAddresses } = await import(
+    "../../signing/btc-usb-signer.js"
+  );
+  const all = getPairedBtcAddresses();
+  const forAccount = all.filter(
+    (e) => e.accountIndex === args.accountIndex,
+  );
+  if (forAccount.length === 0) {
+    throw new Error(
+      `No paired Bitcoin entries cached for accountIndex=${args.accountIndex}. ` +
+        `Run \`pair_ledger_btc({ accountIndex: ${args.accountIndex} })\` first ` +
+        `to populate the cache.`,
+    );
+  }
+  // Used = ever observed on-chain history at scan time. Empty (txCount===0)
+  // entries are kept in the cache for receive-UX (next fresh address) but
+  // skipped here to avoid 80 unneeded indexer hits per call.
+  const used = forAccount.filter((e) => (e.txCount ?? 0) > 0);
+  if (used.length === 0) {
+    return {
+      accountIndex: args.accountIndex,
+      addressesQueried: 0,
+      addressesCached: forAccount.length,
+      totalConfirmedSats: "0",
+      totalConfirmedBtc: "0",
+      totalMempoolSats: "0",
+      totalSats: "0",
+      breakdown: [] as Array<{
+        address: string;
+        addressType: string;
+        chain: 0 | 1 | null;
+        addressIndex: number | null;
+        path: string;
+        confirmedSats: string;
+        mempoolSats: string;
+        totalSats: string;
+      }>,
+      note:
+        "All cached addresses for this account had zero on-chain history at " +
+        "scan time. If you've recently received funds, re-run pair_ledger_btc " +
+        "to refresh the gap-limit scan.",
+    };
+  }
+  const { getBitcoinBalance } = await import("../btc/balances.js");
+  const results = await Promise.allSettled(
+    used.map((e) => getBitcoinBalance(e.address)),
+  );
+  let totalConfirmed = 0n;
+  let totalMempool = 0n;
+  const breakdown: Array<{
+    address: string;
+    addressType: string;
+    chain: 0 | 1 | null;
+    addressIndex: number | null;
+    path: string;
+    confirmedSats: string;
+    mempoolSats: string;
+    totalSats: string;
+  }> = [];
+  for (let i = 0; i < used.length; i++) {
+    const entry = used[i];
+    const r = results[i];
+    if (r.status !== "fulfilled") continue;
+    totalConfirmed += r.value.confirmedSats;
+    totalMempool += r.value.mempoolSats;
+    breakdown.push({
+      address: entry.address,
+      addressType: entry.addressType,
+      chain: entry.chain ?? null,
+      addressIndex: entry.addressIndex ?? null,
+      path: entry.path,
+      confirmedSats: r.value.confirmedSats.toString(),
+      mempoolSats: r.value.mempoolSats.toString(),
+      totalSats: r.value.totalSats.toString(),
+    });
+  }
+  // Format BTC string from bigint sats (8 decimals, trailing zeros stripped).
+  const SATS_PER_BTC = 100_000_000n;
+  const fmt = (sats: bigint): string => {
+    const negative = sats < 0n;
+    const abs = negative ? -sats : sats;
+    const whole = abs / SATS_PER_BTC;
+    const frac = abs - whole * SATS_PER_BTC;
+    const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "") || "0";
+    const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+    return negative ? `-${body}` : body;
+  };
+  return {
+    accountIndex: args.accountIndex,
+    addressesQueried: breakdown.length,
+    addressesCached: forAccount.length,
+    totalConfirmedSats: totalConfirmed.toString(),
+    totalConfirmedBtc: fmt(totalConfirmed),
+    totalMempoolSats: totalMempool.toString(),
+    totalSats: (totalConfirmed + totalMempool).toString(),
+    breakdown,
+  };
 }
 
 export async function getBitcoinTxHistory(args: GetBitcoinTxHistoryArgs) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -49,11 +49,27 @@ export const pairLedgerBitcoinInput = z.object({
     .optional()
     .describe(
       "Ledger Bitcoin account slot. One call enumerates ALL FOUR address types " +
-        "for the given index (legacy at `44'/0'/<n>'/0/0`, p2sh-segwit at " +
-        "`49'/0'/<n>'/0/0`, native segwit at `84'/0'/<n>'/0/0`, taproot at " +
-        "`86'/0'/<n>'/0/0`) so the user sees their full footprint per Ledger Live " +
-        "Bitcoin account. 0 = first Bitcoin account, 1 = second, etc. Omit for the " +
-        "default (index 0). Call again with a different index to expose more accounts."
+        "for the given index (legacy at `44'/0'/<n>'/...`, p2sh-segwit at " +
+        "`49'/0'/<n>'/...`, native segwit at `84'/0'/<n>'/...`, taproot at " +
+        "`86'/0'/<n>'/...`) AND walks both the receive (`/0/i`) and change " +
+        "(`/1/i`) chains using BIP44 gap-limit scanning so a previously-used " +
+        "wallet's later-index funds aren't missed. 0 = first Bitcoin account, " +
+        "1 = second, etc. Omit for the default (index 0). Call again with a " +
+        "different index to expose more accounts; calling with the same index " +
+        "refreshes the cache."
+    ),
+  gapLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      "BIP44 gap limit — stop walking each (type, chain) after this many " +
+        "consecutive addresses with zero on-chain history. Default 20 (matches " +
+        "Electrum / Sparrow / Trezor Suite / Ledger Live). Lower values speed " +
+        "the scan up but risk missing funds across larger gaps; raise it for " +
+        "wallets that may have skipped indices. Capped at 100."
     ),
 });
 
@@ -1035,6 +1051,23 @@ export const getBitcoinFeeEstimatesInput = z.object({});
 
 export const getBitcoinBlockTipInput = z.object({});
 
+export const getBitcoinAccountBalanceInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe(
+      "Ledger Bitcoin account slot to aggregate. Must have been paired via " +
+        "`pair_ledger_btc` first — the tool fans out across every cached " +
+        "USED address (txCount > 0 at scan time) for this accountIndex, sums " +
+        "their on-chain balances, and surfaces the per-address breakdown so the " +
+        "agent can show which legs hold the funds. Empty cached addresses are " +
+        "skipped to keep the response tight; if you suspect the cache is stale, " +
+        "re-run `pair_ledger_btc` first."
+    ),
+});
+
 export const prepareBitcoinNativeSendInput = z.object({
   wallet: bitcoinAddressSchema.describe(
     "Paired Bitcoin source address. Must already be in `pairings.bitcoin` " +
@@ -1102,6 +1135,9 @@ export type GetBitcoinBalanceArgs = z.infer<typeof getBitcoinBalanceInput>;
 export type GetBitcoinBalancesArgs = z.infer<typeof getBitcoinBalancesInput>;
 export type GetBitcoinFeeEstimatesArgs = z.infer<typeof getBitcoinFeeEstimatesInput>;
 export type GetBitcoinBlockTipArgs = z.infer<typeof getBitcoinBlockTipInput>;
+export type GetBitcoinAccountBalanceArgs = z.infer<
+  typeof getBitcoinAccountBalanceInput
+>;
 export const signBtcMessageInput = z.object({
   wallet: bitcoinAddressSchema.describe(
     "Paired Bitcoin source address. Must already be in `pairings.bitcoin` " +

--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -5,6 +5,7 @@ import {
   openLedger,
   getAppAndVersion,
   type BtcAddressFormat,
+  type BtcLedgerApp,
   type BtcLedgerTransport,
 } from "./btc-usb-loader.js";
 import { getConfigPath, patchUserConfig, readUserConfig } from "../config/user-config.js";
@@ -68,6 +69,20 @@ export function btcPathForAccountIndex(
   accountIndex: number,
   addressType: BtcAddressType,
 ): string {
+  return btcLeafPath(accountIndex, addressType, 0, 0);
+}
+
+/**
+ * Build a full BIP-32 leaf path for a specific (account, type, chain,
+ * index) tuple. Used by gap-limit scanning to walk both the receive
+ * chain (chain=0) and change chain (chain=1) at non-zero indices.
+ */
+export function btcLeafPath(
+  accountIndex: number,
+  addressType: BtcAddressType,
+  chain: 0 | 1,
+  addressIndex: number,
+): string {
   if (
     !Number.isInteger(accountIndex) ||
     accountIndex < 0 ||
@@ -77,29 +92,45 @@ export function btcPathForAccountIndex(
       `Invalid Bitcoin accountIndex ${accountIndex} — must be an integer in [0, ${MAX_BTC_ACCOUNT_INDEX}].`,
     );
   }
+  if (chain !== 0 && chain !== 1) {
+    throw new Error(`Invalid BIP-32 chain ${chain} — must be 0 (receive) or 1 (change).`);
+  }
+  if (!Number.isInteger(addressIndex) || addressIndex < 0) {
+    throw new Error(
+      `Invalid BIP-32 addressIndex ${addressIndex} — must be a non-negative integer.`,
+    );
+  }
   const { purpose } = TYPE_META[addressType];
-  return `${purpose}'/0'/${accountIndex}'/0/0`;
+  return `${purpose}'/0'/${accountIndex}'/${chain}/${addressIndex}`;
 }
 
-const BTC_PATH_RE = /^(44|49|84|86)'\/0'\/(\d+)'\/0\/0$/;
+const BTC_PATH_RE = /^(44|49|84|86)'\/0'\/(\d+)'\/(0|1)\/(\d+)$/;
 
 /**
- * Parse the address type + account index out of a BTC BIP-44 path.
- * Returns null when the path doesn't match the standard 5-segment
- * `<purpose>'/0'/<account>'/0/0` shape — a custom path we'd cache but
- * couldn't index.
+ * Parse the address type, account index, BIP-32 chain (0 = receive,
+ * 1 = change), and address index out of a BTC BIP-44 path. Returns
+ * null when the path doesn't match the standard 5-segment shape —
+ * custom paths get cached but can't be indexed.
  */
 export function parseBtcPath(
   path: string,
-): { addressType: BtcAddressType; accountIndex: number } | null {
+): {
+  addressType: BtcAddressType;
+  accountIndex: number;
+  chain: 0 | 1;
+  addressIndex: number;
+} | null {
   const m = BTC_PATH_RE.exec(path);
   if (!m) return null;
   const purpose = Number(m[1]);
   const accountIndex = Number(m[2]);
+  const chain = Number(m[3]) as 0 | 1;
+  const addressIndex = Number(m[4]);
   if (!Number.isInteger(accountIndex)) return null;
+  if (!Number.isInteger(addressIndex)) return null;
   for (const t of BTC_ADDRESS_TYPES) {
     if (TYPE_META[t].purpose === purpose) {
-      return { addressType: t, accountIndex };
+      return { addressType: t, accountIndex, chain, addressIndex };
     }
   }
   return null;
@@ -132,6 +163,8 @@ interface DerivedAddress {
   appVersion: string;
   addressType: BtcAddressType;
   accountIndex: number;
+  chain: 0 | 1;
+  addressIndex: number;
 }
 
 /**
@@ -161,19 +194,215 @@ export async function getBtcLedgerAddress(
       const { format } = TYPE_META[addressType];
       const out = await app.getWalletPublicKey(path, { format });
       const parsed = parseBtcPath(path);
-      const accountIndex = parsed?.accountIndex ?? 0;
       return {
         address: out.bitcoinAddress,
         publicKey: out.publicKey,
         path,
         appVersion: appVer.version,
         addressType,
-        accountIndex,
+        accountIndex: parsed?.accountIndex ?? 0,
+        chain: parsed?.chain ?? 0,
+        addressIndex: parsed?.addressIndex ?? 0,
       };
     } finally {
       await (transport as BtcLedgerTransport).close().catch(() => {});
     }
   });
+}
+
+/**
+ * BIP44 gap-limit default. Standard across Electrum / Sparrow / Trezor
+ * Suite / Ledger Live: stop walking a chain after 20 consecutive
+ * addresses with zero on-chain history. Issue #189.
+ */
+export const DEFAULT_BTC_GAP_LIMIT = 20;
+/** Hard cap on `gapLimit` to bound USB roundtrips. */
+export const MAX_BTC_GAP_LIMIT = 100;
+
+/**
+ * Caller-supplied callback that fetches the current on-chain tx count
+ * for an address. Injected (rather than hard-wired to the indexer) so
+ * `scanBtcAccount` stays usable from tests with mocked tx-count
+ * responses, and so the hot-path indexer module isn't a runtime
+ * dependency of this file's import graph (keeps the USB signer
+ * independent of the HTTP indexer abstraction).
+ */
+export type BtcAddressTxCountFetcher = (
+  address: string,
+) => Promise<number>;
+
+/**
+ * Result of a single (type, chain) walk: the addresses we derived,
+ * and how many of them ended the run with txCount === 0 (the gap
+ * window that ultimately tripped the stop condition).
+ */
+export interface ScanChainResult {
+  /**
+   * Every derived address along this chain, in walk order. Includes
+   * the trailing gap of empties that triggered the stop — the LAST
+   * empty is the wallet's "next fresh receive address" for receive
+   * chains, useful for UX. All except the trailing gap have
+   * `txCount > 0`.
+   */
+  addresses: DerivedAddress[];
+  /** Tx counts aligned 1:1 with `addresses`. */
+  txCounts: number[];
+  /** True when the chain returned all-zeros immediately (no usage). */
+  empty: boolean;
+}
+
+/**
+ * BIP44 gap-limit scan for one account index. Walks each address-type
+ * (44'/49'/84'/86') across both BIP-32 chains (receive=0, change=1),
+ * stopping each chain after `gapLimit` consecutive empty addresses.
+ *
+ * Optimization: when the receive chain (chain=0) returns all-empty for
+ * a given type, the change chain is skipped — change addresses can
+ * only have history if at least one corresponding receive saw a spend,
+ * and "no receives" → "no spends" → "no change history". Saves ~half
+ * the USB roundtrips on a fresh wallet.
+ *
+ * Performance: a fresh wallet (every chain empty) takes
+ * `4 types × gapLimit` derivations = 80 with the default gap of 20.
+ * A heavily-used wallet does that plus `numUsed` extra calls per
+ * chain. USB calls are serialized via `withBtcUsbLock`; the indexer
+ * txCount probe is awaited inline rather than batched because the
+ * stop decision is per-call.
+ */
+export async function scanBtcAccount(args: {
+  accountIndex: number;
+  gapLimit?: number;
+  fetchTxCount: BtcAddressTxCountFetcher;
+}): Promise<{
+  appVersion: string;
+  entries: Array<DerivedAddress & { txCount: number }>;
+}> {
+  const accountIndex = args.accountIndex;
+  const gapLimit = args.gapLimit ?? DEFAULT_BTC_GAP_LIMIT;
+  if (
+    !Number.isInteger(gapLimit) ||
+    gapLimit < 1 ||
+    gapLimit > MAX_BTC_GAP_LIMIT
+  ) {
+    throw new Error(
+      `Invalid gapLimit ${gapLimit} — must be an integer in [1, ${MAX_BTC_GAP_LIMIT}].`,
+    );
+  }
+  return withBtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Bitcoin" &&
+        appVer.name !== "Bitcoin Test" &&
+        appVer.name !== "BTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Bitcoin is required. ` +
+            `Open the Bitcoin app on your device and retry.`,
+        );
+      }
+
+      const all: Array<DerivedAddress & { txCount: number }> = [];
+      for (const addressType of BTC_ADDRESS_TYPES) {
+        const receive = await scanChain({
+          app,
+          accountIndex,
+          addressType,
+          chain: 0,
+          gapLimit,
+          appVersion: appVer.version,
+          fetchTxCount: args.fetchTxCount,
+        });
+        for (let i = 0; i < receive.addresses.length; i++) {
+          all.push({ ...receive.addresses[i], txCount: receive.txCounts[i] });
+        }
+        // No receives ever → no change can exist. Skip the change-chain
+        // walk entirely (saves up to `gapLimit` USB roundtrips per type).
+        if (receive.empty) continue;
+        const change = await scanChain({
+          app,
+          accountIndex,
+          addressType,
+          chain: 1,
+          gapLimit,
+          appVersion: appVer.version,
+          fetchTxCount: args.fetchTxCount,
+        });
+        for (let i = 0; i < change.addresses.length; i++) {
+          all.push({ ...change.addresses[i], txCount: change.txCounts[i] });
+        }
+      }
+      return { appVersion: appVer.version, entries: all };
+    } finally {
+      await (transport as BtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * Walk a single (type, chain) starting at index 0 until `gapLimit`
+ * consecutive empty addresses are observed. Returns every address we
+ * derived along the way, including the trailing empty window — the
+ * trailing FIRST empty is the wallet's next fresh address for that
+ * chain, useful for receive UX.
+ *
+ * Helper for `scanBtcAccount`; not exported because the caller already
+ * holds the USB lock + open transport.
+ */
+async function scanChain(args: {
+  app: { getWalletPublicKey: BtcLedgerApp["getWalletPublicKey"] };
+  accountIndex: number;
+  addressType: BtcAddressType;
+  chain: 0 | 1;
+  gapLimit: number;
+  appVersion: string;
+  fetchTxCount: BtcAddressTxCountFetcher;
+}): Promise<ScanChainResult> {
+  const { format } = TYPE_META[args.addressType];
+  const addresses: DerivedAddress[] = [];
+  const txCounts: number[] = [];
+  let consecutiveEmpty = 0;
+  let addressIndex = 0;
+  while (consecutiveEmpty < args.gapLimit) {
+    const path = btcLeafPath(
+      args.accountIndex,
+      args.addressType,
+      args.chain,
+      addressIndex,
+    );
+    const out = await args.app.getWalletPublicKey(path, { format });
+    let txCount: number;
+    try {
+      txCount = await args.fetchTxCount(out.bitcoinAddress);
+    } catch {
+      // Indexer hiccup — treat as zero so the scan can make forward
+      // progress. The user can re-pair to refresh; we don't want a
+      // single flaky HTTP call to abort a 100-call scan.
+      txCount = 0;
+    }
+    addresses.push({
+      address: out.bitcoinAddress,
+      publicKey: out.publicKey,
+      path,
+      appVersion: args.appVersion,
+      addressType: args.addressType,
+      accountIndex: args.accountIndex,
+      chain: args.chain,
+      addressIndex,
+    });
+    txCounts.push(txCount);
+    if (txCount === 0) {
+      consecutiveEmpty++;
+    } else {
+      consecutiveEmpty = 0;
+    }
+    addressIndex++;
+  }
+  // `empty` = chain returned ZERO used addresses; equivalent to "the
+  // first `gapLimit` entries are all zero-tx" and `addresses.length === gapLimit`.
+  const empty = txCounts.every((c) => c === 0);
+  return { addresses, txCounts, empty };
 }
 
 /**
@@ -212,6 +441,8 @@ export async function deriveBtcLedgerAccount(
           appVersion: appVer.version,
           addressType,
           accountIndex,
+          chain: 0,
+          addressIndex: 0,
         });
       }
       return { appVersion: appVer.version, entries };
@@ -432,6 +663,19 @@ function ensurePairedBtcHydrated(): void {
   pairedBtcHydrated = true;
   const persisted = readUserConfig()?.pairings?.bitcoin ?? [];
   for (const entry of persisted) {
+    // Backfill chain/addressIndex from the path for pre-#189 entries
+    // (which only ever had chain=0, addressIndex=0). Keeps callers
+    // from having to handle the absence at every read site.
+    if (entry.chain === undefined || entry.addressIndex === undefined) {
+      const parsed = parseBtcPath(entry.path);
+      if (parsed) {
+        entry.chain = parsed.chain;
+        entry.addressIndex = parsed.addressIndex;
+      } else {
+        entry.chain = null;
+        entry.addressIndex = null;
+      }
+    }
     pairedBtcByPath.set(entry.path, entry);
   }
 }
@@ -445,15 +689,25 @@ function persistPairedBtc(): void {
 export function getPairedBtcAddresses(): PairedBitcoinEntry[] {
   ensurePairedBtcHydrated();
   return Array.from(pairedBtcByPath.values()).sort((a, b) => {
-    // Sort by accountIndex first, then by purpose so each account's four
-    // address types appear together (legacy → p2sh-segwit → segwit →
-    // taproot, the BIP-44 purpose order).
+    // Sort by accountIndex → addressType (BIP-44 purpose order:
+    // legacy 44 → p2sh 49 → segwit 84 → taproot 86) → chain (receive
+    // before change) → addressIndex. Keeps each account's full
+    // footprint contiguous and ordered the way most wallets display it.
     if (a.accountIndex !== b.accountIndex) {
       if (a.accountIndex === null) return 1;
       if (b.accountIndex === null) return -1;
       return a.accountIndex - b.accountIndex;
     }
-    return BTC_ADDRESS_TYPES.indexOf(a.addressType) - BTC_ADDRESS_TYPES.indexOf(b.addressType);
+    const typeOrder =
+      BTC_ADDRESS_TYPES.indexOf(a.addressType) -
+      BTC_ADDRESS_TYPES.indexOf(b.addressType);
+    if (typeOrder !== 0) return typeOrder;
+    const aChain = a.chain ?? -1;
+    const bChain = b.chain ?? -1;
+    if (aChain !== bChain) return aChain - bChain;
+    const aIdx = a.addressIndex ?? -1;
+    const bIdx = b.addressIndex ?? -1;
+    return aIdx - bIdx;
   });
 }
 
@@ -476,10 +730,31 @@ export function setPairedBtcAddress(
     appVersion: entry.appVersion,
     addressType: entry.addressType,
     accountIndex: entry.accountIndex,
+    ...(entry.chain !== undefined ? { chain: entry.chain } : {}),
+    ...(entry.addressIndex !== undefined ? { addressIndex: entry.addressIndex } : {}),
+    ...(entry.txCount !== undefined ? { txCount: entry.txCount } : {}),
   };
   pairedBtcByPath.set(entry.path, full);
   persistPairedBtc();
   return full;
+}
+
+/**
+ * Drop every cached entry whose `accountIndex` matches. Used by
+ * `pair_ledger_btc` before re-scanning so an account that previously
+ * extended further than the current gap-limit window doesn't leave
+ * stale (and now-incorrect) entries in the cache.
+ */
+export function clearPairedBtcAccount(accountIndex: number): void {
+  ensurePairedBtcHydrated();
+  let changed = false;
+  for (const [path, entry] of pairedBtcByPath) {
+    if (entry.accountIndex === accountIndex) {
+      pairedBtcByPath.delete(path);
+      changed = true;
+    }
+  }
+  if (changed) persistPairedBtc();
 }
 
 export function clearPairedBtcAddresses(): void {

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -124,6 +124,12 @@ export interface SessionStatus {
     addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
     /** Null when the path doesn't match the standard 5-segment layout. */
     accountIndex: number | null;
+    /** BIP-32 chain: 0 = receive, 1 = change. Null for non-standard paths. */
+    chain?: 0 | 1 | null;
+    /** BIP-32 address index. Null for non-standard paths. */
+    addressIndex?: number | null;
+    /** Tx count from the indexer at last pair_ledger_btc scan. Snapshot only. */
+    txCount?: number;
   }>;
 }
 
@@ -253,6 +259,9 @@ export async function getSessionStatus(): Promise<SessionStatus> {
             appVersion: e.appVersion,
             addressType: e.addressType,
             accountIndex: e.accountIndex,
+            ...(e.chain !== undefined ? { chain: e.chain } : {}),
+            ...(e.addressIndex !== undefined ? { addressIndex: e.addressIndex } : {}),
+            ...(e.txCount !== undefined ? { txCount: e.txCount } : {}),
           })),
         }
       : {};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1196,10 +1196,18 @@ export interface PairedTronEntry {
 
 /**
  * Bitcoin pairing entry. Bitcoin has 4 standard mainnet address types,
- * each on its own BIP-44 purpose (BIP-44 / BIP-49 / BIP-84 / BIP-86),
- * so a single account index produces 4 entries — one per type. The
- * `addressType` discriminator tells callers which path generated this
- * address without re-parsing the path.
+ * each on its own BIP-44 purpose (BIP-44 / BIP-49 / BIP-84 / BIP-86).
+ *
+ * Pre-#189 a single account index produced exactly 4 entries — one per
+ * type, all on the receive chain at index 0. After gap-limit scanning
+ * lands, an account index produces N entries per (type, chain) — every
+ * used address plus the first unused on each chain, for both receive
+ * (chain=0) and change (chain=1). The `chain` + `addressIndex` fields
+ * disambiguate the path without re-parsing.
+ *
+ * Backwards compat: old cached entries (pre-#189) had only the
+ * `<purpose>'/0'/<account>'/0/0` leaf. Hydrate-time backfill parses the
+ * path so `chain`/`addressIndex` are always present after load.
  */
 export interface PairedBitcoinEntry {
   address: string;
@@ -1216,6 +1224,21 @@ export interface PairedBitcoinEntry {
   addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
   /** Null when the path doesn't match the standard 5-segment layout. */
   accountIndex: number | null;
+  /**
+   * BIP-32 chain: 0 = external/receive, 1 = internal/change. Null when
+   * the path doesn't match the standard 5-segment layout.
+   */
+  chain?: 0 | 1 | null;
+  /** BIP-32 address index (final path segment). Null when non-standard. */
+  addressIndex?: number | null;
+  /**
+   * Last known on-chain tx count from the indexer at scan time. Optional
+   * + a snapshot — goes stale immediately after pairing but useful for
+   * the agent to tell at-a-glance which addresses have history. Refresh
+   * by calling `pair_ledger_btc` again, or `get_btc_account_balance`
+   * for a live read.
+   */
+  txCount?: number;
 }
 
 export interface UserConfig {

--- a/test/btc-pair.test.ts
+++ b/test/btc-pair.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pjoin } from "node:path";
@@ -34,6 +35,24 @@ vi.mock("../src/signing/btc-usb-loader.js", () => ({
     rawTransport: {},
   }),
   getAppAndVersion: (rt: unknown) => getAppAndVersionMock(rt),
+}));
+
+// pair_ledger_btc's gap-limit scan piggybacks on the indexer's
+// getBalance() to fetch txCount per derived address. Mock the entire
+// indexer module so a fresh wallet (txCount=0 for everything) walks
+// the gap window without any HTTP IO.
+const indexerGetBalanceMock = vi.fn(async (address: string) => ({
+  address,
+  confirmedSats: 0n,
+  mempoolSats: 0n,
+  totalSats: 0n,
+  txCount: 0,
+}));
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getBalance: indexerGetBalanceMock,
+  }),
+  resetBitcoinIndexer: () => {},
 }));
 
 let tmpHome: string;
@@ -79,25 +98,33 @@ describe("btcPathForAccountIndex", () => {
 });
 
 describe("parseBtcPath", () => {
-  it("decodes standard paths back into address-type + accountIndex", async () => {
+  it("decodes standard paths back into addressType + accountIndex + chain + addressIndex", async () => {
     const { parseBtcPath } = await import(
       "../src/signing/btc-usb-signer.js"
     );
     expect(parseBtcPath("44'/0'/0'/0/0")).toEqual({
       addressType: "legacy",
       accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
     });
-    expect(parseBtcPath("49'/0'/3'/0/0")).toEqual({
+    expect(parseBtcPath("49'/0'/3'/1/5")).toEqual({
       addressType: "p2sh-segwit",
       accountIndex: 3,
+      chain: 1,
+      addressIndex: 5,
     });
-    expect(parseBtcPath("84'/0'/7'/0/0")).toEqual({
+    expect(parseBtcPath("84'/0'/7'/0/12")).toEqual({
       addressType: "segwit",
       accountIndex: 7,
+      chain: 0,
+      addressIndex: 12,
     });
-    expect(parseBtcPath("86'/0'/12'/0/0")).toEqual({
+    expect(parseBtcPath("86'/0'/12'/1/99")).toEqual({
       addressType: "taproot",
       accountIndex: 12,
+      chain: 1,
+      addressIndex: 99,
     });
   });
 
@@ -109,65 +136,142 @@ describe("parseBtcPath", () => {
     expect(parseBtcPath("44'/1'/0'/0/0")).toBeNull();
     // Wrong segment count (account-level xpub path, not leaf).
     expect(parseBtcPath("84'/0'/0'")).toBeNull();
+    // Invalid chain segment (only 0/1 allowed by BIP-44).
+    expect(parseBtcPath("84'/0'/0'/2/0")).toBeNull();
     // Garbage.
     expect(parseBtcPath("not-a-path")).toBeNull();
   });
 });
 
-describe("pairLedgerBitcoin", () => {
-  it("derives all four address types in one call and persists each entry", async () => {
+describe("btcLeafPath", () => {
+  it("composes arbitrary BIP-32 leaf paths for receive + change chains", async () => {
+    const { btcLeafPath } = await import("../src/signing/btc-usb-signer.js");
+    expect(btcLeafPath(0, "segwit", 0, 0)).toBe("84'/0'/0'/0/0");
+    expect(btcLeafPath(0, "segwit", 1, 5)).toBe("84'/0'/0'/1/5");
+    expect(btcLeafPath(2, "taproot", 0, 12)).toBe("86'/0'/2'/0/12");
+  });
+
+  it("rejects out-of-range arguments", async () => {
+    const { btcLeafPath } = await import("../src/signing/btc-usb-signer.js");
+    expect(() => btcLeafPath(-1, "segwit", 0, 0)).toThrow();
+    expect(() => btcLeafPath(0, "segwit", 2 as 0 | 1, 0)).toThrow(/chain/);
+    expect(() => btcLeafPath(0, "segwit", 0, -1)).toThrow();
+  });
+});
+
+describe("pairLedgerBitcoin (BIP44 gap-limit scan, issue #189)", () => {
+  // Helper: synthesize a unique fake address for each derived path so
+  // the in-memory cache (keyed by path) doesn't deduplicate. Real
+  // checksum validation happens at signing time, not here.
+  function fakeAddressForPath(path: string): string {
+    // Deterministic per-path slug — use the SHA-1 of the whole path
+    // (truncated to 12 hex chars) so each unique BIP-32 leaf gets a
+    // distinct fake address. Earlier attempt sliced the raw path bytes
+    // which collapsed to the same slug because the differing trailing
+    // segments (chain/index) all share the leading 6 bytes.
+    const hash = createHash("sha1").update(path).digest("hex").slice(0, 12);
+    if (path.startsWith("44'")) return `1Fake${hash}H1nADuVeoUaqcJBZ`;
+    if (path.startsWith("49'")) return `3Fake${hash}H1nADuVeoUaqcJBZ`;
+    if (path.startsWith("84'"))
+      return `bc1qfake${hash}h1naduveoaqcjbz1ypqsxz3y`;
+    return `bc1pfake${hash}h1naduveoaqcjbz1ypqsxz3y`;
+  }
+
+  beforeEach(() => {
+    indexerGetBalanceMock.mockReset();
+    // Default: every address is empty (fresh wallet).
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: 0,
+    }));
+  });
+
+  it("walks gap-limit empty receive chains and skips change for a fresh wallet", async () => {
     getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
-    // Ledger BTC app returns one address per format. Map by format string.
-    getWalletPublicKeyMock.mockImplementation(
-      async (_path: string, opts: { format: string }) => {
-        const addr =
-          opts.format === "legacy"
-            ? LEGACY_ADDR
-            : opts.format === "p2sh"
-              ? P2SH_ADDR
-              : opts.format === "bech32"
-                ? SEGWIT_ADDR
-                : TAPROOT_ADDR;
-        return { publicKey: FAKE_PUBKEY, bitcoinAddress: addr, chainCode: FAKE_CHAIN_CODE };
-      },
-    );
+    getWalletPublicKeyMock.mockImplementation(async (path: string) => ({
+      publicKey: FAKE_PUBKEY,
+      bitcoinAddress: fakeAddressForPath(path),
+      chainCode: FAKE_CHAIN_CODE,
+    }));
 
     const { pairLedgerBitcoin } = await import(
       "../src/modules/execution/index.js"
     );
-    const out = await pairLedgerBitcoin({ accountIndex: 0 });
+    // Use a smaller gapLimit to keep the test fast.
+    const out = await pairLedgerBitcoin({ accountIndex: 0, gapLimit: 5 });
 
     expect(out.accountIndex).toBe(0);
+    expect(out.gapLimit).toBe(5);
     expect(out.appVersion).toBe("2.2.3");
-    expect(out.addresses).toHaveLength(4);
-    const byType = Object.fromEntries(out.addresses.map((a) => [a.addressType, a]));
-    expect(byType.legacy.address).toBe(LEGACY_ADDR);
-    expect(byType.legacy.path).toBe("44'/0'/0'/0/0");
-    expect(byType["p2sh-segwit"].address).toBe(P2SH_ADDR);
-    expect(byType["p2sh-segwit"].path).toBe("49'/0'/0'/0/0");
-    expect(byType.segwit.address).toBe(SEGWIT_ADDR);
-    expect(byType.segwit.path).toBe("84'/0'/0'/0/0");
-    expect(byType.taproot.address).toBe(TAPROOT_ADDR);
-    expect(byType.taproot.path).toBe("86'/0'/0'/0/0");
+    // 4 types × 1 chain (change skipped) × 5 gap-window = 20 addresses.
+    expect(out.addresses).toHaveLength(20);
+    // All on receive chain.
+    expect(out.addresses.every((a) => a.chain === 0)).toBe(true);
+    // Indices 0..4 per type.
+    const segwitWalk = out.addresses
+      .filter((a) => a.addressType === "segwit")
+      .map((a) => a.addressIndex);
+    expect(segwitWalk).toEqual([0, 1, 2, 3, 4]);
+    expect(out.summary).toEqual({ totalDerived: 20, used: 0, unused: 20 });
 
-    // Cached + persisted: get_ledger_status's btc section should now
-    // surface all four entries.
-    const { getPairedBtcAddresses } = await import(
-      "../src/signing/btc-usb-signer.js"
-    );
-    const cached = getPairedBtcAddresses();
-    expect(cached).toHaveLength(4);
-    expect(cached.map((e) => e.addressType)).toEqual([
-      "legacy",
-      "p2sh-segwit",
-      "segwit",
-      "taproot",
-    ]);
-    expect(cached.every((e) => e.accountIndex === 0)).toBe(true);
-    expect(cached.every((e) => e.appVersion === "2.2.3")).toBe(true);
-
-    // Single transport open + close (deriveBtcLedgerAccount reuses it).
+    // 4 types × 5 derivations = 20 USB calls; one transport open.
+    expect(getWalletPublicKeyMock).toHaveBeenCalledTimes(20);
+    expect(indexerGetBalanceMock).toHaveBeenCalledTimes(20);
     expect(transportCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("walks both receive and change chains when receive has activity", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    getWalletPublicKeyMock.mockImplementation(async (path: string) => ({
+      publicKey: FAKE_PUBKEY,
+      bitcoinAddress: fakeAddressForPath(path),
+      chainCode: FAKE_CHAIN_CODE,
+    }));
+    // Mark the segwit /0/0 (receive index 0) as USED. Every other
+    // address stays at txCount=0. Receive chain stops after the gap
+    // window FOLLOWING that single used entry; change chain runs too
+    // because receive isn't fully empty.
+    const segwitReceive0 = fakeAddressForPath("84'/0'/0'/0/0");
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: address === segwitReceive0 ? 1 : 0,
+    }));
+
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await pairLedgerBitcoin({ accountIndex: 0, gapLimit: 3 });
+
+    // legacy/p2sh/taproot receives all empty → 3 chains × 3 = 9 entries.
+    // segwit receive: index 0 used + 3 trailing empties = 4 entries.
+    // segwit change: 3 empties (because receive wasn't fully empty).
+    // Total: 9 + 4 + 3 = 16.
+    expect(out.addresses).toHaveLength(16);
+    expect(out.summary.used).toBe(1);
+    // Verify the segwit change-chain was walked (chain=1 entries exist).
+    const segwitChange = out.addresses.filter(
+      (a) => a.addressType === "segwit" && a.chain === 1,
+    );
+    expect(segwitChange.length).toBe(3);
+  });
+
+  it("rejects gapLimit out of [1, 100]", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    const { pairLedgerBitcoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      pairLedgerBitcoin({ accountIndex: 0, gapLimit: 0 }),
+    ).rejects.toThrow(/Invalid gapLimit/);
+    await expect(
+      pairLedgerBitcoin({ accountIndex: 0, gapLimit: 101 }),
+    ).rejects.toThrow(/Invalid gapLimit/);
   });
 
   it("refuses when the wrong app is open on-device", async () => {
@@ -175,61 +279,163 @@ describe("pairLedgerBitcoin", () => {
     const { pairLedgerBitcoin } = await import(
       "../src/modules/execution/index.js"
     );
-    await expect(pairLedgerBitcoin({ accountIndex: 0 })).rejects.toThrow(
+    await expect(pairLedgerBitcoin({ accountIndex: 0, gapLimit: 5 })).rejects.toThrow(
       /open app as "Ethereum".*Bitcoin is required/,
     );
   });
 
-  it("survives multiple pairings at different account indices", async () => {
+  it("clears stale entries for an accountIndex before re-pairing", async () => {
     getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
-    let callCount = 0;
-    getWalletPublicKeyMock.mockImplementation(async (path: string) => {
-      callCount++;
-      // Synthesize a unique-looking address per call. Real validation
-      // happens in the regex; we just need the bench32m prefix for the
-      // taproot case below to round-trip.
-      const idx = callCount.toString().padStart(2, "0");
-      return {
-        publicKey: FAKE_PUBKEY,
-        bitcoinAddress: path.startsWith("44'")
-          ? `1FakeAddr${idx}vH1nADuVeoUaqcJBZ1Yp`
-          : path.startsWith("49'")
-            ? `3FakeAddr${idx}vH1nADuVeoUaqcJBZ1Yp`
-            : path.startsWith("84'")
-              ? `bc1qfakeaddr${idx}vh1naduveoaqcjbz1ypqsxz3yrm`
-              : `bc1pfakeaddr${idx}vh1naduveoaqcjbz1ypqsxz3yrm`,
-        chainCode: FAKE_CHAIN_CODE,
-      };
-    });
-
+    getWalletPublicKeyMock.mockImplementation(async (path: string) => ({
+      publicKey: FAKE_PUBKEY,
+      bitcoinAddress: fakeAddressForPath(path),
+      chainCode: FAKE_CHAIN_CODE,
+    }));
     const { pairLedgerBitcoin } = await import(
       "../src/modules/execution/index.js"
     );
-    await pairLedgerBitcoin({ accountIndex: 0 });
-    await pairLedgerBitcoin({ accountIndex: 1 });
-
+    // First pair with gap=10 → 4 types × 10 entries = 40 cached.
+    await pairLedgerBitcoin({ accountIndex: 0, gapLimit: 10 });
     const { getPairedBtcAddresses } = await import(
       "../src/signing/btc-usb-signer.js"
     );
-    const cached = getPairedBtcAddresses();
-    expect(cached).toHaveLength(8); // 2 accounts × 4 types
-    // Sorted by accountIndex first, then by purpose order.
-    expect(cached.map((e) => e.accountIndex)).toEqual([0, 0, 0, 0, 1, 1, 1, 1]);
-    expect(cached.slice(0, 4).map((e) => e.addressType)).toEqual([
-      "legacy",
-      "p2sh-segwit",
-      "segwit",
-      "taproot",
-    ]);
+    expect(getPairedBtcAddresses()).toHaveLength(40);
+
+    // Re-pair same account with smaller gap → must DROP the 40 stale
+    // entries and end up with only the new 4 × 5 = 20.
+    await pairLedgerBitcoin({ accountIndex: 0, gapLimit: 5 });
+    expect(getPairedBtcAddresses()).toHaveLength(20);
+  });
+});
+
+describe("get_btc_account_balance (issue #189)", () => {
+  it("aggregates confirmed sats across cached used-addresses for one account", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    // Two USED addresses (txCount > 0) on account 0; one UNUSED address
+    // that should be skipped from the indexer fan-out.
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 5,
+    });
+    setPairedBtcAddress({
+      address: TAPROOT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "86'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 3,
+    });
+    const FRESH_RECEIVE = "bc1qfreshfreshfreshfreshfreshfreshfreshfre";
+    setPairedBtcAddress({
+      address: FRESH_RECEIVE,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/1",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 1,
+      txCount: 0, // unused — should be skipped from the live fan-out
+    });
+
+    indexerGetBalanceMock.mockReset();
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      if (address === SEGWIT_ADDR) {
+        return {
+          address,
+          confirmedSats: 100_000n,
+          mempoolSats: 0n,
+          totalSats: 100_000n,
+          txCount: 5,
+        };
+      }
+      if (address === TAPROOT_ADDR) {
+        return {
+          address,
+          confirmedSats: 250_000n,
+          mempoolSats: 50_000n,
+          totalSats: 300_000n,
+          txCount: 3,
+        };
+      }
+      throw new Error(`unexpected address fan-out: ${address}`);
+    });
+
+    const { getBitcoinAccountBalance } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await getBitcoinAccountBalance({ accountIndex: 0 });
+    expect(out.accountIndex).toBe(0);
+    expect(out.addressesQueried).toBe(2); // skip the unused fresh-receive
+    expect(out.addressesCached).toBe(3);
+    expect(out.totalConfirmedSats).toBe("350000");
+    expect(out.totalConfirmedBtc).toBe("0.0035");
+    expect(out.totalMempoolSats).toBe("50000");
+    expect(out.breakdown).toHaveLength(2);
+    expect(indexerGetBalanceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when no entries are cached for the requested accountIndex", async () => {
+    const { getBitcoinAccountBalance } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      getBitcoinAccountBalance({ accountIndex: 99 }),
+    ).rejects.toThrow(/No paired Bitcoin entries cached/);
+  });
+});
+
+describe("clearPairedBtcAccount", () => {
+  it("drops only entries matching the given accountIndex", async () => {
+    const { setPairedBtcAddress, clearPairedBtcAccount, getPairedBtcAddresses } =
+      await import("../src/signing/btc-usb-signer.js");
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+    setPairedBtcAddress({
+      address: TAPROOT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "86'/0'/1'/0/0",
+      appVersion: "2.2.3",
+      addressType: "taproot",
+      accountIndex: 1,
+      chain: 0,
+      addressIndex: 0,
+    });
+    expect(getPairedBtcAddresses()).toHaveLength(2);
+    clearPairedBtcAccount(0);
+    const remaining = getPairedBtcAddresses();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].accountIndex).toBe(1);
   });
 });
 
 describe("get_ledger_status — btc section", () => {
-  it("surfaces paired BTC entries when at least one is cached", async () => {
+  it("surfaces paired BTC entries with chain/addressIndex/txCount", async () => {
     // Reset the module cache + stub walletconnect so getSessionStatus's
     // getSignClient() call doesn't try to resolve a WC project ID under
     // CI (where WALLETCONNECT_PROJECT_ID is unset). Mirrors the TRON
-    // get-ledger-status test's pattern.
+    // get-ledger-status test's pattern. Also re-stub the indexer + USB
+    // mocks since vi.resetModules() drops the file-scope mocks.
     vi.resetModules();
     vi.doMock("../src/signing/walletconnect.js", () => ({
       getSignClient: async () => ({}),
@@ -237,37 +443,69 @@ describe("get_ledger_status — btc section", () => {
       getConnectedAccountsDetailed: async () => [],
       isPeerUnreachable: () => false,
     }));
+    vi.doMock("../src/signing/btc-usb-loader.js", () => ({
+      openLedger: async () => ({
+        app: {
+          getWalletPublicKey: getWalletPublicKeyMock,
+          signMessage: signMessageMock,
+        },
+        transport: { close: transportCloseMock },
+        rawTransport: {},
+      }),
+      getAppAndVersion: (rt: unknown) => getAppAndVersionMock(rt),
+    }));
+    vi.doMock("../src/modules/btc/indexer.ts", () => ({
+      getBitcoinIndexer: () => ({
+        getBalance: async (address: string) => ({
+          address,
+          confirmedSats: 0n,
+          mempoolSats: 0n,
+          totalSats: 0n,
+          txCount: 0,
+        }),
+      }),
+      resetBitcoinIndexer: () => {},
+    }));
 
     getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.2.3" });
+    let counter = 0;
     getWalletPublicKeyMock.mockImplementation(
-      async (_path: string, opts: { format: string }) => ({
-        publicKey: FAKE_PUBKEY,
-        bitcoinAddress:
+      async (path: string, opts: { format: string }) => {
+        counter++;
+        // Synthesize a unique fake per call with type-correct prefixes.
+        const slug = counter.toString().padStart(3, "0");
+        const addr =
           opts.format === "legacy"
-            ? LEGACY_ADDR
+            ? `1Fake${slug}H1nADuVeoUaqcJBZ1Yp`
             : opts.format === "p2sh"
-              ? P2SH_ADDR
+              ? `3Fake${slug}H1nADuVeoUaqcJBZ1Yp`
               : opts.format === "bech32"
-                ? SEGWIT_ADDR
-                : TAPROOT_ADDR,
-        chainCode: FAKE_CHAIN_CODE,
-      }),
+                ? `bc1qfake${slug}h1naduveoaqcjbz1ypqsxz3yr`
+                : `bc1pfake${slug}h1naduveoaqcjbz1ypqsxz3yr`;
+        return {
+          publicKey: FAKE_PUBKEY,
+          bitcoinAddress: addr,
+          chainCode: FAKE_CHAIN_CODE,
+        };
+      },
     );
 
     const { pairLedgerBitcoin } = await import(
       "../src/modules/execution/index.js"
     );
-    await pairLedgerBitcoin({ accountIndex: 0 });
+    await pairLedgerBitcoin({ accountIndex: 0, gapLimit: 3 });
 
     const { getSessionStatus } = await import("../src/signing/session.js");
     const status = await getSessionStatus();
     expect(status.bitcoin).toBeDefined();
-    expect(status.bitcoin?.length).toBe(4);
-    const byType = Object.fromEntries(
-      (status.bitcoin ?? []).map((e) => [e.addressType, e]),
-    );
-    expect(byType.taproot.address).toBe(TAPROOT_ADDR);
-    expect(byType.segwit.path).toBe("84'/0'/0'/0/0");
+    // 4 types × gap=3 (no change-chain walk for fresh wallet) = 12 entries.
+    expect(status.bitcoin?.length).toBe(12);
+    // Every entry carries the new fields.
+    expect(
+      status.bitcoin?.every(
+        (e) => e.chain === 0 && typeof e.addressIndex === "number" && e.txCount === 0,
+      ),
+    ).toBe(true);
   });
 
   it("omits the btc section when no Bitcoin pairings are cached", async () => {


### PR DESCRIPTION
Closes #189.

Pre-#189, \`pair_ledger_btc\` enumerated only the index-0 receive address per type (\`<purpose>'/0'/<account>'/0/0\`). For any wallet that's been used for a while — Bitcoin best-practice mandates a fresh address per receive — the index-0 leaf is almost always empty while funds sit on later receive indices and on the change chain. The agent had no way to discover those addresses without the user pasting each one manually, defeating pairing.

## What ships

- **Gap-limit scan** — \`pair_ledger_btc({ accountIndex?, gapLimit? })\` walks both the receive (\`/0/i\`) and change (\`/1/i\`) chains for each address type (44'/49'/84'/86'), stopping each chain after \`gapLimit\` consecutive empty addresses. Default 20 (matches Electrum / Sparrow / Trezor Suite / Ledger Live), capped at 100.
- **Skip-empty optimization** — when the receive chain returns all-empty for a given type, the change chain is skipped entirely. Change addresses can only have history if at least one corresponding receive saw a spend (\`no receives → no spends → no change\`). Saves ~half the USB roundtrips on a fresh wallet (down to \`4 × gapLimit\` derivations).
- **Stale-entry clearing on re-pair** — re-pairing the same \`accountIndex\` first drops every cached entry for that account so a shrinking gap-window doesn't leave dangling old paths.
- **Single HTTP surface** — the txCount probe reuses the indexer's existing \`getBalance().txCount\`. No new API.

## New companion tool

\`get_btc_account_balance({ accountIndex })\` — aggregates on-chain balances across every cached USED address (txCount > 0 at scan time) for one account index. Returns per-address breakdown (address + type + chain + addressIndex + path + sats) AND rolled-up totals (confirmed / mempool / total sats + BTC). Empty cached entries (the trailing fresh-receive addresses) are skipped to keep fan-out tight.

## Type / projection updates

- \`PairedBitcoinEntry\` gains optional \`chain: 0 | 1\`, \`addressIndex\`, \`txCount\`. Hydrate-time backfill parses pre-#189 entries' paths so every loaded entry has the new fields populated.
- \`parseBtcPath\` now returns \`chain\` and \`addressIndex\` (rejects invalid chain values; previously accepted any integer).
- \`btcLeafPath(account, type, chain, index)\` exported as the canonical arbitrary-leaf builder; \`btcPathForAccountIndex\` becomes a thin wrapper.
- \`get_ledger_status.bitcoin[]\` forwards \`chain\`, \`addressIndex\`, \`txCount\`. Sort order: accountIndex → addressType → chain → addressIndex.

## Performance

A fresh wallet with default \`gapLimit=20\` runs \`4 types × 1 chain × 20 = 80\` USB roundtrips + 80 indexer calls. A used wallet runs that plus \`numUsed + gapLimit\` extras per chain (roughly: \`4 × (numUsed_receive + 20 + numUsed_change + 20)\`). USB calls are serialized via \`withBtcUsbLock\`; indexer fan-out is sequential because the stop decision is per-call.

## Verification

- 10 new tests in \`btc-pair.test.ts\` cover: fresh-wallet walk + change-skip optimization, used-wallet walk with change activation, gapLimit range validation, app-mismatch refusal, stale-entry clear on re-pair, \`get_btc_account_balance\` aggregation + unused-address skip, missing-account error, \`parseBtcPath\` new return shape, \`btcLeafPath\`, \`clearPairedBtcAccount\`.
- \`npm run build\` clean
- Full suite 1062/1062 (1055 baseline + 7 net new)

## Out of scope (per the issue's explicit deferrals)

- Send-side: aggregate UTXOs across all cached account addresses (today's \`prepare_btc_send\` still operates per-address)
- Send-side: use a real BIP-32 internal-chain change leaf instead of receive-as-change (Phase 1 simplification still in place)
- Multi-account scanning in one call (today's flow: call \`pair_ledger_btc\` once per accountIndex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)