### PR TITLE
test(send-hash-pin): fix flake in clearSignOnly LEDGER-HASH gating

### DIFF
--- a/test/send-hash-pin.test.ts
+++ b/test/send-hash-pin.test.ts
@@ -472,8 +472,16 @@ describe("renderLedgerHashBlock", () => {
 });
 
 describe("previewSendHandler — LEDGER BLIND-SIGN HASH gating", () => {
-  beforeEach(() => vi.resetModules());
-  afterEach(() => vi.restoreAllMocks());
+  // No `vi.resetModules()` here on purpose. These tests don't use
+  // `vi.doMock` — the `fakePreview` closure is the full input — so a
+  // module reset would only buy module-graph cache invalidation we
+  // don't need. Keeping the reset made these tests flaky: each fresh
+  // `await import("../src/index.js")` re-walks the entire server
+  // module graph (BTC + Solana + TRON + LiFi + Kamino + …) and on a
+  // contended worker can spill past vitest's 5s default timeout. The
+  // `previewSendHandler` returned function is pure (no module-level
+  // state read/written), so cross-test contamination from upstream
+  // tests in other files is impossible here.
 
   // Live-test regression: on a 0.1 ETH self-send the user saw a
   // `LEDGER BLIND-SIGN HASH — RELAY VERBATIM TO USER` block even though


### PR DESCRIPTION
The "does NOT emit the LEDGER BLIND-SIGN HASH block when result.clearSignOnly is true" test was timing out (~5s default) under suite-level worker contention.

## Root cause

\`beforeEach(() => vi.resetModules())\` at the top of the describe forced every test to re-walk the entire server module graph (\`src/index.js\` pulls in BTC + Solana + TRON + LiFi + Kamino + every reader). On a warm uncontended worker the import finishes ~1s; on a contended one it crosses 5s and the test fails with no diagnostic value.

## Fix

Drop the unneeded \`vi.resetModules()\` (and the matching \`restoreAllMocks\` afterEach) from this describe:

- Both tests pass a synthetic \`fakePreview\` closure as the full input — no \`vi.doMock\` anywhere
- \`previewSendHandler\` is a pure wrapper returning a closure that reads no module-level state and writes none — cross-test contamination from upstream describes / files is impossible

This cuts per-test cost from a fresh module-graph load to a single cached resolve.

## Verification

6 consecutive full-suite runs locally (1076/1076 each) with no recurrence. The same describe's other test ("DOES emit ... when clearSignOnly is absent") was passing the timeout consistently in prior runs but benefits from the same speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)