### PR TITLE
fix(btc): compress SEC1 pubkey before PSBT derivation map (#211)

### DIFF
--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -585,6 +585,37 @@ function extractWitnessProgramHex(scriptPubKey: Buffer): string {
 }
 
 /**
+ * Compress a SEC1 public key to its 33-byte form. Ledger's
+ * `getWalletPublicKey` returns the uncompressed encoding (`0x04 || X
+ * || Y`, 65 bytes), but PSBT consumers downstream of
+ * `signPsbtBuffer.knownAddressDerivations` expect the compressed
+ * encoding (`0x02 || X` if Y is even, `0x03 || X` if odd, 33 bytes) —
+ * the SDK then strips the prefix byte for taproot's x-only key. Issue
+ * #211: a 65-byte buffer threaded straight through threw "Invalid
+ * pubkey length: 65" before any device prompt. Idempotent on inputs
+ * already in compressed form.
+ */
+export function compressPubkey(pubkey: Buffer): Buffer {
+  if (
+    pubkey.length === 33 &&
+    (pubkey[0] === 0x02 || pubkey[0] === 0x03)
+  ) {
+    return pubkey;
+  }
+  if (pubkey.length !== 65 || pubkey[0] !== 0x04) {
+    throw new Error(
+      `Unexpected SEC1 pubkey shape (length=${pubkey.length}, ` +
+        `prefix=0x${pubkey[0]?.toString(16) ?? "??"}). Expected 65-byte ` +
+        `uncompressed (0x04 || X || Y) or 33-byte compressed (0x02/0x03 || X).`,
+    );
+  }
+  const x = pubkey.subarray(1, 33);
+  const yLast = pubkey[64];
+  const prefix = (yLast & 1) === 0 ? 0x02 : 0x03;
+  return Buffer.concat([Buffer.from([prefix]), x]);
+}
+
+/**
  * Sign a base64-encoded PSBT v0 on the Ledger BTC app. The device walks
  * every output (address + amount + the "change" label for known
  * internal-chain outputs), shows the total fee, and asks the user to
@@ -651,7 +682,7 @@ export async function signBtcPsbtOnLedger(args: {
       const lookupKey = extractWitnessProgramHex(scriptPubKey);
       const known = new Map<string, { pubkey: Buffer; path: number[] }>();
       known.set(lookupKey, {
-        pubkey: Buffer.from(derived.publicKey, "hex"),
+        pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
         path: pathStringToNumbers(args.path),
       });
 

--- a/test/btc-pr3-send.test.ts
+++ b/test/btc-pr3-send.test.ts
@@ -19,7 +19,17 @@ import { setConfigDirForTesting } from "../src/config/user-config.js";
 // (Using bitcoinjs-lib's network constants + a fake leaf pubkey is enough
 // — we don't broadcast or sign for real.)
 const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+// Compressed (33-byte) form. The signer's pubkey buffer for the SDK's
+// knownAddressDerivations map MUST be in this shape regardless of what
+// Ledger returned, so the SDK's downstream P2WPKH/P2TR derivation
+// arithmetic doesn't choke. Issue #211.
 const SEGWIT_PUBKEY = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+// Uncompressed (65-byte) form of the same on-curve point — what Ledger
+// `getWalletPublicKey` actually returns. Tests stub the device with this
+// to exercise the compress-on-the-way-in path.
+const SEGWIT_PUBKEY_UNCOMPRESSED =
+  "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd" +
+  "5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235";
 const TAPROOT_ADDR =
   "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg";
 // A well-formed P2WPKH derived from a deterministic 20-byte pubkey hash
@@ -265,9 +275,13 @@ describe("sendBitcoinTransaction", () => {
       name: "Bitcoin",
       version: "2.2.0",
     });
+    // Mirror what Ledger BTC v2.4.6 actually returns: SEC1 uncompressed
+    // (65 bytes, 0x04 || X || Y). Issue #211 — the signer must compress
+    // before threading into knownAddressDerivations or the SDK throws
+    // "Invalid pubkey length: 65" before any device prompt.
     getWalletPublicKeyMock.mockResolvedValueOnce({
       bitcoinAddress: SEGWIT_ADDR,
-      publicKey: SEGWIT_PUBKEY,
+      publicKey: SEGWIT_PUBKEY_UNCOMPRESSED,
       chainCode: "0".repeat(64),
     });
     signPsbtBufferMock.mockResolvedValueOnce({
@@ -360,6 +374,62 @@ describe("sendBitcoinTransaction", () => {
         confirmed: true,
       }),
     ).rejects.toThrow(/derived .* but the prepared tx lists/);
+  });
+});
+
+// Issue #211 regression. Ledger BTC v2.4.6 returns SEC1-uncompressed
+// pubkeys (65 bytes); the SDK's PSBT machinery downstream of
+// knownAddressDerivations chokes on anything other than the 33-byte
+// compressed form. Verify the compressor in isolation so failures
+// surface here instead of as "Invalid pubkey length: 65" mid-flow.
+describe("compressPubkey", () => {
+  const COMPRESSED =
+    "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+  const UNCOMPRESSED =
+    "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd" +
+    "5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235";
+  // Even-Y test vector — secp256k1 generator point G.
+  const G_COMPRESSED =
+    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+  const G_UNCOMPRESSED =
+    "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" +
+    "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8";
+
+  it("compresses a 65-byte uncompressed pubkey with odd Y to 0x03 prefix", async () => {
+    const { compressPubkey } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const out = compressPubkey(Buffer.from(UNCOMPRESSED, "hex"));
+    expect(out.length).toBe(33);
+    expect(out.toString("hex")).toBe(COMPRESSED);
+  });
+
+  it("compresses a 65-byte uncompressed pubkey with even Y to 0x02 prefix", async () => {
+    const { compressPubkey } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const out = compressPubkey(Buffer.from(G_UNCOMPRESSED, "hex"));
+    expect(out.toString("hex")).toBe(G_COMPRESSED);
+  });
+
+  it("is idempotent on already-compressed input", async () => {
+    const { compressPubkey } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const buf = Buffer.from(COMPRESSED, "hex");
+    expect(compressPubkey(buf).toString("hex")).toBe(COMPRESSED);
+  });
+
+  it("rejects unexpected pubkey shapes", async () => {
+    const { compressPubkey } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    expect(() =>
+      compressPubkey(Buffer.from("00".repeat(33), "hex")),
+    ).toThrow(/Unexpected SEC1 pubkey shape/);
+    expect(() => compressPubkey(Buffer.alloc(64))).toThrow(
+      /Unexpected SEC1 pubkey shape/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes #211 — every Phase 1 BTC native-segwit `send_transaction` call was throwing `Invalid pubkey length: 65` before any on-device prompt, blocking the flow end-to-end.
- Root cause: Ledger BTC v2.x's `getWalletPublicKey` returns SEC1 **uncompressed** pubkeys (65 bytes: `0x04 || X || Y`), but the SDK's `signPsbtBuffer.knownAddressDerivations` consumer needs the **compressed** 33-byte form — the downstream P2WPKH path wants `hash160(compressed)` to match the witness program payload, and the P2TR path strips the prefix byte for x-only conversion. After #209 made the lookup actually succeed, the buffer threading became visible.
- Fix: small local `compressPubkey` helper (8 lines, branchless: `0x02` for even Y, `0x03` for odd) called at the single site that materializes a Buffer from `derived.publicKey`. Idempotent on already-compressed input, so the host-side gap-limit-scan path (compressed via `@scure/bip32`) is unaffected.

## Test plan

- [x] `npx vitest run test/btc-pr3-send.test.ts` — 20/20 pass (16 existing + 4 new `compressPubkey` unit tests covering odd-Y, even-Y / generator point G, already-compressed idempotence, and rejected shapes).
- [x] Updated the existing end-to-end PSBT-build-and-sign test to mock Ledger returning **uncompressed** (the real device shape) and assert the `knownAddressDerivations` entry materializes compressed.
- [x] Full suite: `npm test` — 1120/1120 pass.
- [ ] **Manual verify on a real Ledger:** repro from the issue (BIP84 segwit source, 0.0001 BTC, 1 sat/vB) — `send_transaction` should now reach the device prompt without the pubkey-length throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)