### PR TITLE
feat(jito): prepare_jito_stake — deposit SOL → jitoSOL via raw stake-pool ix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import {
   prepareMarginfiBorrow,
   prepareMarginfiRepay,
   prepareMarinadeStake,
+  prepareJitoStake,
   prepareMarinadeUnstakeImmediate,
   prepareNativeStakeDelegate,
   prepareNativeStakeDeactivate,
@@ -131,6 +132,7 @@ import {
   prepareMarginfiBorrowInput,
   prepareMarginfiRepayInput,
   prepareMarinadeStakeInput,
+  prepareJitoStakeInput,
   prepareMarinadeUnstakeImmediateInput,
   prepareNativeStakeDelegateInput,
   prepareNativeStakeDeactivateInput,
@@ -1592,6 +1594,29 @@ async function main() {
       inputSchema: prepareMarinadeStakeInput.shape,
     },
     handler(prepareMarinadeStake)
+  );
+
+  server.registerTool(
+    "prepare_jito_stake",
+    {
+      description:
+        "Build an unsigned Jito stake-pool deposit tx: deposit `amountSol` SOL " +
+        "into Jito's stake pool and receive jitoSOL (Jito's liquid-staking token). " +
+        "Uses the SPL stake-pool program's raw `DepositSol` instruction with the " +
+        "user's wallet as the on-chain `fundingAccount` — no ephemeral keypair, " +
+        "Ledger-compatible. The high-level @solana/spl-stake-pool helper would " +
+        "generate an ephemeral SOL-transfer keypair (incompatible with Ledger-only " +
+        "signing); we hand-build the ix to avoid that. The jitoSOL ATA is created " +
+        "automatically on first stake (~0.002 SOL ATA rent, reclaimable). DURABLE " +
+        "NONCE REQUIRED — wallet must have run `prepare_solana_nonce_init` first; " +
+        "otherwise this tool errors. BLIND-SIGN on Ledger (the SPL stake-pool " +
+        "program is not in the Solana app's clear-sign registry) — match the " +
+        "Message Hash on-device after `preview_solana_send`. Unstake (immediate " +
+        "via WithdrawSol or delayed via WithdrawStake) is not yet exposed; tracked " +
+        "as a follow-up.",
+      inputSchema: prepareJitoStakeInput.shape,
+    },
+    handler(prepareJitoStake)
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -110,6 +110,7 @@ import type {
   PrepareMarginfiRepayArgs,
   PrepareMarinadeStakeArgs,
   PrepareMarinadeUnstakeImmediateArgs,
+  PrepareJitoStakeArgs,
   PrepareNativeStakeDelegateArgs,
   PrepareNativeStakeDeactivateArgs,
   PrepareNativeStakeWithdrawArgs,
@@ -491,6 +492,17 @@ export async function prepareMarinadeUnstakeImmediate(
   const prepared = await buildMarinadeUnstakeImmediate({
     wallet: args.wallet,
     amountMSol: args.amountMSol,
+  });
+  return prepared as unknown as PreparedSolanaTx;
+}
+
+export async function prepareJitoStake(
+  args: PrepareJitoStakeArgs,
+): Promise<PreparedSolanaTx> {
+  const { buildJitoStake } = await import("../solana/jito.js");
+  const prepared = await buildJitoStake({
+    wallet: args.wallet,
+    amountSol: args.amountSol,
   });
   return prepared as unknown as PreparedSolanaTx;
 }
@@ -2157,6 +2169,7 @@ export interface SolanaVerificationArtifact {
     | "marginfi_repay"
     | "marinade_stake"
     | "marinade_unstake_immediate"
+    | "jito_stake"
     | "native_stake_delegate"
     | "native_stake_deactivate"
     | "native_stake_withdraw"

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -302,6 +302,29 @@ export const prepareMarinadeStakeInput = z.object({
     ),
 });
 
+/**
+ * Jito stake-pool deposit. Mirrors the Marinade-stake schema shape but
+ * uses the SPL stake-pool program directly via raw `StakePoolInstruction`
+ * builders (no ephemeral keypair — Ledger-compatible). Withdraw flows
+ * are not yet exposed; see `src/modules/solana/jito.ts` doc-comment for
+ * the rationale.
+ */
+export const prepareJitoStakeInput = z.object({
+  wallet: solanaAddressSchema.describe(
+    "Solana wallet that funds the deposit and receives jitoSOL. Must have an " +
+      "initialized durable-nonce account (prepare_solana_nonce_init) and enough " +
+      "SOL to cover the deposit + jitoSOL ATA rent (~0.002 SOL if the ATA " +
+      "doesn't exist yet) + tx fee.",
+  ),
+  amountSol: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable SOL amount to stake (e.g. "1.5"). Decimals are SOL-native ' +
+        "(9 dec); the builder rounds down to lamport precision.",
+    ),
+});
+
 export const prepareMarinadeUnstakeImmediateInput = z.object({
   wallet: solanaAddressSchema.describe(
     "Solana wallet that burns mSOL and receives SOL. Must have an initialized " +
@@ -869,6 +892,7 @@ export type PrepareMarinadeStakeArgs = z.infer<typeof prepareMarinadeStakeInput>
 export type PrepareMarinadeUnstakeImmediateArgs = z.infer<
   typeof prepareMarinadeUnstakeImmediateInput
 >;
+export type PrepareJitoStakeArgs = z.infer<typeof prepareJitoStakeInput>;
 export type PrepareNativeStakeDelegateArgs = z.infer<
   typeof prepareNativeStakeDelegateInput
 >;

--- a/src/modules/solana/actions.ts
+++ b/src/modules/solana/actions.ts
@@ -122,6 +122,7 @@ export interface PreparedSolanaTx {
     | "marginfi_repay"
     | "marinade_stake"
     | "marinade_unstake_immediate"
+    | "jito_stake"
     | "native_stake_delegate"
     | "native_stake_deactivate"
     | "native_stake_withdraw"

--- a/src/modules/solana/jito.ts
+++ b/src/modules/solana/jito.ts
@@ -1,0 +1,250 @@
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import BigNumber from "bignumber.js";
+import { assertSolanaAddress } from "./address.js";
+import { getSolanaConnection } from "./rpc.js";
+import {
+  buildAdvanceNonceIx,
+  deriveNonceAccountAddress,
+  getNonceAccountValue,
+} from "./nonce.js";
+import { throwNonceRequired } from "./actions.js";
+import {
+  issueSolanaDraftHandle,
+  type SolanaTxDraft,
+} from "../../signing/solana-tx-store.js";
+
+/**
+ * Jito stake-pool write actions — currently `prepare_jito_stake` only
+ * (deposit SOL → jitoSOL). Mirrors `marinade.ts`'s shape on top of the
+ * shared durable-nonce pipeline.
+ *
+ * Why we hand-build the ix instead of using `@solana/spl-stake-pool`'s
+ * high-level `depositSol(connection, ...)`: the high-level wrapper
+ * generates an ephemeral SOL-transfer keypair to satisfy the program's
+ * `fundingAccount` signer requirement, which is incompatible with
+ * Ledger-only signing (the ephemeral key has no signature path). The raw
+ * `StakePoolInstruction.depositSol` exposed by the SDK accepts
+ * `fundingAccount: PublicKey` directly and lets us pass the user's own
+ * wallet — the user signs via Ledger, no ephemeral key needed.
+ *
+ * What's NOT shipped here (deferred follow-up):
+ *
+ *   - **Immediate `WithdrawSol`** — Jito's stake pool generally requires
+ *     `WithdrawStake` (which yields a fresh stake-account in deactivating
+ *     state, not SOL back to the wallet). `WithdrawSol` would only succeed
+ *     when the pool's reserve has spare SOL AND the pool has no
+ *     `solWithdrawAuthority` set, both of which are uncommon. Skipped to
+ *     avoid a UX where the tool builds a tx that often reverts on chain.
+ *   - **`WithdrawStake`** — produces a stake account the user then has to
+ *     deactivate + withdraw across multiple epochs. The instruction needs
+ *     a freshly-created destination stake account, which we can build with
+ *     `CreateAccountWithSeed` (no ephemeral keypair) — same pattern as the
+ *     durable-nonce account. Material additional work; tracked as a
+ *     follow-up plan rather than v1.
+ *
+ * Stake-pool program docs: https://spl.solana.com/stake-pool. Jito's
+ * pool address (mints jitoSOL): `Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb`
+ * — confirmed via the existing read path at
+ * `src/modules/positions/solana-staking.ts`.
+ */
+
+const JITO_STAKE_POOL = new PublicKey(
+  "Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb",
+);
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+export interface JitoStakeParams {
+  /** Base58 wallet address — funds the deposit, receives jitoSOL. */
+  wallet: string;
+  /** Human-readable SOL amount (decimal string, e.g. "1.5"). */
+  amountSol: string;
+}
+
+export interface PreparedJitoTx {
+  handle: string;
+  action: "jito_stake";
+  chain: "solana";
+  from: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  /** Nonce-account PDA for this wallet (durable-nonce-protected). */
+  nonceAccount: string;
+}
+
+function solToLamports(solDecimal: string): bigint {
+  const bn = new BigNumber(solDecimal);
+  if (!bn.isFinite() || bn.lte(0)) {
+    throw new Error(
+      `Invalid SOL amount "${solDecimal}" — expected a positive decimal (e.g. "1.5").`,
+    );
+  }
+  return BigInt(
+    bn.times(LAMPORTS_PER_SOL).integerValue(BigNumber.ROUND_DOWN).toString(10),
+  );
+}
+
+async function loadNonceContext(walletStr: string): Promise<{
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+}> {
+  const fromPubkey = assertSolanaAddress(walletStr);
+  const conn = getSolanaConnection();
+  const noncePubkey = await deriveNonceAccountAddress(fromPubkey);
+  const nonceState = await getNonceAccountValue(conn, noncePubkey);
+  if (!nonceState) throwNonceRequired(walletStr);
+  return { fromPubkey, noncePubkey, nonceValue: nonceState!.nonce };
+}
+
+function buildDraft(args: {
+  fromPubkey: PublicKey;
+  noncePubkey: PublicKey;
+  nonceValue: string;
+  walletStr: string;
+  description: string;
+  decoded: { functionName: string; args: Record<string, string> };
+  actionIxs: TransactionInstruction[];
+}): SolanaTxDraft {
+  const nonceIx = buildAdvanceNonceIx(args.noncePubkey, args.fromPubkey);
+  const instructions: TransactionInstruction[] = [nonceIx, ...args.actionIxs];
+  return {
+    kind: "v0",
+    payerKey: args.fromPubkey,
+    instructions,
+    addressLookupTableAccounts: [],
+    meta: {
+      action: "jito_stake",
+      from: args.walletStr,
+      description: args.description,
+      decoded: args.decoded,
+      nonce: {
+        account: args.noncePubkey.toBase58(),
+        authority: args.fromPubkey.toBase58(),
+        value: args.nonceValue,
+      },
+    },
+  };
+}
+
+/**
+ * Build the deposit-SOL ix list:
+ *   1. (optional) `createAssociatedTokenAccountIdempotent` if the user's
+ *      jitoSOL ATA doesn't exist yet — sender pays the ~0.002 SOL rent.
+ *   2. `StakePoolInstruction.depositSol` with `fundingAccount = user`,
+ *      so the user signs the deposit via Ledger.
+ *
+ * Pool state (`reserveStake`, `poolMint`, `managerFeeAccount`,
+ * `withdrawAuthority`) is read from chain at prepare time so we follow
+ * pool-config changes without redeploying.
+ */
+export async function buildJitoStake(
+  p: JitoStakeParams,
+): Promise<PreparedJitoTx> {
+  const lamports = solToLamports(p.amountSol);
+  const ctx = await loadNonceContext(p.wallet);
+
+  const conn = getSolanaConnection();
+  const {
+    StakePoolInstruction,
+    getStakePoolAccount,
+    STAKE_POOL_PROGRAM_ID,
+  } = await import("@solana/spl-stake-pool");
+
+  const pool = await getStakePoolAccount(conn, JITO_STAKE_POOL);
+  const poolMint = pool.account.data.poolMint;
+  const reserveStake = pool.account.data.reserveStake;
+  const managerFeeAccount = pool.account.data.managerFeeAccount;
+
+  // PDA derivation for the pool's withdraw authority. Re-implemented
+  // locally rather than imported from `@solana/spl-stake-pool/dist/utils/
+  // program-address` because that helper isn't re-exported from the
+  // package's public entry point — a deep import would couple us to an
+  // internal subpath. The derivation itself is stable: ["<stakePoolPubkey>",
+  // "withdraw"] under STAKE_POOL_PROGRAM_ID.
+  const [withdrawAuthority] = PublicKey.findProgramAddressSync(
+    [JITO_STAKE_POOL.toBuffer(), Buffer.from("withdraw")],
+    STAKE_POOL_PROGRAM_ID,
+  );
+
+  const jitoSolAta = getAssociatedTokenAddressSync(poolMint, ctx.fromPubkey);
+  const ataInfo = await conn.getAccountInfo(jitoSolAta, "confirmed");
+
+  const actionIxs: TransactionInstruction[] = [];
+  if (!ataInfo) {
+    // Idempotent variant: safe even if the ATA shows up between our
+    // probe and broadcast (race-free).
+    actionIxs.push(
+      createAssociatedTokenAccountIdempotentInstruction(
+        ctx.fromPubkey, // payer
+        jitoSolAta,
+        ctx.fromPubkey, // owner
+        poolMint,
+      ),
+    );
+  }
+
+  // Raw depositSol — no ephemeral keypair. The high-level wrapper uses
+  // an ephemeral SOL-transfer account because of how its abstraction
+  // wants to keep the user's main account out of the program's signer
+  // set; we don't have that constraint (Ledger signs whatever message
+  // bytes we hand it), so the user's wallet IS the fundingAccount.
+  actionIxs.push(
+    StakePoolInstruction.depositSol({
+      stakePool: JITO_STAKE_POOL,
+      depositAuthority: undefined,
+      withdrawAuthority,
+      reserveStake,
+      fundingAccount: ctx.fromPubkey,
+      destinationPoolAccount: jitoSolAta,
+      managerFeeAccount,
+      // Self-referral: the pool requires a referral pool account; using
+      // the user's own jitoSOL ATA is the canonical no-affiliate value
+      // (matches the high-level SDK's behavior when no `referrerTokenAccount`
+      // is passed).
+      referralPoolAccount: jitoSolAta,
+      poolMint,
+      lamports: Number(lamports),
+    }),
+  );
+
+  const ataSuffix = ataInfo
+    ? ""
+    : " (+ create jitoSOL ATA, ~0.002 SOL rent, reclaimable on token-account close)";
+
+  const draft = buildDraft({
+    fromPubkey: ctx.fromPubkey,
+    noncePubkey: ctx.noncePubkey,
+    nonceValue: ctx.nonceValue,
+    walletStr: p.wallet,
+    description: `Jito stake: deposit ${p.amountSol} SOL → jitoSOL${ataSuffix}`,
+    decoded: {
+      functionName: "spl_stake_pool.depositSol",
+      args: {
+        wallet: p.wallet,
+        amountSol: p.amountSol,
+        amountLamports: lamports.toString(),
+        stakePool: JITO_STAKE_POOL.toBase58(),
+        jitoSolAta: jitoSolAta.toBase58(),
+        nonceAccount: ctx.noncePubkey.toBase58(),
+        ...(ataInfo ? {} : { createsAta: "true" }),
+      },
+    },
+    actionIxs,
+  });
+
+  const { handle } = issueSolanaDraftHandle(draft);
+  return {
+    handle,
+    action: "jito_stake",
+    chain: "solana",
+    from: p.wallet,
+    description: draft.meta.description,
+    decoded: draft.meta.decoded,
+    nonceAccount: ctx.noncePubkey.toBase58(),
+  };
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -949,6 +949,7 @@ export interface RenderableSolanaPrepareResult {
     | "marginfi_repay"
     | "marinade_stake"
     | "marinade_unstake_immediate"
+    | "jito_stake"
     | "native_stake_delegate"
     | "native_stake_deactivate"
     | "native_stake_withdraw"
@@ -999,6 +1000,8 @@ function solanaActionLabel(action: RenderableSolanaPrepareResult["action"]): str
       return "Marinade stake (SOL → mSOL)";
     case "marinade_unstake_immediate":
       return "Marinade liquid unstake (mSOL → SOL via pool)";
+    case "jito_stake":
+      return "Jito stake (SOL → jitoSOL via SPL stake-pool)";
     case "native_stake_delegate":
       return "Native stake delegate (create stake account + delegate to validator)";
     case "native_stake_deactivate":

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -52,6 +52,7 @@ export interface SolanaDraftMeta {
     | "marginfi_repay"
     | "marinade_stake"
     | "marinade_unstake_immediate"
+    | "jito_stake"
     | "native_stake_delegate"
     | "native_stake_deactivate"
     | "native_stake_withdraw"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -878,6 +878,7 @@ export interface UnsignedSolanaTx {
     | "marginfi_repay"
     | "marinade_stake"
     | "marinade_unstake_immediate"
+    | "jito_stake"
     | "native_stake_delegate"
     | "native_stake_deactivate"
     | "native_stake_withdraw"

--- a/test/solana-jito-write.test.ts
+++ b/test/solana-jito-write.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  Keypair,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+
+/**
+ * Jito stake write-builder tests. Mocks the SPL stake-pool SDK so we
+ * never touch the real package's BorshAccountsCoder / web3.js subtree
+ * and never hit a real Solana RPC. Asserts:
+ *   - ix[0] is SystemProgram.nonceAdvance (mirror of every other Solana
+ *     send this server builds — durable-nonce protection is the
+ *     ix[0]-detected validity gate).
+ *   - The action ix is built from `StakePoolInstruction.depositSol`
+ *     with `fundingAccount = user wallet` (NOT an ephemeral keypair —
+ *     the whole point of this implementation).
+ *   - When the user's jitoSOL ATA doesn't exist, the builder prepends
+ *     `createAssociatedTokenAccountIdempotent` before the deposit.
+ *   - Pre-flight: missing nonce account → throwNonceRequired error.
+ */
+
+const WALLET_KEYPAIR = Keypair.generate();
+const WALLET = WALLET_KEYPAIR.publicKey.toBase58();
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const STAKE_POOL_PROGRAM = new PublicKey(
+  "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy",
+);
+const FAKE_POOL_MINT = new PublicKey(
+  "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+);
+const FAKE_RESERVE_STAKE = Keypair.generate().publicKey;
+const FAKE_MANAGER_FEE = Keypair.generate().publicKey;
+
+const connectionStub = {
+  getAccountInfo: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+};
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => connectionStub,
+  resetSolanaConnection: () => {},
+}));
+
+vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+  return {
+    ...actual,
+    getNonceAccountValue: vi.fn(),
+  };
+});
+
+// SDK fake — the only call sites we exercise are getStakePoolAccount +
+// StakePoolInstruction.depositSol + STAKE_POOL_PROGRAM_ID.
+const depositSolMock = vi.fn();
+const getStakePoolAccountMock = vi.fn();
+
+vi.mock("@solana/spl-stake-pool", () => ({
+  STAKE_POOL_PROGRAM_ID: STAKE_POOL_PROGRAM,
+  getStakePoolAccount: (...args: unknown[]) => getStakePoolAccountMock(...args),
+  StakePoolInstruction: {
+    depositSol: (...args: unknown[]) => depositSolMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  connectionStub.getAccountInfo.mockReset();
+  connectionStub.getLatestBlockhash.mockReset();
+  depositSolMock.mockReset();
+  getStakePoolAccountMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function setNoncePresent(): Promise<void> {
+  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
+    authority: WALLET_KEYPAIR.publicKey,
+  });
+}
+
+async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+function setStakePoolAccount(): void {
+  getStakePoolAccountMock.mockResolvedValue({
+    pubkey: new PublicKey("Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb"),
+    account: {
+      data: {
+        poolMint: FAKE_POOL_MINT,
+        reserveStake: FAKE_RESERVE_STAKE,
+        managerFeeAccount: FAKE_MANAGER_FEE,
+      },
+    },
+  });
+}
+
+function setDepositSolReturn(): void {
+  // Synthetic instruction — what matters for the test is identity, not
+  // wire-correctness.
+  const ix = new TransactionInstruction({
+    keys: [],
+    programId: STAKE_POOL_PROGRAM,
+    data: Buffer.from([]),
+  });
+  depositSolMock.mockReturnValue(ix);
+}
+
+describe("buildJitoStake", () => {
+  it("composes nonceAdvance + depositSol when ATA already exists", async () => {
+    await setNoncePresent();
+    setStakePoolAccount();
+    // ATA exists — single getAccountInfo call returns truthy.
+    connectionStub.getAccountInfo.mockResolvedValue({ data: Buffer.alloc(165) });
+    setDepositSolReturn();
+
+    const { buildJitoStake } = await import("../src/modules/solana/jito.js");
+    const result = await buildJitoStake({ wallet: WALLET, amountSol: "1.5" });
+
+    expect(result.action).toBe("jito_stake");
+    expect(result.from).toBe(WALLET);
+    expect(result.decoded.args.amountSol).toBe("1.5");
+    expect(result.decoded.args.amountLamports).toBe("1500000000");
+    expect(result.decoded.args.createsAta).toBeUndefined();
+
+    expect(depositSolMock).toHaveBeenCalledTimes(1);
+    const callArgs = depositSolMock.mock.calls[0]![0]! as {
+      fundingAccount: PublicKey;
+      lamports: number;
+    };
+    // The whole point: fundingAccount IS the user's wallet — no
+    // ephemeral keypair.
+    expect(callArgs.fundingAccount.toBase58()).toBe(WALLET);
+    expect(callArgs.lamports).toBe(1_500_000_000);
+
+    const { getSolanaDraft } = await import("../src/signing/solana-tx-store.js");
+    const draft = getSolanaDraft(result.handle);
+    expect(draft.kind).toBe("v0");
+    if (draft.kind !== "v0") throw new Error("expected v0 draft");
+    // ix[0] is SystemProgram.nonceAdvance (tag 0x04 in u32-LE).
+    expect(draft.instructions[0]!.programId.toBase58()).toBe(SYSTEM_PROGRAM);
+    expect(draft.instructions[0]!.data.readUInt32LE(0)).toBe(4);
+    // ix[1] is the depositSol stub.
+    expect(draft.instructions[1]!.programId.toBase58()).toBe(
+      STAKE_POOL_PROGRAM.toBase58(),
+    );
+    expect(draft.instructions.length).toBe(2);
+  });
+
+  it("prepends createAssociatedTokenAccountIdempotent when jitoSOL ATA missing", async () => {
+    await setNoncePresent();
+    setStakePoolAccount();
+    // ATA missing.
+    connectionStub.getAccountInfo.mockResolvedValue(null);
+    setDepositSolReturn();
+
+    const { buildJitoStake } = await import("../src/modules/solana/jito.js");
+    const result = await buildJitoStake({ wallet: WALLET, amountSol: "0.1" });
+
+    expect(result.decoded.args.createsAta).toBe("true");
+    const { getSolanaDraft } = await import("../src/signing/solana-tx-store.js");
+    const draft = getSolanaDraft(result.handle);
+    if (draft.kind !== "v0") throw new Error("expected v0 draft");
+    // ix[0] = nonceAdvance, ix[1] = createATAIdempotent (ATA program),
+    // ix[2] = depositSol.
+    expect(draft.instructions.length).toBe(3);
+    expect(draft.instructions[1]!.programId.toBase58()).toBe(
+      "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    );
+    expect(draft.instructions[2]!.programId.toBase58()).toBe(
+      STAKE_POOL_PROGRAM.toBase58(),
+    );
+  });
+
+  it("refuses with structured error when nonce account missing", async () => {
+    await setNonceMissing();
+    const { buildJitoStake } = await import("../src/modules/solana/jito.js");
+    await expect(
+      buildJitoStake({ wallet: WALLET, amountSol: "1" }),
+    ).rejects.toThrow(/durable-nonce account not initialized/i);
+  });
+
+  it("rejects non-positive or malformed amounts", async () => {
+    await setNoncePresent();
+    const { buildJitoStake } = await import("../src/modules/solana/jito.js");
+    await expect(
+      buildJitoStake({ wallet: WALLET, amountSol: "0" }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+    await expect(
+      buildJitoStake({ wallet: WALLET, amountSol: "abc" }),
+    ).rejects.toThrow(/Invalid SOL amount/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the last gap from \`HIGH-solana-roadmap.md\` section 3 — Jito stake-pool deposit support. Jito was explicitly skipped in PR #149's native-stake batch because the high-level \`@solana/spl-stake-pool\` \`depositSol\` helper generates an ephemeral SOL-transfer keypair (incompatible with Ledger-only signing).

This PR uses the **raw** \`StakePoolInstruction.depositSol\` builder and passes the user's wallet directly as \`fundingAccount\` — Ledger signs via the standard durable-nonce pipeline; no ephemeral keypair needed.

## What's shipped
- New tool: \`prepare_jito_stake({ wallet, amountSol })\` — deposit SOL, receive jitoSOL.
- Pool state (\`reserveStake\`, \`poolMint\`, \`managerFeeAccount\`) read from chain at prepare time.
- Withdraw-authority PDA derived locally (\`PublicKey.findProgramAddressSync\`) to avoid coupling to the SDK's internal \`dist/utils/program-address\` path.
- Tx shape: ix[0] = nonceAdvance → optional createATAIdempotent → depositSol. v0 + empty ALT.

## What's deferred (documented in module + tool description)
- **WithdrawSol** — Jito's pool typically requires \`WithdrawStake\`. \`WithdrawSol\` rarely succeeds in practice; building a tx that often reverts is worse UX than not building one.
- **WithdrawStake** — feasible Ledger-friendly via \`CreateAccountWithSeed\` (same pattern as our durable-nonce account); materially more work, tracked as a follow-up.

## Test plan
- [x] \`npm test\` — 1059 tests pass (4 new in \`test/solana-jito-write.test.ts\`)
- [x] \`npm run build\` — clean TS
- [ ] Live: small mainnet deposit (e.g. 0.01 SOL) → verify on Solscan that the deposit landed and jitoSOL was minted to the user's ATA at the expected ratio
- [ ] Live with brand-new wallet (no jitoSOL ATA): tx includes \`createATAIdempotent\` + deposit, lands cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)