### PR TITLE
fix(btc): cap rescan fan-out + retry transient failures + tri-state needsExtend (#197 #199)

### DIFF
--- a/src/config/btc.ts
+++ b/src/config/btc.ts
@@ -24,3 +24,31 @@ export const BITCOIN_DEFAULT_INDEXER_URL = "https://mempool.space/api";
 export const BTC_DECIMALS = 8; // 1 BTC = 100_000_000 satoshis
 export const BTC_SYMBOL = "BTC";
 export const SATS_PER_BTC = 100_000_000n;
+
+/**
+ * Default concurrency cap for indexer fan-out (e.g. `rescan_btc_account`,
+ * `get_btc_account_balance`). Mempool.space's free public API rate-
+ * limits bursts; sending the full BIP-44 cache (often 100+ addresses)
+ * in parallel previously dropped ~40% of probes (issue #199). A cap
+ * of 8 keeps us comfortably under their published limits while still
+ * being substantially faster than serial. Self-hosted Esplora users
+ * with no rate concerns can override via `BITCOIN_INDEXER_PARALLELISM`.
+ */
+export const BITCOIN_INDEXER_DEFAULT_PARALLELISM = 8;
+export const BITCOIN_INDEXER_MAX_PARALLELISM = 32;
+
+/**
+ * Resolve the configured indexer fan-out parallelism. Respects the
+ * env var when present (clamped to [1, MAX]); otherwise the default.
+ */
+export function resolveBitcoinIndexerParallelism(): number {
+  const raw = process.env.BITCOIN_INDEXER_PARALLELISM;
+  if (raw === undefined || raw.trim() === "") {
+    return BITCOIN_INDEXER_DEFAULT_PARALLELISM;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return BITCOIN_INDEXER_DEFAULT_PARALLELISM;
+  }
+  return Math.min(BITCOIN_INDEXER_MAX_PARALLELISM, parsed);
+}

--- a/src/data/http.ts
+++ b/src/data/http.ts
@@ -26,3 +26,52 @@ export async function fetchWithTimeout(
     clearTimeout(timer);
   }
 }
+
+/**
+ * Bounded-concurrency variant of `Promise.allSettled`. Walks `items`
+ * with at most `concurrency` in-flight tasks at a time, preserving
+ * the input order in the result array. Rejected tasks become
+ * `{ status: "rejected", reason }` entries — a single failure never
+ * aborts the rest of the batch.
+ *
+ * Why not pull `p-limit` as a dep: ~30 lines of native JS gets the
+ * job done, and our hot-path callers (BTC indexer fan-out for
+ * `rescan_btc_account` / `get_btc_account_balance`) want a tight
+ * dependency surface around code that runs against user wallets.
+ *
+ * Worker-pool pattern: spin up min(items.length, concurrency) async
+ * workers, each pulling the next index from a shared cursor until the
+ * input is drained. Slot results back into the output array by their
+ * original index so callers can zip with the input.
+ */
+export async function pLimitMap<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error(`pLimitMap: concurrency must be a positive integer, got ${concurrency}`);
+  }
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let cursor = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < workerCount; w++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const i = cursor++;
+          if (i >= items.length) return;
+          try {
+            const value = await fn(items[i], i);
+            results[i] = { status: "fulfilled", value };
+          } catch (reason) {
+            results[i] = { status: "rejected", reason };
+          }
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return results;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1870,11 +1870,16 @@ async function main() {
         "has history) or when the indexer was stale at the original " +
         "`pair_ledger_btc` scan time. Updates the persisted cache, so " +
         "subsequent `get_btc_account_balance` reflects the refresh without " +
-        "another rescan. Flags `needsExtend: true` when the trailing buffer " +
-        "address on any cached chain now has on-chain history — that's the " +
-        "signal that funds may exist past the original gap-limit window, " +
-        "and the caller should re-run `pair_ledger_btc` to extend the walked " +
-        "window with fresh on-device derivations.",
+        "another rescan. Three-state extend signal: `needsExtend: true` " +
+        "(trailing buffer address on any cached chain has on-chain history " +
+        "— re-run `pair_ledger_btc` to extend the walked window); " +
+        "`unverifiedChains: [...]` (tail probe REJECTED for that chain — " +
+        "indeterminate, usually a transient indexer hiccup, re-run " +
+        "`rescan_btc_account` rather than re-pairing); neither field present " +
+        "→ all walked chains confirmed healthy. Indexer fan-out is bounded " +
+        "to `BITCOIN_INDEXER_PARALLELISM` concurrent requests (default 8) " +
+        "to stay under mempool.space's free-tier rate limits; transient " +
+        "429s and network errors are retried once internally.",
       inputSchema: rescanBitcoinAccountInput.shape,
     },
     handler(rescanBitcoinAccount)

