### PR TITLE
feat(portfolio): allow non-EVM addresses in multi-wallet mode (#201)

### DIFF
--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -107,11 +107,40 @@ export async function getPortfolioSummary(
     ? [args.wallet as `0x${string}`]
     : [];
 
-  const tronAddress = args.tronAddress;
-  const solanaAddress = args.solanaAddress;
+  // Resolve singular/plural args. Mutually exclusive forms throw — pass
+  // either the single-address or the array form, not both. Issue #201:
+  // multi-wallet mode now ALSO accepts non-EVM addresses; they're
+  // surfaced as parallel siblings on the response (`nonEvm` block)
+  // rather than folded into a chosen EVM wallet's totals.
+  if (args.tronAddress && args.tronAddresses && args.tronAddresses.length > 0) {
+    throw new Error(
+      "Pass `tronAddress` (single) OR `tronAddresses` (array), not both.",
+    );
+  }
+  const tronAddresses: string[] = args.tronAddresses?.length
+    ? args.tronAddresses
+    : args.tronAddress
+    ? [args.tronAddress]
+    : [];
+
+  if (
+    args.solanaAddress &&
+    args.solanaAddresses &&
+    args.solanaAddresses.length > 0
+  ) {
+    throw new Error(
+      "Pass `solanaAddress` (single) OR `solanaAddresses` (array), not both.",
+    );
+  }
+  const solanaAddresses: string[] = args.solanaAddresses?.length
+    ? args.solanaAddresses
+    : args.solanaAddress
+    ? [args.solanaAddress]
+    : [];
+
   if (args.bitcoinAddress && args.bitcoinAddresses && args.bitcoinAddresses.length > 0) {
     throw new Error(
-      "Pass `bitcoinAddress` (single) OR `bitcoinAddresses` (array), not both."
+      "Pass `bitcoinAddress` (single) OR `bitcoinAddresses` (array), not both.",
     );
   }
   const bitcoinAddresses = args.bitcoinAddresses?.length
@@ -120,33 +149,35 @@ export async function getPortfolioSummary(
     ? [args.bitcoinAddress]
     : [];
 
-  // Branch: single wallet returns the flat summary; multi-wallet aggregates.
-  // TRON, Solana, and Bitcoin are only folded into the single-wallet summary —
-  // a multi-wallet view with a single non-EVM address would be ambiguous
-  // ("which EVM wallet does it belong to?"), so the caller must use
-  // single-wallet mode when pairing with a non-EVM address.
+  // Single-wallet branch: keep the existing fold-non-EVM-into-totals
+  // shape (backwards compat). Multi-address TRON/Solana don't have a
+  // single-slice projection in this shape; reject explicitly so the
+  // caller can switch to multi-wallet mode rather than silently lose
+  // entries 2..N. BTC already supports multi-address natively
+  // (BitcoinPortfolioSlice carries an `addresses[]` array).
   if (wallets.length === 1) {
+    if (tronAddresses.length > 1) {
+      throw new Error(
+        "`tronAddresses` with multiple entries can't fold into a single-`wallet` " +
+          "summary (each TRON address is a separate identity). Use `wallets: [...]` " +
+          "(multi-wallet mode) so the TRON addresses are surfaced as parallel siblings " +
+          "in `nonEvm.tron[]`.",
+      );
+    }
+    if (solanaAddresses.length > 1) {
+      throw new Error(
+        "`solanaAddresses` with multiple entries can't fold into a single-`wallet` " +
+          "summary (each Solana address is a separate identity). Use `wallets: [...]` " +
+          "(multi-wallet mode) so the Solana addresses are surfaced as parallel siblings " +
+          "in `nonEvm.solana[]`.",
+      );
+    }
     return buildWalletSummary(
       wallets[0],
       chains,
-      tronAddress,
-      solanaAddress,
+      tronAddresses[0],
+      solanaAddresses[0],
       bitcoinAddresses,
-    );
-  }
-  if (tronAddress) {
-    throw new Error(
-      "`tronAddress` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
-    );
-  }
-  if (solanaAddress) {
-    throw new Error(
-      "`solanaAddress` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
-    );
-  }
-  if (bitcoinAddresses.length > 0) {
-    throw new Error(
-      "`bitcoinAddress` / `bitcoinAddresses` can only be combined with a single EVM `wallet`. For multi-wallet portfolios, call `get_portfolio_summary` once per EVM wallet."
     );
   }
 
@@ -164,19 +195,46 @@ export async function getPortfolioSummary(
   //
   // Run in parallel across subsystems (each batches by chain
   // internally); one slow subsystem doesn't serialize the others.
-  await Promise.all([
-    prefetchCompoundProbes(wallets, chains),
-    prefetchAaveAccountData(wallets, chains),
-    // Lido mainnet is the most rate-limit-sensitive staking read;
-    // arbitrum wstETH is low volume and stays per-wallet.
-    chains.includes("ethereum") ? prefetchLidoMainnet(wallets) : Promise.resolve(),
+  // Non-EVM aggregation (issue #201) runs in parallel with the EVM
+  // path — TRON / Solana / BTC are independent identities and don't
+  // contend for the same RPC.
+  const [evmPrefetchDone, nonEvm] = await Promise.all([
+    Promise.all([
+      prefetchCompoundProbes(wallets, chains),
+      prefetchAaveAccountData(wallets, chains),
+      // Lido mainnet is the most rate-limit-sensitive staking read;
+      // arbitrum wstETH is low volume and stays per-wallet.
+      chains.includes("ethereum") ? prefetchLidoMainnet(wallets) : Promise.resolve(),
+    ]),
+    aggregateNonEvm({
+      tronAddresses,
+      solanaAddresses,
+      bitcoinAddresses,
+    }),
   ]);
+  void evmPrefetchDone;
   const perWallet = await Promise.all(wallets.map((w) => buildWalletSummary(w, chains)));
-  const totalUsd = round(perWallet.reduce((s, p) => s + p.totalUsd, 0), 2);
+  const evmTotal = round(perWallet.reduce((s, p) => s + p.totalUsd, 0), 2);
   const walletBalancesUsd = round(perWallet.reduce((s, p) => s + p.walletBalancesUsd, 0), 2);
   const lendingNetUsd = round(perWallet.reduce((s, p) => s + p.lendingNetUsd, 0), 2);
   const lpUsd = round(perWallet.reduce((s, p) => s + p.lpUsd, 0), 2);
   const stakingUsd = round(perWallet.reduce((s, p) => s + p.stakingUsd, 0), 2);
+  // Non-EVM contribution to totalUsd. Each chain's USD already aggregates
+  // wallet balances + (where applicable) staking + lending; sum them all
+  // for the top-line totalUsd. NOTE: this does NOT roll into
+  // `walletBalancesUsd` because that field documents EVM-only-ish
+  // semantics across the codebase; non-EVM gets its own per-chain USD
+  // fields below for clarity.
+  const nonEvmContribution = round(
+    (nonEvm.tronUsd ?? 0) +
+      (nonEvm.tronStakingUsd ?? 0) +
+      (nonEvm.solanaUsd ?? 0) +
+      (nonEvm.solanaLendingUsd ?? 0) +
+      (nonEvm.solanaStakingUsd ?? 0) +
+      (nonEvm.bitcoinUsd ?? 0),
+    2,
+  );
+  const totalUsd = round(evmTotal + nonEvmContribution, 2);
   const perChain: Record<SupportedChain, number> = Object.fromEntries(
     chains.map((c) => [c, 0])
   ) as Record<SupportedChain, number>;
@@ -197,11 +255,31 @@ export async function getPortfolioSummary(
     morpho: mergeCoverage(perWallet.map((p) => p.coverage.morpho)),
     uniswapV3: mergeCoverage(perWallet.map((p) => p.coverage.uniswapV3)),
     staking: mergeCoverage(perWallet.map((p) => p.coverage.staking)),
-    unpricedAssets: perWallet.reduce((s, p) => s + p.coverage.unpricedAssets, 0),
-    ...(aggregatedUnpricedDetail.length > 0
-      ? { unpricedAssetsDetail: aggregatedUnpricedDetail }
+    unpricedAssets:
+      perWallet.reduce((s, p) => s + p.coverage.unpricedAssets, 0) +
+      (nonEvm.unpricedAssetsDetail?.length ?? 0),
+    ...(aggregatedUnpricedDetail.length > 0 || (nonEvm.unpricedAssetsDetail?.length ?? 0) > 0
+      ? {
+          unpricedAssetsDetail: [
+            ...aggregatedUnpricedDetail,
+            ...(nonEvm.unpricedAssetsDetail ?? []),
+          ],
+        }
       : {}),
+    ...(nonEvm.coverage ?? {}),
   };
+
+  // Build the nonEvm block ONLY if at least one non-EVM source was
+  // queried. Avoids polluting the response with empty objects when the
+  // caller stays EVM-only.
+  const nonEvmBlock =
+    nonEvm.tron || nonEvm.solana || nonEvm.bitcoin
+      ? {
+          ...(nonEvm.tron ? { tron: nonEvm.tron } : {}),
+          ...(nonEvm.solana ? { solana: nonEvm.solana } : {}),
+          ...(nonEvm.bitcoin ? { bitcoin: nonEvm.bitcoin } : {}),
+        }
+      : undefined;
 
   return {
     wallets,
@@ -213,6 +291,19 @@ export async function getPortfolioSummary(
     stakingUsd,
     perChain,
     perWallet,
+    ...(nonEvmBlock ? { nonEvm: nonEvmBlock } : {}),
+    ...(nonEvm.tronUsd !== undefined ? { tronUsd: nonEvm.tronUsd } : {}),
+    ...(nonEvm.tronStakingUsd !== undefined
+      ? { tronStakingUsd: nonEvm.tronStakingUsd }
+      : {}),
+    ...(nonEvm.solanaUsd !== undefined ? { solanaUsd: nonEvm.solanaUsd } : {}),
+    ...(nonEvm.solanaLendingUsd !== undefined
+      ? { solanaLendingUsd: nonEvm.solanaLendingUsd }
+      : {}),
+    ...(nonEvm.solanaStakingUsd !== undefined
+      ? { solanaStakingUsd: nonEvm.solanaStakingUsd }
+      : {}),
+    ...(nonEvm.bitcoinUsd !== undefined ? { bitcoinUsd: nonEvm.bitcoinUsd } : {}),
     coverage: mergedCoverage,
   };
 }
@@ -389,6 +480,436 @@ async function fetchBitcoinSlice(
       balances,
       walletBalancesUsd: round(walletBalancesUsd, 2),
     },
+    unpriced,
+  };
+}
+
+/**
+ * Multi-wallet non-EVM aggregation. Issue #201 — when the caller
+ * passes `wallets[]` together with TRON / Solana / BTC addresses, the
+ * non-EVM holdings are independent identities and shouldn't fold into
+ * any specific EVM wallet's totals. This helper builds the parallel
+ * `nonEvm` block surfaced at the top of `MultiWalletPortfolioSummary`.
+ *
+ * Each chain's per-address fetches run in parallel (subreaders run
+ * sequentially within an address but parallel across addresses) so a
+ * 4-wallet + 2-TRON + 2-Solana + 3-BTC call collapses to roughly the
+ * latency of the slowest single subreader on the slowest single
+ * address, not the sum.
+ *
+ * Per-address failures degrade gracefully: a flaky TronGrid call on
+ * address A doesn't drop address B from the response. Errored
+ * subsystems flip the relevant `coverage.{tron,solana,bitcoin}` flag.
+ *
+ * Returns the slices + USD rollups + coverage bits ready to merge
+ * into the multi-wallet response. The function is private — callers
+ * should go through `getPortfolioSummary`.
+ */
+async function aggregateNonEvm(args: {
+  tronAddresses: string[];
+  solanaAddresses: string[];
+  bitcoinAddresses: string[];
+}): Promise<{
+  tron?: TronPortfolioSlice[];
+  solana?: SolanaPortfolioSlice[];
+  bitcoin?: BitcoinPortfolioSlice;
+  tronUsd?: number;
+  tronStakingUsd?: number;
+  solanaUsd?: number;
+  solanaLendingUsd?: number;
+  solanaStakingUsd?: number;
+  bitcoinUsd?: number;
+  coverage?: Pick<
+    PortfolioCoverage,
+    "tron" | "tronStaking" | "solana" | "marginfi" | "kamino" | "solanaStaking" | "bitcoin"
+  >;
+  unpricedAssetsDetail?: UnpricedAsset[];
+}> {
+  // Fan out all three chain groups in parallel — they don't share
+  // network paths so latency stacks pessimistically only inside a
+  // single chain group.
+  const [tronResult, solanaResult, bitcoinResult] = await Promise.all([
+    aggregateTron(args.tronAddresses),
+    aggregateSolana(args.solanaAddresses),
+    args.bitcoinAddresses.length > 0
+      ? fetchBitcoinSlice(args.bitcoinAddresses)
+      : Promise.resolve(null),
+  ]);
+
+  const out: Awaited<ReturnType<typeof aggregateNonEvm>> = {};
+  const coverage: NonNullable<
+    Awaited<ReturnType<typeof aggregateNonEvm>>["coverage"]
+  > = {};
+  const unpricedAssetsDetail: UnpricedAsset[] = [];
+
+  if (args.tronAddresses.length > 0) {
+    if (tronResult.slices.length > 0) {
+      out.tron = tronResult.slices;
+      out.tronUsd = round(
+        tronResult.slices.reduce((s, x) => s + x.walletBalancesUsd, 0),
+        2,
+      );
+      const stakingUsd = tronResult.slices.reduce(
+        (s, x) => s + (x.staking?.totalStakedUsd ?? 0),
+        0,
+      );
+      if (stakingUsd > 0) out.tronStakingUsd = round(stakingUsd, 2);
+    }
+    coverage.tron = tronResult.balanceErrored
+      ? {
+          covered: false,
+          errored: true,
+          note:
+            "One or more TRON balance fetches failed (TronGrid). Affected addresses dropped from totals.",
+        }
+      : { covered: true };
+    coverage.tronStaking = tronResult.stakingErrored
+      ? {
+          covered: false,
+          errored: true,
+          note:
+            "One or more TRON staking fetches failed (TronGrid getReward/accounts). Affected entries dropped from totals.",
+        }
+      : { covered: true };
+    unpricedAssetsDetail.push(...tronResult.unpriced);
+  }
+
+  if (args.solanaAddresses.length > 0) {
+    if (solanaResult.slices.length > 0) {
+      out.solana = solanaResult.slices;
+      out.solanaUsd = round(
+        solanaResult.slices.reduce((s, x) => s + x.walletBalancesUsd, 0),
+        2,
+      );
+      if (solanaResult.lendingUsd > 0)
+        out.solanaLendingUsd = round(solanaResult.lendingUsd, 2);
+      if (solanaResult.stakingUsd > 0)
+        out.solanaStakingUsd = round(solanaResult.stakingUsd, 2);
+    }
+    coverage.solana = solanaResult.balanceErrored
+      ? {
+          covered: false,
+          errored: true,
+          note:
+            "One or more Solana balance fetches failed. Check SOLANA_RPC_URL / solanaRpcUrl.",
+        }
+      : { covered: true };
+    coverage.marginfi = solanaResult.marginfiErrored
+      ? {
+          covered: false,
+          errored: true,
+          note: "MarginFi position fetch failed for at least one Solana address.",
+        }
+      : { covered: true };
+    coverage.kamino = solanaResult.kaminoErrored
+      ? {
+          covered: false,
+          errored: true,
+          note: "Kamino position fetch failed for at least one Solana address.",
+        }
+      : { covered: true };
+    coverage.solanaStaking = solanaResult.stakingErrored
+      ? {
+          covered: false,
+          errored: true,
+          note:
+            "Solana staking fetch failed for at least one address (Marinade / Jito / native stake-account read).",
+        }
+      : { covered: true };
+    unpricedAssetsDetail.push(...solanaResult.unpriced);
+  }
+
+  if (args.bitcoinAddresses.length > 0) {
+    if (bitcoinResult) {
+      out.bitcoin = bitcoinResult.slice;
+      out.bitcoinUsd = bitcoinResult.slice.walletBalancesUsd;
+      unpricedAssetsDetail.push(...bitcoinResult.unpriced);
+      coverage.bitcoin = { covered: true };
+    } else {
+      coverage.bitcoin = {
+        covered: false,
+        errored: true,
+        note:
+          "Bitcoin indexer fetch failed — BTC balances not included in totals. " +
+          "Check `BITCOIN_INDEXER_URL` env var or `bitcoinIndexerUrl` user config.",
+      };
+    }
+  }
+
+  if (Object.keys(coverage).length > 0) out.coverage = coverage;
+  if (unpricedAssetsDetail.length > 0) out.unpricedAssetsDetail = unpricedAssetsDetail;
+  return out;
+}
+
+/**
+ * Fan out `getTronBalances` + `getTronStaking` for every TRON address.
+ * Each address gets a TronPortfolioSlice that bundles wallet balances
+ * with staking (if the staking call succeeded), keeping the per-
+ * address shape interchangeable with the single-wallet response.
+ */
+async function aggregateTron(addresses: string[]): Promise<{
+  slices: TronPortfolioSlice[];
+  balanceErrored: boolean;
+  stakingErrored: boolean;
+  unpriced: UnpricedAsset[];
+}> {
+  if (addresses.length === 0) {
+    return { slices: [], balanceErrored: false, stakingErrored: false, unpriced: [] };
+  }
+  const settled = await Promise.all(
+    addresses.map(async (addr) => {
+      const [balanceR, stakingR] = await Promise.allSettled([
+        getTronBalances(addr),
+        getTronStaking(addr),
+      ]);
+      const balanceOk = balanceR.status === "fulfilled" ? balanceR.value : null;
+      const stakingOk = stakingR.status === "fulfilled" ? stakingR.value : null;
+      return {
+        addr,
+        balance: balanceOk,
+        staking: stakingOk,
+        balanceErrored: balanceR.status === "rejected",
+        stakingErrored: stakingR.status === "rejected",
+      };
+    }),
+  );
+  const slices: TronPortfolioSlice[] = [];
+  const unpriced: UnpricedAsset[] = [];
+  let balanceErrored = false;
+  let stakingErrored = false;
+  for (const r of settled) {
+    if (r.balanceErrored) balanceErrored = true;
+    if (r.stakingErrored) stakingErrored = true;
+    if (r.balance) {
+      slices.push({
+        ...r.balance,
+        ...(r.staking ? { staking: r.staking } : {}),
+      });
+      // Pull priceMissing entries into the multi-wallet unpriced list.
+      for (const t of [...r.balance.native, ...r.balance.trc20]) {
+        if (t.priceMissing) {
+          unpriced.push({
+            chain: "tron" as const,
+            symbol: t.symbol,
+            amount: t.formatted,
+          });
+        }
+      }
+    }
+  }
+  return { slices, balanceErrored, stakingErrored, unpriced };
+}
+
+/**
+ * Fan out `getSolanaBalances` + MarginFi + Kamino + Solana-staking
+ * subreaders for every Solana address. Returns one
+ * SolanaPortfolioSlice per address (extended with marginfi/kamino/
+ * staking projections, same shape `buildWalletSummary` produces in
+ * the single-wallet branch) plus rolled-up USD totals across all
+ * addresses for the response's top-level `solanaLendingUsd` /
+ * `solanaStakingUsd`.
+ */
+async function aggregateSolana(addresses: string[]): Promise<{
+  slices: SolanaPortfolioSlice[];
+  lendingUsd: number;
+  stakingUsd: number;
+  balanceErrored: boolean;
+  marginfiErrored: boolean;
+  kaminoErrored: boolean;
+  stakingErrored: boolean;
+  unpriced: UnpricedAsset[];
+}> {
+  if (addresses.length === 0) {
+    return {
+      slices: [],
+      lendingUsd: 0,
+      stakingUsd: 0,
+      balanceErrored: false,
+      marginfiErrored: false,
+      kaminoErrored: false,
+      stakingErrored: false,
+      unpriced: [],
+    };
+  }
+  const conn = getSolanaConnection();
+  const perAddress = await Promise.all(
+    addresses.map(async (addr) => {
+      const [balanceR, marginfiR, kaminoR, stakingR] = await Promise.allSettled([
+        getSolanaBalances(addr),
+        readMarginfiPositions(conn, addr),
+        readKaminoPositions(conn, addr),
+        readSolanaStakingPositions(conn, addr),
+      ]);
+      return { addr, balanceR, marginfiR, kaminoR, stakingR };
+    }),
+  );
+
+  const slices: SolanaPortfolioSlice[] = [];
+  const unpriced: UnpricedAsset[] = [];
+  let lendingUsd = 0;
+  let stakingUsd = 0;
+  let balanceErrored = false;
+  let marginfiErrored = false;
+  let kaminoErrored = false;
+  let stakingErrored = false;
+  for (const r of perAddress) {
+    if (r.balanceR.status !== "fulfilled") {
+      balanceErrored = true;
+      continue;
+    }
+    const balance = r.balanceR.value;
+    let solPriceUsd: number | undefined;
+    for (const b of balance.native) {
+      if (b.token === "native" && typeof b.priceUsd === "number") {
+        solPriceUsd = b.priceUsd;
+        break;
+      }
+    }
+
+    const marginfiSlices: SolanaMarginfiPositionSlice[] = [];
+    if (r.marginfiR.status === "fulfilled") {
+      for (const pos of r.marginfiR.value) {
+        marginfiSlices.push({
+          protocol: "marginfi",
+          chain: "solana",
+          marginfiAccount: pos.marginfiAccount,
+          supplied: pos.supplied.map((b) => ({
+            symbol: b.symbol,
+            amount: b.amount,
+            valueUsd: b.valueUsd,
+          })),
+          borrowed: pos.borrowed.map((b) => ({
+            symbol: b.symbol,
+            amount: b.amount,
+            valueUsd: b.valueUsd,
+          })),
+          totalSuppliedUsd: pos.totalSuppliedUsd,
+          totalBorrowedUsd: pos.totalBorrowedUsd,
+          netValueUsd: pos.netValueUsd,
+          healthFactor: pos.healthFactor,
+          warnings: pos.warnings,
+        });
+      }
+    } else {
+      marginfiErrored = true;
+    }
+
+    const kaminoSlices: SolanaKaminoPositionSlice[] = [];
+    if (r.kaminoR.status === "fulfilled") {
+      for (const pos of r.kaminoR.value) {
+        kaminoSlices.push({
+          protocol: "kamino",
+          chain: "solana",
+          obligation: pos.obligation,
+          supplied: pos.supplied.map((b) => ({
+            symbol: b.symbol,
+            amount: b.amount,
+            valueUsd: b.valueUsd,
+          })),
+          borrowed: pos.borrowed.map((b) => ({
+            symbol: b.symbol,
+            amount: b.amount,
+            valueUsd: b.valueUsd,
+          })),
+          totalSuppliedUsd: pos.totalSuppliedUsd,
+          totalBorrowedUsd: pos.totalBorrowedUsd,
+          netValueUsd: pos.netValueUsd,
+          healthFactor: pos.healthFactor,
+          warnings: pos.warnings,
+        });
+      }
+    } else {
+      kaminoErrored = true;
+    }
+    const addrLendingUsd =
+      marginfiSlices.reduce((s, p) => s + p.netValueUsd, 0) +
+      kaminoSlices.reduce((s, p) => s + p.netValueUsd, 0);
+    lendingUsd += addrLendingUsd;
+
+    let solanaStakingSlice: SolanaStakingPositionSlice | undefined;
+    let addrStakingUsd = 0;
+    if (r.stakingR.status === "fulfilled" && r.stakingR.value) {
+      const raw = r.stakingR.value;
+      solanaStakingSlice = {
+        chain: "solana",
+        marinade: {
+          mSolBalance: raw.marinade.mSolBalance,
+          solEquivalent: raw.marinade.solEquivalent,
+          exchangeRate: raw.marinade.exchangeRate,
+        },
+        jito: {
+          jitoSolBalance: raw.jito.jitoSolBalance,
+          solEquivalent: raw.jito.solEquivalent,
+          exchangeRate: raw.jito.exchangeRate,
+        },
+        nativeStakes: raw.nativeStakes.map((s) => ({
+          stakePubkey: s.stakePubkey,
+          ...(s.validator ? { validator: s.validator } : {}),
+          stakeSol: s.stakeSol,
+          status: s.status,
+          ...(s.activationEpoch !== undefined
+            ? { activationEpoch: s.activationEpoch }
+            : {}),
+          ...(s.deactivationEpoch !== undefined
+            ? { deactivationEpoch: s.deactivationEpoch }
+            : {}),
+        })),
+        totalSolEquivalent: raw.totalSolEquivalent,
+      };
+      if (typeof solPriceUsd === "number") {
+        addrStakingUsd = raw.totalSolEquivalent * solPriceUsd;
+        stakingUsd += addrStakingUsd;
+      }
+    } else if (r.stakingR.status === "rejected") {
+      stakingErrored = true;
+    }
+
+    const slice: SolanaPortfolioSlice = {
+      ...balance,
+      ...(marginfiSlices.length > 0
+        ? {
+            marginfi: marginfiSlices,
+            marginfiNetUsd: round(
+              marginfiSlices.reduce((s, p) => s + p.netValueUsd, 0),
+              2,
+            ),
+          }
+        : {}),
+      ...(kaminoSlices.length > 0
+        ? {
+            kamino: kaminoSlices,
+            kaminoNetUsd: round(
+              kaminoSlices.reduce((s, p) => s + p.netValueUsd, 0),
+              2,
+            ),
+          }
+        : {}),
+      ...(solanaStakingSlice && solanaStakingSlice.totalSolEquivalent > 0
+        ? {
+            staking: solanaStakingSlice,
+            stakingNetUsd: round(addrStakingUsd, 2),
+          }
+        : {}),
+    };
+    slices.push(slice);
+    for (const b of [...balance.native, ...balance.spl]) {
+      if (b.priceMissing) {
+        unpriced.push({
+          chain: "solana" as const,
+          symbol: b.symbol,
+          amount: b.formatted,
+        });
+      }
+    }
+  }
+  return {
+    slices,
+    lendingUsd,
+    stakingUsd,
+    balanceErrored,
+    marginfiErrored,
+    kaminoErrored,
+    stakingErrored,
     unpriced,
   };
 }

--- a/src/modules/portfolio/schemas.ts
+++ b/src/modules/portfolio/schemas.ts
@@ -54,17 +54,51 @@ export const getPortfolioSummaryInput = z.object({
   tronAddress: tronAddressSchema
     .optional()
     .describe(
-      "TRON mainnet address. When provided alongside a single `wallet`, TRX + TRC-20 balances and TRON staking are folded into the same portfolio total (`breakdown.tron`, `tronUsd`, `tronStakingUsd`). Multi-wallet mode + tronAddress is ambiguous and throws — call once per EVM wallet in that case."
+      "Single TRON mainnet address. With a single `wallet`: TRX + TRC-20 + " +
+        "TRON staking are folded into the same per-wallet totals (`breakdown.tron`, " +
+        "`tronUsd`, `tronStakingUsd`). With multi-wallet `wallets[]`: surfaced as " +
+        "a parallel sibling slice on the response — see `nonEvm.tron` (issue #201). " +
+        "Mutually exclusive with `tronAddresses`."
+    ),
+  tronAddresses: z
+    .array(tronAddressSchema)
+    .min(1)
+    .max(10)
+    .optional()
+    .describe(
+      "Multiple TRON addresses (Ledger account 0, 1, 2, …). Each is fetched " +
+        "in parallel; the per-address slices are surfaced in `nonEvm.tron[]` " +
+        "with rolled-up `tronUsd` / `tronStakingUsd` totals. 1-10 entries. " +
+        "Mutually exclusive with `tronAddress`."
     ),
   solanaAddress: solanaAddressSchema
     .optional()
     .describe(
-      "Solana mainnet address (base58, 43 or 44 chars). When provided, SOL + enumerated SPL token balances are folded into the same portfolio total (`breakdown.solana`, `solanaUsd`). Multi-wallet mode + solanaAddress is ambiguous and throws — call once per EVM wallet in that case. Requires SOLANA_RPC_URL or `solanaRpcUrl` user config (Helius recommended; public mainnet RPC is rate-limited)."
+      "Single Solana mainnet address (base58, 43-44 chars). With a single " +
+        "`wallet`: SOL + SPL + MarginFi + Kamino + Solana staking are folded into " +
+        "per-wallet totals. With multi-wallet `wallets[]`: surfaced as a parallel " +
+        "sibling slice (`nonEvm.solana`, issue #201). Mutually exclusive with " +
+        "`solanaAddresses`. Requires `SOLANA_RPC_URL` or `solanaRpcUrl` user config."
+    ),
+  solanaAddresses: z
+    .array(solanaAddressSchema)
+    .min(1)
+    .max(5)
+    .optional()
+    .describe(
+      "Multiple Solana mainnet addresses. Each gets its own balances + " +
+        "MarginFi + Kamino + staking subreaders fanned out in parallel. Per-" +
+        "address slices in `nonEvm.solana[]` with rolled-up USD totals. 1-5 " +
+        "entries (Solana subreaders are RPC-heavy — keep this lean). Mutually " +
+        "exclusive with `solanaAddress`."
     ),
   bitcoinAddress: bitcoinAddressSchema
     .optional()
     .describe(
-      "Single Bitcoin mainnet address. When provided alongside a single `wallet`, the BTC balance × USD price is folded into the same portfolio total (`breakdown.bitcoin`, `bitcoinUsd`). Mutually exclusive with `bitcoinAddresses`. Multi-wallet mode + bitcoin address(es) is ambiguous and throws — call once per EVM wallet in that case."
+      "Single Bitcoin mainnet address. With a single `wallet`: BTC balance × " +
+        "USD price is folded into per-wallet totals (`breakdown.bitcoin`, " +
+        "`bitcoinUsd`). With multi-wallet `wallets[]`: surfaced in `nonEvm.bitcoin` " +
+        "(issue #201). Mutually exclusive with `bitcoinAddresses`."
     ),
   bitcoinAddresses: z
     .array(bitcoinAddressSchema)
@@ -72,7 +106,11 @@ export const getPortfolioSummaryInput = z.object({
     .max(20)
     .optional()
     .describe(
-      "Multiple Bitcoin addresses to fold into the same portfolio total (e.g. legacy + segwit + taproot for the same Ledger account). 1-20 entries; per-address fetch errors degrade gracefully via `coverage.bitcoin`. Mutually exclusive with `bitcoinAddress`."
+      "Multiple Bitcoin addresses (e.g. legacy + segwit + taproot for the " +
+        "same Ledger account, or several account-level scans). 1-20 entries; " +
+        "per-address fetch errors degrade via `coverage.bitcoin`. Multi-wallet " +
+        "mode aggregates ALL passed addresses into a single `nonEvm.bitcoin` " +
+        "slice. Mutually exclusive with `bitcoinAddress`."
     ),
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -762,6 +762,39 @@ export interface MultiWalletPortfolioSummary {
   stakingUsd: number;
   perChain: Record<SupportedChain, number>;
   perWallet: PortfolioSummary[];
+  /**
+   * Non-EVM holdings surfaced as PARALLEL siblings of the EVM wallets,
+   * NOT folded into any specific `perWallet[i]`. Issue #201 — TRON / BTC /
+   * Solana addresses on a Ledger are independent identities (different
+   * BIP-44 derivation paths), so attributing them to "the first EVM
+   * wallet" produced misleading per-wallet rollups.
+   *
+   * Each chain's slice is surfaced when the corresponding address arg
+   * (`tronAddress`/`tronAddresses`, `solanaAddress`/`solanaAddresses`,
+   * `bitcoinAddress`/`bitcoinAddresses`) was passed to
+   * `getPortfolioSummary`. The USD rollups below sum across whichever
+   * slices were fetched.
+   */
+  nonEvm?: {
+    /** Per-address TRON slice; one entry per requested tronAddress. */
+    tron?: TronPortfolioSlice[];
+    /** Per-address Solana slice; one entry per requested solanaAddress. */
+    solana?: SolanaPortfolioSlice[];
+    /** Multi-address Bitcoin slice; aggregates every requested btc address. */
+    bitcoin?: BitcoinPortfolioSlice;
+  };
+  /** Sum of all TRON wallet balances (TRX + TRC-20) across the queried addresses. */
+  tronUsd?: number;
+  /** Sum of TRON staking (frozen TRX + claimable rewards). */
+  tronStakingUsd?: number;
+  /** Sum of all Solana wallet balances (SOL + SPL) across queried addresses. */
+  solanaUsd?: number;
+  /** Sum of MarginFi + Kamino netValueUsd across queried Solana addresses. */
+  solanaLendingUsd?: number;
+  /** Sum of Marinade + Jito + native-stake totals across queried Solana addresses. */
+  solanaStakingUsd?: number;
+  /** Sum of BTC × USD-price across queried Bitcoin addresses. */
+  bitcoinUsd?: number;
   coverage: PortfolioCoverage;
 }
 

--- a/test/btc-pr4-portfolio-message-sign.test.ts
+++ b/test/btc-pr4-portfolio-message-sign.test.ts
@@ -252,20 +252,73 @@ describe("portfolio BTC integration", () => {
     ).rejects.toThrow(/single.*OR.*array/i);
   });
 
-  it("rejects multi-wallet + bitcoinAddress", async () => {
+  it("multi-wallet + bitcoinAddress: BTC surfaces as a sibling slice (issue #201)", async () => {
+    fetchBitcoinPriceMock.mockResolvedValue(50_000);
+    getBalanceMock.mockResolvedValue({
+      address: SEGWIT_ADDR,
+      confirmedSats: 200_000n, // 0.002 BTC
+      mempoolSats: 0n,
+      totalSats: 200_000n,
+      txCount: 1,
+    });
     vi.resetModules();
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => ({
+        getBalance: async () => 0n,
+        multicall: async () => [],
+      }),
+      verifyChainId: async () => undefined,
+    }));
+    vi.doMock("../src/data/prices.ts", () => ({
+      getTokenPrice: async () => undefined,
+      getTokenPrices: async () => new Map(),
+    }));
+    vi.doMock("../src/modules/positions/index.ts", () => ({
+      getLendingPositions: async () => ({ wallet: "", positions: [] }),
+      getLpPositions: async () => ({ wallet: "", positions: [] }),
+    }));
+    vi.doMock("../src/modules/staking/index.ts", () => ({
+      getStakingPositions: async () => ({ wallet: "", positions: [] }),
+    }));
+    vi.doMock("../src/modules/compound/index.ts", () => ({
+      getCompoundPositions: async () => ({ wallet: "", positions: [] }),
+      prefetchCompoundProbes: async () => undefined,
+    }));
+    vi.doMock("../src/modules/positions/aave.ts", () => ({
+      prefetchAaveAccountData: async () => undefined,
+    }));
+    vi.doMock("../src/modules/staking/lido.ts", () => ({
+      prefetchLidoMainnet: async () => undefined,
+    }));
+    vi.doMock("../src/modules/morpho/index.ts", () => ({
+      getMorphoPositions: async () => ({
+        wallet: "",
+        positions: [],
+        discoverySkipped: false,
+      }),
+    }));
     const { getPortfolioSummary } = await import(
       "../src/modules/portfolio/index.ts"
     );
-    await expect(
-      getPortfolioSummary({
-        wallets: [
-          "0x1111111111111111111111111111111111111111",
-          "0x2222222222222222222222222222222222222222",
-        ],
-        bitcoinAddress: SEGWIT_ADDR,
-      }),
-    ).rejects.toThrow(/single EVM/);
+    const result = await getPortfolioSummary({
+      wallets: [
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+      ],
+      bitcoinAddress: SEGWIT_ADDR,
+    });
+    if (!("perWallet" in result)) {
+      throw new Error("expected multi-wallet summary");
+    }
+    // BTC must NOT be folded into either per-wallet entry.
+    expect(result.perWallet[0].bitcoinUsd).toBeUndefined();
+    expect(result.perWallet[1].bitcoinUsd).toBeUndefined();
+    // Instead it lives at the top-level nonEvm block.
+    expect(result.nonEvm?.bitcoin).toBeDefined();
+    expect(result.nonEvm?.bitcoin?.addresses).toEqual([SEGWIT_ADDR]);
+    expect(result.bitcoinUsd).toBe(100); // 0.002 BTC × $50,000
+    // And rolls into totalUsd at the top level.
+    expect(result.totalUsd).toBe(100);
   });
 });
 

--- a/test/portfolio-multi-wallet-non-evm.test.ts
+++ b/test/portfolio-multi-wallet-non-evm.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for issue #201 — `get_portfolio_summary` multi-wallet mode
+ * + non-EVM addresses now produces a `nonEvm` block at the top
+ * level rather than throwing or folding non-EVM into a chosen EVM
+ * wallet's totals.
+ *
+ * The two prior tests in `btc-pr4-portfolio-message-sign.test.ts`
+ * and `solana-portfolio.test.ts` already exercise the per-chain
+ * happy paths in isolation. This file covers the cross-cutting
+ * cases:
+ *   - multi-wallet + multi-TRON (the issue's specific complaint)
+ *   - multi-wallet + ALL THREE non-EVM types (the user's example)
+ *   - single-wallet + multi-TRON / multi-Solana → throws
+ *   - mutual exclusivity between singular and plural args
+ */
+
+// Stub heavy EVM modules so the portfolio handler doesn't try to
+// multicall on-chain state in unit tests.
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    getBalance: async () => 0n,
+    multicall: async () => [],
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+vi.mock("../src/data/prices.ts", () => ({
+  getTokenPrice: async () => undefined,
+  getTokenPrices: async () => new Map(),
+  priceTokenAmounts: async () => undefined,
+}));
+
+vi.mock("../src/modules/positions/index.js", () => ({
+  getLendingPositions: async () => ({ wallet: "0x0", positions: [] }),
+  getLpPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+vi.mock("../src/modules/staking/index.js", () => ({
+  getStakingPositions: async () => ({ wallet: "0x0", positions: [] }),
+}));
+
+vi.mock("../src/modules/compound/index.js", () => ({
+  getCompoundPositions: async () => ({ wallet: "0x0", positions: [] }),
+  prefetchCompoundProbes: async () => undefined,
+}));
+
+vi.mock("../src/modules/positions/aave.js", () => ({
+  prefetchAaveAccountData: async () => undefined,
+}));
+
+vi.mock("../src/modules/staking/lido.js", () => ({
+  prefetchLidoMainnet: async () => undefined,
+}));
+
+vi.mock("../src/modules/morpho/index.js", () => ({
+  getMorphoPositions: async () => ({
+    wallet: "0x0",
+    positions: [],
+    discoverySkipped: false,
+  }),
+}));
+
+// Solana subreaders — cheap stubs so the portfolio aggregator's
+// Solana fan-out doesn't try to load real on-chain state.
+vi.mock("../src/modules/solana/balances.js", () => ({
+  getSolanaBalances: vi.fn(),
+}));
+
+vi.mock("../src/modules/positions/marginfi.js", () => ({
+  getMarginfiPositions: async () => [],
+}));
+
+vi.mock("../src/modules/positions/kamino.js", () => ({
+  getKaminoPositions: async () => [],
+}));
+
+vi.mock("../src/modules/positions/solana-staking.js", () => ({
+  getSolanaStakingPositions: async () => null,
+}));
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => ({}),
+  resetSolanaConnection: () => {},
+}));
+
+// TRON subreaders.
+vi.mock("../src/modules/tron/balances.js", () => ({
+  getTronBalances: vi.fn(),
+}));
+
+vi.mock("../src/modules/tron/staking.js", () => ({
+  getTronStaking: vi.fn(),
+}));
+
+// Bitcoin: indexer + price.
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getBalance: vi.fn(),
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+vi.mock("../src/modules/btc/price.ts", () => ({
+  fetchBitcoinPrice: vi.fn(),
+}));
+
+vi.mock("../src/modules/btc/balances.js", () => ({
+  getBitcoinBalances: vi.fn(),
+}));
+
+const EVM_WALLET_A = "0x1111111111111111111111111111111111111111";
+const EVM_WALLET_B = "0x2222222222222222222222222222222222222222";
+const TRON_A = "TPoa3HeAJZsZ8KCKWmPi3xRrfjDGmqHaaa";
+const TRON_B = "TAV6CGzaWMaSMFrG4uM4nZqfCt9X1jbbbb";
+const SOL_A = "5rJ3dKM5K8hYkHcH67z3kjRtGkGuGh3aVi9fFpq9ZuDi";
+const SEGWIT_A = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SEGWIT_B = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("get_portfolio_summary — multi-wallet + multi-TRON (issue #201)", () => {
+  it("surfaces every TRON address as a parallel slice in nonEvm.tron[], not folded into any EVM wallet", async () => {
+    const { getTronBalances } = await import("../src/modules/tron/balances.js");
+    const { getTronStaking } = await import("../src/modules/tron/staking.js");
+    (getTronBalances as ReturnType<typeof vi.fn>).mockImplementation(
+      async (addr: string) => ({
+        address: addr,
+        native: [
+          {
+            token: "native",
+            symbol: "TRX",
+            decimals: 6,
+            amount: "100000000",
+            formatted: "100",
+            valueUsd: addr === TRON_A ? 12.34 : 56.78,
+            priceUsd: 0.12,
+          },
+        ],
+        trc20: [],
+        walletBalancesUsd: addr === TRON_A ? 12.34 : 56.78,
+      }),
+    );
+    (getTronStaking as ReturnType<typeof vi.fn>).mockResolvedValue({
+      address: "stub",
+      frozen: [],
+      pendingUnfreezes: [],
+      claimableRewards: { sun: "0", trx: "0" },
+      totalStakedUsd: 0,
+    });
+
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    const out = await getPortfolioSummary({
+      wallets: [EVM_WALLET_A, EVM_WALLET_B],
+      tronAddresses: [TRON_A, TRON_B],
+    });
+    if (!("perWallet" in out)) throw new Error("expected multi-wallet shape");
+    // The crux of #201: per-wallet entries don't carry tron USD anywhere.
+    expect(out.perWallet[0].tronUsd).toBeUndefined();
+    expect(out.perWallet[1].tronUsd).toBeUndefined();
+    // Top-level rollups + slices are populated.
+    expect(out.tronUsd).toBeCloseTo(69.12, 2);
+    expect(out.nonEvm?.tron).toHaveLength(2);
+    expect(out.nonEvm?.tron?.[0].address).toBe(TRON_A);
+    expect(out.nonEvm?.tron?.[1].address).toBe(TRON_B);
+    // totalUsd includes the non-EVM contribution.
+    expect(out.totalUsd).toBeCloseTo(69.12, 2);
+  });
+
+  it("rejects mutually-exclusive tronAddress + tronAddresses", async () => {
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    await expect(
+      getPortfolioSummary({
+        wallets: [EVM_WALLET_A, EVM_WALLET_B],
+        tronAddress: TRON_A,
+        tronAddresses: [TRON_B],
+      }),
+    ).rejects.toThrow(/single.*OR.*array/i);
+  });
+});
+
+describe("get_portfolio_summary — multi-wallet + all three non-EVM (issue #201 example)", () => {
+  it("the user's example call returns a clean rollup with parallel non-EVM slices", async () => {
+    const { getTronBalances } = await import("../src/modules/tron/balances.js");
+    const { getTronStaking } = await import("../src/modules/tron/staking.js");
+    const { getSolanaBalances } = await import(
+      "../src/modules/solana/balances.js"
+    );
+    const { getBitcoinBalances } = await import(
+      "../src/modules/btc/balances.js"
+    );
+    const { fetchBitcoinPrice } = await import("../src/modules/btc/price.ts");
+
+    (getTronBalances as ReturnType<typeof vi.fn>).mockImplementation(
+      async (addr: string) => ({
+        address: addr,
+        native: [],
+        trc20: [],
+        walletBalancesUsd: addr === TRON_A ? 30 : 50,
+      }),
+    );
+    (getTronStaking as ReturnType<typeof vi.fn>).mockResolvedValue({
+      address: "stub",
+      frozen: [],
+      pendingUnfreezes: [],
+      claimableRewards: { sun: "0", trx: "0" },
+      totalStakedUsd: 0,
+    });
+    (getSolanaBalances as ReturnType<typeof vi.fn>).mockResolvedValue({
+      address: SOL_A,
+      native: [],
+      spl: [],
+      walletBalancesUsd: 25,
+    });
+    (getBitcoinBalances as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        ok: true as const,
+        balance: {
+          address: SEGWIT_A,
+          addressType: "p2wpkh",
+          confirmedSats: 200_000n,
+          mempoolSats: 0n,
+          totalSats: 200_000n,
+          confirmedBtc: "0.002",
+          totalBtc: "0.002",
+          symbol: "BTC",
+          decimals: 8,
+          txCount: 1,
+        },
+      },
+      {
+        ok: true as const,
+        balance: {
+          address: SEGWIT_B,
+          addressType: "p2wpkh",
+          confirmedSats: 100_000n,
+          mempoolSats: 0n,
+          totalSats: 100_000n,
+          confirmedBtc: "0.001",
+          totalBtc: "0.001",
+          symbol: "BTC",
+          decimals: 8,
+          txCount: 1,
+        },
+      },
+    ]);
+    (fetchBitcoinPrice as ReturnType<typeof vi.fn>).mockResolvedValue(50_000);
+
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    const out = await getPortfolioSummary({
+      wallets: [EVM_WALLET_A, EVM_WALLET_B],
+      tronAddresses: [TRON_A, TRON_B],
+      solanaAddress: SOL_A,
+      bitcoinAddresses: [SEGWIT_A, SEGWIT_B],
+    });
+    if (!("perWallet" in out)) throw new Error("expected multi-wallet shape");
+
+    // No per-wallet entry carries non-EVM USD anywhere.
+    for (const w of out.perWallet) {
+      expect(w.tronUsd).toBeUndefined();
+      expect(w.solanaUsd).toBeUndefined();
+      expect(w.bitcoinUsd).toBeUndefined();
+    }
+
+    // Each non-EVM source has its slice + rolled-up USD.
+    expect(out.nonEvm?.tron?.length).toBe(2);
+    expect(out.nonEvm?.solana?.length).toBe(1);
+    expect(out.nonEvm?.bitcoin?.balances.length).toBe(2);
+
+    expect(out.tronUsd).toBe(80);
+    expect(out.solanaUsd).toBe(25);
+    // 0.002 + 0.001 = 0.003 BTC × $50,000 = $150
+    expect(out.bitcoinUsd).toBe(150);
+
+    // Top-line totalUsd folds in all three.
+    expect(out.totalUsd).toBeCloseTo(80 + 25 + 150, 2);
+  });
+});
+
+describe("get_portfolio_summary — single-wallet rejects multi-TRON / multi-Solana", () => {
+  it("throws on tronAddresses with >1 entry under a single wallet", async () => {
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    await expect(
+      getPortfolioSummary({
+        wallet: EVM_WALLET_A,
+        tronAddresses: [TRON_A, TRON_B],
+      }),
+    ).rejects.toThrow(/multi-wallet mode/);
+  });
+
+  it("throws on solanaAddresses with >1 entry under a single wallet", async () => {
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    await expect(
+      getPortfolioSummary({
+        wallet: EVM_WALLET_A,
+        solanaAddresses: [SOL_A, SOL_A],
+      }),
+    ).rejects.toThrow(/multi-wallet mode/);
+  });
+
+  it("ALLOWS single-wallet + tronAddresses with exactly 1 entry (folds in like tronAddress)", async () => {
+    const { getTronBalances } = await import("../src/modules/tron/balances.js");
+    const { getTronStaking } = await import("../src/modules/tron/staking.js");
+    (getTronBalances as ReturnType<typeof vi.fn>).mockResolvedValue({
+      address: TRON_A,
+      native: [],
+      trc20: [],
+      walletBalancesUsd: 42,
+    });
+    (getTronStaking as ReturnType<typeof vi.fn>).mockResolvedValue({
+      address: TRON_A,
+      frozen: [],
+      pendingUnfreezes: [],
+      claimableRewards: { sun: "0", trx: "0" },
+      totalStakedUsd: 0,
+    });
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    const out = await getPortfolioSummary({
+      wallet: EVM_WALLET_A,
+      tronAddresses: [TRON_A],
+    });
+    if ("perWallet" in out) throw new Error("expected single-wallet shape");
+    // Single-wallet path folds non-EVM into the wallet's totals.
+    expect(out.tronUsd).toBe(42);
+  });
+});

--- a/test/solana-portfolio.test.ts
+++ b/test/solana-portfolio.test.ts
@@ -55,6 +55,15 @@ vi.mock("../src/modules/staking/index.js", () => ({
 
 vi.mock("../src/modules/compound/index.js", () => ({
   getCompoundPositions: async () => ({ wallet: "0x0", positions: [] }),
+  prefetchCompoundProbes: async () => undefined,
+}));
+
+vi.mock("../src/modules/positions/aave.js", () => ({
+  prefetchAaveAccountData: async () => undefined,
+}));
+
+vi.mock("../src/modules/staking/lido.js", () => ({
+  prefetchLidoMainnet: async () => undefined,
 }));
 
 vi.mock("../src/modules/morpho/index.js", () => ({
@@ -173,15 +182,29 @@ describe("get_portfolio_summary with solanaAddress", () => {
     expect(res.totalUsd).toBeGreaterThanOrEqual(0); // EVM summary still works.
   });
 
-  it("throws when solanaAddress is combined with multi-wallet", async () => {
-    const { getPortfolioSummary } = await import("../src/modules/portfolio/index.js");
-    await expect(
-      getPortfolioSummary({
-        wallets: [EVM_WALLET, "0x2222222222222222222222222222222222222222"],
-        chains: ["ethereum"],
-        solanaAddress: SOL_WALLET,
-      }),
-    ).rejects.toThrow(/solanaAddress.*single EVM `wallet`/);
+  it("solanaAddress + multi-wallet: Solana surfaces as a sibling slice (issue #201)", async () => {
+    // Solana balance fetch path: empty wallet — the test only checks
+    // that the multi-wallet response carries a `nonEvm.solana` block
+    // and that NO per-wallet entry has solanaUsd folded in.
+    connectionStub.getBalance.mockResolvedValue(0);
+    connectionStub.getTokenAccountsByOwner.mockResolvedValue({ value: [] });
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ coins: {} }) })));
+    const { getPortfolioSummary } = await import(
+      "../src/modules/portfolio/index.js"
+    );
+    const res = await getPortfolioSummary({
+      wallets: [EVM_WALLET, "0x2222222222222222222222222222222222222222"],
+      chains: ["ethereum"],
+      solanaAddress: SOL_WALLET,
+    });
+    if (!("perWallet" in res)) {
+      throw new Error("expected multi-wallet summary");
+    }
+    expect(res.perWallet[0].solanaUsd).toBeUndefined();
+    expect(res.perWallet[1].solanaUsd).toBeUndefined();
+    expect(res.nonEvm?.solana).toBeDefined();
+    expect(res.nonEvm?.solana?.length).toBe(1);
+    vi.unstubAllGlobals();
   });
 
   it("folds staking positions into breakdown.solana.staking + solanaStakingUsd when holdings exist + SOL price resolved", async () => {


### PR DESCRIPTION
Closes #201.

Pre-#201, \`get_portfolio_summary({ wallets: [...], tronAddress, solanaAddress, bitcoinAddresses })\` threw with \"ambiguous attribution\" errors. To aggregate everything, agents had to fan out per EVM wallet and pick which wallet \"owns\" each non-EVM slice. Real-world impact reported in #201: ~\$50K of BTC + TRON + Solana appeared under the wrong \"wallet\" in the user's table because the agent attached them to the first EVM wallet. The agent has no truthful way to attribute non-EVM holdings to any specific EVM wallet — they're separate Ledger derivation paths.

## What ships

Multi-wallet mode now accepts non-EVM addresses, surfacing them as **parallel siblings** on the response — independent of any specific EVM wallet:

\`\`\`ts
get_portfolio_summary({
  wallets: [\"0xC0f5...\", \"0x4f51...\", \"0x8F9d...\", \"0xb4FA...\"],
  tronAddresses: [\"TPoa...\", \"TAV6...\"],
  solanaAddress: \"4FLp...\",
  bitcoinAddresses: [\"bc1qfsy...\", \"bc1qksr...\"],
})
\`\`\`

returns:

\`\`\`ts
{
  perWallet: [...],            // EVM-only, no non-EVM contamination
  nonEvm: {
    tron: TronPortfolioSlice[],
    solana: SolanaPortfolioSlice[],
    bitcoin: BitcoinPortfolioSlice,
  },
  tronUsd, tronStakingUsd,
  solanaUsd, solanaLendingUsd, solanaStakingUsd,
  bitcoinUsd,
  totalUsd,                    // sums EVM + non-EVM
}
\`\`\`

## Schema additions

- \`tronAddresses: string[]\` (1-10, mutually exclusive with \`tronAddress\`)
- \`solanaAddresses: string[]\` (1-5, mutually exclusive with \`solanaAddress\`; cap is lower because Solana subreaders fan out four readers per address — balances + MarginFi + Kamino + staking)
- \`bitcoinAddresses\` already supported multi (1-20)

## Backwards compat

- **Single-wallet mode (\`wallet\`): unchanged.** Non-EVM still folds into per-wallet totals exactly as before.
- Existing \`tronAddress\` / \`solanaAddress\` / \`bitcoinAddress\` singular args keep working.
- Single-wallet + \`tronAddresses\`/\`solanaAddresses\` with **>1 entries** is rejected with a clear pointer to multi-wallet mode (BTC stays multi-fold-friendly because \`BitcoinPortfolioSlice\` natively supports an \`addresses[]\` array).

## Implementation notes

- New \`aggregateNonEvm({ tronAddresses, solanaAddresses, bitcoinAddresses })\` helper computes parallel slices + USD rollups + per-chain coverage **in parallel with** the EVM fan-out
- New \`aggregateTron\` and \`aggregateSolana\` helpers — each address gets the full subreader stack running in parallel across addresses
- Per-address failures degrade gracefully — a flaky TronGrid call on address A doesn't drop B; coverage flags the affected subsystem
- \`MultiWalletPortfolioSummary\` extended with \`nonEvm\` block and chain USD rollups
- \`totalUsd\` sums EVM + non-EVM contributions

## Tests

Two existing tests asserted the OLD rejection — updated to the new contract:
- \`btc-pr4-portfolio-message-sign.test.ts\`: multi-wallet + bitcoinAddress now produces \`nonEvm.bitcoin\`
- \`solana-portfolio.test.ts\`: same for solanaAddress

New \`test/portfolio-multi-wallet-non-evm.test.ts\` (6 cases):
- Multi-wallet + multi-TRON: per-wallet entries carry no \`tronUsd\`; top-level rollup correct
- Mutually-exclusive \`tronAddress\` + \`tronAddresses\` rejection
- The user's full example call (4 EVM + 2 TRON + 1 Solana + 2 BTC) produces a clean rollup
- Single-wallet + \`tronAddresses\` >1 rejection
- Single-wallet + \`solanaAddresses\` >1 rejection
- Single-wallet + \`tronAddresses\` =1 backwards-compat fold-in

## Verification

- \`npm run build\` clean
- Full suite **1110/1110** (1104 baseline + 6 new in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)