### PR TITLE
feat(btc): rescan_btc_account — refresh cached txCount without the Ledger (#191)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
   getBitcoinFeeEstimates,
   getBitcoinBlockTip,
   getBitcoinAccountBalance,
+  rescanBitcoinAccount,
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   signBtcMessage,
@@ -151,6 +152,7 @@ import {
   getBitcoinFeeEstimatesInput,
   getBitcoinBlockTipInput,
   getBitcoinAccountBalanceInput,
+  rescanBitcoinAccountInput,
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   signBtcMessageInput,
@@ -1846,6 +1848,27 @@ async function main() {
   );
 
   server.registerTool(
+    "rescan_btc_account",
+    {
+      description:
+        "READ-ONLY — refresh the cached on-chain `txCount` for every paired " +
+        "Bitcoin address under one Ledger account by re-querying the indexer. " +
+        "Pure indexer-side: NO Ledger / USB interaction. Use this after the " +
+        "user has received funds (so a previously-empty cached address now " +
+        "has history) or when the indexer was stale at the original " +
+        "`pair_ledger_btc` scan time. Updates the persisted cache, so " +
+        "subsequent `get_btc_account_balance` reflects the refresh without " +
+        "another rescan. Flags `needsExtend: true` when the trailing buffer " +
+        "address on any cached chain now has on-chain history — that's the " +
+        "signal that funds may exist past the original gap-limit window, " +
+        "and the caller should re-run `pair_ledger_btc` to extend the walked " +
+        "window with fresh on-device derivations.",
+      inputSchema: rescanBitcoinAccountInput.shape,
+    },
+    handler(rescanBitcoinAccount)
+  );
+
+  server.registerTool(
     "get_btc_account_balance",
     {
       description:
@@ -1856,9 +1879,12 @@ async function main() {
         "rolled-up totals (confirmed + mempool + total sats / BTC) and a " +
         "per-address breakdown including type, BIP-32 chain (0=receive, " +
         "1=change), and addressIndex. Skips empty cached entries (the trailing " +
-        "fresh-receive addresses) to keep fan-out tight. Re-run `pair_ledger_btc` " +
-        "if you suspect the cache is stale (e.g. recent receive past the gap " +
-        "window).",
+        "fresh-receive addresses) to keep fan-out tight. If the cache is " +
+        "stale (recent receive on a previously-empty cached address), call " +
+        "`rescan_btc_account` to refresh — pure indexer fetch, no Ledger " +
+        "needed. Only re-run `pair_ledger_btc` when funds may have landed " +
+        "PAST the originally-walked gap window (the rescan flags that case " +
+        "via `needsExtend: true`).",
       inputSchema: getBitcoinAccountBalanceInput.shape,
     },
     handler(getBitcoinAccountBalance)

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -127,6 +127,7 @@ import type {
   GetBitcoinFeeEstimatesArgs,
   GetBitcoinBlockTipArgs,
   GetBitcoinAccountBalanceArgs,
+  RescanBitcoinAccountArgs,
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   SignBtcMessageArgs,
@@ -725,6 +726,149 @@ export async function getBitcoinBlockTip(_args: GetBitcoinBlockTipArgs) {
 }
 
 /**
+ * Refresh the indexer-side `txCount` for every cached BTC address
+ * under one Ledger account, without touching the device. Distinct from
+ * `pair_ledger_btc` (which DOES touch the device, deriving fresh leaf
+ * paths) — this tool only re-probes the indexer for already-derived
+ * addresses and updates the persisted cache.
+ *
+ * Use case: the user received funds AFTER the original gap-limit scan
+ * (so the cached entry's `txCount === 0` is stale), or the indexer
+ * was cold/lagging at scan time. Either way the addresses themselves
+ * are correct; only the on-chain history snapshot needs refreshing.
+ *
+ * If the LAST cached address on a chain (the trailing buffer empty)
+ * now has on-chain history, the response flags `needsExtend: true` —
+ * funds may exist past the originally-walked gap window, and the
+ * caller should run `pair_ledger_btc` again (which DOES use the
+ * device) to extend the scan.
+ *
+ * Issue #191.
+ */
+export async function rescanBitcoinAccount(args: RescanBitcoinAccountArgs) {
+  const { getPairedBtcAddresses, setPairedBtcAddress } = await import(
+    "../../signing/btc-usb-signer.js"
+  );
+  const all = getPairedBtcAddresses();
+  const forAccount = all.filter(
+    (e) => e.accountIndex === args.accountIndex,
+  );
+  if (forAccount.length === 0) {
+    throw new Error(
+      `No paired Bitcoin entries cached for accountIndex=${args.accountIndex}. ` +
+        `Run \`pair_ledger_btc({ accountIndex: ${args.accountIndex} })\` first ` +
+        `to populate the cache. \`rescan_btc_account\` only refreshes existing ` +
+        `entries — it cannot derive new addresses (that needs the Ledger device).`,
+    );
+  }
+  const { getBitcoinIndexer } = await import("../btc/indexer.js");
+  const indexer = getBitcoinIndexer();
+  // Indexer fan-out is purely HTTP — parallelize for speed. Per-address
+  // failures degrade gracefully (the entry's txCount stays at its prior
+  // value rather than getting wiped to 0).
+  const probes = await Promise.allSettled(
+    forAccount.map((e) => indexer.getBalance(e.address)),
+  );
+
+  type BTCEntry = (typeof forAccount)[number];
+  type ChainKey = `${BTCEntry["addressType"]}:${0 | 1}`;
+  const chainBuckets = new Map<ChainKey, BTCEntry[]>();
+  const refreshed: Array<{
+    address: string;
+    addressType: BTCEntry["addressType"];
+    chain: 0 | 1 | null;
+    addressIndex: number | null;
+    path: string;
+    previousTxCount: number;
+    txCount: number;
+    delta: number;
+    fetchOk: boolean;
+  }> = [];
+  for (let i = 0; i < forAccount.length; i++) {
+    const entry = forAccount[i];
+    const probe = probes[i];
+    const previousTxCount = entry.txCount ?? 0;
+    let liveTxCount = previousTxCount;
+    let fetchOk = false;
+    if (probe.status === "fulfilled") {
+      liveTxCount = probe.value.txCount;
+      fetchOk = true;
+      // Persist the refresh so subsequent get_btc_account_balance
+      // calls reflect the updated state without re-rescanning.
+      if (liveTxCount !== previousTxCount) {
+        setPairedBtcAddress({ ...entry, txCount: liveTxCount });
+      }
+    }
+    refreshed.push({
+      address: entry.address,
+      addressType: entry.addressType,
+      chain: entry.chain ?? null,
+      addressIndex: entry.addressIndex ?? null,
+      path: entry.path,
+      previousTxCount,
+      txCount: liveTxCount,
+      delta: liveTxCount - previousTxCount,
+      fetchOk,
+    });
+    if (entry.chain === 0 || entry.chain === 1) {
+      const key: ChainKey = `${entry.addressType}:${entry.chain}`;
+      const bucket = chainBuckets.get(key);
+      if (bucket) bucket.push(entry);
+      else chainBuckets.set(key, [entry]);
+    }
+  }
+
+  // needsExtend: for any (type, chain), if the entry with the LARGEST
+  // addressIndex (the trailing buffer empty from the original walk)
+  // now has txCount > 0, the gap window may no longer cover all funds.
+  // The user should re-pair to extend.
+  let needsExtend = false;
+  const extendChains: Array<{
+    addressType: BTCEntry["addressType"];
+    chain: 0 | 1;
+    lastAddressIndex: number;
+  }> = [];
+  for (const [key, bucket] of chainBuckets) {
+    const tail = bucket.reduce((max, e) =>
+      (e.addressIndex ?? -1) > (max.addressIndex ?? -1) ? e : max,
+    );
+    const i = forAccount.indexOf(tail);
+    const probe = probes[i];
+    if (probe.status === "fulfilled" && probe.value.txCount > 0) {
+      needsExtend = true;
+      const [addressTypeStr, chainStr] = key.split(":");
+      extendChains.push({
+        addressType: addressTypeStr as BTCEntry["addressType"],
+        chain: Number(chainStr) as 0 | 1,
+        lastAddressIndex: tail.addressIndex ?? -1,
+      });
+    }
+  }
+
+  const fetchFailures = refreshed.filter((r) => !r.fetchOk).length;
+  const txCountChanges = refreshed.filter((r) => r.delta !== 0).length;
+  return {
+    accountIndex: args.accountIndex,
+    addressesScanned: refreshed.length,
+    txCountChanges,
+    fetchFailures,
+    needsExtend,
+    ...(needsExtend ? { extendChains } : {}),
+    refreshed,
+    ...(needsExtend
+      ? {
+          note:
+            "The trailing empty address on at least one cached chain now has " +
+            "on-chain history. The original gap-limit window may miss funds " +
+            "past it. Run `pair_ledger_btc({ accountIndex: " +
+            args.accountIndex +
+            " })` to extend the scan with fresh on-device derivations.",
+        }
+      : {}),
+  };
+}
+
+/**
  * Aggregate the on-chain balance across every CACHED used-address for
  * one Ledger BTC account index. Walks the in-memory + persisted
  * pairing cache (populated by `pair_ledger_btc`'s gap-limit scan),
@@ -776,8 +920,10 @@ export async function getBitcoinAccountBalance(
       }>,
       note:
         "All cached addresses for this account had zero on-chain history at " +
-        "scan time. If you've recently received funds, re-run pair_ledger_btc " +
-        "to refresh the gap-limit scan.",
+        "scan time. If you've recently received funds, call " +
+        "`rescan_btc_account` to refresh the cached txCount via the indexer " +
+        "(no Ledger device needed). If funds may have landed past the original " +
+        "gap-limit window, re-run `pair_ledger_btc` to extend the scan.",
     };
   }
   const { getBitcoinBalance } = await import("../btc/balances.js");

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -248,6 +248,7 @@ export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
  * plugged in, unlocked, with the Solana app open. Reads + caches the
  * device address at path `44'/501'/<accountIndex>'` (default 0 = first
  * Ledger Live Solana account).
+ * bump
  */
 /**
  * Pair the host's directly-connected Ledger device for Bitcoin signing.

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1088,7 +1088,27 @@ export const getBitcoinAccountBalanceInput = z.object({
         "their on-chain balances, and surfaces the per-address breakdown so the " +
         "agent can show which legs hold the funds. Empty cached addresses are " +
         "skipped to keep the response tight; if you suspect the cache is stale, " +
-        "re-run `pair_ledger_btc` first."
+        "call `rescan_btc_account` (indexer-only, no Ledger needed)."
+    ),
+});
+
+export const rescanBitcoinAccountInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe(
+      "Ledger Bitcoin account slot to rescan. Must already be paired (call " +
+        "`pair_ledger_btc` first). Re-queries the indexer for the live " +
+        "`txCount` of every cached address under this account and updates " +
+        "the persisted cache — useful after the user has received funds or " +
+        "the indexer was stale at original scan time. Pure indexer-side: no " +
+        "Ledger / USB interaction. If the LAST cached address on a chain " +
+        "(originally an empty buffer) now has on-chain history, the response " +
+        "flags `needsExtend: true` — the gap-limit window may now miss funds " +
+        "past it, and the caller should re-run `pair_ledger_btc` (which DOES " +
+        "use the device) to extend the walked window."
     ),
 });
 
@@ -1161,6 +1181,9 @@ export type GetBitcoinFeeEstimatesArgs = z.infer<typeof getBitcoinFeeEstimatesIn
 export type GetBitcoinBlockTipArgs = z.infer<typeof getBitcoinBlockTipInput>;
 export type GetBitcoinAccountBalanceArgs = z.infer<
   typeof getBitcoinAccountBalanceInput
+>;
+export type RescanBitcoinAccountArgs = z.infer<
+  typeof rescanBitcoinAccountInput
 >;
 export const signBtcMessageInput = z.object({
   wallet: bitcoinAddressSchema.describe(

--- a/test/btc-pair.test.ts
+++ b/test/btc-pair.test.ts
@@ -397,6 +397,237 @@ describe("get_btc_account_balance (issue #189)", () => {
   });
 });
 
+describe("rescan_btc_account (issue #191)", () => {
+  beforeEach(() => {
+    indexerGetBalanceMock.mockReset();
+  });
+
+  it("refreshes stale txCount on cached entries without touching the device", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    // Cached state: an entry that was empty at original scan time.
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/2",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 2,
+      txCount: 0,
+    });
+    // Indexer now reports 4 txs on it (user received funds).
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 100_000n,
+      mempoolSats: 0n,
+      totalSats: 100_000n,
+      txCount: 4,
+    }));
+
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.addressesScanned).toBe(1);
+    expect(out.txCountChanges).toBe(1);
+    expect(out.fetchFailures).toBe(0);
+    expect(out.refreshed[0].previousTxCount).toBe(0);
+    expect(out.refreshed[0].txCount).toBe(4);
+    expect(out.refreshed[0].delta).toBe(4);
+
+    // Assert no USB activity — the rescan must NOT call openLedger.
+    expect(getWalletPublicKeyMock).not.toHaveBeenCalled();
+    expect(getAppAndVersionMock).not.toHaveBeenCalled();
+    expect(transportCloseMock).not.toHaveBeenCalled();
+
+    // Cache mutation persisted: subsequent get_btc_account_balance
+    // skips the indexer fan-out for entries with txCount > 0 and uses
+    // the now-refreshed value. We just check via getPairedBtcAddresses.
+    const { getPairedBtcAddresses } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const cached = getPairedBtcAddresses();
+    expect(cached[0].txCount).toBe(4);
+  });
+
+  it("flags needsExtend when the trailing buffer empty becomes used", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    // Three cached segwit-receive entries: indices 0..2. The TRAILING
+    // empty (index 2) is what becomes used on rescan — that means funds
+    // may also exist past the original gap window.
+    setPairedBtcAddress({
+      address: "bc1qaaa1aaa1aaa1aaa1aaa1aaa1aaa1aaa1abcdef",
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 5,
+    });
+    setPairedBtcAddress({
+      address: "bc1qbbb1bbb1bbb1bbb1bbb1bbb1bbb1bbb1abcdef",
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/1",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 1,
+      txCount: 0,
+    });
+    const TRAILING = "bc1qccc1ccc1ccc1ccc1ccc1ccc1ccc1ccc1abcdef";
+    setPairedBtcAddress({
+      address: TRAILING,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/2",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 2,
+      txCount: 0,
+    });
+    // Indexer reports the trailing empty (index 2) is now used.
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: address === TRAILING ? 1 : address.startsWith("bc1qaaa") ? 5 : 0,
+    }));
+
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(true);
+    expect(out.extendChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 2 },
+    ]);
+    expect(out.note).toMatch(/Run `pair_ledger_btc/);
+  });
+
+  it("does NOT flag needsExtend when only an interior empty becomes used", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    // Index 0 (used), index 1 (interior empty), index 2 (trailing empty).
+    setPairedBtcAddress({
+      address: "bc1qaaa2aaa2aaa2aaa2aaa2aaa2aaa2aaa2abcdef",
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 5,
+    });
+    const INTERIOR = "bc1qbbb2bbb2bbb2bbb2bbb2bbb2bbb2bbb2abcdef";
+    setPairedBtcAddress({
+      address: INTERIOR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/1",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 1,
+      txCount: 0,
+    });
+    const TRAILING = "bc1qccc2ccc2ccc2ccc2ccc2ccc2ccc2ccc2abcdef";
+    setPairedBtcAddress({
+      address: TRAILING,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/2",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 2,
+      txCount: 0,
+    });
+    // Interior gets activity; trailing stays empty.
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: address === INTERIOR ? 1 : address.startsWith("bc1qaaa") ? 5 : 0,
+    }));
+
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(false);
+    expect(out.txCountChanges).toBe(1);
+  });
+
+  it("throws when no entries are cached for the requested accountIndex", async () => {
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      rescanBitcoinAccount({ accountIndex: 99 }),
+    ).rejects.toThrow(/No paired Bitcoin entries cached/);
+  });
+
+  it("degrades gracefully when one indexer call fails", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 7,
+    });
+    setPairedBtcAddress({
+      address: TAPROOT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "86'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 3,
+    });
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      if (address === SEGWIT_ADDR) throw new Error("indexer 502");
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 5,
+      };
+    });
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.fetchFailures).toBe(1);
+    // Failed entry keeps its prior txCount.
+    const segwit = out.refreshed.find((r) => r.address === SEGWIT_ADDR);
+    expect(segwit?.txCount).toBe(7);
+    expect(segwit?.fetchOk).toBe(false);
+  });
+});
+
 describe("clearPairedBtcAccount", () => {
   it("drops only entries matching the given accountIndex", async () => {
     const { setPairedBtcAddress, clearPairedBtcAccount, getPairedBtcAddresses } =


### PR DESCRIPTION
Closes #191.

**Stacked on #190.** Base is \`feat/btc-bip44-gap-limit-scan\` so the GitHub diff shows just this PR's delta. Once #190 merges, GitHub auto-retargets to \`main\`.

## What ships

\`rescan_btc_account({ accountIndex })\` — re-queries the indexer for the live \`txCount\` of every cached BTC address under one paired account, updates the persisted cache, returns a per-address \`before/after/delta\` breakdown plus aggregate counts. Pure HTTP fan-out via \`Promise.allSettled\`; no \`openLedger\` call (asserted in tests).

\`needsExtend: true\` fires when the LAST cached address on any (type, chain) — the trailing buffer empty from the original gap-limit walk — now has on-chain history. That's the signal that funds may exist past the originally-walked window, and the caller should run \`pair_ledger_btc\` to extend the walked window with on-device derivations. Interior gaps becoming non-empty don't trip the flag.

## Why split off pair_ledger_btc

\`pair_ledger_btc\` touches the Ledger device (USB-HID, derives xpubs, prompts on-screen). Surfacing a pairing tool to a user who is just asking about balance is awkward — the prior note in \`get_btc_account_balance\` literally said "If you've recently received funds, re-run pair_ledger_btc to refresh". That's misleading: the rescan is purely indexer-side. Other chains (EVM portfolio, TRON, Solana) don't ask the user to re-pair to refresh balances; this brings BTC inline with that pattern.

## Updated guidance (also in this PR)

- \`get_btc_account_balance\`'s stale-cache note now points at \`rescan_btc_account\` first; \`pair_ledger_btc\` is reserved for the \`needsExtend\` case
- Both tool descriptions in \`src/index.ts\` updated with the same split
- \`get_btc_account_balance\`'s schema description updated likewise

## Tests

5 new cases in \`btc-pair.test.ts\`:

- Refreshes stale \`txCount\` + asserts NO USB / device interaction (\`getWalletPublicKey\` / \`openLedger\` / \`transport.close\` mocks all untouched)
- \`needsExtend: true\` when the trailing empty becomes used
- \`needsExtend: false\` when only an interior empty becomes used
- Throws clearly on missing-account
- Per-address indexer failure preserved prior \`txCount\`, surfaced via \`fetchOk: false\`

## Verification

- \`npm run build\` clean
- Full suite 1067/1067 (1062 baseline from #190 + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)