### PR TITLE
fix(btc): populate nonWitnessUtxo on every PSBT input (#213)

### DIFF
--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -31,11 +31,16 @@ import { BTC_DECIMALS, SATS_PER_BTC } from "../../config/btc.js";
  * replaceable). Pass `rbf: false` to set `0xFFFFFFFE` (final, not
  * replaceable). Locktime stays at 0.
  *
- * The PSBT is v0 (the only format `signPsbtBuffer` accepts). For native
- * segwit (P2WPKH) and taproot (P2TR) inputs, only `witnessUtxo` is
- * populated — full prev-tx hex isn't required for segwit. Legacy /
- * P2SH-wrapped sends would need `nonWitnessUtxo` (raw prev-tx); deferred
- * to follow-up alongside legacy support.
+ * The PSBT is v0 (the only format `signPsbtBuffer` accepts). Every
+ * input carries BOTH `witnessUtxo` (script + value, used by the segwit
+ * sighash) AND `nonWitnessUtxo` (the full prev-tx hex). The latter is
+ * mandatory on Ledger BTC app 2.x even for segwit/taproot inputs — the
+ * device cryptographically verifies the input amount against the
+ * prev-tx because BIP-143 sighash doesn't commit to input amount,
+ * which is how a malicious offline signer could otherwise lie about
+ * the input value to inflate the fee. Omitting it trips a
+ * "Security risk: unverified inputs" device prompt and rejects with
+ * 0x6985. Issue #213.
  */
 
 const requireCjs = createRequire(import.meta.url);
@@ -46,6 +51,7 @@ const bitcoinjs = requireCjs("bitcoinjs-lib") as {
       index: number;
       sequence?: number;
       witnessUtxo?: { script: Buffer; value: number };
+      nonWitnessUtxo?: Buffer;
     }): unknown;
     addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
     toBase64(): string;
