### PR TITLE
fix(btc): key knownAddressDerivations by witness-program payload (#206)

### DIFF
--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import {
   openLedger,
@@ -554,6 +553,38 @@ function pathStringToNumbers(path: string): number[] {
 }
 
 /**
+ * Extract the witness-program payload from a P2WPKH or P2TR scriptPubKey
+ * as the lookup key for `signPsbtBuffer.knownAddressDerivations`. The
+ * Ledger SDK's `populateMissingBip32Derivations` keys its lookup map by
+ * this same payload (bytes 2..22 — hash160(pubkey) — for P2WPKH; bytes
+ * 2..34 — tweaked x-only key — for P2TR), not by sha256(scriptPubKey).
+ * Mirrors `@ledgerhq/psbtv2::extractHashFromScriptPubKey` for just the
+ * two script types Phase 1 sends support; legacy / P2SH-wrapped sends
+ * are out of scope (`buildBitcoinNativeSend` rejects them upfront).
+ */
+function extractWitnessProgramHex(scriptPubKey: Buffer): string {
+  if (
+    scriptPubKey.length === 22 &&
+    scriptPubKey[0] === 0x00 &&
+    scriptPubKey[1] === 0x14
+  ) {
+    return scriptPubKey.subarray(2, 22).toString("hex");
+  }
+  if (
+    scriptPubKey.length === 34 &&
+    scriptPubKey[0] === 0x51 &&
+    scriptPubKey[1] === 0x20
+  ) {
+    return scriptPubKey.subarray(2, 34).toString("hex");
+  }
+  throw new Error(
+    `Unexpected scriptPubKey shape (length=${scriptPubKey.length}, ` +
+      `bytes=0x${scriptPubKey.subarray(0, Math.min(4, scriptPubKey.length)).toString("hex")}). ` +
+      `Phase 1 BTC sends only support P2WPKH (segwit, bc1q...) and P2TR (taproot, bc1p...).`,
+  );
+}
+
+/**
  * Sign a base64-encoded PSBT v0 on the Ledger BTC app. The device walks
  * every output (address + amount + the "change" label for known
  * internal-chain outputs), shows the total fee, and asks the user to
@@ -605,16 +636,21 @@ export async function signBtcPsbtOnLedger(args: {
 
       // Build the knownAddressDerivations map. Phase 1 sends keep change
       // on the source address, so a single entry covers both inputs and
-      // any same-address output. The script the wallet owns is the
-      // source address's scriptPubKey; the SDK keys the map by sha256
-      // of the scriptPubKey, hex-encoded.
+      // any same-address output. The SDK keys the map by the witness-
+      // program payload extracted from each scriptPubKey — bytes 2..22
+      // (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked x-only key)
+      // for P2TR. Mirrors @ledgerhq/psbtv2 `extractHashFromScriptPubKey`,
+      // which is what `populateMissingBip32Derivations` looks up against.
+      // Issue #206: an earlier sha256(scriptPubKey) key never matched, so
+      // the library left the PSBT without bip32Derivation and the Ledger
+      // BTC app v2.x rejected with 0x6a80 before any UI.
       const scriptPubKey = bitcoinjs.address.toOutputScript(
         args.expectedFrom,
         bitcoinjs.networks.bitcoin,
       );
-      const scriptHash = createHash("sha256").update(scriptPubKey).digest("hex");
+      const lookupKey = extractWitnessProgramHex(scriptPubKey);
       const known = new Map<string, { pubkey: Buffer; path: number[] }>();
-      known.set(scriptHash, {
+      known.set(lookupKey, {
         pubkey: Buffer.from(derived.publicKey, "hex"),
         path: pathStringToNumbers(args.path),
       });

--- a/test/btc-pr3-send.test.ts
+++ b/test/btc-pr3-send.test.ts
@@ -301,6 +301,28 @@ describe("sendBitcoinTransaction", () => {
     expect(options.accountPath).toBe("84'/0'/0'");
     expect(options.addressFormat).toBe("bech32");
     expect(options.finalizePsbt).toBe(true);
+    // Issue #206 regression: the SDK keys knownAddressDerivations by the
+    // witness-program payload (P2WPKH: 20-byte hash160 from the script's
+    // bytes 2..22), NOT sha256(scriptPubKey). The previous sha256 keying
+    // never matched at lookup time → derivations stayed empty → Ledger
+    // BTC app v2.x rejected with 0x6a80 before any UI.
+    const known = options.knownAddressDerivations as Map<
+      string,
+      { pubkey: Buffer; path: number[] }
+    >;
+    expect(known.size).toBe(1);
+    const [[lookupKey, entry]] = [...known.entries()];
+    expect(lookupKey).toMatch(/^[0-9a-f]{40}$/);
+    expect(lookupKey).not.toMatch(/^[0-9a-f]{64}$/);
+    expect(entry.pubkey.toString("hex")).toBe(SEGWIT_PUBKEY);
+    // 84'/0'/0'/0/0 — three hardened segments + receive chain + index 0.
+    expect(entry.path).toEqual([
+      (84 | 0x80000000) >>> 0,
+      (0 | 0x80000000) >>> 0,
+      (0 | 0x80000000) >>> 0,
+      0,
+      0,
+    ]);
   });
 
   it("refuses to sign when the device derives a different address", async () => {


### PR DESCRIPTION
## Summary

- Fixes #206 — `prepare_btc_send` → `send_transaction` was non-functional end-to-end on Ledger BTC app v2.x, failing with `Ledger device: Invalid data received (0x6a80)` before any clear-sign UI.
- Root cause: our `knownAddressDerivations` map was keyed by `sha256(scriptPubKey)`, but the Ledger SDK's `populateMissingBip32Derivations` keys its lookup by the witness-program payload (`extractHashFromScriptPubKey(scriptPubKey).hashHex` — 20-byte hash160 for P2WPKH, 32-byte tweaked x-only key for P2TR). Lookup never matched → SDK left the PSBT without `bip32Derivation` → Ledger rejected.
- Fix: small local helper `extractWitnessProgramHex` for the two script types Phase 1 supports (P2WPKH + P2TR), used as the map key. Mirrors the upstream `@ledgerhq/psbtv2::extractHashFromScriptPubKey` logic for just the cases we need; avoids importing from a transitive dep.

## Test plan

- [x] Targeted test: `npx vitest run test/btc-pr3-send.test.ts` — 16/16 pass (existing PSBT-build-and-sign test extended to assert the lookup key is 40 hex chars / 20-byte hash160, not 64 / sha256, and that the entry carries the cached pubkey + BIP-84 leaf path).
- [x] Full suite: `npm test` — 1115/1116 pass; the 1 failure (`test/send-hash-pin.test.ts`) is a parallel-run timeout that passes in isolation, no overlap with BTC code.
- [ ] **Manual verify on a real Ledger:** repro from the issue (BIP84 segwit source, 0.0001 BTC, 1 sat/vB, RBF default) — `send_transaction` should now reach the clear-sign UI on the device instead of erroring with `0x6a80`. Cannot exercise without hardware; needs reviewer to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)