### PR TITLE
chore(release): bump to 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
\`v0.8.0\` was the last shipped release. \`0.8.1\` was bumped in package.json after that but never tagged / released — see the \"more fixes are underway\" hold during PR #187 / #188 / #195. Now that the BTC Phase 1 work + correctness fixes have all settled, treating the unreleased 0.8.1 as a skipped intermediate and going straight to 0.8.2 is cleaner than retroactively tagging it a month into work.

## Highlights since v0.8.0

**BTC Phase 1 complete**
- \`prepare_btc_send\` + \`send_transaction\` (PRs #176, #177)
- \`sign_message_btc\`, BTC portfolio fold-in, \`get_btc_block_tip\`
- \`pair_ledger_btc\` gap-limit scanning across receive + change chains, all 4 BIP-44 purposes (#190)
- \`get_btc_account_balance\` + \`rescan_btc_account\` (#191, #193)

**BTC perf + correctness**
- Account-xpub host-side derivation: 160 USB roundtrips → 4 + parallel indexer fan-out (#195)
- Rescan throttle (\`BITCOIN_INDEXER_PARALLELISM\` cap + 429 retry) + tri-state \`needsExtend\` (#200)
- bs58 / base-x ESM-CJS interop fixes (#181 + base-x carve-out)
- P2WSH detector fix + tighter taproot regex (#182, #185)

**Other fixes + features**
- Marinade BN named-export resolution + nested anchor 0.28 override (#178)
- Multi-wallet \`get_portfolio_summary\` now accepts non-EVM addresses (TRON / Solana / BTC), surfaced as parallel siblings instead of forcing misattribution to a chosen EVM wallet (#202)
- Marketing headline lead-in: \"Safety first.\"

## Verification

- \`npm run build\` clean
- Full suite **1123/1123**
- All three version files (\`package.json\` / \`server.json\` / \`package-lock.json\`) consistent at 0.8.2

## Test plan

- [ ] CI green
- [ ] After merge, tag \`v0.8.2\` and create the GitHub Release. \`publish.yml\` (npm) + \`release-binaries.yml\` (4-OS binaries) fire on \`release.published\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)