### PR TITLE
feat(litecoin): add Litecoin support — pair, balance, send, message-sign

### DIFF
--- a/src/config/litecoin.ts
+++ b/src/config/litecoin.ts
@@ -1,0 +1,53 @@
+/**
+ * Litecoin mainnet configuration.
+ *
+ * Litecoin is a Bitcoin fork (UTXO-based, base58/bech32 addresses, no
+ * smart contracts on L1). The server treats Litecoin as strictly
+ * additive — existing modules never see Litecoin, and the Litecoin
+ * code lives in `src/modules/litecoin/`.
+ */
+
+/**
+ * Default indexer endpoint — litecoinspace.org is mempool.space's
+ * Litecoin sister deployment, exposing the same Esplora-compatible REST
+ * surface as mempool.space does for BTC. No API key needed for
+ * personal-volume usage. Override via `LITECOIN_INDEXER_URL` env var
+ * or `userConfig.litecoinIndexerUrl`.
+ *
+ * For self-hosted Esplora / Electrs the URL just needs to expose the
+ * same REST surface — the indexer abstraction is modeled on
+ * Blockstream Esplora's API, which both mempool.space and litecoinspace.org
+ * fork.
+ */
+export const LITECOIN_DEFAULT_INDEXER_URL = "https://litecoinspace.org/api";
+
+/** Native asset metadata. */
+export const LTC_DECIMALS = 8; // 1 LTC = 100_000_000 litoshis (sats in code)
+export const LTC_SYMBOL = "LTC";
+export const LITOSHIS_PER_LTC = 100_000_000n;
+
+/**
+ * Default concurrency cap for indexer fan-out. litecoinspace.org has
+ * the same throttling characteristics as mempool.space (forked from
+ * the same project), so we use the same defaults BTC does. Self-
+ * hosted Esplora users with no rate concerns can override via
+ * `LITECOIN_INDEXER_PARALLELISM`.
+ */
+export const LITECOIN_INDEXER_DEFAULT_PARALLELISM = 8;
+export const LITECOIN_INDEXER_MAX_PARALLELISM = 32;
+
+/**
+ * Resolve the configured indexer fan-out parallelism. Respects the
+ * env var when present (clamped to [1, MAX]); otherwise the default.
+ */
+export function resolveLitecoinIndexerParallelism(): number {
+  const raw = process.env.LITECOIN_INDEXER_PARALLELISM;
+  if (raw === undefined || raw.trim() === "") {
+    return LITECOIN_INDEXER_DEFAULT_PARALLELISM;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return LITECOIN_INDEXER_DEFAULT_PARALLELISM;
+  }
+  return Math.min(LITECOIN_INDEXER_MAX_PARALLELISM, parsed);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,10 @@ import {
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   signBtcMessage,
+  pairLedgerLitecoin,
+  getLitecoinBalance,
+  prepareLitecoinNativeSend,
+  signLtcMessage,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -158,6 +162,10 @@ import {
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   signBtcMessageInput,
+  pairLedgerLitecoinInput,
+  getLitecoinBalanceInput,
+  prepareLitecoinNativeSendInput,
+  signLtcMessageInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -275,6 +283,7 @@ import {
   renderPostBroadcastBlock,
   renderPostSendPollBlock,
   renderBitcoinVerificationBlock,
+  renderLitecoinVerificationBlock,
   renderPrepareReceiptBlock,
   renderPreviewVerifyAgentTaskBlock,
   renderSolanaAgentTaskBlock,
@@ -291,6 +300,7 @@ import type {
   SupportedChain,
   TxVerification,
   UnsignedBitcoinTx,
+  UnsignedLitecoinTx,
   UnsignedSolanaTx,
   UnsignedTronTx,
   UnsignedTx,
@@ -498,6 +508,10 @@ export async function collectVerificationBlocks(
   // early-return that the EVM branch relies on.
   if (chain === "bitcoin" && typeof r.psbtBase64 === "string") {
     blocks.push(renderBitcoinVerificationBlock(result as UnsignedBitcoinTx));
+    return blocks;
+  }
+  if (chain === "litecoin" && typeof r.psbtBase64 === "string") {
+    blocks.push(renderLitecoinVerificationBlock(result as UnsignedLitecoinTx));
     return blocks;
   }
   if (!verification) return blocks;
@@ -776,7 +790,7 @@ function previewSolanaSendHandler(
 function sendTransactionHandler(
   fn: (args: SendTransactionArgs) => Promise<{
     txHash: `0x${string}` | string;
-    chain: SupportedChain | "tron" | "solana" | "bitcoin";
+    chain: SupportedChain | "tron" | "solana" | "bitcoin" | "litecoin";
     nextHandle?: string;
     preSignHash?: `0x${string}`;
     to?: `0x${string}`;
@@ -1975,6 +1989,72 @@ async function main() {
       inputSchema: signBtcMessageInput.shape,
     },
     handler(signBtcMessage, { toolName: "sign_message_btc" })
+  );
+
+  server.registerTool(
+    "pair_ledger_ltc",
+    {
+      description:
+        "Pair the host's directly-connected Ledger device for Litecoin signing. " +
+        "REQUIREMENTS: Ledger plugged in over USB, device unlocked, the 'Litecoin' " +
+        "app open on-screen. Ledger Live's WalletConnect relay does not expose " +
+        "Litecoin accounts to dApps, so signing goes over USB HID via " +
+        "`@ledgerhq/hw-app-btc` (the same SDK as Bitcoin, with `currency:'litecoin'` " +
+        "selecting Litecoin-specific encoding). One call enumerates all four " +
+        "address types (legacy `L…`, p2sh-segwit `M…`, native segwit `ltc1q…`, " +
+        "taproot `ltc1p…`) for the given account index. BIP-44 coin_type 2. " +
+        "Note: Litecoin Core has not activated Taproot on mainnet, so `ltc1p…` " +
+        "outputs are not yet spendable — the address is derived for forward " +
+        "compat. All paired entries surface under the `litecoin: [...]` section " +
+        "of `get_ledger_status`.",
+      inputSchema: pairLedgerLitecoinInput.shape,
+    },
+    handler(pairLedgerLitecoin, { toolName: "pair_ledger_ltc" })
+  );
+
+  server.registerTool(
+    "get_ltc_balance",
+    {
+      description:
+        "Return the on-chain balance for one Litecoin mainnet address via the " +
+        "Esplora indexer (litecoinspace.org by default; override via " +
+        "`LITECOIN_INDEXER_URL` env var or `userConfig.litecoinIndexerUrl`). " +
+        "Returns confirmed + mempool litoshis and an LTC-decimal projection. " +
+        "Accepts L/M/3/ltc1q/ltc1p — the read path validates format only.",
+      inputSchema: getLitecoinBalanceInput.shape,
+    },
+    handler(getLitecoinBalance, { toolName: "get_ltc_balance" })
+  );
+
+  server.registerTool(
+    "prepare_litecoin_native_send",
+    {
+      description:
+        "Build an unsigned Litecoin native-send PSBT. Same pipeline as " +
+        "`prepare_btc_send`: fetch UTXOs + fee rate, run coin-selection, build a " +
+        "PSBT v0 with `nonWitnessUtxo` populated on every input (Ledger app 2.x " +
+        "requirement). Initial release: source addresses must be native segwit " +
+        "(`ltc1q…`) or taproot (`ltc1p…`); recipients can be L/M/ltc1q/ltc1p " +
+        "(legacy 3-prefix P2SH refused on send because bitcoinjs-lib ties the " +
+        "`scriptHash` byte to a single network object). Returns a handle " +
+        "consumed by `send_transaction`, which signs over USB HID with the " +
+        "Litecoin app and broadcasts via the indexer.",
+      inputSchema: prepareLitecoinNativeSendInput.shape,
+    },
+    handler(prepareLitecoinNativeSend, { toolName: "prepare_litecoin_native_send" })
+  );
+
+  server.registerTool(
+    "sign_message_ltc",
+    {
+      description:
+        "Sign a UTF-8 message with a paired Litecoin address using the BIP-137 " +
+        "compact-signature scheme (with Litecoin's `\\x19Litecoin Signed Message:\\n` " +
+        "prefix). Same on-device clear-sign UX as `sign_message_btc`. Taproot " +
+        "(`ltc1p…`) is refused — BIP-322 isn't exposed by the Ledger Litecoin app.",
+      inputSchema: signLtcMessageInput.shape,
+    },
+    handler(signLtcMessage, { toolName: "sign_message_ltc" })
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -27,9 +27,18 @@ import {
   hasBitcoinHandle,
 } from "../../signing/btc-tx-store.js";
 import {
+  consumeLitecoinHandle,
+  retireLitecoinHandle,
+  hasLitecoinHandle,
+} from "../../signing/ltc-tx-store.js";
+import {
   signBtcPsbtOnLedger,
   getPairedBtcByAddress,
 } from "../../signing/btc-usb-signer.js";
+import {
+  signLtcPsbtOnLedger,
+  getPairedLtcByAddress,
+} from "../../signing/ltc-usb-signer.js";
 import {
   getTronLedgerAddress,
   signTronTxOnLedger,
@@ -131,6 +140,10 @@ import type {
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   SignBtcMessageArgs,
+  PairLedgerLitecoinArgs,
+  GetLitecoinBalanceArgs,
+  PrepareLitecoinNativeSendArgs,
+  SignLtcMessageArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -1060,6 +1073,134 @@ export async function signBtcMessage(args: SignBtcMessageArgs) {
   return signBitcoinMessage({ wallet: args.wallet, message: args.message });
 }
 
+/**
+ * Pair the Ledger device for Litecoin signing. Mirror of
+ * `pairLedgerBitcoin`. The Ledger Litecoin app shares its host-side
+ * SDK (`@ledgerhq/hw-app-btc`) with the Bitcoin app, parametrized by
+ * `currency: "litecoin"` in our `ltc-usb-loader.ts`.
+ *
+ * One call enumerates all four address types for the given account
+ * index. BIP-44 coin_type 2 (`<purpose>'/2'/<account>'/...`) instead
+ * of 0.
+ */
+export async function pairLedgerLitecoin(
+  args: PairLedgerLitecoinArgs = {},
+): Promise<{
+  accountIndex: number;
+  gapLimit: number;
+  appVersion: string;
+  addresses: Array<{
+    addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+    address: string;
+    path: string;
+    chain: 0 | 1;
+    addressIndex: number;
+    txCount: number;
+  }>;
+  summary: { totalDerived: number; used: number; unused: number };
+  instructions: string;
+}> {
+  const accountIndex = args.accountIndex ?? 0;
+  const {
+    scanLtcAccount,
+    setPairedLtcAddress,
+    clearPairedLtcAccount,
+    DEFAULT_LTC_GAP_LIMIT,
+  } = await import("../../signing/ltc-usb-signer.js");
+  const gapLimit = args.gapLimit ?? DEFAULT_LTC_GAP_LIMIT;
+
+  const { getLitecoinIndexer } = await import("../litecoin/indexer.js");
+  const indexer = getLitecoinIndexer();
+  const fetchTxCount = async (addr: string): Promise<number> => {
+    const bal = await indexer.getBalance(addr);
+    return bal.txCount;
+  };
+
+  let derived;
+  try {
+    derived = await scanLtcAccount({
+      accountIndex,
+      gapLimit,
+      fetchTxCount,
+    });
+  } catch (e) {
+    const hint = await getDeviceStateHint("Litecoin");
+    if (hint && e instanceof Error) {
+      throw new Error(`${e.message} ${hint}`, { cause: e });
+    }
+    throw e;
+  }
+  clearPairedLtcAccount(accountIndex);
+  for (const entry of derived.entries) {
+    setPairedLtcAddress({
+      address: entry.address,
+      publicKey: entry.publicKey,
+      path: entry.path,
+      appVersion: entry.appVersion,
+      addressType: entry.addressType,
+      accountIndex: entry.accountIndex,
+      chain: entry.chain,
+      addressIndex: entry.addressIndex,
+      txCount: entry.txCount,
+    });
+  }
+  const used = derived.entries.filter((e) => e.txCount > 0).length;
+  return {
+    accountIndex,
+    gapLimit,
+    appVersion: derived.appVersion,
+    addresses: derived.entries.map((e) => ({
+      addressType: e.addressType,
+      address: e.address,
+      path: e.path,
+      chain: e.chain,
+      addressIndex: e.addressIndex,
+      txCount: e.txCount,
+    })),
+    summary: {
+      totalDerived: derived.entries.length,
+      used,
+      unused: derived.entries.length - used,
+    },
+    instructions:
+      "Litecoin account paired with BIP44 gap-limit scanning. Both the receive " +
+      "(/0/i) and change (/1/i) chains were walked across all four address types " +
+      "until " +
+      gapLimit +
+      " consecutive empty addresses were observed. Use `get_ltc_balance` against " +
+      "any cached address. Re-run `pair_ledger_ltc` to refresh; previously-cached " +
+      "entries for this accountIndex are dropped before the new scan persists.",
+  };
+}
+
+export async function getLitecoinBalance(args: GetLitecoinBalanceArgs) {
+  const { getLitecoinBalance: reader } = await import(
+    "../litecoin/balances.js"
+  );
+  return reader(args.address);
+}
+
+export async function prepareLitecoinNativeSend(
+  args: PrepareLitecoinNativeSendArgs,
+) {
+  const { buildLitecoinNativeSend } = await import("../litecoin/actions.js");
+  return buildLitecoinNativeSend({
+    wallet: args.wallet,
+    to: args.to,
+    amount: args.amount,
+    ...(args.feeRateSatPerVb !== undefined
+      ? { feeRateSatPerVb: args.feeRateSatPerVb }
+      : {}),
+    ...(args.rbf !== undefined ? { rbf: args.rbf } : {}),
+    ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
+  });
+}
+
+export async function signLtcMessage(args: SignLtcMessageArgs) {
+  const { signLitecoinMessage } = await import("../litecoin/actions.js");
+  return signLitecoinMessage({ wallet: args.wallet, message: args.message });
+}
+
 export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {
   const { getMarginfiPositions: reader } = await import(
     "../positions/marginfi.js"
@@ -1548,6 +1689,36 @@ async function sendBitcoinTransaction(args: SendTransactionArgs): Promise<{
   // policy as the Solana / TRON branches.
   retireBitcoinHandle(args.handle);
   return { txHash: txid, chain: "bitcoin" };
+}
+
+/**
+ * Send a Litecoin tx — mirror of `sendBitcoinTransaction`. Same Ledger
+ * BTC-app SDK with `currency:"litecoin"`, same PSBT + finalize +
+ * broadcast flow.
+ */
+async function sendLitecoinTransaction(args: SendTransactionArgs): Promise<{
+  txHash: string;
+  chain: "litecoin";
+}> {
+  const tx = consumeLitecoinHandle(args.handle);
+  const paired = getPairedLtcByAddress(tx.from);
+  if (!paired) {
+    throw new Error(
+      `Litecoin source ${tx.from} is no longer in the pairing cache. Re-pair via ` +
+        `\`pair_ledger_ltc\` and re-run prepare_litecoin_native_send for a fresh handle.`,
+    );
+  }
+  const { rawTxHex } = await signLtcPsbtOnLedger({
+    psbtBase64: tx.psbtBase64,
+    expectedFrom: tx.from,
+    path: paired.path,
+    accountPath: tx.accountPath,
+    addressFormat: tx.addressFormat,
+  });
+  const { getLitecoinIndexer } = await import("../litecoin/indexer.js");
+  const txid = await getLitecoinIndexer().broadcastTx(rawTxHex);
+  retireLitecoinHandle(args.handle);
+  return { txHash: txid, chain: "litecoin" };
 }
 
 /** Attach eth_call simulation result, gas estimate, and USD cost. */
@@ -2133,7 +2304,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
  */
 export async function sendTransaction(args: SendTransactionArgs): Promise<{
   txHash: `0x${string}` | string;
-  chain: SupportedChain | "tron" | "solana" | "bitcoin";
+  chain: SupportedChain | "tron" | "solana" | "bitcoin" | "litecoin";
   nextHandle?: string;
   /**
    * EIP-1559 pre-sign RLP hash the user already matched on-device during
@@ -2171,6 +2342,9 @@ export async function sendTransaction(args: SendTransactionArgs): Promise<{
   }
   if (hasBitcoinHandle(args.handle)) {
     return sendBitcoinTransaction(args);
+  }
+  if (hasLitecoinHandle(args.handle)) {
+    return sendLitecoinTransaction(args);
   }
   const stashed = getPinnedGas(args.handle);
   if (!stashed) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1210,3 +1210,102 @@ export type PrepareBitcoinNativeSendArgs = z.infer<typeof prepareBitcoinNativeSe
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;
+
+/**
+ * Litecoin (initial release) — minimal core surface: pair, single-address
+ * balance, send, and message-sign. Multi-address read, fee estimates,
+ * block tip, account-level balance, rescan, tx-history, and portfolio
+ * integration are deferred to a follow-up PR.
+ */
+const litecoinAddressSchema = z
+  .string()
+  .min(26)
+  .max(64)
+  .describe(
+    "Litecoin mainnet address. Accepts legacy (L...), P2SH (M...), legacy " +
+      "P2SH (3...), native segwit (ltc1q...), or taproot (ltc1p...). Note " +
+      "that Litecoin Core has not activated Taproot on mainnet, so ltc1p... " +
+      "outputs derive but are not yet spendable. Testnet (tltc1...) and " +
+      "MWEB (ltcmweb1...) addresses are not supported."
+  );
+
+export const pairLedgerLitecoinInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "Ledger Litecoin account slot. One call enumerates ALL FOUR address " +
+        "types (legacy at `44'/2'/<n>'/...`, p2sh-segwit at `49'/2'/<n>'/...`, " +
+        "native segwit at `84'/2'/<n>'/...`, taproot at `86'/2'/<n>'/...`) " +
+        "AND walks both receive (`/0/i`) and change (`/1/i`) chains using " +
+        "BIP44 gap-limit scanning. 0 = first Litecoin account, 1 = second, etc."
+    ),
+  gapLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      "BIP44 gap limit — stop walking each (type, chain) after this many " +
+        "consecutive addresses with zero on-chain history. Default 20."
+    ),
+});
+
+export const getLitecoinBalanceInput = z.object({
+  address: litecoinAddressSchema,
+});
+
+export const prepareLitecoinNativeSendInput = z.object({
+  wallet: litecoinAddressSchema.describe(
+    "Paired Litecoin source address. Must already be in `pairings.litecoin` " +
+      "(call `pair_ledger_ltc` first). Initial release sends only support " +
+      "native segwit (`ltc1q...`) and taproot (`ltc1p...`) source addresses; " +
+      "legacy (`L...`) and P2SH-wrapped (`M.../3...`) sends are deferred."
+  ),
+  to: litecoinAddressSchema.describe(
+    "Litecoin recipient address. L/M/ltc1q/ltc1p accepted. Legacy 3-prefix " +
+      "P2SH is rejected on send (it's read-supported only) — ask the recipient " +
+      "for an M-prefix address."
+  ),
+  amount: z
+    .string()
+    .max(50)
+    .regex(/^(max|\d+(\.\d{1,8})?)$/)
+    .describe(
+      'Decimal LTC string (up to 8 fractional digits, e.g. "0.001") or "max" ' +
+        "to sweep the full balance minus fees."
+    ),
+  feeRateSatPerVb: z
+    .number()
+    .positive()
+    .max(10000)
+    .optional()
+    .describe(
+      "Fee rate in litoshi/vB. Optional — when omitted, uses the indexer's " +
+        "halfHourFee recommendation."
+    ),
+  rbf: z.boolean().optional().describe("BIP-125 RBF. Default true."),
+  allowHighFee: z.boolean().optional(),
+});
+
+export const signLtcMessageInput = z.object({
+  wallet: litecoinAddressSchema.describe(
+    "Paired Litecoin source address. Must already be in `pairings.litecoin`. " +
+      "Taproot (`ltc1p...`) is refused — BIP-322 is not yet exposed by the " +
+      "Ledger Litecoin app."
+  ),
+  message: z
+    .string()
+    .min(1)
+    .max(10_000)
+    .describe("UTF-8 message to sign."),
+});
+
+export type PairLedgerLitecoinArgs = z.infer<typeof pairLedgerLitecoinInput>;
+export type GetLitecoinBalanceArgs = z.infer<typeof getLitecoinBalanceInput>;
+export type PrepareLitecoinNativeSendArgs = z.infer<typeof prepareLitecoinNativeSendInput>;
+export type SignLtcMessageArgs = z.infer<typeof signLtcMessageInput>;

--- a/src/modules/litecoin/actions.ts
+++ b/src/modules/litecoin/actions.ts
@@ -1,0 +1,387 @@
+import { createRequire } from "node:module";
+import { assertLitecoinAddress, type LitecoinAddressType } from "./address.js";
+import { getLitecoinIndexer } from "./indexer.js";
+import { selectInputs, type CoinSelectInput } from "./coin-select.js";
+import { issueLitecoinHandle } from "../../signing/ltc-tx-store.js";
+import {
+  getPairedLtcByAddress,
+  type LtcAddressType as PairedLtcAddressType,
+} from "../../signing/ltc-usb-signer.js";
+import type { UnsignedLitecoinTx } from "../../types/index.js";
+import { LTC_DECIMALS, LITOSHIS_PER_LTC } from "../../config/litecoin.js";
+
+/**
+ * Litecoin native-send builder. Mirror of `src/modules/btc/actions.ts`.
+ * Same PSBT v0 / coin-selection / fee-cap pattern; only network params
+ * and chain identifiers differ.
+ *
+ * bitcoinjs-lib does not ship a Litecoin network preset, so we
+ * construct one inline (mainnet only). pubKeyHash 0x30 (L-prefix),
+ * scriptHash 0x32 (M-prefix; modern Litecoin P2SH version), bech32
+ * HRP `ltc`. The xpub/xprv version bytes match BTC's `0x0488B21E` /
+ * `0x0488ADE4` — Litecoin Core uses the standard BIP-32 versions
+ * (Ltub/Ltpv exist in some third-party wallets but Core does not
+ * emit them).
+ *
+ * Legacy 3-prefix (0x05) Litecoin P2SH addresses are READ-side only:
+ * `assertLitecoinAddress` accepts them, but the SEND path rejects
+ * them because bitcoinjs-lib's `address.toOutputScript` validates the
+ * version byte against the configured `scriptHash` and we only carry
+ * one `scriptHash` per network object. Recipients on 3-prefix P2SH
+ * are vanishingly rare on Litecoin (the M-prefix migration completed
+ * years ago); when one shows up, we surface a clear error pointing
+ * the user to ask the recipient for an M-prefix address.
+ *
+ * Same Phase 1 simplification as BTC: change goes back to the source
+ * address. Same RBF default (`0xFFFFFFFD`). Same nonWitnessUtxo
+ * requirement on every input (Ledger BTC/LTC app 2.x — issue #213).
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: new (opts?: { network?: unknown }) => {
+    addInput(input: {
+      hash: string | Buffer;
+      index: number;
+      sequence?: number;
+      witnessUtxo?: { script: Buffer; value: number };
+      nonWitnessUtxo?: Buffer;
+    }): unknown;
+    addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
+    toBase64(): string;
+  };
+  address: {
+    toOutputScript(address: string, network?: unknown): Buffer;
+  };
+};
+
+/**
+ * Litecoin mainnet network params, in the bitcoinjs-lib `Network`
+ * shape. Since bitcoinjs-lib doesn't ship a Litecoin preset we define
+ * it here.
+ */
+const LITECOIN_NETWORK = {
+  messagePrefix: "\x19Litecoin Signed Message:\n",
+  bech32: "ltc",
+  bip32: {
+    public: 0x0488b21e, // xpub — Litecoin Core convention
+    private: 0x0488ade4, // xprv
+  },
+  pubKeyHash: 0x30, // L-prefix
+  scriptHash: 0x32, // M-prefix (modern); legacy 3-prefix not supported on send
+  wif: 0xb0,
+};
+
+const NETWORK = LITECOIN_NETWORK;
+
+/**
+ * Map BIP-32-purpose-to-our-paired-type.
+ */
+const ADDRESS_FORMAT_BY_TYPE: Record<
+  PairedLtcAddressType,
+  UnsignedLitecoinTx["addressFormat"]
+> = {
+  legacy: "legacy",
+  "p2sh-segwit": "p2sh",
+  segwit: "bech32",
+  taproot: "bech32m",
+};
+
+/**
+ * Account-level path derivation from leaf path.
+ */
+function accountPathFromLeaf(leafPath: string): string {
+  const parts = leafPath.split("/");
+  if (parts.length < 5) {
+    throw new Error(
+      `Invalid Litecoin leaf path "${leafPath}" — expected at least 5 segments ` +
+        `(<purpose>'/2'/<account>'/<change>/<index>).`,
+    );
+  }
+  return parts.slice(0, -2).join("/");
+}
+
+function roughVbytes(inputCount: number, outputCount: number): number {
+  return 10 + inputCount * 68 + outputCount * 31;
+}
+
+function litoshisToLtcString(litoshis: bigint): string {
+  const negative = litoshis < 0n;
+  const abs = negative ? -litoshis : litoshis;
+  const whole = abs / LITOSHIS_PER_LTC;
+  const frac = abs - whole * LITOSHIS_PER_LTC;
+  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "") || "0";
+  const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+  return negative ? `-${body}` : body;
+}
+
+function parseLtcAmountToLitoshis(amount: string): bigint | null {
+  if (amount === "max") return null;
+  if (!/^\d+(\.\d{1,8})?$/.test(amount)) {
+    throw new Error(
+      `Invalid LTC amount "${amount}" — expected a decimal with up to 8 fractional ` +
+        `digits (e.g. "0.001", "0.5") or "max" for the full balance minus fees.`,
+    );
+  }
+  const [whole, frac = ""] = amount.split(".");
+  const padded = frac.padEnd(LTC_DECIMALS, "0");
+  return BigInt(whole) * LITOSHIS_PER_LTC + BigInt(padded);
+}
+
+export interface BuildLitecoinNativeSendArgs {
+  /** Paired LTC source address. Must be in `UserConfig.pairings.litecoin`. */
+  wallet: string;
+  /** Recipient. L/M/ltc1q/ltc1p — 3-prefix legacy P2SH not supported on send. */
+  to: string;
+  /** Decimal LTC string ("0.001"), or "max" for full-balance-minus-fee. */
+  amount: string;
+  /** Fee rate in litoshi/vB. Default: indexer's halfHourFee recommendation. */
+  feeRateSatPerVb?: number;
+  /** BIP-125 RBF. Default true. */
+  rbf?: boolean;
+  /** Override the fee-cap guard. Default false. */
+  allowHighFee?: boolean;
+}
+
+export async function buildLitecoinNativeSend(
+  args: BuildLitecoinNativeSendArgs,
+): Promise<UnsignedLitecoinTx> {
+  // 1. Validate source + destination format.
+  assertLitecoinAddress(args.wallet);
+  const toType = assertLitecoinAddress(args.to);
+  // Reject 3-prefix legacy P2SH on send-side — see file docstring.
+  if (toType === "p2sh" && args.to.startsWith("3")) {
+    throw new Error(
+      `Sending to legacy 3-prefix Litecoin P2SH addresses (${args.to}) is not supported. ` +
+        `Litecoin migrated P2SH to the M-prefix (version 0x32) form years ago. Ask the ` +
+        `recipient for their modern M-prefix address, or send via Litecoin Core directly.`,
+    );
+  }
+
+  // 2. Resolve the paired entry for the source.
+  const paired = getPairedLtcByAddress(args.wallet);
+  if (!paired) {
+    throw new Error(
+      `Litecoin address ${args.wallet} is not paired. Run \`pair_ledger_ltc\` ` +
+        `to register the four standard address types (legacy/p2sh-segwit/segwit/taproot) ` +
+        `for an account, then pass any of those addresses as \`wallet\`.`,
+    );
+  }
+  // Phase 1 send-side scope: native segwit + taproot only — same scope
+  // discipline as BTC. (Note: Litecoin Core has not activated Taproot
+  // on mainnet, so taproot sends will derive correctly but recipients
+  // can't spend until activation. Native segwit is the recommended
+  // path.)
+  if (paired.addressType !== "segwit" && paired.addressType !== "taproot") {
+    throw new Error(
+      `Litecoin sends from ${paired.addressType} (${paired.path}) addresses are not ` +
+        `supported in Phase 1 — only native segwit (ltc1q...) and taproot (ltc1p...). ` +
+        `Move funds to your paired segwit address first.`,
+    );
+  }
+
+  const indexer = getLitecoinIndexer();
+
+  // 3. Resolve fee rate.
+  let feeRate: number;
+  if (args.feeRateSatPerVb !== undefined) {
+    feeRate = args.feeRateSatPerVb;
+  } else {
+    const fees = await indexer.getFeeEstimates();
+    feeRate = fees.halfHourFee;
+  }
+  if (!Number.isFinite(feeRate) || feeRate <= 0) {
+    throw new Error(
+      `Resolved fee rate ${feeRate} litoshi/vB is not positive. Pass an explicit ` +
+        `\`feeRateSatPerVb\` or check the indexer URL.`,
+    );
+  }
+
+  // 4. Fetch UTXOs.
+  const utxos = await indexer.getUtxos(args.wallet);
+  if (utxos.length === 0) {
+    throw new Error(
+      `No UTXOs at ${args.wallet} — the wallet has zero spendable balance. ` +
+        `Verify with \`get_token_balance\` (chain:"litecoin") and confirm at least one ` +
+        `tx has confirmed.`,
+    );
+  }
+
+  // 5. Resolve "max" → fee-aware amount, or convert decimal-LTC → litoshis.
+  const csUtxos: CoinSelectInput[] = utxos.map((u) => ({
+    txid: u.txid,
+    vout: u.vout,
+    value: u.value,
+  }));
+  let amountSats: bigint;
+  if (args.amount === "max") {
+    const totalSats = csUtxos.reduce((sum, u) => sum + u.value, 0);
+    const vbytes = roughVbytes(csUtxos.length, 1);
+    const feeMax = Math.ceil(feeRate * vbytes) + Math.ceil(feeRate * 5);
+    if (totalSats <= feeMax) {
+      throw new Error(
+        `Cannot "max": total balance ${litoshisToLtcString(BigInt(totalSats))} LTC is at or below ` +
+          `the estimated fee ${litoshisToLtcString(BigInt(feeMax))} LTC at ${feeRate} litoshi/vB. ` +
+          `Lower the feeRate or wait for more confirmations.`,
+      );
+    }
+    amountSats = BigInt(totalSats - feeMax);
+  } else {
+    const parsed = parseLtcAmountToLitoshis(args.amount);
+    if (parsed === null) {
+      throw new Error(`Internal error: parseLtcAmountToLitoshis returned null for ${args.amount}`);
+    }
+    amountSats = parsed;
+  }
+  if (amountSats <= 0n) {
+    throw new Error(
+      `Resolved send amount ${amountSats} litoshis is not positive. Increase the amount.`,
+    );
+  }
+
+  // 6. Coin-selection.
+  const selection = selectInputs({
+    utxos: csUtxos,
+    outputs: [{ address: args.to, value: Number(amountSats) }],
+    feeRate,
+    changeAddress: args.wallet,
+    ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
+  });
+
+  // 7. Fetch full prev-tx hex for every UNIQUE input txid (issue #213).
+  const uniqueTxids = [...new Set(selection.inputs.map((i) => i.txid))];
+  const prevTxHexEntries = await Promise.all(
+    uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
+  );
+  const prevTxHexByTxid = new Map(prevTxHexEntries);
+
+  // 8. Build PSBT.
+  const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+  const sequence = args.rbf === false ? 0xfffffffe : 0xfffffffd;
+  const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
+  for (const input of selection.inputs) {
+    const prevTxHex = prevTxHexByTxid.get(input.txid);
+    if (!prevTxHex) {
+      throw new Error(
+        `Internal error: prev-tx hex missing for selected input ${input.txid}:${input.vout} ` +
+          `after fan-out fetch.`,
+      );
+    }
+    psbt.addInput({
+      hash: input.txid,
+      index: input.vout,
+      sequence,
+      witnessUtxo: { script: sourceScript, value: input.value },
+      nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
+    });
+  }
+  for (const output of selection.outputs) {
+    const outScript = bitcoinjs.address.toOutputScript(
+      output.address ?? args.wallet,
+      NETWORK,
+    );
+    psbt.addOutput({ script: outScript, value: output.value });
+  }
+  const psbtBase64 = psbt.toBase64();
+
+  const decodedOutputs = selection.outputs.map((o) => ({
+    address: o.address ?? args.wallet,
+    amountSats: o.value.toString(),
+    amountLtc: litoshisToLtcString(BigInt(o.value)),
+    isChange: o.isChange,
+  }));
+
+  const accountPath = accountPathFromLeaf(paired.path);
+  const vsize = roughVbytes(selection.inputs.length, selection.outputs.length);
+  const description = `Send ${litoshisToLtcString(amountSats)} LTC to ${args.to}`;
+
+  const tx: Omit<UnsignedLitecoinTx, "handle" | "fingerprint"> = {
+    chain: "litecoin",
+    action: "native_send",
+    from: args.wallet,
+    psbtBase64,
+    accountPath,
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    description,
+    decoded: {
+      functionName: "litecoin.native_send",
+      args: {
+        from: args.wallet,
+        to: args.to,
+        amount: litoshisToLtcString(amountSats),
+        feeRate: `${feeRate} litoshi/vB`,
+      },
+      outputs: decodedOutputs,
+      feeSats: selection.fee.toString(),
+      feeLtc: litoshisToLtcString(BigInt(selection.fee)),
+      feeRateSatPerVb: feeRate,
+      rbfEligible: args.rbf !== false,
+    },
+    vsize,
+  };
+  return issueLitecoinHandle(tx);
+}
+
+/** Validate an LTC address against the four mainnet types. Re-export for tests. */
+export function _isSendableAddressType(
+  type: LitecoinAddressType,
+): type is "p2wpkh" | "p2tr" {
+  return type === "p2wpkh" || type === "p2tr";
+}
+
+/**
+ * Sign a UTF-8 message with the paired Litecoin address using the
+ * Litecoin Signed Message format (BIP-137 with Litecoin's message
+ * prefix). Mirrors BTC's signBitcoinMessage.
+ */
+export interface SignLitecoinMessageArgs {
+  wallet: string;
+  message: string;
+}
+
+export interface SignedLitecoinMessage {
+  address: string;
+  message: string;
+  signature: string;
+  format: "BIP-137";
+  addressType: PairedLtcAddressType;
+}
+
+export async function signLitecoinMessage(
+  args: SignLitecoinMessageArgs,
+): Promise<SignedLitecoinMessage> {
+  assertLitecoinAddress(args.wallet);
+  if (typeof args.message !== "string" || args.message.length === 0) {
+    throw new Error("`message` must be a non-empty string.");
+  }
+  if (args.message.length > 10_000) {
+    throw new Error(
+      `Message length ${args.message.length} exceeds the 10000-char ceiling.`,
+    );
+  }
+  const paired = getPairedLtcByAddress(args.wallet);
+  if (!paired) {
+    throw new Error(
+      `Litecoin address ${args.wallet} is not paired. Run \`pair_ledger_ltc\` to register ` +
+        `the four standard address types and retry with one of the resulting addresses.`,
+    );
+  }
+  const { signLtcMessageOnLedger } = await import(
+    "../../signing/ltc-usb-signer.js"
+  );
+  const messageHex = Buffer.from(args.message, "utf-8").toString("hex");
+  const result = await signLtcMessageOnLedger({
+    expectedFrom: args.wallet,
+    path: paired.path,
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    messageHex,
+    addressType: paired.addressType,
+  });
+  return {
+    address: args.wallet,
+    message: args.message,
+    signature: result.signature,
+    format: result.format,
+    addressType: paired.addressType,
+  };
+}

--- a/src/modules/litecoin/address.ts
+++ b/src/modules/litecoin/address.ts
@@ -1,0 +1,81 @@
+/**
+ * Litecoin mainnet address validation. Local format checks (regex +
+ * base58/bech32 charset constraints) — does NOT verify on-chain
+ * existence or checksum-validate the address.
+ *
+ * Litecoin address types and version bytes:
+ *   - P2PKH: version `0x30` → addresses start with `L` (capital L).
+ *   - P2SH-modern: version `0x32` → addresses start with `M`. The
+ *     Litecoin community migrated from version `0x05` (3-prefix, same
+ *     as BTC P2SH) to `0x32` for disambiguation, but a long tail of
+ *     wallets / exchanges still emit/accept the legacy `0x05` (3-prefix)
+ *     form. We accept BOTH.
+ *   - Native segwit (P2WPKH/P2WSH): bech32 with HRP `ltc` →
+ *     addresses start with `ltc1q…`.
+ *   - Taproot (P2TR): bech32m with HRP `ltc` → `ltc1p…`. Note:
+ *     Litecoin Core has NOT activated Taproot on mainnet as of 2026.
+ *     The address format is still well-defined and the Ledger LTC
+ *     app derives the correct keys; outputs to `ltc1p…` won't be
+ *     spendable until mainnet activation.
+ *
+ * MWEB (Mimblewimble Extension Block) addresses (`ltcmweb1…`) are NOT
+ * supported here — the Ledger Litecoin app cannot sign for MWEB
+ * outputs. Sends to MWEB addresses must go through Litecoin Core
+ * directly.
+ *
+ * Testnet/regtest addresses (`tltc1…`, `mltc1…`) are refused — this
+ * server is mainnet-only.
+ */
+
+/**
+ * Discriminated union of mainnet address types we recognize.
+ */
+export type LitecoinAddressType =
+  | "p2pkh" // Legacy `L...`
+  | "p2sh" // P2SH-wrapped — `M...` (modern, version 0x32) OR `3...` (legacy, version 0x05)
+  | "p2wpkh" // Native segwit, 20-byte program (`ltc1q…`, 43 chars)
+  | "p2wsh" // Native segwit, 32-byte program (`ltc1q…`, 63 chars — typically multisig)
+  | "p2tr"; // Taproot `ltc1p…` (not yet activated on mainnet)
+
+// Legacy P2PKH: starts with `L`, 26-34 chars, base58 charset.
+const P2PKH_RE = /^L[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+// P2SH modern (version 0x32): starts with `M`, 26-34 chars, base58.
+const P2SH_M_RE = /^M[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+// P2SH legacy (version 0x05, BTC-shape, still emitted by some exchanges
+// and older Litecoin wallets): starts with `3`, 26-34 chars, base58.
+const P2SH_3_RE = /^3[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+// Bech32 native segwit (witness version 0). Same BIP-141 length
+// disambiguation as BTC, with HRP `ltc` instead of `bc`:
+//   - 20-byte program → P2WPKH (`ltc1q…`, 43 chars total = `ltc1q` + 38)
+//   - 32-byte program → P2WSH  (`ltc1q…`, 63 chars total = `ltc1q` + 58)
+const BECH32_P2WPKH_RE = /^ltc1q[02-9ac-hj-np-z]{38}$/;
+const BECH32_P2WSH_RE = /^ltc1q[02-9ac-hj-np-z]{58}$/;
+// Bech32m taproot (witness version 1). v1 SegWit is always a 32-byte
+// program → exactly 63 chars total.
+const BECH32_TAPROOT_RE = /^ltc1p[02-9ac-hj-np-z]{58}$/;
+
+export function detectLitecoinAddressType(addr: string): LitecoinAddressType | null {
+  if (P2PKH_RE.test(addr)) return "p2pkh";
+  if (P2SH_M_RE.test(addr)) return "p2sh";
+  if (P2SH_3_RE.test(addr)) return "p2sh";
+  if (BECH32_P2WPKH_RE.test(addr)) return "p2wpkh";
+  if (BECH32_P2WSH_RE.test(addr)) return "p2wsh";
+  if (BECH32_TAPROOT_RE.test(addr)) return "p2tr";
+  return null;
+}
+
+export function isLitecoinAddress(addr: string): boolean {
+  return detectLitecoinAddressType(addr) !== null;
+}
+
+export function assertLitecoinAddress(addr: string): LitecoinAddressType {
+  const type = detectLitecoinAddressType(addr);
+  if (!type) {
+    throw new Error(
+      `"${addr}" is not a valid Litecoin mainnet address. Expected one of: ` +
+        `legacy (L...), P2SH (M.../3...), native segwit (ltc1q...), or taproot (ltc1p...). ` +
+        `Testnet (tltc1...) and MWEB (ltcmweb1...) addresses are not supported.`,
+    );
+  }
+  return type;
+}

--- a/src/modules/litecoin/balances.ts
+++ b/src/modules/litecoin/balances.ts
@@ -1,0 +1,89 @@
+import { assertLitecoinAddress, type LitecoinAddressType } from "./address.js";
+import {
+  getLitecoinIndexer,
+  type LitecoinAddressBalance,
+} from "./indexer.js";
+import { LTC_DECIMALS, LTC_SYMBOL, LITOSHIS_PER_LTC } from "../../config/litecoin.js";
+
+/**
+ * Litecoin balance reader. Mirror of `src/modules/btc/balances.ts` —
+ * single + multi-address surface, multi fans out via Promise.allSettled
+ * so one failed indexer call doesn't drop the other addresses.
+ */
+
+export interface LitecoinBalance {
+  address: string;
+  addressType: LitecoinAddressType;
+  /** Confirmed balance in litoshis (sat-equivalents). */
+  confirmedSats: bigint;
+  /** Mempool delta in litoshis (can be negative). */
+  mempoolSats: bigint;
+  /** Confirmed + mempool. */
+  totalSats: bigint;
+  /** Confirmed-balance LTC as a human-readable decimal string (8 decimals). */
+  confirmedLtc: string;
+  /** Total (confirmed + mempool) LTC as a human-readable decimal string. */
+  totalLtc: string;
+  /** Symbol — always "LTC" on mainnet. */
+  symbol: typeof LTC_SYMBOL;
+  decimals: typeof LTC_DECIMALS;
+  /** Number of total tx (confirmed + mempool) the address has been involved in. */
+  txCount: number;
+}
+
+/**
+ * Format litoshis as an LTC decimal string, padding fractional digits to 8.
+ */
+function litoshisToLtcString(litoshis: bigint): string {
+  const negative = litoshis < 0n;
+  const abs = negative ? -litoshis : litoshis;
+  const whole = abs / LITOSHIS_PER_LTC;
+  const frac = abs - whole * LITOSHIS_PER_LTC;
+  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "") || "0";
+  const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+  return negative ? `-${body}` : body;
+}
+
+function projectBalance(
+  raw: LitecoinAddressBalance,
+  addressType: LitecoinAddressType,
+): LitecoinBalance {
+  return {
+    address: raw.address,
+    addressType,
+    confirmedSats: raw.confirmedSats,
+    mempoolSats: raw.mempoolSats,
+    totalSats: raw.totalSats,
+    confirmedLtc: litoshisToLtcString(raw.confirmedSats),
+    totalLtc: litoshisToLtcString(raw.totalSats),
+    symbol: LTC_SYMBOL,
+    decimals: LTC_DECIMALS,
+    txCount: raw.txCount,
+  };
+}
+
+export async function getLitecoinBalance(address: string): Promise<LitecoinBalance> {
+  const addressType = assertLitecoinAddress(address);
+  const raw = await getLitecoinIndexer().getBalance(address);
+  return projectBalance(raw, addressType);
+}
+
+export type MultiLitecoinBalance =
+  | { ok: true; balance: LitecoinBalance }
+  | { ok: false; address: string; error: string };
+
+export async function getLitecoinBalances(
+  addresses: string[],
+): Promise<MultiLitecoinBalance[]> {
+  for (const a of addresses) assertLitecoinAddress(a);
+
+  const settled = await Promise.allSettled(addresses.map((a) => getLitecoinBalance(a)));
+  return settled.map((r, i) => {
+    if (r.status === "fulfilled") return { ok: true as const, balance: r.value };
+    return {
+      ok: false as const,
+      address: addresses[i],
+      error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+    };
+  });
+}

--- a/src/modules/litecoin/coin-select.ts
+++ b/src/modules/litecoin/coin-select.ts
@@ -1,0 +1,190 @@
+import { createRequire } from "node:module";
+
+/**
+ * Wrapper around the `coinselect` library's branch-and-bound + accumulative
+ * coin-selection. Adds:
+ *   - sat/vB feeRate validation
+ *   - fee-cap guard: refuses to prepare a tx whose fee exceeds
+ *     `max(10× user-specified rate × estimated-vbytes, 2% of total
+ *     output value)`. Catches both fat-finger feeRates and
+ *     MCP-injected fee-drain attacks.
+ *
+ * `coinselect` ships as CommonJS without TypeScript declarations;
+ * `createRequire` is the cleanest path for the import.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const coinSelect = requireCjs("coinselect") as (
+  utxos: Array<{ value: number; [k: string]: unknown }>,
+  outputs: Array<{ value?: number; [k: string]: unknown }>,
+  feeRate: number,
+) => { inputs?: Array<unknown>; outputs?: Array<unknown>; fee?: number };
+
+/**
+ * coinselect's default input/output estimator assumes legacy P2PKH
+ * (148 vbytes per input, 34 per output). Our send path is segwit/
+ * taproot only, so we pass explicit `script` Buffers on each input/
+ * output to override coinselect's per-element vbyte estimate.
+ *
+ * P2WPKH input vsize ≈ 68; subtract coinselect's TX_INPUT_BASE of 41 →
+ * 27 bytes of "script" we feed in. P2WPKH output scriptPubKey is 22
+ * bytes (OP_0 + 0x14 + 20-byte hash). Same approximation for taproot
+ * (P2TR input vsize ≈ 57; output scriptPubKey is 34 bytes).
+ */
+const SEGWIT_INPUT_SCRIPT_LEN = 27;
+const SEGWIT_OUTPUT_SCRIPT_LEN = 22;
+
+export interface CoinSelectInput {
+  /** Tx hash of the prev-out (txid). */
+  txid: string;
+  /** Output index in the prev-tx. */
+  vout: number;
+  /** UTXO value in sats. */
+  value: number;
+}
+
+export interface CoinSelectOutput {
+  /** Recipient address (passed through opaque to the caller). */
+  address: string;
+  /** Amount in sats. */
+  value: number;
+}
+
+export interface CoinSelectResult {
+  inputs: CoinSelectInput[];
+  outputs: Array<{ address?: string; value: number; isChange: boolean }>;
+  /** Total fee in sats. */
+  fee: number;
+  /**
+   * Index of the change output in `outputs`, or null if the selection
+   * fits exactly without change. The caller wires this index to the
+   * change-address path so Ledger can label it on-screen.
+   */
+  changeIndex: number | null;
+}
+
+/**
+ * Select inputs from `utxos` to cover `outputs[]` + fee at `feeRate`.
+ * `changeAddress` is appended internally so coinselect produces the
+ * change-output value. Returns `null` if no feasible solution exists
+ * (insufficient funds at the requested feeRate).
+ *
+ * Throws when the resulting fee would exceed the cap. The cap is the
+ * MAXIMUM of two thresholds — a coarse vbyte-based cap (10× the
+ * requested feeRate × estimated tx vsize) and a percentage-of-value
+ * cap (2% of total non-change output value). Either alone has gaps
+ * (vbyte-only doesn't catch a fat-fingered amount; percentage-only
+ * doesn't catch a fat-fingered feeRate). Override via `allowHighFee`
+ * for the rare legitimate >2% / >10× case.
+ */
+export function selectInputs(args: {
+  utxos: CoinSelectInput[];
+  outputs: CoinSelectOutput[];
+  feeRate: number; // sat/vB
+  changeAddress: string;
+  allowHighFee?: boolean;
+}): CoinSelectResult {
+  if (
+    !Number.isFinite(args.feeRate) ||
+    args.feeRate <= 0 ||
+    args.feeRate > 10_000
+  ) {
+    throw new Error(
+      `Invalid feeRate ${args.feeRate} sat/vB — expected a positive finite number ≤ 10000.`,
+    );
+  }
+  if (args.utxos.length === 0) {
+    throw new Error(
+      "No UTXOs available at the source address. The wallet needs at least one " +
+        "confirmed UTXO; check `get_btc_balance` for the current state.",
+    );
+  }
+  if (args.outputs.length === 0 || args.outputs.some((o) => o.value <= 0)) {
+    throw new Error("All outputs must have a strictly-positive value (sats).");
+  }
+
+  // coinselect mutates / re-orders inputs internally; pass copies so
+  // the caller's UTXO list isn't reordered. Inject `script` Buffers on
+  // every input and output so coinselect's vbyte estimator matches
+  // segwit/taproot reality (it defaults to legacy P2PKH otherwise —
+  // ~80 vbytes per input over-estimate that turns "max" sends into
+  // INSUFFICIENT-FUNDS errors).
+  const utxosCopy = args.utxos.map((u) => ({
+    ...u,
+    script: { length: SEGWIT_INPUT_SCRIPT_LEN },
+  }));
+  const outputsForCS = args.outputs.map((o) => ({
+    ...o,
+    address: o.address,
+    script: { length: SEGWIT_OUTPUT_SCRIPT_LEN },
+  }));
+  // coinselect appends change automatically when needed by adding an
+  // output with no `address` field (we tag the change output below by
+  // matching the un-addressed entry).
+  const result = coinSelect(utxosCopy, outputsForCS, args.feeRate);
+  if (!result.inputs || !result.outputs || result.fee === undefined) {
+    throw new Error(
+      `Insufficient funds for the requested send at ${args.feeRate} sat/vB. ` +
+        "Available UTXOs cannot cover the outputs + fee. Lower the amount, " +
+        "wait for more confirmations, or pass a lower feeRate.",
+    );
+  }
+
+  // coinselect's output entries are { address?, value }. Entries
+  // without an address are change. Tag them and inject the change
+  // address.
+  const outputs = (result.outputs as Array<{ address?: string; value: number }>).map(
+    (o) => {
+      if (o.address) {
+        return { address: o.address, value: o.value, isChange: false };
+      }
+      return { address: args.changeAddress, value: o.value, isChange: true };
+    },
+  );
+  const changeIndex = outputs.findIndex((o) => o.isChange);
+  const inputs = (result.inputs as CoinSelectInput[]).map((i) => ({
+    txid: i.txid,
+    vout: i.vout,
+    value: i.value,
+  }));
+
+  // Fee-cap guard.
+  const totalOutputValue = args.outputs.reduce((sum, o) => sum + o.value, 0);
+  const estimatedVbytes = roughVbytes(inputs.length, outputs.length);
+  const vbyteCap = Math.ceil(args.feeRate * 10 * estimatedVbytes);
+  const percentCap = Math.ceil(totalOutputValue * 0.02);
+  const cap = Math.max(vbyteCap, percentCap);
+  if (!args.allowHighFee && result.fee > cap) {
+    throw new Error(
+      `Fee ${result.fee} sats exceeds safety cap ${cap} sats ` +
+        `(max of 10× feeRate-based ${vbyteCap} and 2%-of-output ${percentCap}). ` +
+        `If this is intentional (priority send through congestion), retry with ` +
+        `\`allowHighFee: true\` after confirming with the user.`,
+    );
+  }
+
+  return {
+    inputs,
+    outputs,
+    fee: result.fee,
+    changeIndex: changeIndex >= 0 ? changeIndex : null,
+  };
+}
+
+/**
+ * Rough vbyte estimate for a P2WPKH single-account tx — same shape
+ * coinselect uses internally. Slightly over-estimated (~2-3%) so the
+ * fee-cap is conservative-tight rather than too loose; doesn't affect
+ * coinselect's own fee math (which has its own internal estimator).
+ *
+ *   - 10 vbytes overhead (4 version + 1 input-count + 1 output-count + 4 locktime)
+ *   - 68 vbytes per P2WPKH input
+ *   - 31 vbytes per P2WPKH output
+ *
+ * For taproot (P2TR), input vbytes drop to ~57 — but the over-estimate
+ * just makes the cap slightly looser, never tighter. Worth not
+ * paramaterizing this for now.
+ */
+function roughVbytes(inputCount: number, outputCount: number): number {
+  return 10 + inputCount * 68 + outputCount * 31;
+}

--- a/src/modules/litecoin/indexer.ts
+++ b/src/modules/litecoin/indexer.ts
@@ -1,0 +1,611 @@
+import { fetchWithTimeout } from "../../data/http.js";
+import { LITECOIN_DEFAULT_INDEXER_URL } from "../../config/litecoin.js";
+import { readUserConfig } from "../../config/user-config.js";
+
+/**
+ * Litecoin indexer abstraction. Single interface, litecoinspace.org
+ * (default) + any Esplora-compatible endpoint as the impl. Self-hosted
+ * Esplora / Electrs all expose the same REST surface; litecoinspace.org
+ * is mempool.space's Litecoin sister deployment, exposing the same API.
+ *
+ * URL resolution priority (highest first):
+ *   1. `LITECOIN_INDEXER_URL` env var
+ *   2. `userConfig.litecoinIndexerUrl`
+ *   3. `LITECOIN_DEFAULT_INDEXER_URL` (litecoinspace.org)
+ *
+ * Mirror of `src/modules/btc/indexer.ts` — same Esplora API surface,
+ * same retry policy, same field shapes; only the default URL and
+ * user-config field name differ.
+ */
+
+/**
+ * Esplora address-stats payload. Both confirmed and mempool stats are
+ * present; we sum them to surface a "total balance" alongside the
+ * confirmed-only number. mempool.space prefers `chain_stats` /
+ * `mempool_stats` field naming (forked from Blockstream).
+ */
+interface EsploraAddressStats {
+  /** Address — echoed back. */
+  address: string;
+  /** Confirmed: funds that have at least 1 confirmation. */
+  chain_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+  /** Unconfirmed: funds in mempool, not yet mined. */
+  mempool_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+}
+
+/**
+ * Litecoin balance for a single address. Confirmed + unconfirmed reported
+ * separately so the caller can decide UX (typically: show confirmed as
+ * the headline, surface unconfirmed only when non-zero).
+ */
+export interface LitecoinAddressBalance {
+  address: string;
+  /** Confirmed funded - confirmed spent, in sats. Always ≥ 0. */
+  confirmedSats: bigint;
+  /** Mempool funded - mempool spent, in sats. Can be negative when funds are in-flight as spent. */
+  mempoolSats: bigint;
+  /** Confirmed + mempool. Convenience field. */
+  totalSats: bigint;
+  /** Total tx count this address has been involved in (confirmed + mempool). */
+  txCount: number;
+}
+
+/**
+ * Fee-rate estimates in sat/vB. Returned by mempool.space's
+ * `/v1/fees/recommended` endpoint — these match the labels the mempool.space
+ * UI shows ("High Priority" / "Medium Priority" / etc.) so users see
+ * familiar terminology.
+ */
+export interface LitecoinFeeEstimates {
+  /** ~next-block target. */
+  fastestFee: number;
+  /** ~3 blocks (~30 min). */
+  halfHourFee: number;
+  /** ~6 blocks (~1 hour). */
+  hourFee: number;
+  /** Lowest fee miners are still including. */
+  economyFee: number;
+  /** Floor below which a tx is unlikely to ever confirm. */
+  minimumFee: number;
+}
+
+/**
+ * Tx history entry. Subset of the Esplora `/address/<addr>/txs` payload
+ * we surface — enough for portfolio history rendering without forcing
+ * callers to learn the full SAT/RBF/witness shape.
+ */
+export interface LitecoinTxHistoryEntry {
+  txid: string;
+  /** Sum of vouts that pay this address (the funding side). Sats. */
+  receivedSats: bigint;
+  /** Sum of vins that come from this address (the spending side). Sats. */
+  sentSats: bigint;
+  /** Tx fee from the Esplora payload (sats). Useful UX context. */
+  feeSats: bigint;
+  /** Block height — undefined when still in mempool. */
+  blockHeight?: number;
+  /** Unix timestamp of the block — undefined for mempool. */
+  blockTime?: number;
+  /** True when sequence < 0xFFFFFFFE on at least one input (BIP-125). */
+  rbfEligible: boolean;
+}
+
+/**
+ * Esplora vin/vout shapes we destructure. Trimmed to fields we read.
+ */
+interface EsploraVin {
+  txid: string;
+  vout: number;
+  prevout?: { scriptpubkey_address?: string; value?: number };
+  sequence?: number;
+}
+
+interface EsploraVout {
+  scriptpubkey_address?: string;
+  value?: number;
+}
+
+interface EsploraTx {
+  txid: string;
+  vin: EsploraVin[];
+  vout: EsploraVout[];
+  fee?: number;
+  status?: { confirmed?: boolean; block_height?: number; block_time?: number };
+}
+
+/**
+ * UTXO entry. Esplora returns these from `/address/<addr>/utxo`.
+ * `scriptPubKey` is NOT in the Esplora payload directly — we derive it
+ * from the address at PSBT-build time (cheaper than a per-UTXO lookup
+ * since all UTXOs for one address share the same scriptPubKey).
+ */
+export interface LitecoinUtxo {
+  txid: string;
+  vout: number;
+  /** UTXO value in sats. */
+  value: number;
+  /** Block height of the funding tx. Undefined for mempool UTXOs. */
+  blockHeight?: number;
+  /** True when the UTXO is in mempool (not yet confirmed). */
+  unconfirmed: boolean;
+}
+
+export interface LitecoinIndexer {
+  getBalance(address: string): Promise<LitecoinAddressBalance>;
+  getFeeEstimates(): Promise<LitecoinFeeEstimates>;
+  /**
+   * Fetch the tx history for an address. `limit` clamps how many entries
+   * to walk (we paginate via the Esplora `/txs/chain/<last_seen>` cursor
+   * pattern; mempool.space honors the same convention). Returns only
+   * confirmed + mempool txs, oldest-first within each segment.
+   */
+  getAddressTxs(
+    address: string,
+    opts?: { limit?: number },
+  ): Promise<LitecoinTxHistoryEntry[]>;
+  /**
+   * Fetch the UTXO set for an address. Returned newest-first (block
+   * height descending). Used as the input set for coin-selection on
+   * `prepare_btc_send`.
+   */
+  getUtxos(address: string): Promise<LitecoinUtxo[]>;
+  /**
+   * Broadcast a fully-signed tx hex via the indexer's `/tx` endpoint.
+   * Returns the on-chain txid on success. Throws with the indexer's
+   * error body on failures (most commonly: "min relay fee not met"
+   * when feeRate is below the mempool floor, or "txn-already-known"
+   * when re-broadcasting a tx that's already in the mempool).
+   */
+  broadcastTx(rawTxHex: string): Promise<string>;
+  /**
+   * Fetch confirmation status for a txid. Used by
+   * `get_transaction_status` BTC branch — returns the confirmation
+   * count at current tip when the tx is mined; returns `confirmed: false`
+   * for in-mempool txs; null when the tx isn't found at all (dropped
+   * or never broadcast).
+   */
+  getTxStatus(txid: string): Promise<{
+    confirmed: boolean;
+    blockHeight?: number;
+    confirmations?: number;
+  } | null>;
+  /**
+   * Fetch the current Litecoin chain tip — height, block hash, header
+   * timestamp, etc. Two HTTP calls under the hood: `/blocks/tip/hash`
+   * for the latest hash, then `/block/<hash>` for the full header
+   * details. Both endpoints are aggressively cached at the indexer
+   * (mempool.space + standard Esplora share the same shape).
+   */
+  getBlockTip(): Promise<LitecoinBlockTip>;
+  /**
+   * Fetch the raw hex of a previous transaction by txid. Required for
+   * `nonWitnessUtxo` population on PSBT inputs — Ledger BTC app 2.x
+   * cryptographically verifies the input amount against this prev-tx
+   * (BIP-143 sighash doesn't commit to input amount, so the prev-tx is
+   * the only way the device can prove a malicious offline signer didn't
+   * lie about the input value to inflate the fee). Without it the device
+   * surfaces a "Security risk: unverified inputs" prompt and refuses to
+   * sign cleanly. Issue #213.
+   */
+  getTxHex(txid: string): Promise<string>;
+}
+
+/**
+ * Latest mainnet block as the indexer reports it. Carries the height,
+ * the 64-hex block hash, the header timestamp (unix seconds), and a
+ * server-computed `ageSeconds` for UX convenience (the agent doesn't
+ * need to grab system time and subtract). `medianTimePast` and
+ * `difficulty` are surfaced when the indexer exposes them — both are
+ * standard Esplora fields but we tolerate their absence for self-
+ * hosted forks that strip them.
+ */
+export interface LitecoinBlockTip {
+  /** Block height — e.g. 946598. */
+  height: number;
+  /** 64-hex block hash. */
+  hash: string;
+  /** Block header timestamp, unix seconds. */
+  timestamp: number;
+  /** Server-computed `now - timestamp` at fetch time, in seconds. */
+  ageSeconds: number;
+  /** BIP-113 median time past, when the indexer exposes it. */
+  medianTimePast?: number;
+  /** Block difficulty, when the indexer exposes it. */
+  difficulty?: number;
+}
+
+/**
+ * Resolve the indexer base URL via env > config > default.
+ */
+function resolveIndexerUrl(): string {
+  const fromEnv = process.env.LITECOIN_INDEXER_URL;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim();
+  const cfg = readUserConfig();
+  if (cfg && cfg.litecoinIndexerUrl && cfg.litecoinIndexerUrl.trim().length > 0) {
+    return cfg.litecoinIndexerUrl.trim();
+  }
+  return LITECOIN_DEFAULT_INDEXER_URL;
+}
+
+/**
+ * Convert an Esplora tx + the address it's queried for into our thin
+ * history shape. The fee comes from the API directly; received/sent are
+ * derived by walking vin/vout for entries that match the address.
+ */
+function summarizeTx(tx: EsploraTx, address: string): LitecoinTxHistoryEntry {
+  let receivedSats = 0n;
+  let sentSats = 0n;
+  let rbfEligible = false;
+  for (const v of tx.vin) {
+    const seq = typeof v.sequence === "number" ? v.sequence : 0xffffffff;
+    if (seq < 0xfffffffe) rbfEligible = true;
+    if (v.prevout?.scriptpubkey_address === address && v.prevout.value !== undefined) {
+      sentSats += BigInt(v.prevout.value);
+    }
+  }
+  for (const v of tx.vout) {
+    if (v.scriptpubkey_address === address && v.value !== undefined) {
+      receivedSats += BigInt(v.value);
+    }
+  }
+  return {
+    txid: tx.txid,
+    receivedSats,
+    sentSats,
+    feeSats: tx.fee !== undefined ? BigInt(tx.fee) : 0n,
+    ...(tx.status?.block_height !== undefined ? { blockHeight: tx.status.block_height } : {}),
+    ...(tx.status?.block_time !== undefined ? { blockTime: tx.status.block_time } : {}),
+    rbfEligible,
+  };
+}
+
+/**
+ * Single retry policy for transient indexer failures (issue #199):
+ *
+ *   - HTTP 429 → honor `Retry-After` header (seconds, capped at 5s) or
+ *     fall back to a small jittered backoff. Mempool.space's free
+ *     public API throttles bursts; without a retry the burst-then-fail
+ *     dynamic of `rescan_btc_account`'s 100+-way fan-out drops ~40%
+ *     of probes.
+ *   - Network errors / timeouts → retry once with a small jittered
+ *     backoff. Doesn't help against a sustained outage but smooths
+ *     the common "one packet dropped" case.
+ *   - HTTP 5xx → NOT retried. A real upstream error should surface to
+ *     the caller, not get silently masked. Callers can rerun the
+ *     whole rescan if they want a second attempt.
+ */
+const ESPLORA_RETRY_BASE_MS = 400;
+const ESPLORA_RETRY_JITTER_MS = 400;
+const ESPLORA_MAX_RETRY_AFTER_MS = 5_000;
+
+function parseRetryAfterMs(headerValue: string | null): number | null {
+  if (!headerValue) return null;
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(ESPLORA_MAX_RETRY_AFTER_MS, seconds * 1000);
+  }
+  // HTTP-date form is also valid for Retry-After; we ignore it (the
+  // delta could be huge or negative under clock skew). Falls back to
+  // the default backoff in the caller.
+  return null;
+}
+
+function jitteredBackoffMs(): number {
+  return ESPLORA_RETRY_BASE_MS + Math.floor(Math.random() * ESPLORA_RETRY_JITTER_MS);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+class EsploraIndexer implements LitecoinIndexer {
+  constructor(private readonly baseUrl: string) {}
+
+  private async getJson<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const init: RequestInit = {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    };
+    // Up to 2 attempts total: original + 1 retry on 429 / network.
+    let lastNetworkError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      let res: Response;
+      try {
+        res = await fetchWithTimeout(url, init);
+      } catch (err) {
+        // Network error / abort — retry once.
+        lastNetworkError = err;
+        if (attempt === 0) {
+          await sleep(jitteredBackoffMs());
+          continue;
+        }
+        throw err;
+      }
+      if (res.status === 429 && attempt === 0) {
+        const retryAfterMs =
+          parseRetryAfterMs(res.headers.get("Retry-After")) ?? jitteredBackoffMs();
+        // Drain the body so the underlying connection can be reused.
+        await res.text().catch(() => "");
+        await sleep(retryAfterMs);
+        continue;
+      }
+      if (!res.ok) {
+        throw new Error(
+          `Litecoin indexer ${path} returned ${res.status} ${res.statusText}`,
+        );
+      }
+      return (await res.json()) as T;
+    }
+    // Both attempts failed with network errors.
+    throw lastNetworkError instanceof Error
+      ? lastNetworkError
+      : new Error(`Litecoin indexer ${path} failed after retry`);
+  }
+
+  async getBalance(address: string): Promise<LitecoinAddressBalance> {
+    const stats = await this.getJson<EsploraAddressStats>(`/address/${address}`);
+    const confirmedSats =
+      BigInt(stats.chain_stats.funded_txo_sum) -
+      BigInt(stats.chain_stats.spent_txo_sum);
+    const mempoolSats =
+      BigInt(stats.mempool_stats.funded_txo_sum) -
+      BigInt(stats.mempool_stats.spent_txo_sum);
+    return {
+      address,
+      confirmedSats,
+      mempoolSats,
+      totalSats: confirmedSats + mempoolSats,
+      txCount: stats.chain_stats.tx_count + stats.mempool_stats.tx_count,
+    };
+  }
+
+  async getFeeEstimates(): Promise<LitecoinFeeEstimates> {
+    // mempool.space's recommended-fees endpoint lives under `/v1/`. Self-
+    // hosted Esplora-only deployments may not have it; for those, the
+    // per-block-target endpoint at `/fee-estimates` is the fallback. We
+    // try the recommended-fees endpoint first (rich labels) and fall
+    // back to deriving the four labels from the per-target map.
+    try {
+      const r = await this.getJson<LitecoinFeeEstimates>("/v1/fees/recommended");
+      // Defensive: ensure the fields are numbers (some Esplora forks may
+      // return strings or omit fields; clamp to the floor in that case).
+      const num = (n: unknown) => (typeof n === "number" && Number.isFinite(n) ? n : 1);
+      return {
+        fastestFee: num(r.fastestFee),
+        halfHourFee: num(r.halfHourFee),
+        hourFee: num(r.hourFee),
+        economyFee: num(r.economyFee),
+        minimumFee: num(r.minimumFee),
+      };
+    } catch {
+      // Esplora fallback: per-target map keyed by block-count.
+      const map = await this.getJson<Record<string, number>>("/fee-estimates");
+      const at = (k: string, fallback: number) =>
+        typeof map[k] === "number" && Number.isFinite(map[k]) ? map[k] : fallback;
+      return {
+        fastestFee: at("1", 20),
+        halfHourFee: at("3", 10),
+        hourFee: at("6", 5),
+        economyFee: at("144", 2),
+        minimumFee: at("1008", 1),
+      };
+    }
+  }
+
+  async getAddressTxs(
+    address: string,
+    opts: { limit?: number } = {},
+  ): Promise<LitecoinTxHistoryEntry[]> {
+    const limit = opts.limit ?? 25;
+    // Esplora returns 50 confirmed txs per page (newest-first) +
+    // mempool txs at the start. For a single page that's enough for
+    // portfolio history rendering. Pagination cursor is `/txs/chain/<last_seen>`
+    // — we don't paginate in PR1.
+    const txs = await this.getJson<EsploraTx[]>(`/address/${address}/txs`);
+    return txs.slice(0, limit).map((tx) => summarizeTx(tx, address));
+  }
+
+  async getUtxos(address: string): Promise<LitecoinUtxo[]> {
+    interface EsploraUtxo {
+      txid: string;
+      vout: number;
+      value: number;
+      status?: { confirmed?: boolean; block_height?: number };
+    }
+    const utxos = await this.getJson<EsploraUtxo[]>(`/address/${address}/utxo`);
+    return utxos.map((u) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      unconfirmed: !u.status?.confirmed,
+      ...(u.status?.block_height !== undefined
+        ? { blockHeight: u.status.block_height }
+        : {}),
+    }));
+  }
+
+  async broadcastTx(rawTxHex: string): Promise<string> {
+    const res = await fetchWithTimeout(`${this.baseUrl}/tx`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: rawTxHex,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Litecoin indexer /tx broadcast returned ${res.status} ${res.statusText}: ${body.slice(0, 200)}`,
+      );
+    }
+    // Esplora returns the txid as plain text.
+    const txid = (await res.text()).trim();
+    if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
+      throw new Error(
+        `Litecoin indexer /tx returned an unexpected response (not a 64-hex-char txid): "${txid.slice(0, 80)}"`,
+      );
+    }
+    return txid;
+  }
+
+  async getTxStatus(txid: string): Promise<{
+    confirmed: boolean;
+    blockHeight?: number;
+    confirmations?: number;
+  } | null> {
+    interface EsploraTxStatus {
+      confirmed: boolean;
+      block_height?: number;
+      block_hash?: string;
+      block_time?: number;
+    }
+    interface EsploraTip {
+      // mempool.space's `/blocks/tip/height` returns plain text
+      // numeric. Esplora-pure returns the same. We fetch via getJson
+      // since the Response.json() coerces a plain numeric body just
+      // fine; for resilience we handle string parsing too.
+      _height?: number;
+    }
+    void ({} as EsploraTip);
+    let status: EsploraTxStatus;
+    try {
+      status = await this.getJson<EsploraTxStatus>(`/tx/${txid}/status`);
+    } catch (err) {
+      // Treat 404 as "tx not found" rather than a hard error — caller
+      // surfaces the not-found case as a distinct "dropped" state.
+      if (err instanceof Error && /returned 404/.test(err.message)) {
+        return null;
+      }
+      throw err;
+    }
+    if (!status.confirmed) return { confirmed: false };
+    // Confirmed → fetch the chain tip to compute confirmation count.
+    const tipRes = await fetchWithTimeout(`${this.baseUrl}/blocks/tip/height`, {
+      method: "GET",
+    });
+    if (!tipRes.ok) {
+      // Tip fetch failed but we know it's confirmed; return without
+      // a count rather than failing the whole call.
+      return {
+        confirmed: true,
+        ...(status.block_height !== undefined ? { blockHeight: status.block_height } : {}),
+      };
+    }
+    const tipText = (await tipRes.text()).trim();
+    const tipHeight = Number(tipText);
+    if (status.block_height !== undefined && Number.isFinite(tipHeight)) {
+      return {
+        confirmed: true,
+        blockHeight: status.block_height,
+        confirmations: Math.max(0, tipHeight - status.block_height + 1),
+      };
+    }
+    return {
+      confirmed: true,
+      ...(status.block_height !== undefined ? { blockHeight: status.block_height } : {}),
+    };
+  }
+
+  async getTxHex(txid: string): Promise<string> {
+    if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
+      throw new Error(
+        `Litecoin indexer getTxHex called with non-64-hex txid "${txid.slice(0, 80)}".`,
+      );
+    }
+    const res = await fetchWithTimeout(`${this.baseUrl}/tx/${txid}/hex`, {
+      method: "GET",
+      headers: { Accept: "text/plain" },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Litecoin indexer /tx/${txid}/hex returned ${res.status} ${res.statusText}`,
+      );
+    }
+    const hex = (await res.text()).trim();
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+      throw new Error(
+        `Litecoin indexer /tx/${txid}/hex returned non-hex body (length ${hex.length}, ` +
+          `head "${hex.slice(0, 32)}").`,
+      );
+    }
+    return hex;
+  }
+
+  async getBlockTip(): Promise<LitecoinBlockTip> {
+    // Esplora exposes the chain tip via two endpoints:
+    //   GET /blocks/tip/hash  → plain-text 64-hex hash
+    //   GET /block/<hash>     → JSON with height, timestamp, mediantime, difficulty
+    // Both are aggressively cached at the indexer (mempool.space caches
+    // for ~10s; self-hosted Esplora similar), so the two-call shape is
+    // cheap. Esplora-pure deployments without `/blocks/tip` (the
+    // alternate single-call shape mempool.space exposes) still work via
+    // this path.
+    const hashRes = await fetchWithTimeout(`${this.baseUrl}/blocks/tip/hash`, {
+      method: "GET",
+    });
+    if (!hashRes.ok) {
+      throw new Error(
+        `Litecoin indexer /blocks/tip/hash returned ${hashRes.status} ${hashRes.statusText}`,
+      );
+    }
+    const hash = (await hashRes.text()).trim();
+    if (!/^[0-9a-fA-F]{64}$/.test(hash)) {
+      throw new Error(
+        `Litecoin indexer /blocks/tip/hash returned an unexpected response (not a 64-hex block hash): "${hash.slice(0, 80)}"`,
+      );
+    }
+    interface EsploraBlock {
+      id?: string;
+      height?: number;
+      timestamp?: number;
+      // BIP-113 median time past — Esplora exposes as `mediantime`.
+      mediantime?: number;
+      difficulty?: number;
+    }
+    const block = await this.getJson<EsploraBlock>(`/block/${hash}`);
+    if (typeof block.height !== "number" || typeof block.timestamp !== "number") {
+      throw new Error(
+        `Litecoin indexer /block/${hash} response missing required fields ` +
+          `(height: ${block.height}, timestamp: ${block.timestamp}). The indexer ` +
+          `may not be Esplora-compatible — check the URL.`,
+      );
+    }
+    const ageSeconds = Math.max(0, Math.floor(Date.now() / 1000) - block.timestamp);
+    return {
+      height: block.height,
+      hash,
+      timestamp: block.timestamp,
+      ageSeconds,
+      ...(typeof block.mediantime === "number" ? { medianTimePast: block.mediantime } : {}),
+      ...(typeof block.difficulty === "number" ? { difficulty: block.difficulty } : {}),
+    };
+  }
+}
+
+let cached: { url: string; impl: LitecoinIndexer } | undefined;
+
+/**
+ * Get the singleton indexer. Re-resolved if the URL has changed (env or
+ * config swap). Lazy — env vars / config files are read on first call.
+ */
+export function getLitecoinIndexer(): LitecoinIndexer {
+  const url = resolveIndexerUrl();
+  if (!cached || cached.url !== url) {
+    cached = { url, impl: new EsploraIndexer(url) };
+  }
+  return cached.impl;
+}
+
+/** Test-only — drop the cached indexer so a fresh URL resolution runs. */
+export function resetLitecoinIndexer(): void {
+  cached = undefined;
+}

--- a/src/modules/litecoin/price.ts
+++ b/src/modules/litecoin/price.ts
@@ -1,0 +1,40 @@
+import { cache } from "../../data/cache.js";
+import { CACHE_TTL } from "../../config/cache.js";
+import { fetchWithTimeout } from "../../data/http.js";
+
+/**
+ * LTC USD price via DefiLlama's `coingecko:litecoin` coin key. Same
+ * 30-second cache TTL the EVM/Solana/TRON/BTC price service uses,
+ * sharing the same in-process `cache` so a single warm read amortizes
+ * across `get_portfolio_summary` + LTC balance reads + future
+ * Litecoin-aware tools.
+ *
+ * Mirror of `src/modules/btc/price.ts` — same hardcoded-key pattern.
+ */
+
+interface LlamaResponse {
+  coins: Record<string, { price: number }>;
+}
+
+const COIN_KEY = "coingecko:litecoin";
+const CACHE_KEY = `price:${COIN_KEY}`;
+const URL = `https://coins.llama.fi/prices/current/${COIN_KEY}`;
+
+export async function fetchLitecoinPrice(): Promise<number | undefined> {
+  const hit = cache.get<number>(CACHE_KEY);
+  if (hit !== undefined) return hit;
+  try {
+    const res = await fetchWithTimeout(URL);
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as LlamaResponse;
+    const price = body.coins[COIN_KEY]?.price;
+    if (typeof price === "number") {
+      cache.set(CACHE_KEY, price, CACHE_TTL.PRICE);
+      return price;
+    }
+  } catch {
+    // Best-effort — caller surfaces the slice as `priceMissing` so the
+    // raw LTC balance still renders without a USD valuation.
+  }
+  return undefined;
+}

--- a/src/signing/ltc-bip32-derive.ts
+++ b/src/signing/ltc-bip32-derive.ts
@@ -1,0 +1,214 @@
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+import { base58check } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2";
+
+/**
+ * Host-side BIP-32 child derivation for Litecoin pairing scans.
+ *
+ * Mirror of `btc-bip32-derive.ts` — same gap-limit-scan optimization
+ * (one device round-trip per (purpose, account) instead of one per
+ * leaf). Differences:
+ *   - bitcoinjs-lib doesn't ship a Litecoin network preset, so we
+ *     construct one inline (mainnet).
+ *   - BIP-32 xpub version bytes stay 0x0488B21E (Litecoin Core
+ *     convention; not Ltub).
+ *
+ * Same privacy posture as BTC: account-level xpubs are NOT persisted
+ * by this module's caller. If a future change adds an xpub field to
+ * `PairedLitecoinEntry`, the same address-linkability trade-off
+ * applies — see the BTC equivalent for the full discussion.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  payments: {
+    p2pkh(opts: { pubkey: Uint8Array; network: unknown }): { address?: string };
+    p2sh(opts: { redeem: { output: Uint8Array }; network: unknown }): {
+      address?: string;
+    };
+    p2wpkh(opts: { pubkey: Uint8Array; network: unknown }): {
+      address?: string;
+      output: Uint8Array;
+    };
+    p2tr(opts: { internalPubkey: Uint8Array; network: unknown }): {
+      address?: string;
+    };
+  };
+  initEccLib(ecc: unknown): void;
+};
+
+// Same one-time global ECC registration as the BTC module — bitcoinjs-lib
+// stores the registered library in a module-global, so registering twice
+// is idempotent. Both modules call this at import time.
+const ecc = requireCjs("@bitcoinerlab/secp256k1");
+bitcoinjs.initEccLib(ecc);
+
+/**
+ * Litecoin mainnet network params. Same shape as
+ * `bitcoinjs.networks.bitcoin` but with LTC-specific version bytes
+ * and bech32 HRP.
+ */
+const LITECOIN_NETWORK = {
+  messagePrefix: "\x19Litecoin Signed Message:\n",
+  bech32: "ltc",
+  bip32: { public: 0x0488b21e, private: 0x0488ade4 },
+  pubKeyHash: 0x30, // L-prefix
+  scriptHash: 0x32, // M-prefix (modern P2SH)
+  wif: 0xb0,
+};
+
+/** BIP-32 mainnet xpub version bytes (`0488B21E` → "xpub..."). */
+const MAINNET_XPUB_VERSION = Uint8Array.of(0x04, 0x88, 0xb2, 0x1e);
+
+const b58check = base58check(sha256);
+
+/**
+ * Compress an uncompressed secp256k1 public key. Verbatim shared
+ * primitive — pubkey compression is chain-agnostic.
+ */
+export function compressSecp256k1Pubkey(uncompressedHex: string): Uint8Array {
+  const hex = uncompressedHex.startsWith("0x")
+    ? uncompressedHex.slice(2)
+    : uncompressedHex;
+  if (hex.length !== 130) {
+    throw new Error(
+      `Expected an uncompressed secp256k1 public key (130 hex chars), got ${hex.length}.`,
+    );
+  }
+  const buf = Buffer.from(hex, "hex");
+  if (buf[0] !== 0x04) {
+    throw new Error(
+      `Expected uncompressed-pubkey prefix 0x04, got 0x${buf[0].toString(16).padStart(2, "0")}.`,
+    );
+  }
+  const x = buf.subarray(1, 33);
+  const y = buf.subarray(33, 65);
+  const yIsEven = (y[31] & 1) === 0;
+  const compressed = new Uint8Array(33);
+  compressed[0] = yIsEven ? 0x02 : 0x03;
+  compressed.set(x, 1);
+  return compressed;
+}
+
+/**
+ * Encode a (publicKey, chainCode) pair into a base58check-encoded BIP-32
+ * mainnet xpub string. Litecoin Core uses the same `0488B21E` version
+ * bytes as Bitcoin (no Ltub remap), so the encoding here is identical
+ * to the BTC module's. Done as a separate function for symmetry.
+ */
+export function encodeXpub(
+  publicKeyCompressed: Uint8Array,
+  chainCode: Uint8Array,
+): string {
+  if (publicKeyCompressed.length !== 33) {
+    throw new Error(
+      `Compressed public key must be 33 bytes, got ${publicKeyCompressed.length}.`,
+    );
+  }
+  if (chainCode.length !== 32) {
+    throw new Error(`Chain code must be 32 bytes, got ${chainCode.length}.`);
+  }
+  const buf = new Uint8Array(78);
+  buf.set(MAINNET_XPUB_VERSION, 0);
+  buf[4] = 0; // depth
+  buf.set([0, 0, 0, 0], 5); // parent fingerprint
+  buf.set([0, 0, 0, 0], 9); // child number
+  buf.set(chainCode, 13);
+  buf.set(publicKeyCompressed, 45);
+  return b58check.encode(buf);
+}
+
+export type AccountAddressFormat = "legacy" | "p2sh" | "bech32" | "bech32m";
+
+/**
+ * Encode a child compressed pubkey into a Litecoin mainnet address per
+ * the BIP-44 / 49 / 84 / 86 address format conventions. Uses the
+ * inline LITECOIN_NETWORK params so bitcoinjs-lib emits L/M/ltc1q/ltc1p
+ * forms.
+ *
+ * Taproot caveat: Litecoin Core has not activated Taproot on mainnet
+ * as of this writing. Addresses derive correctly here, the Ledger
+ * Litecoin app emits them, but outputs paying ltc1p... are not
+ * spendable until activation. This module emits the addresses anyway
+ * so the user-facing pairing flow shows all four address types
+ * uniformly with BTC.
+ */
+export function encodeAddressForFormat(
+  compressedPubkey: Uint8Array,
+  format: AccountAddressFormat,
+): string {
+  const network = LITECOIN_NETWORK;
+  const pubkey = Buffer.from(compressedPubkey);
+  switch (format) {
+    case "legacy": {
+      const out = bitcoinjs.payments.p2pkh({ pubkey, network }).address;
+      if (!out) throw new Error("p2pkh: no address derived");
+      return out;
+    }
+    case "p2sh": {
+      const inner = bitcoinjs.payments.p2wpkh({ pubkey, network });
+      const out = bitcoinjs.payments.p2sh({
+        redeem: { output: inner.output },
+        network,
+      }).address;
+      if (!out) throw new Error("p2sh-segwit: no address derived");
+      return out;
+    }
+    case "bech32": {
+      const out = bitcoinjs.payments.p2wpkh({ pubkey, network }).address;
+      if (!out) throw new Error("p2wpkh: no address derived");
+      return out;
+    }
+    case "bech32m": {
+      const xOnly = pubkey.subarray(1);
+      const out = bitcoinjs.payments.p2tr({
+        internalPubkey: xOnly,
+        network,
+      }).address;
+      if (!out) throw new Error("p2tr: no address derived");
+      return out;
+    }
+  }
+}
+
+export interface AccountNode {
+  hd: HDKey;
+  addressFormat: AccountAddressFormat;
+}
+
+export function accountNodeFromLedgerResponse(args: {
+  publicKeyHex: string;
+  chainCodeHex: string;
+  addressFormat: AccountAddressFormat;
+}): AccountNode {
+  const compressed = compressSecp256k1Pubkey(args.publicKeyHex);
+  const chainCodeHex = args.chainCodeHex.startsWith("0x")
+    ? args.chainCodeHex.slice(2)
+    : args.chainCodeHex;
+  if (chainCodeHex.length !== 64) {
+    throw new Error(
+      `Chain code must be 32 bytes (64 hex chars), got ${chainCodeHex.length}.`,
+    );
+  }
+  const xpub = encodeXpub(compressed, Buffer.from(chainCodeHex, "hex"));
+  const hd = HDKey.fromExtendedKey(xpub);
+  return { hd, addressFormat: args.addressFormat };
+}
+
+export function deriveAccountChildAddress(
+  node: AccountNode,
+  chain: 0 | 1,
+  addressIndex: number,
+): { address: string; publicKey: Uint8Array } {
+  const child = node.hd.derive(`m/${chain}/${addressIndex}`);
+  if (!child.publicKey) {
+    throw new Error(
+      `BIP-32 child at m/${chain}/${addressIndex} produced no public key.`,
+    );
+  }
+  return {
+    address: encodeAddressForFormat(child.publicKey, node.addressFormat),
+    publicKey: child.publicKey,
+  };
+}

--- a/src/signing/ltc-tx-store.ts
+++ b/src/signing/ltc-tx-store.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
+import type { UnsignedLitecoinTx } from "../types/index.js";
+
+/**
+ * In-memory registry of prepared Litecoin transactions. Mirror of
+ * `btc-tx-store.ts`. Separate store so `send_transaction` can route
+ * BTC vs LTC handles to the correct signing path.
+ *
+ * Same TTL semantics: 15 min from issue, single-use after submission.
+ */
+const TX_TTL_MS = 15 * 60_000;
+
+interface StoredLitecoinTx {
+  tx: UnsignedLitecoinTx;
+  expiresAt: number;
+}
+
+const store = new Map<string, StoredLitecoinTx>();
+
+function prune(now = Date.now()): void {
+  for (const [handle, entry] of store) {
+    if (entry.expiresAt < now) store.delete(handle);
+  }
+}
+
+/**
+ * Compute an LTC fingerprint over the PSBT bytes. Domain tag includes
+ * `:ltc:` so a collision with the BTC fingerprint scheme is
+ * cryptographically impossible.
+ */
+function ltcPayloadHash(psbtBase64: string): `0x${string}` {
+  const payload = Buffer.concat([
+    Buffer.from("VaultPilot-txverify-v1:ltc:", "utf-8"),
+    Buffer.from(psbtBase64, "utf-8"),
+  ]);
+  const digest = createHash("sha256").update(payload).digest("hex");
+  return `0x${digest}` as `0x${string}`;
+}
+
+export function issueLitecoinHandle(
+  tx: Omit<UnsignedLitecoinTx, "handle" | "fingerprint">,
+): UnsignedLitecoinTx {
+  prune();
+  // Distinct prefix avoids collision with BTC handle namespace; the
+  // execution dispatcher uses `hasLitecoinHandle` / `hasBitcoinHandle`
+  // to route, so prefixes aren't load-bearing for routing — but they
+  // help debug-log readability.
+  const handle = `ltc-${randomUUID()}`;
+  const fingerprint = ltcPayloadHash(tx.psbtBase64);
+  const withHandle: UnsignedLitecoinTx = { ...tx, handle, fingerprint };
+  const { handle: _h, ...stored } = withHandle;
+  store.set(handle, {
+    tx: stored as UnsignedLitecoinTx,
+    expiresAt: Date.now() + TX_TTL_MS,
+  });
+  return withHandle;
+}
+
+export function consumeLitecoinHandle(handle: string): UnsignedLitecoinTx {
+  prune();
+  const entry = store.get(handle);
+  if (!entry) {
+    throw new Error(
+      `Unknown or expired Litecoin tx handle. Prepared transactions expire after 15 minutes ` +
+        `and are single-use after submission. Re-run prepare_litecoin_native_send for a fresh handle.`,
+    );
+  }
+  return entry.tx;
+}
+
+export function retireLitecoinHandle(handle: string): void {
+  store.delete(handle);
+}
+
+export function hasLitecoinHandle(handle: string): boolean {
+  prune();
+  return store.has(handle);
+}
+
+/** Test-only — drop the entire store. */
+export function __clearLitecoinTxStore(): void {
+  store.clear();
+}

--- a/src/signing/ltc-usb-loader.ts
+++ b/src/signing/ltc-usb-loader.ts
@@ -1,0 +1,104 @@
+import { createRequire } from "node:module";
+
+/**
+ * Thin loader that brings the Ledger Litecoin packages in via CommonJS.
+ * Mirror of `btc-usb-loader.ts` — `@ledgerhq/hw-app-btc` is the same
+ * SDK for both BTC and LTC, parametrized by the `currency` argument
+ * to its constructor. The Ledger device runs a separate "Litecoin"
+ * app from the "Bitcoin" app; switching app on the device is what
+ * picks the network-specific address-encoding behavior, but the
+ * host-side API is shared.
+ *
+ * Isolating the `require()` here lets tests
+ * `vi.mock("../signing/ltc-usb-loader.js")` with a fake `openLedger()`
+ * and avoid touching the Ledger SDK entirely.
+ */
+
+export type LtcAddressFormat = "legacy" | "p2sh" | "bech32" | "bech32m";
+
+export interface LtcLedgerTransport {
+  close(): Promise<void>;
+}
+
+export interface LtcLedgerApp {
+  /**
+   * Returns the public key + address at the BIP-32 path for the given
+   * address format. Pass `verify: true` to have the Ledger show the
+   * address on-screen for user confirmation (used during pairing).
+   *
+   * `bitcoinAddress` is encoded for the requested format using the
+   * Litecoin network's version bytes / HRP (the Litecoin app handles
+   * encoding):
+   *   - `legacy`   → P2PKH (`L...`)
+   *   - `p2sh`     → P2SH-wrapped segwit (`M...`)
+   *   - `bech32`   → native segwit P2WPKH (`ltc1q...`)
+   *   - `bech32m`  → taproot P2TR (`ltc1p...`)
+   */
+  getWalletPublicKey(
+    path: string,
+    opts?: { verify?: boolean; format?: LtcAddressFormat },
+  ): Promise<{
+    publicKey: string;
+    bitcoinAddress: string;
+    chainCode: string;
+  }>;
+  /**
+   * Sign a message (BIP-137 with Litecoin's "Litecoin Signed Message"
+   * prefix). Used by `sign_litecoin_message`.
+   */
+  signMessage(
+    path: string,
+    messageHex: string,
+  ): Promise<{ v: number; r: string; s: string }>;
+  /**
+   * Sign a v0 PSBT on the Ledger Litecoin app. Same options shape as
+   * the BTC app — the SDK handles network-specific encoding internally.
+   */
+  signPsbtBuffer(
+    psbtBuffer: Buffer,
+    options: {
+      finalizePsbt: boolean;
+      accountPath: string;
+      addressFormat: LtcAddressFormat;
+      knownAddressDerivations: Map<string, { pubkey: Buffer; path: number[] }>;
+    },
+  ): Promise<{ psbt: Buffer; tx?: string }>;
+}
+
+export interface LtcAppAndVersion {
+  name: string;
+  version: string;
+}
+
+const requireCjs = createRequire(import.meta.url);
+
+export async function openLedger(): Promise<{
+  app: LtcLedgerApp;
+  transport: LtcLedgerTransport;
+  rawTransport: unknown;
+}> {
+  const TransportNodeHid = requireCjs("@ledgerhq/hw-transport-node-hid").default;
+  const Btc = requireCjs("@ledgerhq/hw-app-btc").default;
+  const transport = (await TransportNodeHid.open("")) as LtcLedgerTransport & {
+    close(): Promise<void>;
+  };
+  // `currency: "litecoin"` flips the SDK's internal serialization to
+  // emit Litecoin-encoded addresses and accept Litecoin BIP-44 paths
+  // (coin type 2). The dashboard-side `getAppAndVersion()` call still
+  // returns whichever app is currently open on the device — the
+  // pairing flow checks for `name === "Litecoin"`.
+  const app = new Btc({ transport, currency: "litecoin" }) as LtcLedgerApp;
+  return { app, transport, rawTransport: transport };
+}
+
+/**
+ * Surface the open app's name + version.
+ */
+export async function getAppAndVersion(
+  rawTransport: unknown,
+): Promise<LtcAppAndVersion> {
+  const mod = requireCjs("@ledgerhq/hw-app-btc/lib/getAppAndVersion");
+  const fn = mod.getAppAndVersion;
+  const out = await fn(rawTransport as never);
+  return { name: out.name, version: out.version };
+}

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -1,0 +1,930 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import {
+  openLedger,
+  getAppAndVersion,
+  type LtcAddressFormat,
+  type LtcLedgerApp,
+  type LtcLedgerTransport,
+} from "./ltc-usb-loader.js";
+import {
+  accountNodeFromLedgerResponse,
+  deriveAccountChildAddress,
+  type AccountNode,
+} from "./ltc-bip32-derive.js";
+import { getConfigPath, patchUserConfig, readUserConfig } from "../config/user-config.js";
+import type { PairedLitecoinEntry } from "../types/index.js";
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  address: { toOutputScript(addr: string, network?: unknown): Buffer };
+};
+
+/**
+ * Litecoin mainnet network params. bitcoinjs-lib doesn't ship a
+ * Litecoin preset, so we define one inline (mirror of the constant
+ * in `src/modules/litecoin/actions.ts`). pubKeyHash 0x30 (L), scriptHash
+ * 0x32 (M), bech32 hrp `ltc`.
+ */
+const LITECOIN_NETWORK = {
+  messagePrefix: "\x19Litecoin Signed Message:\n",
+  bech32: "ltc",
+  bip32: { public: 0x0488b21e, private: 0x0488ade4 },
+  pubKeyHash: 0x30,
+  scriptHash: 0x32,
+  wif: 0xb0,
+};
+
+export type { PairedLitecoinEntry };
+
+/**
+ * Litecoin BIP-44/49/84/86 paths — one purpose per address format. Per
+ * SLIP-44 + the relevant BIPs:
+ *
+ *   - BIP-44 (legacy P2PKH):              `44'/2'/<account>'/0/0`
+ *   - BIP-49 (P2SH-wrapped segwit):       `49'/2'/<account>'/0/0`
+ *   - BIP-84 (native segwit P2WPKH):      `84'/2'/<account>'/0/0`
+ *   - BIP-86 (taproot P2TR):              `86'/2'/<account>'/0/0`
+ *
+ * Path layout matches Ledger Live's so account-index 0 in this server
+ * corresponds to the first Litecoin account in Ledger Live for each
+ * address type.
+ *
+ * The 5-segment shape (`<purpose>'/2'/<account>'/0/0`) drills all the way
+ * to the first receive address (`change=0, index=0`). The Ledger Litecoin app
+ * accepts any prefix (down to `m/<purpose>'/2'/<account>'`) for the
+ * account-level xpub; for our pair-and-cache flow we ask for the leaf
+ * receive address directly so the user sees a concrete `ltc1p…` value
+ * during pairing rather than an xpub.
+ */
+const MAX_LTC_ACCOUNT_INDEX = 100;
+
+export const LTC_ADDRESS_TYPES = [
+  "legacy",
+  "p2sh-segwit",
+  "segwit",
+  "taproot",
+] as const;
+
+export type LtcAddressType = (typeof LTC_ADDRESS_TYPES)[number];
+
+/**
+ * Map our address-type label → Ledger Litecoin app's `format` enum + the
+ * BIP-44 purpose number. Single source of truth so paths and formats
+ * never drift.
+ */
+const TYPE_META: Record<
+  LtcAddressType,
+  { purpose: number; format: LtcAddressFormat }
+> = {
+  legacy: { purpose: 44, format: "legacy" },
+  "p2sh-segwit": { purpose: 49, format: "p2sh" },
+  segwit: { purpose: 84, format: "bech32" },
+  taproot: { purpose: 86, format: "bech32m" },
+};
+
+export function ltcPathForAccountIndex(
+  accountIndex: number,
+  addressType: LtcAddressType,
+): string {
+  return ltcLeafPath(accountIndex, addressType, 0, 0);
+}
+
+/**
+ * Build a full BIP-32 leaf path for a specific (account, type, chain,
+ * index) tuple. Used by gap-limit scanning to walk both the receive
+ * chain (chain=0) and change chain (chain=1) at non-zero indices.
+ */
+/**
+ * Build the BIP-44 account-level path (3 hardened segments — purpose,
+ * coin_type, account). This is the deepest path the Ledger Litecoin app
+ * needs to derive on-device per address type; everything below it
+ * (`/0/i`, `/1/i`) is non-hardened and computable host-side from the
+ * returned (publicKey, chainCode) pair. Issue #192.
+ */
+export function ltcAccountLevelPath(
+  accountIndex: number,
+  addressType: LtcAddressType,
+): string {
+  if (
+    !Number.isInteger(accountIndex) ||
+    accountIndex < 0 ||
+    accountIndex > MAX_LTC_ACCOUNT_INDEX
+  ) {
+    throw new Error(
+      `Invalid Litecoin accountIndex ${accountIndex} — must be an integer in [0, ${MAX_LTC_ACCOUNT_INDEX}].`,
+    );
+  }
+  const { purpose } = TYPE_META[addressType];
+  return `${purpose}'/2'/${accountIndex}'`;
+}
+
+export function ltcLeafPath(
+  accountIndex: number,
+  addressType: LtcAddressType,
+  chain: 0 | 1,
+  addressIndex: number,
+): string {
+  if (
+    !Number.isInteger(accountIndex) ||
+    accountIndex < 0 ||
+    accountIndex > MAX_LTC_ACCOUNT_INDEX
+  ) {
+    throw new Error(
+      `Invalid Litecoin accountIndex ${accountIndex} — must be an integer in [0, ${MAX_LTC_ACCOUNT_INDEX}].`,
+    );
+  }
+  if (chain !== 0 && chain !== 1) {
+    throw new Error(`Invalid BIP-32 chain ${chain} — must be 0 (receive) or 1 (change).`);
+  }
+  if (!Number.isInteger(addressIndex) || addressIndex < 0) {
+    throw new Error(
+      `Invalid BIP-32 addressIndex ${addressIndex} — must be a non-negative integer.`,
+    );
+  }
+  const { purpose } = TYPE_META[addressType];
+  return `${purpose}'/2'/${accountIndex}'/${chain}/${addressIndex}`;
+}
+
+const LTC_PATH_RE = /^(44|49|84|86)'\/2'\/(\d+)'\/(0|1)\/(\d+)$/;
+
+/**
+ * Parse the address type, account index, BIP-32 chain (0 = receive,
+ * 1 = change), and address index out of an LTC BIP-44 path. Returns
+ * null when the path doesn't match the standard 5-segment shape —
+ * custom paths get cached but can't be indexed.
+ */
+export function parseLtcPath(
+  path: string,
+): {
+  addressType: LtcAddressType;
+  accountIndex: number;
+  chain: 0 | 1;
+  addressIndex: number;
+} | null {
+  const m = LTC_PATH_RE.exec(path);
+  if (!m) return null;
+  const purpose = Number(m[1]);
+  const accountIndex = Number(m[2]);
+  const chain = Number(m[3]) as 0 | 1;
+  const addressIndex = Number(m[4]);
+  if (!Number.isInteger(accountIndex)) return null;
+  if (!Number.isInteger(addressIndex)) return null;
+  for (const t of LTC_ADDRESS_TYPES) {
+    if (TYPE_META[t].purpose === purpose) {
+      return { addressType: t, accountIndex, chain, addressIndex };
+    }
+  }
+  return null;
+}
+
+/**
+ * Module-local serialization for HID transport calls. USB-HID is
+ * single-tenant — opening a second transport while the first is in
+ * flight throws "device busy". Same primitive Solana / TRON signers use.
+ */
+let usbLock: Promise<void> = Promise.resolve();
+export async function withLtcUsbLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = usbLock;
+  let release!: () => void;
+  usbLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+interface DerivedAddress {
+  address: string;
+  publicKey: string;
+  path: string;
+  appVersion: string;
+  addressType: LtcAddressType;
+  accountIndex: number;
+  chain: 0 | 1;
+  addressIndex: number;
+}
+
+/**
+ * Open the Litecoin app, derive the address at `path` for `addressType`, and
+ * close. Single round-trip per call. The caller is responsible for
+ * batching when deriving multiple paths — `pair_ledger_ltc` reuses the
+ * same transport for all four BIP-44 / BIP-49 / BIP-84 / BIP-86 paths.
+ */
+export async function getLtcLedgerAddress(
+  path: string,
+  addressType: LtcAddressType,
+): Promise<DerivedAddress> {
+  return withLtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Litecoin" &&
+        appVer.name !== "Litecoin Test" &&
+        appVer.name !== "LTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Litecoin is required. ` +
+            `Open the Litecoin app on your device and retry.`,
+        );
+      }
+      const { format } = TYPE_META[addressType];
+      const out = await app.getWalletPublicKey(path, { format });
+      const parsed = parseLtcPath(path);
+      return {
+        address: out.bitcoinAddress,
+        publicKey: out.publicKey,
+        path,
+        appVersion: appVer.version,
+        addressType,
+        accountIndex: parsed?.accountIndex ?? 0,
+        chain: parsed?.chain ?? 0,
+        addressIndex: parsed?.addressIndex ?? 0,
+      };
+    } finally {
+      await (transport as LtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * BIP44 gap-limit default. Standard across Electrum / Sparrow / Trezor
+ * Suite / Ledger Live: stop walking a chain after 20 consecutive
+ * addresses with zero on-chain history. Issue #189.
+ */
+export const DEFAULT_LTC_GAP_LIMIT = 20;
+/** Hard cap on `gapLimit` to bound USB roundtrips. */
+export const MAX_LTC_GAP_LIMIT = 100;
+
+/**
+ * Caller-supplied callback that fetches the current on-chain tx count
+ * for an address. Injected (rather than hard-wired to the indexer) so
+ * `scanLtcAccount` stays usable from tests with mocked tx-count
+ * responses, and so the hot-path indexer module isn't a runtime
+ * dependency of this file's import graph (keeps the USB signer
+ * independent of the HTTP indexer abstraction).
+ */
+export type LtcAddressTxCountFetcher = (
+  address: string,
+) => Promise<number>;
+
+/**
+ * Result of a single (type, chain) walk: the addresses we derived,
+ * and how many of them ended the run with txCount === 0 (the gap
+ * window that ultimately tripped the stop condition).
+ */
+export interface ScanChainResult {
+  /**
+   * Every derived address along this chain, in walk order. Includes
+   * the trailing gap of empties that triggered the stop — the LAST
+   * empty is the wallet's "next fresh receive address" for receive
+   * chains, useful for UX. All except the trailing gap have
+   * `txCount > 0`.
+   */
+  addresses: DerivedAddress[];
+  /** Tx counts aligned 1:1 with `addresses`. */
+  txCounts: number[];
+  /** True when the chain returned all-zeros immediately (no usage). */
+  empty: boolean;
+}
+
+/**
+ * BIP44 gap-limit scan for one account index. Walks each address-type
+ * (44'/49'/84'/86') across both BIP-32 chains (receive=0, change=1),
+ * stopping each chain after `gapLimit` consecutive empty addresses.
+ *
+ * Performance posture (issue #192):
+ *
+ *   - Per address type, exactly ONE device call: `getWalletPublicKey`
+ *     at the account-level path (`<purpose>'/2'/<account>'`), returning
+ *     the (publicKey, chainCode) pair for that account-level node.
+ *   - All `0/i` and `1/i` leaves below that node are derived host-side
+ *     via @scure/bip32 — no further device interaction. BIP-32 is
+ *     deterministic for non-hardened descendants of a known parent
+ *     pubkey + chainCode, so the math is identical to what the device
+ *     would have produced.
+ *   - Per (type, chain) the gap-limit window is probed in PARALLEL
+ *     against the indexer (`Promise.all` over a chunk equal to the
+ *     remaining `gapLimit` budget). The serial `getWalletPublicKey →
+ *     fetchTxCount` round-trip from before is gone.
+ *
+ * Combined floor: 4 device calls per accountIndex (one per BIP-44
+ * purpose) plus ~`O(gapLimit)` parallel HTTP calls per (type, chain).
+ * Down from the prior `4 × 2 × gapLimit ≈ 160` device round-trips.
+ *
+ * Optimization: when the receive chain (chain=0) returns all-empty for
+ * a given type, the change chain is skipped entirely — change
+ * addresses can only have history if at least one corresponding
+ * receive saw a spend, and "no receives" → "no spends" → "no change".
+ * Saves the change-chain HTTP round on fresh wallets.
+ */
+export async function scanLtcAccount(args: {
+  accountIndex: number;
+  gapLimit?: number;
+  fetchTxCount: LtcAddressTxCountFetcher;
+}): Promise<{
+  appVersion: string;
+  entries: Array<DerivedAddress & { txCount: number }>;
+}> {
+  const accountIndex = args.accountIndex;
+  const gapLimit = args.gapLimit ?? DEFAULT_LTC_GAP_LIMIT;
+  if (
+    !Number.isInteger(gapLimit) ||
+    gapLimit < 1 ||
+    gapLimit > MAX_LTC_GAP_LIMIT
+  ) {
+    throw new Error(
+      `Invalid gapLimit ${gapLimit} — must be an integer in [1, ${MAX_LTC_GAP_LIMIT}].`,
+    );
+  }
+  return withLtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Litecoin" &&
+        appVer.name !== "Litecoin Test" &&
+        appVer.name !== "LTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Litecoin is required. ` +
+            `Open the Litecoin app on your device and retry.`,
+        );
+      }
+
+      const all: Array<DerivedAddress & { txCount: number }> = [];
+      for (const addressType of LTC_ADDRESS_TYPES) {
+        // ONE device call per type — pull the account-level (publicKey,
+        // chainCode). Everything below this in the BIP-44 tree is
+        // non-hardened and host-derivable.
+        const accountPath = ltcAccountLevelPath(accountIndex, addressType);
+        const { format } = TYPE_META[addressType];
+        const accountResp = await app.getWalletPublicKey(accountPath, {
+          format,
+        });
+        const node: AccountNode = accountNodeFromLedgerResponse({
+          publicKeyHex: accountResp.publicKey,
+          chainCodeHex: accountResp.chainCode,
+          addressFormat: format,
+        });
+
+        const receive = await scanChainHostSide({
+          node,
+          accountIndex,
+          addressType,
+          chain: 0,
+          gapLimit,
+          appVersion: appVer.version,
+          fetchTxCount: args.fetchTxCount,
+        });
+        for (let i = 0; i < receive.addresses.length; i++) {
+          all.push({ ...receive.addresses[i], txCount: receive.txCounts[i] });
+        }
+        // No receives ever → no change can exist. Skip the change-chain
+        // walk entirely (saves the entire change-chain HTTP round).
+        if (receive.empty) continue;
+        const change = await scanChainHostSide({
+          node,
+          accountIndex,
+          addressType,
+          chain: 1,
+          gapLimit,
+          appVersion: appVer.version,
+          fetchTxCount: args.fetchTxCount,
+        });
+        for (let i = 0; i < change.addresses.length; i++) {
+          all.push({ ...change.addresses[i], txCount: change.txCounts[i] });
+        }
+      }
+      return { appVersion: appVer.version, entries: all };
+    } finally {
+      await (transport as LtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * Walk a single (type, chain) host-side until `gapLimit` consecutive
+ * empty addresses are observed. Each iteration derives a window of
+ * children purely via BIP-32 math, then probes the indexer for all
+ * window entries in parallel. The window is sized dynamically to
+ * `gapLimit - consecutiveEmpty` — we only ever probe the addresses we
+ * still NEED to satisfy the stop condition, so there's no over-fetch
+ * if a chunk has activity that resets the counter.
+ *
+ * Returns every address we derived in walk order, including the
+ * trailing empty window — the FIRST trailing empty is the wallet's
+ * next fresh address for that chain, useful for receive UX.
+ */
+async function scanChainHostSide(args: {
+  node: AccountNode;
+  accountIndex: number;
+  addressType: LtcAddressType;
+  chain: 0 | 1;
+  gapLimit: number;
+  appVersion: string;
+  fetchTxCount: LtcAddressTxCountFetcher;
+}): Promise<ScanChainResult> {
+  const addresses: DerivedAddress[] = [];
+  const txCounts: number[] = [];
+  let consecutiveEmpty = 0;
+  let addressIndex = 0;
+  while (consecutiveEmpty < args.gapLimit) {
+    // Window size = remaining-empties-needed. If we already have N
+    // trailing empties, we only need (gapLimit - N) more to terminate;
+    // probing more would be wasted HTTP. The window shrinks
+    // monotonically toward the stop unless an interior result in the
+    // chunk turns out to be USED (which resets consecutiveEmpty back
+    // to 0 and re-grows the next window to gapLimit).
+    const windowSize = args.gapLimit - consecutiveEmpty;
+    const windowStart = addressIndex;
+
+    // Host-side BIP-32 child derivations — no I/O, near-instant.
+    const window: Array<{
+      addressIndex: number;
+      address: string;
+      publicKey: Uint8Array;
+    }> = [];
+    for (let i = 0; i < windowSize; i++) {
+      const idx = windowStart + i;
+      const child = deriveAccountChildAddress(args.node, args.chain, idx);
+      window.push({
+        addressIndex: idx,
+        address: child.address,
+        publicKey: child.publicKey,
+      });
+    }
+
+    // Parallel indexer fan-out for the whole window. Per-call failures
+    // degrade to txCount=0 so a flaky HTTP doesn't abort the scan.
+    const counts = await Promise.all(
+      window.map((w) =>
+        args.fetchTxCount(w.address).catch(() => 0),
+      ),
+    );
+
+    // Process results in order. Update consecutiveEmpty inside the
+    // loop so a USED address mid-window resets the counter and any
+    // empties AFTER it in the same window contribute fresh to the
+    // next stop budget.
+    for (let i = 0; i < window.length; i++) {
+      const w = window[i];
+      addresses.push({
+        address: w.address,
+        publicKey: Buffer.from(w.publicKey).toString("hex"),
+        path: ltcLeafPath(
+          args.accountIndex,
+          args.addressType,
+          args.chain,
+          w.addressIndex,
+        ),
+        appVersion: args.appVersion,
+        addressType: args.addressType,
+        accountIndex: args.accountIndex,
+        chain: args.chain,
+        addressIndex: w.addressIndex,
+      });
+      txCounts.push(counts[i]);
+      if (counts[i] === 0) consecutiveEmpty++;
+      else consecutiveEmpty = 0;
+    }
+    addressIndex += window.length;
+  }
+  // `empty` = chain returned ZERO used addresses; equivalent to "the
+  // first `gapLimit` entries are all zero-tx" and `addresses.length === gapLimit`.
+  const empty = txCounts.every((c) => c === 0);
+  return { addresses, txCounts, empty };
+}
+
+/**
+ * Derive ALL four address types for one account index in a single
+ * USB-HID session. Reuses the open transport so the user only sees one
+ * "approve on device" prompt per type if they have `display: true`
+ * configured (we don't pass it in pairing — Ledger's Litecoin app shows the
+ * derivation on-screen on signing, not on derivation by default).
+ */
+export async function deriveLtcLedgerAccount(
+  accountIndex: number,
+): Promise<{ appVersion: string; entries: DerivedAddress[] }> {
+  return withLtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Litecoin" &&
+        appVer.name !== "Litecoin Test" &&
+        appVer.name !== "LTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Litecoin is required. ` +
+            `Open the Litecoin app on your device and retry.`,
+        );
+      }
+      const entries: DerivedAddress[] = [];
+      for (const addressType of LTC_ADDRESS_TYPES) {
+        const path = ltcPathForAccountIndex(accountIndex, addressType);
+        const { format } = TYPE_META[addressType];
+        const out = await app.getWalletPublicKey(path, { format });
+        entries.push({
+          address: out.bitcoinAddress,
+          publicKey: out.publicKey,
+          path,
+          appVersion: appVer.version,
+          addressType,
+          accountIndex,
+          chain: 0,
+          addressIndex: 0,
+        });
+      }
+      return { appVersion: appVer.version, entries };
+    } finally {
+      await (transport as LtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * Build a Ledger derivation-path number array from a string path like
+ * `84'/0'/0'/0/0`. Hardened segments (trailing `'`) get the
+ * 0x80000000 high bit; non-hardened segments are passed through. Used
+ * to populate `signPsbtBuffer.knownAddressDerivations`, which the
+ * device's owner-input + change-output detection relies on.
+ */
+function pathStringToNumbers(path: string): number[] {
+  return path.split("/").map((seg) => {
+    const hardened = seg.endsWith("'");
+    const n = Number(hardened ? seg.slice(0, -1) : seg);
+    if (!Number.isInteger(n) || n < 0) {
+      throw new Error(`Invalid Litecoin path segment "${seg}" in "${path}".`);
+    }
+    return hardened ? (n | 0x80000000) >>> 0 : n;
+  });
+}
+
+/**
+ * Extract the witness-program payload from a P2WPKH or P2TR scriptPubKey
+ * as the lookup key for `signPsbtBuffer.knownAddressDerivations`. The
+ * Ledger SDK's `populateMissingBip32Derivations` keys its lookup map by
+ * this same payload (bytes 2..22 — hash160(pubkey) — for P2WPKH; bytes
+ * 2..34 — tweaked x-only key — for P2TR), not by sha256(scriptPubKey).
+ * Mirrors `@ledgerhq/psbtv2::extractHashFromScriptPubKey` for just the
+ * two script types Phase 1 sends support; legacy / P2SH-wrapped sends
+ * are out of scope (`buildLitecoinNativeSend` rejects them upfront).
+ */
+function extractWitnessProgramHex(scriptPubKey: Buffer): string {
+  if (
+    scriptPubKey.length === 22 &&
+    scriptPubKey[0] === 0x00 &&
+    scriptPubKey[1] === 0x14
+  ) {
+    return scriptPubKey.subarray(2, 22).toString("hex");
+  }
+  if (
+    scriptPubKey.length === 34 &&
+    scriptPubKey[0] === 0x51 &&
+    scriptPubKey[1] === 0x20
+  ) {
+    return scriptPubKey.subarray(2, 34).toString("hex");
+  }
+  throw new Error(
+    `Unexpected scriptPubKey shape (length=${scriptPubKey.length}, ` +
+      `bytes=0x${scriptPubKey.subarray(0, Math.min(4, scriptPubKey.length)).toString("hex")}). ` +
+      `Phase 1 LTC sends only support P2WPKH (segwit, ltc1q...) and P2TR (taproot, ltc1p...).`,
+  );
+}
+
+/**
+ * Compress a SEC1 public key to its 33-byte form. Ledger's
+ * `getWalletPublicKey` returns the uncompressed encoding (`0x04 || X
+ * || Y`, 65 bytes), but PSBT consumers downstream of
+ * `signPsbtBuffer.knownAddressDerivations` expect the compressed
+ * encoding (`0x02 || X` if Y is even, `0x03 || X` if odd, 33 bytes) —
+ * the SDK then strips the prefix byte for taproot's x-only key. Issue
+ * #211: a 65-byte buffer threaded straight through threw "Invalid
+ * pubkey length: 65" before any device prompt. Idempotent on inputs
+ * already in compressed form.
+ */
+export function compressPubkey(pubkey: Buffer): Buffer {
+  if (
+    pubkey.length === 33 &&
+    (pubkey[0] === 0x02 || pubkey[0] === 0x03)
+  ) {
+    return pubkey;
+  }
+  if (pubkey.length !== 65 || pubkey[0] !== 0x04) {
+    throw new Error(
+      `Unexpected SEC1 pubkey shape (length=${pubkey.length}, ` +
+        `prefix=0x${pubkey[0]?.toString(16) ?? "??"}). Expected 65-byte ` +
+        `uncompressed (0x04 || X || Y) or 33-byte compressed (0x02/0x03 || X).`,
+    );
+  }
+  const x = pubkey.subarray(1, 33);
+  const yLast = pubkey[64];
+  const prefix = (yLast & 1) === 0 ? 0x02 : 0x03;
+  return Buffer.concat([Buffer.from([prefix]), x]);
+}
+
+/**
+ * Sign a base64-encoded PSBT v0 on the Ledger Litecoin app. The device walks
+ * every output (address + amount + the "change" label for known
+ * internal-chain outputs), shows the total fee, and asks the user to
+ * confirm. Returns the network-broadcastable raw tx hex.
+ *
+ * `expectedFrom` is the source address the prepare-time receipt
+ * advertised. We re-derive the address from `path` against the live
+ * device and refuse to sign if it doesn't match — same proof-of-identity
+ * pattern as `signSolanaTxOnLedger` / `signTronTxOnLedger`. Catches a
+ * stale or planted pairing entry that points at an address the device
+ * no longer derives the same way.
+ */
+export async function signLtcPsbtOnLedger(args: {
+  psbtBase64: string;
+  expectedFrom: string;
+  path: string;
+  accountPath: string;
+  addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+}): Promise<{ rawTxHex: string }> {
+  return withLtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Litecoin" &&
+        appVer.name !== "Litecoin Test" &&
+        appVer.name !== "LTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Litecoin is required. ` +
+            `Open the Litecoin app on your device and retry.`,
+        );
+      }
+      // Re-derive + validate the source address. If the device produces
+      // a different address for the same path the pairing cache
+      // registered, refuse to sign — something is wrong (different seed,
+      // different app, planted pairing). Don't blind-sign through it.
+      const derived = await app.getWalletPublicKey(args.path, {
+        format: args.addressFormat,
+      });
+      if (derived.bitcoinAddress !== args.expectedFrom) {
+        throw new Error(
+          `Ledger derived ${derived.bitcoinAddress} at ${args.path}, but the prepared tx ` +
+            `lists ${args.expectedFrom} as the source. The device may have a different seed ` +
+            `loaded, the Litecoin app version may have changed the derivation, or the cached ` +
+            `pairing is stale. Re-pair via \`pair_ledger_ltc\` and retry.`,
+        );
+      }
+
+      // Build the knownAddressDerivations map. Phase 1 sends keep change
+      // on the source address, so a single entry covers both inputs and
+      // any same-address output. The SDK keys the map by the witness-
+      // program payload extracted from each scriptPubKey — bytes 2..22
+      // (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked x-only key)
+      // for P2TR. Mirrors @ledgerhq/psbtv2 `extractHashFromScriptPubKey`,
+      // which is what `populateMissingBip32Derivations` looks up against.
+      // Issue #206: an earlier sha256(scriptPubKey) key never matched, so
+      // the library left the PSBT without bip32Derivation and the Ledger
+      // Litecoin app v2.x rejected with 0x6a80 before any UI.
+      const scriptPubKey = bitcoinjs.address.toOutputScript(
+        args.expectedFrom,
+        LITECOIN_NETWORK,
+      );
+      const lookupKey = extractWitnessProgramHex(scriptPubKey);
+      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
+      known.set(lookupKey, {
+        pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
+        path: pathStringToNumbers(args.path),
+      });
+
+      const psbtBuffer = Buffer.from(args.psbtBase64, "base64");
+      const result = await app.signPsbtBuffer(psbtBuffer, {
+        finalizePsbt: true,
+        accountPath: args.accountPath,
+        addressFormat: args.addressFormat,
+        knownAddressDerivations: known,
+      });
+      if (!result.tx) {
+        throw new Error(
+          `Ledger Litecoin app returned no finalized tx hex from signPsbtBuffer. ` +
+            `The PSBT may have been signed but not finalized — check the device for an ` +
+            `unexpected approval state and retry.`,
+        );
+      }
+      return { rawTxHex: result.tx };
+    } finally {
+      await (transport as LtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+/**
+ * Sign an arbitrary message with the Litecoin Signed Message format
+ * (BIP-137, ECDSA). Returns a base64-encoded compact signature in the
+ * shape `<headerByte><r><s>`, where the header byte encodes recovery id
+ * + address type:
+ *
+ *   - legacy (P2PKH, compressed key):           31..34 (= 27 + 4 + recid)
+ *   - P2SH-wrapped segwit (BIP-137 extension):  35..38 (= 35 + recid)
+ *   - native segwit P2WPKH (BIP-137 extension): 39..42 (= 39 + recid)
+ *   - taproot P2TR:                              NOT SUPPORTED (BIP-322
+ *     is the canonical scheme for taproot, and the Ledger Litecoin app does
+ *     not expose a BIP-322 path; refusing is more honest than emitting
+ *     a non-verifying ECDSA blob).
+ *
+ * The `expectedFrom` re-derivation guard mirrors `signLtcPsbtOnLedger`:
+ * if the device produces a different address for `path`, refuse to sign
+ * — same proof-of-identity invariant we apply to tx signing.
+ */
+export async function signLtcMessageOnLedger(args: {
+  expectedFrom: string;
+  path: string;
+  addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  /** UTF-8 message bytes — the SDK takes the hex of the raw bytes. */
+  messageHex: string;
+  addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+}): Promise<{
+  signature: string;
+  format: "BIP-137";
+}> {
+  if (args.addressType === "taproot") {
+    throw new Error(
+      "Taproot (P2TR) message signing requires BIP-322, which the Ledger Litecoin app " +
+        "does not yet expose. Sign with a paired segwit (`ltc1q…`), P2SH-wrapped " +
+        "(`3…`), or legacy (`1…`) address instead. The 4 address types share a " +
+        "Ledger account — `pair_ledger_ltc` derives all four — so picking a " +
+        "non-taproot address from the same Ledger wallet is one tool call away.",
+    );
+  }
+  return withLtcUsbLock(async () => {
+    const { app, transport, rawTransport } = await openLedger();
+    try {
+      const appVer = await getAppAndVersion(rawTransport);
+      if (
+        appVer.name !== "Litecoin" &&
+        appVer.name !== "Litecoin Test" &&
+        appVer.name !== "LTC"
+      ) {
+        throw new Error(
+          `Ledger reports the open app as "${appVer.name}" v${appVer.version}, but Litecoin is required. ` +
+            `Open the Litecoin app on your device and retry.`,
+        );
+      }
+      const derived = await app.getWalletPublicKey(args.path, {
+        format: args.addressFormat,
+      });
+      if (derived.bitcoinAddress !== args.expectedFrom) {
+        throw new Error(
+          `Ledger derived ${derived.bitcoinAddress} at ${args.path}, but the request asks ` +
+            `to sign with ${args.expectedFrom}. The device may have a different seed loaded, ` +
+            `the Litecoin app version may have changed the derivation, or the cached pairing ` +
+            `is stale. Re-pair via \`pair_ledger_ltc\` and retry.`,
+        );
+      }
+      const sig = await app.signMessage(args.path, args.messageHex);
+      // Address-type → BIP-137 header offset (compressed-key + segwit
+      // extensions). The Ledger SDK returns `v` as the recovery id (0 or
+      // 1); we add the address-type-specific base.
+      let base: number;
+      switch (args.addressType) {
+        case "legacy":
+          base = 31; // 27 + 4 (compressed)
+          break;
+        case "p2sh-segwit":
+          base = 35;
+          break;
+        case "segwit":
+          base = 39;
+          break;
+        default:
+          // Unreachable — taproot is rejected up-top.
+          throw new Error(`Unsupported addressType ${String(args.addressType)}`);
+      }
+      const recid = sig.v & 1;
+      const headerByte = base + recid;
+      const sigBuf = Buffer.concat([
+        Buffer.from([headerByte]),
+        Buffer.from(sig.r, "hex"),
+        Buffer.from(sig.s, "hex"),
+      ]);
+      return { signature: sigBuf.toString("base64"), format: "BIP-137" as const };
+    } finally {
+      await (transport as LtcLedgerTransport).close().catch(() => {});
+    }
+  });
+}
+
+// --- Pairing cache --------------------------------------------------------
+
+const pairedLtcByPath = new Map<string, PairedLitecoinEntry>();
+let pairedLtcHydrated = false;
+
+function ensurePairedLtcHydrated(): void {
+  if (pairedLtcHydrated) return;
+  pairedLtcHydrated = true;
+  const persisted = readUserConfig()?.pairings?.bitcoin ?? [];
+  for (const entry of persisted) {
+    // Backfill chain/addressIndex from the path for pre-#189 entries
+    // (which only ever had chain=0, addressIndex=0). Keeps callers
+    // from having to handle the absence at every read site.
+    if (entry.chain === undefined || entry.addressIndex === undefined) {
+      const parsed = parseLtcPath(entry.path);
+      if (parsed) {
+        entry.chain = parsed.chain;
+        entry.addressIndex = parsed.addressIndex;
+      } else {
+        entry.chain = null;
+        entry.addressIndex = null;
+      }
+    }
+    pairedLtcByPath.set(entry.path, entry);
+  }
+}
+
+function persistPairedLtc(): void {
+  patchUserConfig({
+    pairings: { litecoin: Array.from(pairedLtcByPath.values()) },
+  });
+}
+
+export function getPairedLtcAddresses(): PairedLitecoinEntry[] {
+  ensurePairedLtcHydrated();
+  return Array.from(pairedLtcByPath.values()).sort((a, b) => {
+    // Sort by accountIndex → addressType (BIP-44 purpose order:
+    // legacy 44 → p2sh 49 → segwit 84 → taproot 86) → chain (receive
+    // before change) → addressIndex. Keeps each account's full
+    // footprint contiguous and ordered the way most wallets display it.
+    if (a.accountIndex !== b.accountIndex) {
+      if (a.accountIndex === null) return 1;
+      if (b.accountIndex === null) return -1;
+      return a.accountIndex - b.accountIndex;
+    }
+    const typeOrder =
+      LTC_ADDRESS_TYPES.indexOf(a.addressType) -
+      LTC_ADDRESS_TYPES.indexOf(b.addressType);
+    if (typeOrder !== 0) return typeOrder;
+    const aChain = a.chain ?? -1;
+    const bChain = b.chain ?? -1;
+    if (aChain !== bChain) return aChain - bChain;
+    const aIdx = a.addressIndex ?? -1;
+    const bIdx = b.addressIndex ?? -1;
+    return aIdx - bIdx;
+  });
+}
+
+export function getPairedLtcByAddress(address: string): PairedLitecoinEntry | null {
+  ensurePairedLtcHydrated();
+  for (const entry of pairedLtcByPath.values()) {
+    if (entry.address === address) return entry;
+  }
+  return null;
+}
+
+export function setPairedLtcAddress(
+  entry: Omit<PairedLitecoinEntry, "accountIndex"> & { accountIndex: number | null },
+): PairedLitecoinEntry {
+  ensurePairedLtcHydrated();
+  const full: PairedLitecoinEntry = {
+    address: entry.address,
+    publicKey: entry.publicKey,
+    path: entry.path,
+    appVersion: entry.appVersion,
+    addressType: entry.addressType,
+    accountIndex: entry.accountIndex,
+    ...(entry.chain !== undefined ? { chain: entry.chain } : {}),
+    ...(entry.addressIndex !== undefined ? { addressIndex: entry.addressIndex } : {}),
+    ...(entry.txCount !== undefined ? { txCount: entry.txCount } : {}),
+  };
+  pairedLtcByPath.set(entry.path, full);
+  persistPairedLtc();
+  return full;
+}
+
+/**
+ * Drop every cached entry whose `accountIndex` matches. Used by
+ * `pair_ledger_ltc` before re-scanning so an account that previously
+ * extended further than the current gap-limit window doesn't leave
+ * stale (and now-incorrect) entries in the cache.
+ */
+export function clearPairedLtcAccount(accountIndex: number): void {
+  ensurePairedLtcHydrated();
+  let changed = false;
+  for (const [path, entry] of pairedLtcByPath) {
+    if (entry.accountIndex === accountIndex) {
+      pairedLtcByPath.delete(path);
+      changed = true;
+    }
+  }
+  if (changed) persistPairedLtc();
+}
+
+export function clearPairedLtcAddresses(): void {
+  pairedLtcByPath.clear();
+  pairedLtcHydrated = false;
+  if (existsSync(getConfigPath())) {
+    patchUserConfig({ pairings: { litecoin: [] } });
+  }
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -3,6 +3,7 @@ import type {
   SupportedChain,
   TxVerification,
   UnsignedBitcoinTx,
+  UnsignedLitecoinTx,
   UnsignedSolanaTx,
   UnsignedTronTx,
   UnsignedTx,
@@ -1001,6 +1002,56 @@ export function renderBitcoinVerificationBlock(tx: UnsignedBitcoinTx): string {
     "the user rejects on-device — no chat-side decode would have caught it",
   );
   lines.push("any earlier.");
+  return lines.join("\n");
+}
+
+/**
+ * Litecoin verification block — mirror of `renderBitcoinVerificationBlock`.
+ * The Ledger Litecoin app uses the same clear-sign UX as the Bitcoin
+ * app (it's the same SDK) so the review surface is identical:
+ * per-output address+amount + fee + RBF + source.
+ */
+export function renderLitecoinVerificationBlock(tx: UnsignedLitecoinTx): string {
+  const lines: string[] = [];
+  lines.push("VERIFY BEFORE SIGNING (Litecoin — native send)");
+  lines.push(
+    "The Ledger Litecoin app clear-signs every output. Confirm on-device:",
+  );
+  for (let i = 0; i < tx.decoded.outputs.length; i++) {
+    const o = tx.decoded.outputs[i];
+    const tag = o.isChange ? "Change" : `Output ${i + 1}`;
+    const labelSuffix = o.isChange ? " (your wallet)" : "";
+    lines.push(`  • ${tag}: ${o.amountLtc} LTC → ${o.address}${labelSuffix}`);
+  }
+  lines.push(
+    `  • Fee:      ${tx.decoded.feeLtc} LTC (~${tx.decoded.feeRateSatPerVb} litoshi/vB)`,
+  );
+  lines.push(
+    `  • RBF:      ${tx.decoded.rbfEligible ? "enabled — replaceable" : "disabled — final"}`,
+  );
+  lines.push(
+    `  • From:     ${tx.from}  (BIP-32 account ${tx.accountPath})`,
+  );
+  lines.push("");
+  lines.push(
+    "If ANY output address or amount on-device differs from the above → " +
+      "REJECT on Ledger and re-prepare.",
+  );
+  lines.push("");
+  lines.push("[AGENT NOTE — do not forward this paragraph to the user]");
+  lines.push(
+    "Do NOT decode the PSBT in chat. The Ledger device clear-signs every",
+  );
+  lines.push(
+    "output address, amount, fee, and RBF flag on its screen — that walk IS",
+  );
+  lines.push(
+    "the verification, and it is a higher-trust source than any chat-side",
+  );
+  lines.push(
+    "decode you could write. Same agent-side rule as Bitcoin: do NOT write",
+  );
+  lines.push("`node -e` scripts or `_psbt-verify.cjs` files.");
   return lines.join("\n");
 }
 

--- a/src/signing/session.ts
+++ b/src/signing/session.ts
@@ -7,6 +7,7 @@ import {
 import { getPairedTronAddresses } from "./tron-usb-signer.js";
 import { getPairedSolanaAddresses } from "./solana-usb-signer.js";
 import { getPairedBtcAddresses } from "./btc-usb-signer.js";
+import { getPairedLtcAddresses } from "./ltc-usb-signer.js";
 import type { SupportedChain } from "../types/index.js";
 
 export interface SessionAccount {
@@ -129,6 +130,20 @@ export interface SessionStatus {
     /** BIP-32 address index. Null for non-standard paths. */
     addressIndex?: number | null;
     /** Tx count from the indexer at last pair_ledger_btc scan. Snapshot only. */
+    txCount?: number;
+  }>;
+  /**
+   * Paired Litecoin addresses, mirror of `bitcoin` above. Same USB-HID
+   * pairing flow, same shape, BIP-44 coin_type 2.
+   */
+  litecoin?: Array<{
+    address: string;
+    path: string;
+    appVersion: string;
+    addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+    accountIndex: number | null;
+    chain?: 0 | 1 | null;
+    addressIndex?: number | null;
     txCount?: number;
   }>;
 }
@@ -265,6 +280,22 @@ export async function getSessionStatus(): Promise<SessionStatus> {
           })),
         }
       : {};
+  const ltcPaired = getPairedLtcAddresses();
+  const ltcSection =
+    ltcPaired.length > 0
+      ? {
+          litecoin: ltcPaired.map((e) => ({
+            address: e.address,
+            path: e.path,
+            appVersion: e.appVersion,
+            addressType: e.addressType,
+            accountIndex: e.accountIndex,
+            ...(e.chain !== undefined ? { chain: e.chain } : {}),
+            ...(e.addressIndex !== undefined ? { addressIndex: e.addressIndex } : {}),
+            ...(e.txCount !== undefined ? { txCount: e.txCount } : {}),
+          })),
+        }
+      : {};
   if (!session)
     return {
       paired: false,
@@ -275,6 +306,7 @@ export async function getSessionStatus(): Promise<SessionStatus> {
       ...tronSection,
       ...solanaSection,
       ...btcSection,
+      ...ltcSection,
     };
   const accountDetails = await getConnectedAccountsDetailed();
   const accounts = accountDetails.map((a) => a.address);
@@ -305,5 +337,6 @@ export async function getSessionStatus(): Promise<SessionStatus> {
     ...tronSection,
     ...solanaSection,
     ...btcSection,
+    ...ltcSection,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -686,6 +686,29 @@ export interface BitcoinPortfolioSlice {
   walletBalancesUsd: number;
 }
 
+/**
+ * Litecoin slice of a portfolio summary. Mirror of `BitcoinPortfolioSlice`.
+ * Same UTXO model, same balance projection, different symbol/HRP.
+ */
+export interface LitecoinPortfolioSlice {
+  addresses: string[];
+  balances: Array<{
+    address: string;
+    addressType: "p2pkh" | "p2sh" | "p2wpkh" | "p2wsh" | "p2tr";
+    confirmedSats: string;
+    mempoolSats: string;
+    totalSats: string;
+    confirmedLtc: string;
+    totalLtc: string;
+    symbol: "LTC";
+    decimals: 8;
+    txCount: number;
+    valueUsd?: number;
+    priceMissing?: boolean;
+  }>;
+  walletBalancesUsd: number;
+}
+
 /** Per-wallet slice of a multi-wallet portfolio, or a stand-alone single-wallet summary. */
 export interface PortfolioSummary {
   wallet: `0x${string}`;
@@ -735,6 +758,12 @@ export interface PortfolioSummary {
    * one BTC address. Folded into `totalUsd`.
    */
   bitcoinUsd?: number;
+  /**
+   * Litecoin totals (sum across every address passed via `litecoinAddress` /
+   * `litecoinAddresses`). Present only when the caller supplied at least
+   * one LTC address. Folded into `totalUsd`.
+   */
+  litecoinUsd?: number;
   breakdown: {
     native: TokenAmount[];
     erc20: TokenAmount[];
@@ -747,6 +776,8 @@ export interface PortfolioSummary {
     solana?: SolanaPortfolioSlice;
     /** Bitcoin slice — absent when no BTC address(es) were queried. */
     bitcoin?: BitcoinPortfolioSlice;
+    /** Litecoin slice — absent when no LTC address(es) were queried. */
+    litecoin?: LitecoinPortfolioSlice;
   };
   coverage: PortfolioCoverage;
 }
@@ -782,6 +813,8 @@ export interface MultiWalletPortfolioSummary {
     solana?: SolanaPortfolioSlice[];
     /** Multi-address Bitcoin slice; aggregates every requested btc address. */
     bitcoin?: BitcoinPortfolioSlice;
+    /** Multi-address Litecoin slice; aggregates every requested ltc address. */
+    litecoin?: LitecoinPortfolioSlice;
   };
   /** Sum of all TRON wallet balances (TRX + TRC-20) across the queried addresses. */
   tronUsd?: number;
@@ -795,6 +828,8 @@ export interface MultiWalletPortfolioSummary {
   solanaStakingUsd?: number;
   /** Sum of BTC × USD-price across queried Bitcoin addresses. */
   bitcoinUsd?: number;
+  /** Sum of LTC × USD-price across queried Litecoin addresses. */
+  litecoinUsd?: number;
   coverage: PortfolioCoverage;
 }
 
@@ -1218,6 +1253,42 @@ export interface UnsignedBitcoinTx {
   fingerprint?: `0x${string}`;
 }
 
+/**
+ * Unsigned Litecoin transaction. Mirror of `UnsignedBitcoinTx` —
+ * same PSBT-v0 shape, same Ledger app interface (currency:"litecoin"
+ * on the SDK side selects Litecoin-specific encoding). Symbol fields
+ * use LTC, but the on-wire bytes (PSBT, raw tx hex) use the same
+ * format as BTC.
+ */
+export interface UnsignedLitecoinTx {
+  chain: "litecoin";
+  action: "native_send";
+  from: string;
+  psbtBase64: string;
+  accountPath: string;
+  addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  description: string;
+  decoded: {
+    functionName: string;
+    args: Record<string, string>;
+    outputs: Array<{
+      address: string;
+      amountSats: string;
+      amountLtc: string;
+      isChange: boolean;
+      changePath?: string;
+    }>;
+    feeSats: string;
+    feeLtc: string;
+    feeRateSatPerVb: number;
+    rbfEligible: boolean;
+  };
+  vsize: number;
+  /** Opaque handle — see ltc-tx-store.ts. */
+  handle?: string;
+  fingerprint?: `0x${string}`;
+}
+
 /** TRON pairing entry — same shape, different BIP-44 layout (`44'/195'/<n>'/0/0`). */
 export interface PairedTronEntry {
   address: string;
@@ -1275,6 +1346,32 @@ export interface PairedBitcoinEntry {
   txCount?: number;
 }
 
+/**
+ * Litecoin pairing entry. Mirror of `PairedBitcoinEntry`. The 4
+ * standard mainnet address types map to Litecoin's L/M/ltc1q/ltc1p
+ * forms instead of BTC's 1/3/bc1q/bc1p.
+ */
+export interface PairedLitecoinEntry {
+  address: string;
+  publicKey: string;
+  path: string;
+  appVersion: string;
+  /**
+   * Discriminator for the four standard mainnet address shapes:
+   *   - "legacy"      → BIP-44 P2PKH (`L...`)
+   *   - "p2sh-segwit" → BIP-49 P2SH-wrapped segwit (`M...`)
+   *   - "segwit"      → BIP-84 native segwit P2WPKH (`ltc1q...`)
+   *   - "taproot"     → BIP-86 P2TR (`ltc1p...`) — derives correctly,
+   *     but Litecoin Core has not activated Taproot on mainnet, so
+   *     `ltc1p…` outputs are not yet spendable.
+   */
+  addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+  accountIndex: number | null;
+  chain?: 0 | 1 | null;
+  addressIndex?: number | null;
+  txCount?: number;
+}
+
 export interface UserConfig {
   rpc: {
     provider: RpcProvider;
@@ -1309,6 +1406,13 @@ export interface UserConfig {
    * over this field.
    */
   bitcoinIndexerUrl?: string;
+  /**
+   * Litecoin indexer base URL (Esplora-compatible REST API). Defaults
+   * to litecoinspace.org's free public API; override here when running
+   * against a self-hosted Esplora / Electrs instance. Env var
+   * `LITECOIN_INDEXER_URL` takes priority over this field.
+   */
+  litecoinIndexerUrl?: string;
   walletConnect?: {
     projectId?: string;
     /** Topic of the active WC session (so we can resume after restart). */
@@ -1332,5 +1436,10 @@ export interface UserConfig {
      * write-through-to-disk semantics as the Solana / TRON slices.
      */
     bitcoin?: PairedBitcoinEntry[];
+    /**
+     * Litecoin pairings — same shape as the Bitcoin slice, BIP-44
+     * coin_type 2 instead of 0.
+     */
+    litecoin?: PairedLitecoinEntry[];
   };
 }

--- a/test/litecoin-core.test.ts
+++ b/test/litecoin-core.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createHash } from "node:crypto";
+import { HDKey } from "@scure/bip32";
+import { secp256k1 } from "@noble/curves/secp256k1";
+
+/**
+ * Litecoin core test — address validation, BIP32 host-side derivation,
+ * USB-signer pairing path, send-side PSBT building, message-signing.
+ *
+ * Mirrors the BTC test pattern: mocks the Ledger SDK via
+ * `vi.mock("../src/signing/ltc-usb-loader.js")` so no USB is touched.
+ * Pairing entries persist to ~/.vaultpilot-mcp/config.json — each test
+ * redirects to a fresh tmp dir.
+ *
+ * Coverage: address-type detection (L/M/3/ltc1q/ltc1p), BIP-44 path
+ * shape (coin_type=2), pairing flow, single-address balance read,
+ * send-side rejection of legacy 3-prefix recipients, message-sign
+ * BIP-137 header.
+ */
+
+import {
+  detectLitecoinAddressType,
+  isLitecoinAddress,
+  assertLitecoinAddress,
+} from "../src/modules/litecoin/address.js";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+// ---- Address validation ------------------------------------------------
+
+describe("Litecoin address validation", () => {
+  it("recognizes the four mainnet types and the legacy 3-prefix P2SH", () => {
+    expect(detectLitecoinAddressType("LfvgypHnpdJDmpyJWqu7zhJrETvjgmWv2D")).toBe("p2pkh");
+    expect(detectLitecoinAddressType("MFhSgYTKNqL36KpVrUasrkUmwYg1NjwdMV")).toBe("p2sh");
+    // Legacy 3-prefix P2SH (still emitted by some exchanges)
+    expect(detectLitecoinAddressType("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")).toBe("p2sh");
+    expect(
+      detectLitecoinAddressType("ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck"),
+    ).toBe("p2wpkh");
+    expect(
+      detectLitecoinAddressType(
+        "ltc1pveaamy78cq5hvl74zmfw52fxyjun3lh7lgt46cur8wzezvqdgvksqsy7m4",
+      ),
+    ).toBe("p2tr");
+  });
+
+  it("rejects testnet, MWEB, and BTC mainnet addresses", () => {
+    // BTC mainnet legacy `1...`
+    expect(detectLitecoinAddressType("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")).toBe(null);
+    // BTC bech32 `bc1...`
+    expect(
+      detectLitecoinAddressType("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"),
+    ).toBe(null);
+    // LTC testnet
+    expect(
+      detectLitecoinAddressType("tltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck"),
+    ).toBe(null);
+    // MWEB (not supported)
+    expect(
+      detectLitecoinAddressType(
+        "ltcmweb1qqfqf9z83zye9q4n75v8nzkacejxgkkesvjdgqd9hu6jnqwqdrlmgyuq22qsy",
+      ),
+    ).toBe(null);
+    expect(isLitecoinAddress("not-a-real-address")).toBe(false);
+  });
+
+  it("assertLitecoinAddress throws with a helpful message", () => {
+    expect(() => assertLitecoinAddress("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"))
+      .toThrow(/not a valid Litecoin/);
+  });
+});
+
+// ---- BIP32 host-side derivation ---------------------------------------
+
+describe("Litecoin BIP32 host-side derivation", () => {
+  it("uses BIP-44 coin_type 2 (not 0)", async () => {
+    const { ltcAccountLevelPath, ltcLeafPath, parseLtcPath } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    expect(ltcAccountLevelPath(0, "segwit")).toBe("84'/2'/0'");
+    expect(ltcLeafPath(0, "segwit", 0, 0)).toBe("84'/2'/0'/0/0");
+    expect(ltcLeafPath(3, "taproot", 1, 5)).toBe("86'/2'/3'/1/5");
+    // Reject BTC-shape paths (coin_type 0)
+    expect(parseLtcPath("84'/0'/0'/0/0")).toBe(null);
+    // Accept LTC-shape paths
+    expect(parseLtcPath("84'/2'/0'/0/0")).toEqual({
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+  });
+
+  it("encodes addresses with the LTC bech32 HRP and version bytes", async () => {
+    const { encodeAddressForFormat, accountNodeFromLedgerResponse } = await import(
+      "../src/signing/ltc-bip32-derive.js"
+    );
+    // Deterministic BIP-32 root from a known seed.
+    const seed = createHash("sha256").update("ltc-test-seed").digest();
+    const root = HDKey.fromMasterSeed(seed);
+    const accountHd = root.derive("m/84'/2'/0'");
+    if (!accountHd.publicKey || !accountHd.chainCode) {
+      throw new Error("test fixture: derivation failed");
+    }
+    // Convert to uncompressed (the shape Ledger returns) so the helper
+    // exercises its compress + xpub-encode path.
+    const point = secp256k1.ProjectivePoint.fromHex(
+      Buffer.from(accountHd.publicKey).toString("hex"),
+    );
+    const node = accountNodeFromLedgerResponse({
+      publicKeyHex: Buffer.from(point.toRawBytes(false)).toString("hex"),
+      chainCodeHex: Buffer.from(accountHd.chainCode).toString("hex"),
+      addressFormat: "bech32",
+    });
+    // Re-derive a leaf and confirm the address is `ltc1q…`
+    const child = node.hd.derive("m/0/0");
+    if (!child.publicKey) throw new Error("no child pubkey");
+    const addr = encodeAddressForFormat(child.publicKey, "bech32");
+    expect(addr.startsWith("ltc1q")).toBe(true);
+    // Same seed via legacy format → L-prefix
+    const legacy = encodeAddressForFormat(child.publicKey, "legacy");
+    expect(legacy.startsWith("L")).toBe(true);
+    // p2sh-segwit → M-prefix (modern)
+    const p2sh = encodeAddressForFormat(child.publicKey, "p2sh");
+    expect(p2sh.startsWith("M")).toBe(true);
+    // taproot → ltc1p
+    const taproot = encodeAddressForFormat(child.publicKey, "bech32m");
+    expect(taproot.startsWith("ltc1p")).toBe(true);
+  });
+});
+
+// ---- Pairing flow (mocked Ledger) -------------------------------------
+
+const TEST_SEED = createHash("sha256").update("ltc-pair-test-seed").digest();
+const TEST_ROOT = HDKey.fromMasterSeed(TEST_SEED);
+
+function makeAccountFixture(purpose: number, accountIndex: number) {
+  const accountHd = TEST_ROOT.derive(`m/${purpose}'/2'/${accountIndex}'`);
+  if (!accountHd.publicKey || !accountHd.chainCode) {
+    throw new Error("derivation failed");
+  }
+  const point = secp256k1.ProjectivePoint.fromHex(
+    Buffer.from(accountHd.publicKey).toString("hex"),
+  );
+  return {
+    publicKeyHex: Buffer.from(point.toRawBytes(false)).toString("hex"),
+    chainCodeHex: Buffer.from(accountHd.chainCode).toString("hex"),
+    hd: accountHd,
+  };
+}
+
+const getWalletPublicKeyMock = vi.fn();
+const signMessageMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+const getAppAndVersionMock = vi.fn();
+
+vi.mock("../src/signing/ltc-usb-loader.js", () => ({
+  openLedger: async () => ({
+    app: {
+      getWalletPublicKey: getWalletPublicKeyMock,
+      signMessage: signMessageMock,
+    },
+    transport: { close: transportCloseMock },
+    rawTransport: {},
+  }),
+  getAppAndVersion: (rt: unknown) => getAppAndVersionMock(rt),
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-ltc-test-"));
+  setConfigDirForTesting(pjoin(tmpHome, ".vaultpilot-mcp"));
+  getWalletPublicKeyMock.mockReset();
+  signMessageMock.mockReset();
+  transportCloseMock.mockReset();
+  getAppAndVersionMock.mockReset();
+  getAppAndVersionMock.mockResolvedValue({ name: "Litecoin", version: "2.4.6" });
+  // Also flush the in-memory pairing cache.
+  const { clearPairedLtcAddresses } = await import(
+    "../src/signing/ltc-usb-signer.js"
+  );
+  clearPairedLtcAddresses();
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("pair_ledger_ltc", () => {
+  it("derives all four address types for accountIndex 0 and stamps coin_type 2", async () => {
+    // Account-level call returns the (publicKey, chainCode) for the
+    // requested purpose — host-side derivation walks under it.
+    const fixturesByPurpose = new Map<number, ReturnType<typeof makeAccountFixture>>();
+    for (const purpose of [44, 49, 84, 86]) {
+      fixturesByPurpose.set(purpose, makeAccountFixture(purpose, 0));
+    }
+    getWalletPublicKeyMock.mockImplementation((path: string) => {
+      const m = /^(\d+)'\/2'\/(\d+)'$/.exec(path);
+      if (!m) {
+        throw new Error(`unexpected non-account path: ${path}`);
+      }
+      const purpose = Number(m[1]);
+      const fixture = fixturesByPurpose.get(purpose);
+      if (!fixture) throw new Error(`no fixture for purpose ${purpose}`);
+      return Promise.resolve({
+        publicKey: fixture.publicKeyHex,
+        bitcoinAddress: "irrelevant-at-account-level",
+        chainCode: fixture.chainCodeHex,
+      });
+    });
+
+    const { pairLedgerLitecoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const { getLitecoinIndexer } = await import(
+      "../src/modules/litecoin/indexer.js"
+    );
+    // Stub the indexer so the gap-limit scan terminates immediately
+    // (every probe → txCount 0).
+    const indexer = getLitecoinIndexer();
+    vi.spyOn(indexer, "getBalance").mockResolvedValue({
+      address: "any",
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: 0,
+    });
+
+    const result = await pairLedgerLitecoin({ accountIndex: 0, gapLimit: 1 });
+    expect(result.accountIndex).toBe(0);
+    expect(result.appVersion).toBe("2.4.6");
+    // Four address types × 2 chains × at least 1 entry → ≥ 4 entries
+    // (with gapLimit=1 + receive empty → change skipped, so exactly 4)
+    expect(result.addresses.length).toBe(4);
+    const types = result.addresses.map((a) => a.addressType).sort();
+    expect(types).toEqual(["legacy", "p2sh-segwit", "segwit", "taproot"]);
+    // Every path must use coin_type 2.
+    for (const a of result.addresses) {
+      expect(a.path).toMatch(/^(44|49|84|86)'\/2'\/0'\/0\/0$/);
+    }
+    // L/M/ltc1q/ltc1p prefixes per address type.
+    const byType = new Map(result.addresses.map((a) => [a.addressType, a.address]));
+    expect(byType.get("legacy")?.startsWith("L")).toBe(true);
+    expect(byType.get("p2sh-segwit")?.startsWith("M")).toBe(true);
+    expect(byType.get("segwit")?.startsWith("ltc1q")).toBe(true);
+    expect(byType.get("taproot")?.startsWith("ltc1p")).toBe(true);
+  });
+
+  it("rejects with a hint when the wrong app is open", async () => {
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.4.6" });
+    getWalletPublicKeyMock.mockResolvedValue({
+      publicKey: "00".repeat(65),
+      bitcoinAddress: "x",
+      chainCode: "00".repeat(32),
+    });
+    const { pairLedgerLitecoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(pairLedgerLitecoin({ accountIndex: 0, gapLimit: 1 })).rejects.toThrow(
+      /Litecoin is required/,
+    );
+  });
+});
+
+// ---- Send-side rejection of legacy 3-prefix recipients ----------------
+
+describe("prepare_litecoin_native_send", () => {
+  it("rejects legacy 3-prefix P2SH recipients with a clear message", async () => {
+    // Insert a fake paired entry so the source-address check passes.
+    const { setPairedLtcAddress } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    setPairedLtcAddress({
+      address: "ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck",
+      publicKey: "00".repeat(33),
+      path: "84'/2'/0'/0/0",
+      appVersion: "2.4.6",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+    const { prepareLitecoinNativeSend } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareLitecoinNativeSend({
+        wallet: "ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck",
+        to: "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy", // legacy 3-prefix
+        amount: "0.001",
+      }),
+    ).rejects.toThrow(/3-prefix Litecoin P2SH addresses.*not supported/);
+  });
+});
+
+// ---- Message-sign BIP-137 header byte ---------------------------------
+
+describe("sign_message_ltc", () => {
+  it("emits a BIP-137 base64 signature with the segwit header byte (39 + recid)", async () => {
+    // Need a paired segwit entry whose address the mocked
+    // `getWalletPublicKey` re-derivation returns. Use the same fixture
+    // helper as the pairing test.
+    const fixture = makeAccountFixture(84, 0);
+    const { encodeAddressForFormat, accountNodeFromLedgerResponse } = await import(
+      "../src/signing/ltc-bip32-derive.js"
+    );
+    const node = accountNodeFromLedgerResponse({
+      publicKeyHex: fixture.publicKeyHex,
+      chainCodeHex: fixture.chainCodeHex,
+      addressFormat: "bech32",
+    });
+    const child = node.hd.derive("m/0/0");
+    if (!child.publicKey) throw new Error("no child pubkey");
+    const segwitAddr = encodeAddressForFormat(child.publicKey, "bech32");
+
+    // Re-derivation guard: ledger returns the same segwit address.
+    getWalletPublicKeyMock.mockImplementation((_path: string) =>
+      Promise.resolve({
+        publicKey: fixture.publicKeyHex,
+        bitcoinAddress: segwitAddr,
+        chainCode: fixture.chainCodeHex,
+      }),
+    );
+    // signMessage: (v, r, s) → header byte = 39 + (v & 1) for segwit.
+    signMessageMock.mockResolvedValue({
+      v: 1,
+      r: "aa".repeat(32),
+      s: "bb".repeat(32),
+    });
+
+    const { setPairedLtcAddress } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    setPairedLtcAddress({
+      address: segwitAddr,
+      publicKey: fixture.publicKeyHex,
+      path: "84'/2'/0'/0/0",
+      appVersion: "2.4.6",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+
+    const { signLtcMessage } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const result = await signLtcMessage({ wallet: segwitAddr, message: "hello LTC" });
+    expect(result.address).toBe(segwitAddr);
+    expect(result.message).toBe("hello LTC");
+    expect(result.format).toBe("BIP-137");
+    expect(result.addressType).toBe("segwit");
+    // Decode base64 sig and verify the header byte = 39 + (v & 1) = 40.
+    const sigBuf = Buffer.from(result.signature, "base64");
+    expect(sigBuf.length).toBe(65);
+    expect(sigBuf[0]).toBe(40);
+  });
+
+  it("refuses taproot message-signing (BIP-322 not supported)", async () => {
+    // Pair a fake taproot entry.
+    const { setPairedLtcAddress } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const taprootAddr =
+      "ltc1pveaamy78cq5hvl74zmfw52fxyjun3lh7lgt46cur8wzezvqdgvksqsy7m4";
+    setPairedLtcAddress({
+      address: taprootAddr,
+      publicKey: "00".repeat(33),
+      path: "86'/2'/0'/0/0",
+      appVersion: "2.4.6",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+    const { signLtcMessage } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      signLtcMessage({ wallet: taprootAddr, message: "hi" }),
+    ).rejects.toThrow(/Taproot.*BIP-322/);
+  });
+});
+
+// ---- Tx-store + handle namespace --------------------------------------
+
+describe("ltc-tx-store handle namespace", () => {
+  it("issues handles with `ltc-` prefix and consumes them once", async () => {
+    const {
+      issueLitecoinHandle,
+      consumeLitecoinHandle,
+      hasLitecoinHandle,
+      __clearLitecoinTxStore,
+    } = await import("../src/signing/ltc-tx-store.js");
+    __clearLitecoinTxStore();
+    const { handle, fingerprint } = issueLitecoinHandle({
+      chain: "litecoin",
+      action: "native_send",
+      from: "ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck",
+      psbtBase64: "cHNidP8BAAoCAAAAAAAAAAAAAA==",
+      accountPath: "84'/2'/0'",
+      addressFormat: "bech32",
+      description: "test",
+      decoded: {
+        functionName: "litecoin.native_send",
+        args: {},
+        outputs: [],
+        feeSats: "0",
+        feeLtc: "0",
+        feeRateSatPerVb: 1,
+        rbfEligible: true,
+      },
+      vsize: 110,
+    });
+    expect(handle).toMatch(/^ltc-/);
+    expect(fingerprint).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(hasLitecoinHandle(handle)).toBe(true);
+    const tx = consumeLitecoinHandle(handle);
+    expect(tx.from).toBe("ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck");
+    // Consumption is non-destructive (matches BTC); must still be there
+    // for the actual send_transaction to retire it after broadcast.
+    expect(hasLitecoinHandle(handle)).toBe(true);
+    __clearLitecoinTxStore();
+    expect(hasLitecoinHandle(handle)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Litecoin mainnet support by mirroring the existing Bitcoin vertical. The Ledger Litecoin app shares the host-side SDK (`@ledgerhq/hw-app-btc`) with the Bitcoin app, parametrized by `currency:"litecoin"` in `ltc-usb-loader.ts`.

Chain-identity differences from BTC:
- **BIP-44 coin_type**: 2 (vs BTC's 0).
- **Address version bytes**: P2PKH `0x30` (L-prefix), P2SH `0x32` (M-prefix, modern). Read-side also accepts legacy `0x05` (3-prefix) for exchange compat.
- **Bech32 HRP**: `ltc` (vs `bc`).
- **xpub version bytes**: standard BIP-32 `0x0488B21E` per Litecoin Core convention (no `Ltub` remap).
- **Indexer**: `https://litecoinspace.org/api` (mempool.space's LTC sister, same Esplora API).

## What's in this PR

Tools:
- `pair_ledger_ltc` — BIP44 gap-limit scan across all four address types (L/M/ltc1q/ltc1p).
- `get_ltc_balance` — single-address Esplora balance read.
- `prepare_litecoin_native_send` — PSBT v0 with `nonWitnessUtxo` on every input (Ledger app 2.x requirement, mirrors BTC fix from #213).
- `sign_message_ltc` — BIP-137 with Litecoin's message prefix.
- `send_transaction` routing via `hasLitecoinHandle`.

Types & wiring:
- `LitecoinPortfolioSlice` / `UnsignedLitecoinTx` / `PairedLitecoinEntry`.
- `get_ledger_status` surfaces paired LTC entries under `litecoin: [...]`.

## Out of scope (deferred to follow-up)

- Multi-address `get_ltc_balances`, fee-estimates, block-tip, account-balance, rescan, tx-history tools.
- Portfolio-summary integration (`litecoinUsd` / `breakdown.litecoin`).
- Transaction-history dispatch.

The deferred surface is the read/diagnostic layer — the core ship-receive vertical is complete in this PR.

## Constraints surfaced in code

- **Taproot caveat**: Litecoin Core has not activated Taproot on mainnet. `ltc1p…` addresses derive correctly and the Ledger Litecoin app emits them, but outputs aren't yet spendable. Documented in `ltc-bip32-derive.ts` and the pair tool description; user explicitly opted in during planning to derive all four types.
- **Legacy 3-prefix P2SH on send**: refused. bitcoinjs-lib's `scriptHash` byte is single-valued per network object, so we configure the modern `0x32` (M-prefix) and ask senders to use the M-prefix recipient form. Receiving from a 3-prefix address works because the regex accepts both.
- **MWEB**: explicitly out of scope. Ledger doesn't expose MWEB signing primitives.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 1134 tests / 92 files green (was 1123/91; +11 new LTC tests).
- New tests in `test/litecoin-core.test.ts`:
  - Address-type detection across L/M/3/ltc1q/ltc1p + rejection of BTC/testnet/MWEB.
  - BIP-44 coin_type 2 in path builders + parser refuses BTC-shape paths.
  - LTC bech32 HRP + version bytes in `encodeAddressForFormat` (L/M/ltc1q/ltc1p prefixes).
  - `pair_ledger_ltc` end-to-end with mocked Ledger SDK + indexer; checks every path uses `/2'/`.
  - Wrong-app rejection ("Bitcoin" open → asks for Litecoin).
  - `prepare_litecoin_native_send` rejects 3-prefix recipients with a clear message.
  - `sign_message_ltc` emits BIP-137 segwit header byte (39 + recid) and refuses taproot.
  - `ltc-tx-store` handles use `ltc-` prefix and survive non-destructive consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)