### PR TITLE
refactor(test): extract shared Solana RPC + nonce mock fixtures (PR 1/5)

### DIFF
--- a/test/fixtures/solana-nonce-mock.ts
+++ b/test/fixtures/solana-nonce-mock.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared `getNonceAccountValue` mock helpers. The `vi.mock(...)` body has to
+ * stay inline in each consumer (vitest hoists it above imports); only the
+ * helpers below are shared.
+ *
+ * Usage:
+ *
+ *   import { setNoncePresent, setNonceMissing } from "./fixtures/solana-nonce-mock.js";
+ *
+ *   vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
+ *     const actual = await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
+ *     return { ...actual, getNonceAccountValue: vi.fn() };
+ *   });
+ *
+ *   beforeEach(async () => { await setNoncePresent(WALLET_PUBKEY); });
+ */
+import { vi } from "vitest";
+import type { PublicKey } from "@solana/web3.js";
+
+export const DEFAULT_TEST_NONCE_VALUE =
+  "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
+
+export async function setNoncePresent(
+  authority: PublicKey,
+  nonceValue: string = DEFAULT_TEST_NONCE_VALUE,
+): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
+    nonce: nonceValue,
+    authority,
+  });
+}
+
+export async function setNonceMissing(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
+export async function resetNonceMock(): Promise<void> {
+  const { getNonceAccountValue } = await import(
+    "../../src/modules/solana/nonce.js"
+  );
+  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+}

--- a/test/fixtures/solana-rpc-mock.ts
+++ b/test/fixtures/solana-rpc-mock.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared Solana `Connection` mock. Replaces per-file `connectionStub = { ... }`
+ * blocks repeated in 20+ tests. Each test stubs a slightly different subset
+ * of methods; the union is the 18 below.
+ *
+ * Usage (`vi.mock` body has to stay inline — vitest hoists it above imports):
+ *
+ *   const connectionStub = makeConnectionStub();
+ *   vi.mock("../src/modules/solana/rpc.js", () => ({
+ *     getSolanaConnection: () => connectionStub,
+ *     resetSolanaConnection: () => {},
+ *   }));
+ *   beforeEach(() => resetConnectionStub(connectionStub));
+ */
+import { vi } from "vitest";
+import type { Mock } from "vitest";
+
+export type SolanaConnectionStub = Record<string, Mock> & {
+  getAccountInfo: Mock;
+  getAddressLookupTable: Mock;
+  getBalance: Mock;
+  getBlockHeight: Mock;
+  getEpochInfo: Mock;
+  getLatestBlockhash: Mock;
+  getMinimumBalanceForRentExemption: Mock;
+  getParsedProgramAccounts: Mock;
+  getParsedTokenAccountsByOwner: Mock;
+  getParsedTransaction: Mock;
+  getRecentPrioritizationFees: Mock;
+  getSignatureStatuses: Mock;
+  getSignaturesForAddress: Mock;
+  getTokenAccountBalance: Mock;
+  getTokenAccountsByOwner: Mock;
+  getTokenSupply: Mock;
+  sendRawTransaction: Mock;
+  simulateTransaction: Mock;
+};
+
+const METHOD_NAMES = [
+  "getAccountInfo",
+  "getAddressLookupTable",
+  "getBalance",
+  "getBlockHeight",
+  "getEpochInfo",
+  "getLatestBlockhash",
+  "getMinimumBalanceForRentExemption",
+  "getParsedProgramAccounts",
+  "getParsedTokenAccountsByOwner",
+  "getParsedTransaction",
+  "getRecentPrioritizationFees",
+  "getSignatureStatuses",
+  "getSignaturesForAddress",
+  "getTokenAccountBalance",
+  "getTokenAccountsByOwner",
+  "getTokenSupply",
+  "sendRawTransaction",
+  "simulateTransaction",
+] as const;
+
+export function makeConnectionStub(): SolanaConnectionStub {
+  const stub = {} as SolanaConnectionStub;
+  for (const name of METHOD_NAMES) stub[name] = vi.fn();
+  return stub;
+}
+
+export function resetConnectionStub(stub: SolanaConnectionStub): void {
+  for (const fn of Object.values(stub)) fn.mockReset();
+}

--- a/test/solana-jito-write.test.ts
+++ b/test/solana-jito-write.test.ts
@@ -4,6 +4,11 @@ import {
   PublicKey,
   TransactionInstruction,
 } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Jito stake write-builder tests. Mocks the SPL stake-pool SDK so we
@@ -32,10 +37,7 @@ const FAKE_POOL_MINT = new PublicKey(
 const FAKE_RESERVE_STAKE = Keypair.generate().publicKey;
 const FAKE_MANAGER_FEE = Keypair.generate().publicKey;
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-  getLatestBlockhash: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -76,16 +78,7 @@ afterEach(() => {
 });
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
-    authority: WALLET_KEYPAIR.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KEYPAIR.publicKey);
 }
 
 function setStakePoolAccount(): void {

--- a/test/solana-kamino-actions.test.ts
+++ b/test/solana-kamino-actions.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Kamino write-builder tests. The builders themselves orchestrate:
@@ -27,9 +32,7 @@ const FAKE_USER_LUT_ADDR = Keypair.generate().publicKey.toBase58();
 const FAKE_OBLIGATION_ADDR = Keypair.generate().publicKey.toBase58();
 const FAKE_KAMINO_PROGRAM = Keypair.generate().publicKey;
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -125,20 +128,7 @@ vi.mock("@solana-program/system", () => ({
 }));
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: FAKE_BLOCKHASH,
-    authority: WALLET_KP.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KP.publicKey, FAKE_BLOCKHASH);
 }
 
 function fakeKitInstruction(label: string) {

--- a/test/solana-kamino-pr3-pr4.test.ts
+++ b/test/solana-kamino-pr3-pr4.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import { setNoncePresent as setNoncePresentFor } from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Kamino PR3 + PR4 — borrow/withdraw/repay write builders, the
@@ -23,9 +25,7 @@ const FAKE_USER_LUT_ADDR = Keypair.generate().publicKey.toBase58();
 const FAKE_OBLIGATION_ADDR = Keypair.generate().publicKey.toBase58();
 const FAKE_KAMINO_PROGRAM = Keypair.generate().publicKey;
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -146,13 +146,7 @@ vi.mock("@solana-program/system", () => ({
 }));
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: FAKE_BLOCKHASH,
-    authority: WALLET_KP.publicKey,
-  });
+  await setNoncePresentFor(WALLET_KP.publicKey, FAKE_BLOCKHASH);
 }
 
 function fakeKitInstruction(label: string) {

--- a/test/solana-lifi-swap.test.ts
+++ b/test/solana-lifi-swap.test.ts
@@ -6,6 +6,11 @@ import {
   TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * LiFi-on-Solana write-builder tests. Mocks the LiFi SDK's `getQuote` to
@@ -27,10 +32,7 @@ const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const FAKE_BRIDGE_PROGRAM = Keypair.generate().publicKey;
 const FAKE_BLOCKHASH = "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-  getAddressLookupTable: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -63,20 +65,7 @@ vi.mock("../src/modules/swap/lifi.js", () => ({
 }));
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: FAKE_BLOCKHASH,
-    authority: WALLET_KEYPAIR.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KEYPAIR.publicKey, FAKE_BLOCKHASH);
 }
 
 /**

--- a/test/solana-marginfi.test.ts
+++ b/test/solana-marginfi.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair, PublicKey, TransactionInstruction } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * MarginFi builder tests. Strategy mirrors solana-jupiter.test.ts: mock the
@@ -22,14 +27,10 @@ const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const BANK_USDC = new PublicKey("2s37akK2eyBbp8DZgCm7RtsaEz8eJP3Nxd4urLHQv7yB");
 const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 
-// Single shared connectionStub object — `getAccountInfo` is the main method
-// both the nonce preflight AND the marginfi-account existence check call.
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-  getMinimumBalanceForRentExemption: vi.fn(),
-  getLatestBlockhash: vi.fn(),
-  getBalance: vi.fn(),
-};
+// Shared Solana connection stub from fixtures/. `getAccountInfo` is the
+// main method both the nonce preflight AND the marginfi-account existence
+// check call.
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -49,10 +50,7 @@ vi.mock("../src/modules/solana/alt.js", () => ({
 vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
-  return {
-    ...actual,
-    getNonceAccountValue: vi.fn(),
-  };
+  return { ...actual, getNonceAccountValue: vi.fn() };
 });
 
 // Fake MarginfiAccountWrapper + SDK surface. The real SDK module is heavy
@@ -137,21 +135,9 @@ vi.mock("@coral-xyz/anchor", () => ({
   Program: class {},
 }));
 
+// Bind the wallet pubkey so callers don't have to repeat it.
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
-    authority: WALLET_KEYPAIR.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KEYPAIR.publicKey);
 }
 
 function buildFakeBank(mint: string, address = BANK_USDC): unknown {

--- a/test/solana-marinade.test.ts
+++ b/test/solana-marinade.test.ts
@@ -5,6 +5,11 @@ import {
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Marinade write-builder tests. Mocks the Marinade SDK so we never touch
@@ -28,10 +33,7 @@ const FAKE_MSOL_ATA = new PublicKey(
   "8JUjWjAyXTMB4ZXcV7nk3p6Gg1fWAAoSCHEPugYzj22h",
 );
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-  getLatestBlockhash: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -80,20 +82,7 @@ vi.mock("@coral-xyz/anchor", () => ({
 }));
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
-    authority: WALLET_KEYPAIR.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KEYPAIR.publicKey);
 }
 
 function fakeMarinadeIx(label: string): TransactionInstruction {

--- a/test/solana-native-stake.test.ts
+++ b/test/solana-native-stake.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair, PublicKey, StakeProgram } from "@solana/web3.js";
+import { makeConnectionStub } from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Native stake-program write builders. Mocks the RPC at the Connection
@@ -27,11 +32,7 @@ const VALIDATOR = VALIDATOR_KEYPAIR.publicKey.toBase58();
 const SYSTEM_PROGRAM = "11111111111111111111111111111111";
 const STAKE_PROGRAM = StakeProgram.programId.toBase58();
 
-const connectionStub = {
-  getAccountInfo: vi.fn(),
-  getMinimumBalanceForRentExemption: vi.fn(),
-  getLatestBlockhash: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
@@ -48,20 +49,7 @@ vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
 });
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9",
-    authority: WALLET_KEYPAIR.publicKey,
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import(
-    "../src/modules/solana/nonce.js"
-  );
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(WALLET_KEYPAIR.publicKey);
 }
 
 beforeEach(async () => {

--- a/test/solana-prepare.test.ts
+++ b/test/solana-prepare.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  makeConnectionStub,
+  resetConnectionStub,
+} from "./fixtures/solana-rpc-mock.js";
+import {
+  setNoncePresent as setNoncePresentFor,
+  setNonceMissing,
+  resetNonceMock,
+  DEFAULT_TEST_NONCE_VALUE,
+} from "./fixtures/solana-nonce-mock.js";
 
 /**
  * Builder tests for `prepare_solana_native_send` / `prepare_solana_spl_send`.
@@ -21,56 +31,30 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 const WALLET = Keypair.generate().publicKey.toBase58();
 const RECIPIENT = Keypair.generate().publicKey.toBase58();
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-const NONCE_VALUE = "GfnhkAa2iy8cZV7X5SyyYmCHxFQjEbBuyyUSCBokixB9";
+const NONCE_VALUE = DEFAULT_TEST_NONCE_VALUE;
 
-const connectionStub = {
-  getBalance: vi.fn(),
-  getAccountInfo: vi.fn(),
-  getTokenAccountBalance: vi.fn(),
-  getTokenSupply: vi.fn(),
-  getLatestBlockhash: vi.fn(),
-  getRecentPrioritizationFees: vi.fn(),
-  getMinimumBalanceForRentExemption: vi.fn(),
-};
+const connectionStub = makeConnectionStub();
 
 vi.mock("../src/modules/solana/rpc.js", () => ({
   getSolanaConnection: () => connectionStub,
   resetSolanaConnection: () => {},
 }));
 
+// vi.mock body stays inline — vitest hoists this above all imports, so the
+// fixture's exported factory can't be referenced here.
 vi.mock("../src/modules/solana/nonce.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../src/modules/solana/nonce.js")>();
-  return {
-    ...actual,
-    getNonceAccountValue: vi.fn(),
-  };
+  return { ...actual, getNonceAccountValue: vi.fn() };
 });
 
 async function setNoncePresent(): Promise<void> {
-  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue({
-    nonce: NONCE_VALUE,
-    authority: new PublicKey(WALLET),
-  });
-}
-
-async function setNonceMissing(): Promise<void> {
-  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  await setNoncePresentFor(new PublicKey(WALLET), NONCE_VALUE);
 }
 
 beforeEach(async () => {
-  connectionStub.getBalance.mockReset();
-  connectionStub.getAccountInfo.mockReset();
-  connectionStub.getTokenAccountBalance.mockReset();
-  connectionStub.getTokenSupply.mockReset();
-  connectionStub.getLatestBlockhash.mockReset();
-  connectionStub.getRecentPrioritizationFees.mockReset();
-  connectionStub.getMinimumBalanceForRentExemption.mockReset();
-
-  const { getNonceAccountValue } = await import("../src/modules/solana/nonce.js");
-  (getNonceAccountValue as ReturnType<typeof vi.fn>).mockReset();
+  resetConnectionStub(connectionStub);
+  await resetNonceMock();
 
   // Default: no congestion — skip priority fee.
   connectionStub.getRecentPrioritizationFees.mockResolvedValue([]);


### PR DESCRIPTION
## Summary
PR 1 of the test-suite-compaction plan. Extracts the most-duplicated test setup pattern — Solana \`Connection\` stub + \`getNonceAccountValue\` mock helpers — into shared \`test/fixtures/\` and refactors 8 high-volume callers to use them.

## What's shared
- **\`test/fixtures/solana-rpc-mock.ts\`** — \`makeConnectionStub()\` returns the union of all 18 \`Connection\` methods any test in the suite stubs. The \`vi.mock("../src/modules/solana/rpc.js", ...)\` line still has to stay inline in each consumer (vitest hoists it above all imports — can't be moved into a helper).
- **\`test/fixtures/solana-nonce-mock.ts\`** — \`setNoncePresent(authority, nonceValue?)\` / \`setNonceMissing()\` / \`resetNonceMock()\`. Same vi.mock-inline constraint. Each consumer wraps \`setNoncePresent()\` with its own wallet pubkey to keep call-sites short.

## Refactored callers (8)
\`solana-marginfi\`, \`solana-prepare\`, \`solana-kamino-actions\`, \`solana-kamino-pr3-pr4\`, \`solana-jito-write\`, \`solana-marinade\`, \`solana-lifi-swap\`, \`solana-native-stake\`.

## Coverage preservation
- **1110/1110 tests pass** on this commit (exact baseline match — zero coverage degradation).
- \`npm run build\` clean.

## LOC delta
- 8 callers: -157 lines
- 2 fixtures: +116 lines
- **Net this PR: -41**

The math improves with adoption: 12+ other test files still mock \`getNonceAccountValue\` with inline copy-paste. Future cleanup PRs that adopt these fixtures are net-negative without further fixture churn.

## Test plan
- [x] \`npm test\` — 1110 tests pass (exact baseline)
- [x] \`npm run build\` — clean TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)