### PR TITLE
chore: lead with "Safety first." across public descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![node](https://img.shields.io/node/v/vaultpilot-mcp.svg)](package.json)
 [![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp)
 
-**Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.**
+**Safety first. Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.**
 
 ![VaultPilot MCP demo](./demo.gif)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vaultpilot-mcp",
   "version": "0.8.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
-  "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
+  "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
-  "description": "DeFi for AI agents, designed for when the AI can be compromised. Agent proposes, you approve.",
+  "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "version": "0.8.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {


### PR DESCRIPTION
Per the marketing-headline recommendation: lead with \`Safety first.\` everywhere VaultPilot describes itself in public, so the threat-model clause (\"designed for when the AI can be compromised\") lands in the first two words.

## Two forms

**Long form** — surfaces with prose room (README header, website hero, LinkedIn headline):
> Safety first. Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.

**Short form** — tight metadata fields (GitHub repo description, npm, MCP registry, awesome-mcp):
> Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.

## Repo-controlled surfaces (this PR)

| File | Form | Sync target |
|---|---|---|
| \`README.md\` line 8 | Long | GitHub README, glama.ai (when they re-scan) |
| \`package.json\` description | Short | npm registry (next publish) |
| \`server.json\` description | Short | MCP official registry (next publish) |

## Surfaces NOT in this PR

- **GitHub repo description** — set via \`gh repo edit\` (independent of file content; also updated in this round outside the PR)
- **Glama.ai** — has its own (stale, pre-BTC/Solana) description; needs a manual rescan or update on their side
- **awesome-mcp lists** (punkpeye / wong2 / appcypher / modelcontextprotocol) — verified via API search: VaultPilot is NOT listed in any of them today, so no PRs needed
- **LinkedIn / external blog / docs site** — owned by you, not in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)