### PR TITLE
fix(wc): clear stale session locally + reword dead/timeout errors (#218, #219)

### DIFF
--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -369,6 +369,65 @@ export interface PinnedGasFields {
  */
 const WC_SEND_REQUEST_TIMEOUT_MS = 120_000;
 
+/**
+ * Compose the dead-session error message. Issue #219: the prior wording
+ * told users to "reconnect in Ledger Live → Settings → Connected Apps",
+ * but on a relay-side end Ledger Live's UI shows the session as still
+ * connected and there is no reconnect affordance — the user has to
+ * `pair_ledger_live` to get a fresh topic. Lead with that and explicitly
+ * call out the stale-UI case so the agent can relay actionable guidance.
+ *
+ * Exported for test-side inspection so we don't have to source-scrape.
+ */
+export function deadSessionMessage(): string {
+  return (
+    "WalletConnect session is gone from the relay's perspective (the local " +
+    "client got an explicit peer-end signal, not a timeout). The local " +
+    "session record has been cleared. " +
+    "Run `pair_ledger_live` to start a fresh session — you'll get a new QR / " +
+    "URI to approve in Ledger Live. The prepared handle is still valid for " +
+    "the next 15 minutes, so re-call send_transaction on the same handle once " +
+    "the new session is active. " +
+    "Heads-up: Ledger Live's UI may still list VaultPilot under Settings → " +
+    "Connected Apps even though the relay has dropped the topic. That listing " +
+    "is stale — there is no \"reconnect\" affordance on the stale entry; the " +
+    "only path forward is `pair_ledger_live` to create a fresh topic. If you " +
+    "want to clean up the stale UI entry, manually disconnect VaultPilot in " +
+    "Ledger Live → Settings → Connected Apps before re-pairing. Issue #219."
+  );
+}
+
+/**
+ * Compose the timeout error message. Issue #218: the prior wording said
+ * "the handle is still valid for retry" without qualification, which
+ * invited blind retries that risk a double-broadcast (Ledger Live may
+ * still complete signing + broadcast asynchronously after our 120s
+ * timer fires — our timer aborts only THIS server's wait, not the
+ * device-side request). Surface the pinned (from, nonce, chainId) so the
+ * agent can suggest concrete on-chain checks before retrying.
+ *
+ * Exported for test-side inspection so we don't have to source-scrape.
+ */
+export function timeoutMessage(args: {
+  timeoutSeconds: number;
+  from: `0x${string}` | string;
+  nonce: number | "<unpinned — check pending nonce on chain>";
+  chainId: number | string;
+}): string {
+  return (
+    `WalletConnect signing request did not complete within ${args.timeoutSeconds}s on this server's clock — ` +
+    `the user may simply still be reviewing the tx on the Ledger device. ` +
+    `CRITICAL: this timeout aborts only THIS server's wait; it does NOT cancel the request on Ledger Live's side. ` +
+    `If the user signs after this point, Ledger Live may still broadcast the tx asynchronously without us seeing the response. ` +
+    `DO NOT retry blindly — that risks a double-broadcast attempt against the chain (saved here only by the chain's duplicate-nonce protection, which is incidental, not by design). ` +
+    `Before any retry, verify the original request did NOT land on chain: ` +
+    `query \`get_transaction_status\` against the chain's mempool / latest block, ` +
+    `or check a block explorer for txs from \`${args.from}\` with nonce \`${args.nonce}\` on chain id \`${args.chainId}\`. ` +
+    `Only retry send_transaction (same handle, 15-min TTL from prepare) if RPC confirms the pinned nonce is still UNCONSUMED on the pending state. ` +
+    `Issue #218.`
+  );
+}
+
 /** Send an `eth_sendTransaction` request. Ledger Live shows it, user signs on device, we get tx hash back. */
 export async function requestSendTransaction(
   tx: UnsignedTx,
@@ -389,13 +448,26 @@ export async function requestSendTransaction(
   // raises an actionable structured error instead.
   const liveness = await probeSessionLiveness(c, currentSession.topic);
   if (liveness === "dead") {
-    throw new WalletConnectSessionUnavailableError(
-      "WalletConnect session has been ended by the peer (Ledger Live disconnected it, " +
-        "or the relay rejected the topic). Open Ledger Live → Settings → Connected " +
-        "Apps → VaultPilot and reconnect, or run `pair_ledger_live` to start a fresh " +
-        "session. The handle is still valid for the next 15 minutes, so you can retry " +
-        "send_transaction with the same handle once WC is reconnected.",
-    );
+    // Issue #219: drop the local session record so subsequent retries
+    // don't replay the same probe→error against a known-dead topic. The
+    // startup branch in `getSignClient` does this same cleanup; without
+    // it here, the user can re-pair and end up with two locally-tracked
+    // sessions where this dead one fires first on every retry. Best-
+    // effort delete; ignore failure (the relay-side record may already
+    // be gone, which is the case that produced the dead probe to begin
+    // with).
+    const deadTopic = currentSession.topic;
+    try {
+      await c.session.delete(deadTopic, getSdkError("USER_DISCONNECTED"));
+    } catch {
+      // Ignore — the local record is what we actually need to clear.
+    }
+    currentSession = null;
+    peerUnreachable = false;
+    patchUserConfig({
+      walletConnect: { sessionTopic: undefined, pairingTopic: undefined },
+    });
+    throw new WalletConnectSessionUnavailableError(deadSessionMessage());
   }
   if (liveness === "unknown") {
     throw new WalletConnectSessionUnavailableError(
@@ -441,6 +513,14 @@ export async function requestSendTransaction(
   // Hard wall-clock cap so even if the peer accepts the request but never
   // responds (common failure mode when Ledger Live is backgrounded mid-sign),
   // the tool eventually surfaces control back to the agent. Issue #75.
+  //
+  // CRITICAL framing — Issue #218: the timeout aborts THIS server's wait,
+  // it does NOT cancel the request on Ledger Live's side. If the user is
+  // mid-review on the Ledger when the timer fires, signing may still
+  // complete and Ledger Live may still broadcast asynchronously after the
+  // error returns. The error message must NOT advise a blind retry — that
+  // risks a double-broadcast. Surface the pinned (from, nonce, chainId)
+  // so the agent can suggest checking on-chain state before re-sending.
   let timedOut = false;
   const hash = await Promise.race([
     c.request(request) as Promise<`0x${string}`>,
@@ -449,9 +529,12 @@ export async function requestSendTransaction(
         timedOut = true;
         reject(
           new WalletConnectRequestTimeoutError(
-            `WalletConnect signing request did not complete within ${WC_SEND_REQUEST_TIMEOUT_MS / 1000}s. ` +
-              "The peer may be unresponsive or the user may have walked away from the Ledger. " +
-              "The handle is still valid for retry (15-minute TTL from prepare time).",
+            timeoutMessage({
+              timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
+              from,
+              nonce: pinned ? pinned.nonce : "<unpinned — check pending nonce on chain>",
+              chainId,
+            }),
           ),
         );
       }, WC_SEND_REQUEST_TIMEOUT_MS),

--- a/test/walletconnect-send-liveness.test.ts
+++ b/test/walletconnect-send-liveness.test.ts
@@ -65,3 +65,88 @@ describe("WalletConnectRequestTimeoutError", () => {
     expect(e instanceof Error).toBe(true);
   });
 });
+
+// Issue #219 regression: when the dead-session error fires from the
+// requestSendTransaction path, the user-facing message must NOT advise
+// "Settings → Connected Apps → reconnect" (Ledger Live's UI is stale on
+// relay-side ends — there is no reconnect affordance on the stale entry).
+// Lead with `pair_ledger_live` and explicitly call out the stale-UI case.
+describe("deadSessionMessage — issue #219 wording lock", () => {
+  it("leads with pair_ledger_live as the recovery, not reconnect-in-settings", async () => {
+    const { deadSessionMessage } = await import(
+      "../src/signing/walletconnect.js"
+    );
+    const msg = deadSessionMessage();
+    expect(msg).toContain("`pair_ledger_live`");
+    expect(msg).toContain("local session record has been cleared");
+    // Stale-UI heads-up — the whole point of #219.
+    expect(msg).toContain("Ledger Live's UI may still list");
+    expect(msg).toContain("listing is stale");
+    expect(msg).toContain('no "reconnect" affordance');
+    // Old wording must NOT survive — it sent users on a wild-goose chase.
+    expect(msg).not.toContain("and reconnect, or run");
+  });
+
+  it("clears local session state in the dead branch (no stale record on disk)", async () => {
+    // The compiled error message + the cleanup sequence are the contract.
+    // Source-scrape the dead branch to confirm the cleanup ordering.
+    // Anchor on the unique `deadTopic` local — the startup branch in
+    // getSignClient does similar cleanup but uses currentSession.topic
+    // directly, and we don't want this assertion to accidentally catch it.
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("../src/signing/walletconnect.ts", import.meta.url),
+      "utf8",
+    );
+    const deadBranch = src.match(
+      /const deadTopic = currentSession\.topic;[\s\S]*?deadSessionMessage\(\)/,
+    );
+    expect(deadBranch, "requestSendTransaction dead branch not found").toBeTruthy();
+    const code = deadBranch![0];
+    expect(code).toMatch(/c\.session\.delete\(deadTopic/);
+    expect(code).toMatch(/currentSession = null/);
+    expect(code).toMatch(/sessionTopic: undefined,\s+pairingTopic: undefined/);
+  });
+});
+
+// Issue #218 regression: the 120s timeout error must NOT advise "the
+// handle is still valid for retry" without qualification — that wording
+// invites a double-broadcast attempt. The new wording warns about the
+// late-broadcast race and surfaces the pinned (from, nonce, chainId) so
+// the agent can suggest concrete on-chain checks before any retry.
+describe("timeoutMessage — issue #218 wording lock", () => {
+  it("warns about async late broadcast and forbids blind retry; embeds pinned (from, nonce, chainId)", async () => {
+    const { timeoutMessage } = await import(
+      "../src/signing/walletconnect.js"
+    );
+    const msg = timeoutMessage({
+      timeoutSeconds: 120,
+      from: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+      nonce: 272,
+      chainId: 1,
+    });
+    expect(msg).toContain("may still broadcast the tx asynchronously");
+    expect(msg).toContain("DO NOT retry blindly");
+    expect(msg).toContain("double-broadcast");
+    expect(msg).toContain("get_transaction_status");
+    // Pinned fields surfaced verbatim so the agent can act on them.
+    expect(msg).toContain("0xC0f5b7f7703BA95dC7C09D4eF50A830622234075");
+    expect(msg).toContain("nonce `272`");
+    expect(msg).toContain("chain id `1`");
+    // Old wording must NOT survive — it implied retry was safe.
+    expect(msg).not.toContain("handle is still valid for retry (15-minute TTL");
+  });
+
+  it("falls back to a clear placeholder when nonce wasn't pinned", async () => {
+    const { timeoutMessage } = await import(
+      "../src/signing/walletconnect.js"
+    );
+    const msg = timeoutMessage({
+      timeoutSeconds: 120,
+      from: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+      nonce: "<unpinned — check pending nonce on chain>",
+      chainId: 1,
+    });
+    expect(msg).toContain("<unpinned — check pending nonce on chain>");
+  });
+});


### PR DESCRIPTION
## Summary

Two coupled WC post-#75 wedges from a live session.

### #219 — dead-session error was unactionable + leaked stale state

- The error told users "reconnect in Ledger Live → Settings → Connected Apps". On relay-side session ends, Ledger Live's UI still lists VaultPilot as connected and offers no reconnect affordance — that advice was a wild-goose chase.
- The dead-branch in \`requestSendTransaction\` threw without clearing the local session record (\`currentSession\` + on-disk \`user-config.walletConnect.{sessionTopic,pairingTopic}\`). Every subsequent retry replayed the same probe→error against the known-dead local state.

**Fix**: mirror the cleanup the startup branch in \`getSignClient\` already does (best-effort \`c.session.delete\`, null \`currentSession\`, patch user-config to clear topic refs). Reword the error to lead with \`pair_ledger_live\` and explicitly warn the user that Ledger Live's UI may show the stale session as connected.

### #218 — 120s timeout error invited a double-broadcast

- The timeout aborts only THIS server's wait — Ledger Live may still complete signing and broadcast asynchronously. The previous "handle is still valid for retry (15-min TTL)" framing missed this and invited blind retries.

**Fix**: reword the error to flag the late-broadcast race, forbid blind retry, and surface the pinned (\`from\`, \`nonce\`, \`chainId\`) so the agent can suggest concrete on-chain checks (\`get_transaction_status\`, block-explorer lookup) before deciding what to do. Implements issue #218 **part (a)**; the optional late-broadcast detection (part b — RPC nonce probe + tx hash recovery) is deferred to a follow-up — it needs non-trivial RPC probing infra.

### Refactor

Extracted both error templates into exported \`deadSessionMessage()\` and \`timeoutMessage()\` functions. Lets tests import compiled strings instead of source-scraping the file (the source-scrape tripped over \`\" +\` continuations in multi-line string literals).

## Test plan

- [x] 4 new tests in \`walletconnect-send-liveness.test.ts\`:
  - \`deadSessionMessage\` wording lock — positive (\`pair_ledger_live\`, "local session record has been cleared", stale-UI heads-up) + negative-regression (old "reconnect in Settings" advice must NOT survive)
  - \`timeoutMessage\` wording lock — positive (late-broadcast warning, \`get_transaction_status\` reference, embedded pinned (\`from\`, \`nonce\`, \`chainId\`)) + negative-regression (old "handle is still valid for retry" must NOT survive)
  - Unpinned-nonce fallback — message gracefully includes the placeholder when no nonce was pinned
  - Source-anchored check on the dead-branch cleanup sequence (try-delete topic → null \`currentSession\` → clear user-config)
- [x] Targeted: \`npx vitest run test/walletconnect-send-liveness.test.ts\` — 9/9 pass
- [x] Full suite: \`npm test\` — 1127/1127 pass
- [ ] **Live verification post-merge**: trigger the dead-session case (e.g. force-disconnect WC in Ledger Live, then call \`send_transaction\`); error should advise \`pair_ledger_live\`, NOT "reconnect in Settings", and a follow-up \`pair_ledger_live\` should succeed without a "session already exists" complaint. For #218: trigger the 120s timeout (e.g. start signing on-device but don't approve for 2 minutes); error should warn against blind retry and embed the pinned (from, nonce, chainId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)