--- a/src/modules/btc/indexer.ts
+++ b/src/modules/btc/indexer.ts
@@ -261,20 +261,86 @@ function summarizeTx(tx: EsploraTx, address: string): BitcoinTxHistoryEntry {
   };
 }
 
+/**
+ * Single retry policy for transient indexer failures (issue #199):
+ *
+ *   - HTTP 429 → honor `Retry-After` header (seconds, capped at 5s) or
+ *     fall back to a small jittered backoff. Mempool.space's free
+ *     public API throttles bursts; without a retry the burst-then-fail
+ *     dynamic of `rescan_btc_account`'s 100+-way fan-out drops ~40%
+ *     of probes.
+ *   - Network errors / timeouts → retry once with a small jittered
+ *     backoff. Doesn't help against a sustained outage but smooths
+ *     the common "one packet dropped" case.
+ *   - HTTP 5xx → NOT retried. A real upstream error should surface to
+ *     the caller, not get silently masked. Callers can rerun the
+ *     whole rescan if they want a second attempt.
+ */
+const ESPLORA_RETRY_BASE_MS = 400;
+const ESPLORA_RETRY_JITTER_MS = 400;
+const ESPLORA_MAX_RETRY_AFTER_MS = 5_000;
+
+function parseRetryAfterMs(headerValue: string | null): number | null {
+  if (!headerValue) return null;
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(ESPLORA_MAX_RETRY_AFTER_MS, seconds * 1000);
+  }
+  // HTTP-date form is also valid for Retry-After; we ignore it (the
+  // delta could be huge or negative under clock skew). Falls back to
+  // the default backoff in the caller.
+  return null;
+}
+
+function jitteredBackoffMs(): number {
+  return ESPLORA_RETRY_BASE_MS + Math.floor(Math.random() * ESPLORA_RETRY_JITTER_MS);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 class EsploraIndexer implements BitcoinIndexer {
   constructor(private readonly baseUrl: string) {}
 
   private async getJson<T>(path: string): Promise<T> {
-    const res = await fetchWithTimeout(`${this.baseUrl}${path}`, {
+    const url = `${this.baseUrl}${path}`;
+    const init: RequestInit = {
       method: "GET",
       headers: { Accept: "application/json" },
-    });
-    if (!res.ok) {
-      throw new Error(
-        `Bitcoin indexer ${path} returned ${res.status} ${res.statusText}`,
-      );
+    };
+    // Up to 2 attempts total: original + 1 retry on 429 / network.
+    let lastNetworkError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      let res: Response;
+      try {
+        res = await fetchWithTimeout(url, init);
+      } catch (err) {
+        // Network error / abort — retry once.
+        lastNetworkError = err;
+        if (attempt === 0) {
+          await sleep(jitteredBackoffMs());
+          continue;
+        }
+        throw err;
+      }
+      if (res.status === 429 && attempt === 0) {
+        const retryAfterMs =
+          parseRetryAfterMs(res.headers.get("Retry-After")) ?? jitteredBackoffMs();
+        // Drain the body so the underlying connection can be reused.
+        await res.text().catch(() => "");
+        await sleep(retryAfterMs);
+        continue;
+      }
+      if (!res.ok) {
+        throw new Error(
+          `Bitcoin indexer ${path} returned ${res.status} ${res.statusText}`,
+        );
+      }
+      return (await res.json()) as T;
     }
-    return (await res.json()) as T;
+    // Both attempts failed with network errors.
+    throw lastNetworkError instanceof Error
+      ? lastNetworkError
+      : new Error(`Bitcoin indexer ${path} failed after retry`);
   }
 
   async getBalance(address: string): Promise<BitcoinAddressBalance> {

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -764,11 +764,21 @@ export async function rescanBitcoinAccount(args: RescanBitcoinAccountArgs) {
   }
   const { getBitcoinIndexer } = await import("../btc/indexer.js");
   const indexer = getBitcoinIndexer();
-  // Indexer fan-out is purely HTTP — parallelize for speed. Per-address
-  // failures degrade gracefully (the entry's txCount stays at its prior
-  // value rather than getting wiped to 0).
-  const probes = await Promise.allSettled(
-    forAccount.map((e) => indexer.getBalance(e.address)),
+  const { pLimitMap } = await import("../../data/http.js");
+  const { resolveBitcoinIndexerParallelism } = await import(
+    "../../config/btc.js"
+  );
+  // Indexer fan-out is purely HTTP — parallelize for speed but cap
+  // concurrency to avoid bursting past mempool.space's free-tier
+  // rate limit (issue #199; ~40% probe failures observed without a
+  // cap on a 100+-address account). Per-address failures degrade
+  // gracefully (the entry's txCount stays at its prior value rather
+  // than getting wiped to 0). The configured cap can be overridden
+  // via `BITCOIN_INDEXER_PARALLELISM` env var; self-hosted Esplora
+  // users with no rate concerns can set it as high as 32.
+  const parallelism = resolveBitcoinIndexerParallelism();
+  const probes = await pLimitMap(forAccount, parallelism, (e) =>
+    indexer.getBalance(e.address),
   );
 
   type BTCEntry = (typeof forAccount)[number];
@@ -821,10 +831,21 @@ export async function rescanBitcoinAccount(args: RescanBitcoinAccountArgs) {
 
   // needsExtend: for any (type, chain), if the entry with the LARGEST
   // addressIndex (the trailing buffer empty from the original walk)
-  // now has txCount > 0, the gap window may no longer cover all funds.
-  // The user should re-pair to extend.
+  // now has txCount > 0, the gap window may no longer cover all funds
+  // and the user should re-pair to extend. Issue #197 — the tail
+  // probe has THREE outcomes; conflating "rejected" with "healthy"
+  // silently masks an extend that's needed.
   let needsExtend = false;
   const extendChains: Array<{
+    addressType: BTCEntry["addressType"];
+    chain: 0 | 1;
+    lastAddressIndex: number;
+  }> = [];
+  // Tail probes whose live HTTP call rejected — we don't know whether
+  // the chain has been exceeded. Caller should rerun the rescan once
+  // (or when the indexer is healthier) to re-test those chains;
+  // re-pairing is only warranted when needsExtend turns true.
+  const unverifiedChains: Array<{
     addressType: BTCEntry["addressType"];
     chain: 0 | 1;
     lastAddressIndex: number;
@@ -835,19 +856,52 @@ export async function rescanBitcoinAccount(args: RescanBitcoinAccountArgs) {
     );
     const i = forAccount.indexOf(tail);
     const probe = probes[i];
-    if (probe.status === "fulfilled" && probe.value.txCount > 0) {
+    const [addressTypeStr, chainStr] = key.split(":");
+    const chainEntry = {
+      addressType: addressTypeStr as BTCEntry["addressType"],
+      chain: Number(chainStr) as 0 | 1,
+      lastAddressIndex: tail.addressIndex ?? -1,
+    };
+    if (probe.status === "rejected") {
+      // Tail probe failed — indeterminate. Surface as `unverifiedChains`
+      // so the caller can distinguish "definitely healthy" from "we
+      // didn't get a clean signal this run".
+      unverifiedChains.push(chainEntry);
+      continue;
+    }
+    if (probe.value.txCount > 0) {
       needsExtend = true;
-      const [addressTypeStr, chainStr] = key.split(":");
-      extendChains.push({
-        addressType: addressTypeStr as BTCEntry["addressType"],
-        chain: Number(chainStr) as 0 | 1,
-        lastAddressIndex: tail.addressIndex ?? -1,
-      });
+      extendChains.push(chainEntry);
     }
   }
 
   const fetchFailures = refreshed.filter((r) => !r.fetchOk).length;
   const txCountChanges = refreshed.filter((r) => r.delta !== 0).length;
+  // Note text adapts to which combination of signals fired. The "go
+  // re-pair" prompt only fires for `needsExtend`; an `unverified`-only
+  // response asks the caller to retry the rescan rather than
+  // immediately re-pair (re-pairing forces a device interaction the
+  // user may not want for a probably-transient indexer hiccup).
+  let note: string | undefined;
+  if (needsExtend) {
+    note =
+      "The trailing empty address on at least one cached chain now has " +
+      "on-chain history. The original gap-limit window may miss funds " +
+      "past it. Run `pair_ledger_btc({ accountIndex: " +
+      args.accountIndex +
+      " })` to extend the scan with fresh on-device derivations." +
+      (unverifiedChains.length > 0
+        ? " (Some other chains' tail probes failed and are reported as " +
+          "`unverifiedChains` — those are independent of the extend signal.)"
+        : "");
+  } else if (unverifiedChains.length > 0) {
+    note =
+      "Some chains' tail probes failed this run, so we can't confirm the " +
+      "gap window is still healthy for them — see `unverifiedChains`. " +
+      "This is usually a transient indexer hiccup (rate limit / 5xx); " +
+      "re-run `rescan_btc_account` after a moment. Don't re-pair on this " +
+      "alone — `needsExtend: true` is the signal for that.";
+  }
   return {
     accountIndex: args.accountIndex,
     addressesScanned: refreshed.length,
@@ -855,17 +909,9 @@ export async function rescanBitcoinAccount(args: RescanBitcoinAccountArgs) {
     fetchFailures,
     needsExtend,
     ...(needsExtend ? { extendChains } : {}),
+    ...(unverifiedChains.length > 0 ? { unverifiedChains } : {}),
     refreshed,
-    ...(needsExtend
-      ? {
-          note:
-            "The trailing empty address on at least one cached chain now has " +
-            "on-chain history. The original gap-limit window may miss funds " +
-            "past it. Run `pair_ledger_btc({ accountIndex: " +
-            args.accountIndex +
-            " })` to extend the scan with fresh on-device derivations.",
-        }
-      : {}),
+    ...(note ? { note } : {}),
   };
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1104,11 +1104,11 @@ export const rescanBitcoinAccountInput = z.object({
         "`txCount` of every cached address under this account and updates " +
         "the persisted cache — useful after the user has received funds or " +
         "the indexer was stale at original scan time. Pure indexer-side: no " +
-        "Ledger / USB interaction. If the LAST cached address on a chain " +
-        "(originally an empty buffer) now has on-chain history, the response " +
-        "flags `needsExtend: true` — the gap-limit window may now miss funds " +
-        "past it, and the caller should re-run `pair_ledger_btc` (which DOES " +
-        "use the device) to extend the walked window."
+        "Ledger / USB interaction. Returns: `needsExtend: true` when the " +
+        "trailing empty address on any cached chain now has history (re-pair " +
+        "to extend the walked window); `unverifiedChains: [...]` when the " +
+        "tail probe ITSELF rejected (transient indexer hiccup, status " +
+        "indeterminate — re-run `rescan_btc_account` rather than re-pairing)."
     ),
 });
 

--- a/test/btc-indexer-retry.test.ts
+++ b/test/btc-indexer-retry.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for `EsploraIndexer.getJson` retry behavior on transient
+ * failures (HTTP 429, network errors). Issue #199 — without retry, a
+ * single rate-limit response from mempool.space drops the cached
+ * txCount refresh for that address until the next manual rescan.
+ *
+ * Kept in a SEPARATE FILE from `btc-rescan-throttle-tristate.test.ts`
+ * because it needs the REAL `EsploraIndexer` module (not the mock the
+ * other file installs at file scope) — `vi.unmock` is module-global
+ * within a worker, so co-locating the two breaks the file-scope mock
+ * for tests scheduled later in the same describe.
+ */
+
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function freshIndexer() {
+  return import("../src/modules/btc/indexer.js").then(
+    ({ getBitcoinIndexer, resetBitcoinIndexer }) => {
+      resetBitcoinIndexer();
+      return getBitcoinIndexer();
+    },
+  );
+}
+
+const balancePayload = {
+  address: SEGWIT_ADDR,
+  chain_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+  mempool_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+};
+
+describe("EsploraIndexer — retry on 429 / network error (issue #199)", () => {
+  it("retries once on HTTP 429 and honors Retry-After (seconds)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(balancePayload), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    const out = await indexer.getBalance(SEGWIT_ADDR);
+    expect(out.txCount).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on HTTP 429 with no Retry-After header (uses jittered backoff)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("rate limited", { status: 429 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(balancePayload), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    const out = await indexer.getBalance(SEGWIT_ADDR);
+    expect(out.txCount).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the 429 error after the second 429 response (does NOT retry forever)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("rate limited", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    await expect(indexer.getBalance(SEGWIT_ADDR)).rejects.toThrow(
+      /returned 429/,
+    );
+    // Single retry: original + 1 retry = 2 fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on a network error and surfaces the error if both fail", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockRejectedValueOnce(new Error("ECONNRESET"));
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    await expect(indexer.getBalance(SEGWIT_ADDR)).rejects.toThrow(/ECONNRESET/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers when the first network error is followed by a successful response", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(balancePayload), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    const out = await indexer.getBalance(SEGWIT_ADDR);
+    expect(out.txCount).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on HTTP 5xx (caller decides whether to rerun)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream broken", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    await expect(indexer.getBalance(SEGWIT_ADDR)).rejects.toThrow(
+      /returned 503/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry on HTTP 4xx other than 429 (e.g. 400 = bad request)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("malformed", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const indexer = await freshIndexer();
+    await expect(indexer.getBalance(SEGWIT_ADDR)).rejects.toThrow(
+      /returned 400/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/btc-rescan-throttle-tristate.test.ts
+++ b/test/btc-rescan-throttle-tristate.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+/**
+ * Tests for issues #199 (rescan_btc_account unbounded fan-out) and
+ * #197 (needsExtend silently false when tail probe rejected).
+ *
+ * Mocks the indexer module wholesale and the BTC USB loader so no
+ * device or network is touched. Pairing entries persist to
+ * ~/.vaultpilot-mcp/config.json so each test redirects the config dir
+ * to a fresh tmp dir to avoid cross-test contamination.
+ */
+
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const TAPROOT_ADDR =
+  "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg";
+const FAKE_PUBKEY = "0".repeat(66);
+
+const indexerGetBalanceMock = vi.fn();
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({ getBalance: indexerGetBalanceMock }),
+  resetBitcoinIndexer: () => {},
+}));
+
+// USB loader is mocked just so any unintended Ledger access fails
+// loudly (no test in this file should trigger pair_ledger_btc).
+vi.mock("../src/signing/btc-usb-loader.js", () => ({
+  openLedger: async () => {
+    throw new Error("test: openLedger should not be called from rescan");
+  },
+  getAppAndVersion: async () => {
+    throw new Error("test: getAppAndVersion should not be called");
+  },
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-rescan-"));
+  setConfigDirForTesting(tmpHome);
+  indexerGetBalanceMock.mockReset();
+  const { clearPairedBtcAddresses } = await import(
+    "../src/signing/btc-usb-signer.js"
+  );
+  clearPairedBtcAddresses();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.BITCOIN_INDEXER_PARALLELISM;
+});
+
+describe("pLimitMap (issue #199)", () => {
+  it("caps in-flight tasks at the configured concurrency", async () => {
+    const { pLimitMap } = await import("../src/data/http.js");
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = new Array(20).fill(0).map((_, i) => i);
+    const fn = vi.fn(async (item: number) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return item * 2;
+    });
+    const results = await pLimitMap(items, 4, fn);
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+    // Even with the cap, every item resolved.
+    expect(results.length).toBe(20);
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    // Order preserved: results[i] corresponds to items[i].
+    for (let i = 0; i < 20; i++) {
+      expect((results[i] as PromiseFulfilledResult<number>).value).toBe(i * 2);
+    }
+  });
+
+  it("isolates rejections (one bad task doesn't break the batch)", async () => {
+    const { pLimitMap } = await import("../src/data/http.js");
+    const fn = async (i: number) => {
+      if (i === 3) throw new Error("boom");
+      return i;
+    };
+    const results = await pLimitMap([0, 1, 2, 3, 4], 2, fn);
+    expect(results[3].status).toBe("rejected");
+    expect((results[3] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+    expect(results.filter((r) => r.status === "fulfilled").length).toBe(4);
+  });
+
+  it("rejects invalid concurrency", async () => {
+    const { pLimitMap } = await import("../src/data/http.js");
+    await expect(pLimitMap([1, 2, 3], 0, async () => 0)).rejects.toThrow(
+      /positive integer/,
+    );
+    await expect(pLimitMap([1, 2, 3], -1, async () => 0)).rejects.toThrow();
+  });
+});
+
+describe("rescan_btc_account — bounded fan-out (issue #199)", () => {
+  it("caps concurrent indexer probes at BITCOIN_INDEXER_PARALLELISM (default 8)", async () => {
+    // Pre-populate the cache with 30 entries so a serial fan-out
+    // would be obviously different from a parallel one.
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    for (let i = 0; i < 30; i++) {
+      setPairedBtcAddress({
+        address: `bc1qfake${i.toString().padStart(2, "0")}aaaaaaaaaaaaaaaaaaaaaaaaaa`,
+        publicKey: FAKE_PUBKEY,
+        path: `84'/0'/0'/0/${i}`,
+        appVersion: "2.2.3",
+        addressType: "segwit",
+        accountIndex: 0,
+        chain: 0,
+        addressIndex: i,
+        txCount: 0,
+      });
+    }
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 0,
+      };
+    });
+
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.addressesScanned).toBe(30);
+    // Default parallelism is 8 (per BITCOIN_INDEXER_DEFAULT_PARALLELISM).
+    expect(maxInFlight).toBeLessThanOrEqual(8);
+    // But we ARE doing parallel work — should approach the cap.
+    expect(maxInFlight).toBeGreaterThanOrEqual(4);
+  });
+
+  it("BITCOIN_INDEXER_PARALLELISM env var overrides the default", async () => {
+    process.env.BITCOIN_INDEXER_PARALLELISM = "16";
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    for (let i = 0; i < 25; i++) {
+      setPairedBtcAddress({
+        address: `bc1qbb${i.toString().padStart(2, "0")}bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`,
+        publicKey: FAKE_PUBKEY,
+        path: `84'/0'/0'/0/${i}`,
+        appVersion: "2.2.3",
+        addressType: "segwit",
+        accountIndex: 0,
+        chain: 0,
+        addressIndex: i,
+        txCount: 0,
+      });
+    }
+    let inFlight = 0;
+    let maxInFlight = 0;
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 0,
+      };
+    });
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(maxInFlight).toBeLessThanOrEqual(16);
+    expect(maxInFlight).toBeGreaterThan(8);
+  });
+
+  it("clamps env var to the maximum (32) and falls back to default for non-numeric values", async () => {
+    const { resolveBitcoinIndexerParallelism } = await import(
+      "../src/config/btc.js"
+    );
+    process.env.BITCOIN_INDEXER_PARALLELISM = "9999";
+    expect(resolveBitcoinIndexerParallelism()).toBe(32);
+    process.env.BITCOIN_INDEXER_PARALLELISM = "abc";
+    expect(resolveBitcoinIndexerParallelism()).toBe(8);
+    process.env.BITCOIN_INDEXER_PARALLELISM = "0";
+    expect(resolveBitcoinIndexerParallelism()).toBe(8);
+    delete process.env.BITCOIN_INDEXER_PARALLELISM;
+    expect(resolveBitcoinIndexerParallelism()).toBe(8);
+  });
+});
+
+describe("rescan_btc_account — tri-state needsExtend (issue #197)", () => {
+  // Helper: cache N entries on a single (type, chain) so the tail is
+  // unambiguous for the test.
+  async function seedSegwitReceiveChain(
+    addresses: Array<{ idx: number; addr: string; txCount: number }>,
+  ) {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    for (const e of addresses) {
+      setPairedBtcAddress({
+        address: e.addr,
+        publicKey: FAKE_PUBKEY,
+        path: `84'/0'/0'/0/${e.idx}`,
+        appVersion: "2.2.3",
+        addressType: "segwit",
+        accountIndex: 0,
+        chain: 0,
+        addressIndex: e.idx,
+        txCount: e.txCount,
+      });
+    }
+  }
+
+  it("flags needsExtend (extendChains populated) when tail fulfilled and used", async () => {
+    const TAIL = "bc1qttt1tttttttttttttttttttttttttttttttabcdef";
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: SEGWIT_ADDR, txCount: 5 },
+      { idx: 1, addr: "bc1qmid1midddmidddmidddmidddmidddmidddabcdef", txCount: 0 },
+      { idx: 2, addr: TAIL, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      // Tail flips to USED — this is what `needsExtend` is supposed to catch.
+      txCount: address === TAIL ? 1 : address === SEGWIT_ADDR ? 5 : 0,
+    }));
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(true);
+    expect(out.extendChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 2 },
+    ]);
+    expect(out.unverifiedChains).toBeUndefined();
+  });
+
+  it("does NOT flag needsExtend when tail fulfilled and empty (regression on prior behavior)", async () => {
+    const TAIL = "bc1qttt2tttttttttttttttttttttttttttttttabcdef";
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: SEGWIT_ADDR, txCount: 5 },
+      { idx: 1, addr: TAIL, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: address === SEGWIT_ADDR ? 5 : 0,
+    }));
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(false);
+    expect(out.extendChains).toBeUndefined();
+    expect(out.unverifiedChains).toBeUndefined();
+  });
+
+  it("surfaces unverifiedChains (NOT needsExtend) when the tail probe rejects", async () => {
+    // The bug from #197: prior code conflated rejected with healthy.
+    const TAIL = "bc1qttt3tttttttttttttttttttttttttttttttabcdef";
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: SEGWIT_ADDR, txCount: 5 },
+      { idx: 1, addr: "bc1qmid3midddmidddmidddmidddmidddmidddabcdef", txCount: 0 },
+      { idx: 2, addr: TAIL, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      if (address === TAIL) {
+        throw new Error("simulated indexer 502 on the tail");
+      }
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: address === SEGWIT_ADDR ? 5 : 0,
+      };
+    });
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    // The whole point of #197: rejected ≠ healthy, but it's also NOT extend.
+    expect(out.needsExtend).toBe(false);
+    expect(out.extendChains).toBeUndefined();
+    expect(out.unverifiedChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 2 },
+    ]);
+    expect(out.note).toMatch(/unverifiedChains/);
+    expect(out.note).toMatch(/transient/);
+  });
+
+  it("can flag both needsExtend AND unverifiedChains when chains are mixed", async () => {
+    // segwit (rcv) tail USED → needsExtend
+    // taproot (rcv) tail REJECTED → unverifiedChains
+    const SEGWIT_TAIL = "bc1qstttsttttttttttttttttttttttttttttttabcdef";
+    const TAPROOT_TAIL =
+      "bc1pttttttttttttttttttttttttttttttttttttttttttttttttttttttttttabc";
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 1,
+    });
+    setPairedBtcAddress({
+      address: SEGWIT_TAIL,
+      publicKey: FAKE_PUBKEY,
+      path: "84'/0'/0'/0/1",
+      appVersion: "2.2.3",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 1,
+      txCount: 0,
+    });
+    setPairedBtcAddress({
+      address: TAPROOT_ADDR,
+      publicKey: FAKE_PUBKEY,
+      path: "86'/0'/0'/0/0",
+      appVersion: "2.2.3",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+      txCount: 1,
+    });
+    setPairedBtcAddress({
+      address: TAPROOT_TAIL,
+      publicKey: FAKE_PUBKEY,
+      path: "86'/0'/0'/0/1",
+      appVersion: "2.2.3",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 1,
+      txCount: 0,
+    });
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      if (address === TAPROOT_TAIL) {
+        throw new Error("simulated 429 on taproot tail");
+      }
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: address === SEGWIT_TAIL ? 1 : address === SEGWIT_ADDR || address === TAPROOT_ADDR ? 1 : 0,
+      };
+    });
+    const { rescanBitcoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanBitcoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(true);
+    expect(out.extendChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 1 },
+    ]);
+    expect(out.unverifiedChains).toEqual([
+      { addressType: "taproot", chain: 0, lastAddressIndex: 1 },
+    ]);
+    // Note explains both signals.
+    expect(out.note).toMatch(/pair_ledger_btc/);
+    expect(out.note).toMatch(/unverifiedChains/);
+  });
+});
+