@@ -259,20 +265,39 @@ export async function buildBitcoinNativeSend(
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 
-  // 7. Build PSBT.
+  // 7. Fetch full prev-tx hex for every UNIQUE input txid. Required by
+  //    Ledger BTC app 2.x's segwit-fee-inflation defense — see file
+  //    docstring + issue #213. Dedup by txid so a multi-vout-from-the-
+  //    same-prev-tx selection only fans out once. Parallel fan-out so
+  //    the wall-time stays bounded even with many distinct prev txs.
+  const uniqueTxids = [...new Set(selection.inputs.map((i) => i.txid))];
+  const prevTxHexEntries = await Promise.all(
+    uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
+  );
+  const prevTxHexByTxid = new Map(prevTxHexEntries);
+
+  // 8. Build PSBT.
   const psbt = new bitcoinjs.Psbt({ network: NETWORK });
   const sequence = args.rbf === false ? 0xfffffffe : 0xfffffffd;
   const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
   for (const input of selection.inputs) {
+    const prevTxHex = prevTxHexByTxid.get(input.txid);
+    if (!prevTxHex) {
+      throw new Error(
+        `Internal error: prev-tx hex missing for selected input ${input.txid}:${input.vout} ` +
+          `after fan-out fetch.`,
+      );
+    }
     psbt.addInput({
       hash: input.txid,
       index: input.vout,
       sequence,
-      // For segwit + taproot, `witnessUtxo` (script + value) is the
-      // minimum required input data for v0 PSBT signing. The Ledger
-      // BTC app validates the input value against this when computing
-      // the segwit sighash.
+      // `witnessUtxo` (script + value) feeds the segwit sighash;
+      // `nonWitnessUtxo` (full prev-tx) is what Ledger BTC app 2.x
+      // uses to cryptographically verify the input amount. Both are
+      // required — see file docstring.
       witnessUtxo: { script: sourceScript, value: input.value },
+      nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
     });
   }
   for (const output of selection.outputs) {
@@ -284,7 +309,7 @@ export async function buildBitcoinNativeSend(
   }
   const psbtBase64 = psbt.toBase64();
 
-  // 8. Decoded-output projection for the verification block. Each
+  // 9. Decoded-output projection for the verification block. Each
   //    output gets a sats + BTC-decimal string + isChange flag. The
   //    Ledger walks every entry on-screen — this projection is what
   //    `render-verification.ts` mirrors for the user to cross-check.

--- a/src/modules/btc/indexer.ts
+++ b/src/modules/btc/indexer.ts
@@ -190,6 +190,17 @@ export interface BitcoinIndexer {
    * (mempool.space + standard Esplora share the same shape).
    */
   getBlockTip(): Promise<BitcoinBlockTip>;
+  /**
+   * Fetch the raw hex of a previous transaction by txid. Required for
+   * `nonWitnessUtxo` population on PSBT inputs — Ledger BTC app 2.x
+   * cryptographically verifies the input amount against this prev-tx
+   * (BIP-143 sighash doesn't commit to input amount, so the prev-tx is
+   * the only way the device can prove a malicious offline signer didn't
+   * lie about the input value to inflate the fee). Without it the device
+   * surfaces a "Security risk: unverified inputs" prompt and refuses to
+   * sign cleanly. Issue #213.
+   */
+  getTxHex(txid: string): Promise<string>;
 }
 
 /**
@@ -503,6 +514,31 @@ class EsploraIndexer implements BitcoinIndexer {
       confirmed: true,
       ...(status.block_height !== undefined ? { blockHeight: status.block_height } : {}),
     };
+  }
+
+  async getTxHex(txid: string): Promise<string> {
+    if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
+      throw new Error(
+        `Bitcoin indexer getTxHex called with non-64-hex txid "${txid.slice(0, 80)}".`,
+      );
+    }
+    const res = await fetchWithTimeout(`${this.baseUrl}/tx/${txid}/hex`, {
+      method: "GET",
+      headers: { Accept: "text/plain" },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Bitcoin indexer /tx/${txid}/hex returned ${res.status} ${res.statusText}`,
+      );
+    }
+    const hex = (await res.text()).trim();
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+      throw new Error(
+        `Bitcoin indexer /tx/${txid}/hex returned non-hex body (length ${hex.length}, ` +
+          `head "${hex.slice(0, 32)}").`,
+      );
+    }
+    return hex;
   }
 
   async getBlockTip(): Promise<BitcoinBlockTip> {

--- a/test/btc-pr3-send.test.ts
+++ b/test/btc-pr3-send.test.ts
@@ -2,7 +2,56 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
 import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjsForFixtures = requireCjs("bitcoinjs-lib") as {
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          witnessUtxo?: { script: Buffer; value: number };
+          nonWitnessUtxo?: Buffer;
+        }>;
+      };
+    };
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+  networks: { bitcoin: unknown };
+};
+
+/**
+ * Build a minimal mainnet prev-tx hex with a single output at `vout`
+ * paying `address` `value` sats. Issue #213 — `prepare_btc_send` now
+ * fetches `getTxHex(input.txid)` for every selected UTXO and stuffs
+ * the result into the PSBT as `nonWitnessUtxo`. bitcoinjs-lib's
+ * `addInput` validates the value matches `witnessUtxo.value`, so the
+ * fixture has to actually carry the right amount at the right vout.
+ */
+function buildPrevTxHex(value: number, address: string, vout = 0): string {
+  const tx = new bitcoinjsForFixtures.Transaction();
+  tx.version = 2;
+  // Coinbase-style dummy input — we don't sign or validate this prev-tx
+  // anywhere; it just needs to be parseable by bitcoinjs.
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  for (let i = 0; i <= vout; i++) {
+    const script = bitcoinjsForFixtures.address.toOutputScript(
+      address,
+      bitcoinjsForFixtures.networks.bitcoin,
+    );
+    tx.addOutput(script, i === vout ? value : 0);
+  }
+  return tx.toHex();
+}
 
 /**
  * BTC PR3 — `prepare_btc_send` (PSBT build) + `send_transaction` BTC
@@ -64,6 +113,7 @@ const getUtxosMock = vi.fn();
 const getFeeEstimatesMock = vi.fn();
 const broadcastTxMock = vi.fn();
 const getTxStatusMock = vi.fn();
+const getTxHexMock = vi.fn();
 
 vi.mock("../src/modules/btc/indexer.ts", () => ({
   getBitcoinIndexer: () => ({
@@ -71,6 +121,7 @@ vi.mock("../src/modules/btc/indexer.ts", () => ({
     getFeeEstimates: getFeeEstimatesMock,
     broadcastTx: broadcastTxMock,
     getTxStatus: getTxStatusMock,
+    getTxHex: getTxHexMock,
   }),
   resetBitcoinIndexer: () => {},
 }));
@@ -88,6 +139,34 @@ beforeEach(async () => {
   getFeeEstimatesMock.mockReset();
   broadcastTxMock.mockReset();
   getTxStatusMock.mockReset();
+  getTxHexMock.mockReset();
+  // Default: derive a valid prev-tx hex from whichever UTXOs the test
+  // most recently registered via getUtxosMock. Tests can override with
+  // mockResolvedValueOnce / mockRejectedValueOnce when they need to
+  // exercise indexer failure modes.
+  getTxHexMock.mockImplementation(async (txid: string) => {
+    const lastResult =
+      getUtxosMock.mock.results[getUtxosMock.mock.results.length - 1];
+    if (!lastResult || lastResult.type !== "return") {
+      throw new Error(
+        `Test setup error: getTxHex(${txid}) called but no getUtxos mock has run.`,
+      );
+    }
+    const utxos = (await lastResult.value) as Array<{
+      txid: string;
+      vout: number;
+      value: number;
+    }>;
+    const matching = utxos.find((u) => u.txid === txid);
+    if (!matching) {
+      throw new Error(
+        `Test setup error: no UTXO matches txid ${txid} (have: ${utxos
+          .map((u) => u.txid)
+          .join(",")}).`,
+      );
+    }
+    return buildPrevTxHex(matching.value, SEGWIT_ADDR, matching.vout);
+  });
   const { clearPairedBtcAddresses, setPairedBtcAddress } = await import(
     "../src/signing/btc-usb-signer.js"
   );
@@ -148,6 +227,16 @@ describe("buildBitcoinNativeSend", () => {
     expect(recipientOutput?.isChange).toBe(false);
     expect(tx.decoded.rbfEligible).toBe(true);
     expect(tx.decoded.feeRateSatPerVb).toBe(10);
+    // Issue #213 regression: every input must carry nonWitnessUtxo
+    // (full prev-tx hex), or Ledger BTC app 2.x raises "Security risk:
+    // unverified inputs" before showing any output details. Decode the
+    // PSBT and assert input #0 has both witnessUtxo AND nonWitnessUtxo.
+    const psbt = bitcoinjsForFixtures.Psbt.fromBase64(tx.psbtBase64);
+    expect(psbt.data.inputs.length).toBe(1);
+    expect(psbt.data.inputs[0].witnessUtxo).toBeDefined();
+    expect(psbt.data.inputs[0].nonWitnessUtxo).toBeDefined();
+    expect((psbt.data.inputs[0].nonWitnessUtxo as Buffer).length).toBeGreaterThan(0);
+    expect(getTxHexMock).toHaveBeenCalledWith(FAKE_TXID);
   });
 
   it("uses an explicit feeRate when passed", async () => {


### PR DESCRIPTION
## Summary

- Fixes #213 — every Phase 1 BTC send on a current-firmware Ledger Nano (BTC app 2.x) was prompting *Security risk: unverified inputs. Continue anyway / Back to safety* before any output detail; pressing *Back to safety* returned `0x6985`. Continuing would sign but the warning correctly flagged a real exposure.
- Root cause: PSBT inputs were built with only `witnessUtxo`. Ledger BTC app 2.x mandates `nonWitnessUtxo` (full prev-tx hex) on every input — even segwit/taproot — as a defense against the segwit fee-inflation attack class. BIP-143 sighash doesn't commit to input amount; the prev-tx is the only way the device can cryptographically verify the value and detect a malicious offline signer lying about it to inflate the fee. The previous comment claiming segwit doesn't need prev-tx was true for older app versions.
- Fix:
  - Add `getTxHex(txid)` to the `BitcoinIndexer` interface (mempool.space `/tx/<txid>/hex`, with the same hex-shape guards as `broadcastTx`).
  - In `buildBitcoinNativeSend`, fetch prev-tx hex for every UNIQUE input txid in parallel (dedupes when one prev tx funds multiple selected vouts), and pass it to `psbt.addInput` as `nonWitnessUtxo` alongside the existing `witnessUtxo`.
  - Update the file docstring — the segwit-without-prev-tx claim is now wrong for current Ledger app versions.

## Test plan

- [x] `npx vitest run test/btc-pr3-send.test.ts` — 20/20 pass. Added a `buildPrevTxHex` fixture helper and a default `getTxHexMock` impl that derives the prev-tx from whichever UTXOs the test most recently registered. The basic-PSBT-build test gains assertions that input #0 carries both `witnessUtxo` AND `nonWitnessUtxo`, and that `getTxHex` was called for the input txid.
- [x] Full suite: `npm test` — 1120/1120 pass.
- [ ] **Manual verify on a real Ledger:** repro from #213 (BIP84 segwit source, 0.0001 BTC) — `send_transaction` should jump straight to per-output clear-sign without the *Security risk* prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)