### PR DESCRIPTION
Closes #197 and #199 in one PR — they compound on \`rescan_btc_account\` and the fixes overlap.

## #199 — Unbounded fan-out trips mempool.space rate limit

\`rescan_btc_account\` fired one indexer call per cached address through \`Promise.allSettled\` with no concurrency cap, no retry, no 429 awareness. For a full BIP44 gap-limit walk (~100+ cached addresses) this burst tripped mempool.space's free-tier rate limit and ~40% of probes failed.

**Fix**:
- \`pLimitMap(items, concurrency, fn)\` worker-pool helper in \`src/data/http.ts\` — bounded-concurrency variant of \`Promise.allSettled\`, preserves input order, isolates rejections, no \`p-limit\` dep
- \`BITCOIN_INDEXER_PARALLELISM\` env var (default 8, capped at 32) — self-hosted Esplora users can opt out
- \`EsploraIndexer.getJson\` retries ONCE on HTTP 429 (honoring \`Retry-After: <seconds>\` up to 5s, falling back to jittered ~400-800ms backoff) and on network errors. Does NOT retry on HTTP 5xx — those should surface to the caller, not get silently masked

## #197 — needsExtend silently false when tail probe fails

The per-chain extend check was a single \`if (probe.status === \"fulfilled\" && probe.value.txCount > 0)\`. That collapsed three states into two outcomes:

| tail probe state | currently |
|---|---|
| fulfilled + used | \`needsExtend: true\` ✓ |
| fulfilled + empty | \`needsExtend: false\` ✓ |
| **rejected** | \`needsExtend: false\` ✗ (was: rejected ≠ healthy) |

When the trailing buffer's probe rejected (rate-limit, 5xx, network blip), the chain was silently reported as healthy. A receive past the gap window stays invisible until a later rescan happens to land a successful tail probe.

**Fix**: distinguish the three states explicitly. Response now carries:
- \`needsExtend: boolean\` — fulfilled-and-USED tail (re-pair to extend the walked window)
- \`unverifiedChains: [...]\` — REJECTED tail (transient; re-run rescan rather than re-pair)

Note text adapts to which combination of signals fired (extend only / unverified only / both).

## Why one PR

#199's concurrency cap reduces the failure rate that trips #197 (fewer 429s on tail probes), but #197's soundness fix goes in regardless — any single transient failure on the tail is enough. They share the rescan code path; splitting would mean two passes through the same handler.

## Tests (17 new)

\`test/btc-rescan-throttle-tristate.test.ts\` (10):
- \`pLimitMap\` concurrency cap, rejection isolation, invalid input
- rescan default cap = 8, env var override = 16, env clamp/fallback
- tri-state needsExtend: fulfilled+used, fulfilled+empty, rejected → unverifiedChains, mixed (both fire)

\`test/btc-indexer-retry.test.ts\` (7) — separate file because \`vi.unmock\` is module-global within a worker:
- retry on 429 with Retry-After
- retry on 429 without Retry-After (jittered backoff)
- exhausted retries surface 429
- network error + recovery
- sustained network error
- no retry on 5xx (caller decides)
- no retry on non-429 4xx

## Verification

- \`npm run build\` clean
- Full suite **1104/1104** (1076 baseline + 28 new — 17 from this PR's two new files plus 11 already-passing tests in test/btc-pair.test.ts that exercise the rescan path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)