### PR TITLE
feat(tx-history): annotate items with suspectedPoisoning (#220)

### DIFF
--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -17,6 +17,7 @@ import type {
   HistoryItem,
   HistoryResponse,
 } from "./schemas.js";
+import { annotateSuspectedPoisoning } from "./poisoning.js";
 
 /**
  * Entry point for `get_transaction_history`. Dispatches to the EVM or TRON
@@ -216,6 +217,9 @@ export async function getTransactionHistory(
   } else {
     priceCoverage = "none";
   }
+
+  // Run after pricing so `valueUsd` is available to the dust check.
+  annotateSuspectedPoisoning(items, wallet);
 
   const response: HistoryResponse = {
     chain,

--- a/src/modules/history/poisoning.ts
+++ b/src/modules/history/poisoning.ts
@@ -1,0 +1,102 @@
+import type { HistoryItem, SuspectedPoisoning } from "./schemas.js";
+
+const EVM_ADDRESS_RE = /^0x[a-f0-9]{40}$/i;
+const DUST_NATIVE_WEI = 10_000_000_000n;
+const DUST_USD_THRESHOLD = 0.01;
+
+function suffixKey(addr: string): string | null {
+  if (!EVM_ADDRESS_RE.test(addr)) return null;
+  const lower = addr.toLowerCase();
+  const hex = lower.slice(2);
+  return hex.slice(0, 4) + hex.slice(-4);
+}
+
+function counterpartyOf(item: HistoryItem, walletLower: string): string {
+  const fromLower = item.from.toLowerCase();
+  return fromLower === walletLower ? item.to : item.from;
+}
+
+function isDust(item: HistoryItem): boolean {
+  if (item.type === "external" || item.type === "internal") {
+    if (item.valueUsd !== undefined && item.valueUsd <= DUST_USD_THRESHOLD) return true;
+    try {
+      return BigInt(item.valueNative) <= DUST_NATIVE_WEI;
+    } catch {
+      return false;
+    }
+  }
+  if (item.type === "token_transfer") {
+    if (item.valueUsd !== undefined && item.valueUsd <= DUST_USD_THRESHOLD) return true;
+    return item.amount === "0";
+  }
+  return false;
+}
+
+export function annotateSuspectedPoisoning(
+  items: HistoryItem[],
+  wallet: string
+): void {
+  // Skip non-EVM addresses; vanity-suffix logic is hex-only.
+  if (!EVM_ADDRESS_RE.test(wallet)) return;
+
+  const walletLower = wallet.toLowerCase();
+  const walletSuffix = suffixKey(wallet);
+
+  // Map suffix -> set of distinct counterparty addresses (lowercased) seen.
+  // Used to detect vanity-suffix collisions across different counterparties.
+  const suffixToCounterparties = new Map<string, Set<string>>();
+  for (const item of items) {
+    const cp = counterpartyOf(item, walletLower);
+    const key = suffixKey(cp);
+    if (!key) continue;
+    const cpLower = cp.toLowerCase();
+    if (cpLower === walletLower) continue;
+    let bucket = suffixToCounterparties.get(key);
+    if (!bucket) {
+      bucket = new Set<string>();
+      suffixToCounterparties.set(key, bucket);
+    }
+    bucket.add(cpLower);
+  }
+
+  for (const item of items) {
+    const reasons: SuspectedPoisoning["reasons"] = [];
+    let mimics: string | undefined;
+
+    if (item.type === "token_transfer" && item.amount === "0") {
+      reasons.push("zero_amount_transfer");
+    }
+
+    const cp = counterpartyOf(item, walletLower);
+    const cpLower = cp.toLowerCase();
+    const cpKey = suffixKey(cp);
+
+    if (cpKey && cpLower !== walletLower && isDust(item)) {
+      const bucket = suffixToCounterparties.get(cpKey);
+      if (bucket && bucket.size > 1) {
+        let legit: string | undefined;
+        for (const addr of bucket) {
+          if (addr !== cpLower) {
+            legit = addr;
+            break;
+          }
+        }
+        if (legit) {
+          reasons.push("vanity_suffix_lookalike");
+          mimics = legit;
+        }
+      }
+
+      if (walletSuffix && cpKey === walletSuffix) {
+        reasons.push("self_suffix_lookalike");
+        if (!mimics) mimics = walletLower;
+      }
+    }
+
+    if (reasons.length > 0) {
+      item.suspectedPoisoning = mimics
+        ? { reasons, mimics }
+        : { reasons };
+    }
+  }
+}

--- a/src/modules/history/schemas.ts
+++ b/src/modules/history/schemas.ts
@@ -47,6 +47,15 @@ export type HistoryItemType =
   | "internal"
   | "program_interaction";
 
+export type SuspectedPoisoning = {
+  reasons: Array<
+    | "zero_amount_transfer"
+    | "vanity_suffix_lookalike"
+    | "self_suffix_lookalike"
+  >;
+  mimics?: string;
+};
+
 interface HistoryItemBase {
   type: HistoryItemType;
   hash: string;
@@ -54,6 +63,7 @@ interface HistoryItemBase {
   from: string;
   to: string;
   status: "success" | "failed";
+  suspectedPoisoning?: SuspectedPoisoning;
 }
 
 export interface ExternalHistoryItem extends HistoryItemBase {

--- a/test/tx-history-poisoning.test.ts
+++ b/test/tx-history-poisoning.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { annotateSuspectedPoisoning } from "../src/modules/history/poisoning.js";
+import type { HistoryItem } from "../src/modules/history/schemas.js";
+
+const WALLET = "0xC0F5111111111111111111111111111111114075";
+const WALLET_LOWER = WALLET.toLowerCase();
+
+function tokenTransfer(over: Partial<Extract<HistoryItem, { type: "token_transfer" }>>): HistoryItem {
+  return {
+    type: "token_transfer",
+    hash: "0x" + "a".repeat(64),
+    timestamp: 1700000000,
+    from: "0x1111111111111111111111111111111111111111",
+    to: WALLET,
+    status: "success",
+    tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    tokenSymbol: "USDC",
+    tokenDecimals: 6,
+    amount: "1000000",
+    amountFormatted: "1",
+    ...over,
+  };
+}
+
+function externalTx(over: Partial<Extract<HistoryItem, { type: "external" }>>): HistoryItem {
+  return {
+    type: "external",
+    hash: "0x" + "b".repeat(64),
+    timestamp: 1700000000,
+    from: "0x2222222222222222222222222222222222222222",
+    to: WALLET,
+    status: "success",
+    valueNative: "0",
+    valueNativeFormatted: "0",
+    ...over,
+  };
+}
+
+describe("annotateSuspectedPoisoning", () => {
+  it("flags zero-amount token_transfer as zero_amount_transfer", () => {
+    const items: HistoryItem[] = [
+      tokenTransfer({
+        from: "0x9999999999999999999999999999999999999999",
+        to: WALLET,
+        amount: "0",
+        amountFormatted: "0",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toEqual({
+      reasons: ["zero_amount_transfer"],
+    });
+  });
+
+  it("flags vanity-suffix lookalike with mimics pointing at the legit counterparty", () => {
+    const legit = "0xAAAA00000000000000000000000000000000BBBB";
+    const lookalike = "0xAAAA99999999999999999999999999999999BBBB";
+    const items: HistoryItem[] = [
+      externalTx({
+        hash: "0x" + "1".repeat(64),
+        from: WALLET,
+        to: legit,
+        valueNative: "1000000000000000000",
+        valueNativeFormatted: "1",
+        valueUsd: 2000,
+      }),
+      externalTx({
+        hash: "0x" + "2".repeat(64),
+        from: lookalike,
+        to: WALLET,
+        valueNative: "1",
+        valueNativeFormatted: "0.000000000000000001",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toBeUndefined();
+    expect(items[1].suspectedPoisoning).toEqual({
+      reasons: ["vanity_suffix_lookalike"],
+      mimics: legit.toLowerCase(),
+    });
+  });
+
+  it("flags self-suffix lookalike with mimics pointing at the wallet", () => {
+    const lookalike = "0xC0F5999999999999999999999999999999994075";
+    const items: HistoryItem[] = [
+      externalTx({
+        from: lookalike,
+        to: WALLET,
+        valueNative: "1",
+        valueNativeFormatted: "0.000000000000000001",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toEqual({
+      reasons: ["self_suffix_lookalike"],
+      mimics: WALLET_LOWER,
+    });
+  });
+
+  it("does not flag legit dust without a vanity match", () => {
+    const items: HistoryItem[] = [
+      externalTx({
+        from: "0x3333333333333333333333333333333333333333",
+        to: WALLET,
+        valueNative: "5",
+        valueNativeFormatted: "0.000000000000000005",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toBeUndefined();
+  });
+
+  it("does not flag airdrop spam tokens with non-zero amount", () => {
+    const items: HistoryItem[] = [
+      tokenTransfer({
+        from: "0x4444444444444444444444444444444444444444",
+        to: WALLET,
+        tokenAddress: "0x5555555555555555555555555555555555555555",
+        tokenSymbol: "SCAM",
+        amount: "1000000000000",
+        amountFormatted: "1000000",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toBeUndefined();
+  });
+
+  it("does not flag a vanity-suffix collision when the tx is not dust", () => {
+    const legit = "0xAAAA00000000000000000000000000000000BBBB";
+    const lookalike = "0xAAAA99999999999999999999999999999999BBBB";
+    const items: HistoryItem[] = [
+      externalTx({
+        hash: "0x" + "1".repeat(64),
+        from: WALLET,
+        to: legit,
+        valueNative: "500000000000000000",
+        valueNativeFormatted: "0.5",
+        valueUsd: 1000,
+      }),
+      externalTx({
+        hash: "0x" + "2".repeat(64),
+        from: lookalike,
+        to: WALLET,
+        valueNative: "100000000000000000",
+        valueNativeFormatted: "0.1",
+        valueUsd: 200,
+      }),
+    ];
+    annotateSuspectedPoisoning(items, WALLET);
+    expect(items[0].suspectedPoisoning).toBeUndefined();
+    expect(items[1].suspectedPoisoning).toBeUndefined();
+  });
+
+  it("early-returns for non-EVM (Solana/TRON) wallet shapes", () => {
+    const solanaWallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const items: HistoryItem[] = [
+      tokenTransfer({
+        from: "0x1111111111111111111111111111111111111111",
+        to: solanaWallet,
+        amount: "0",
+        amountFormatted: "0",
+      }),
+    ];
+    annotateSuspectedPoisoning(items, solanaWallet);
+    expect(items[0].suspectedPoisoning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `suspectedPoisoning` field to entries in `get_transaction_history` items, implementing the three precision-first detection rules from #220:

- `zero_amount_transfer` — `type === "token_transfer"` AND `amount === "0"` (USDC `transferFrom` exploit class).
- `vanity_suffix_lookalike` — counterparty shares first-4 + last-4 hex chars with another distinct counterparty in the same history, AND the tx is dust (native ≤ 10 gwei or `valueUsd <= 0.01`). Sets `mimics` to the legit address.
- `self_suffix_lookalike` — same suffix match against the queried wallet itself; sets `mimics` to the wallet.

Detection runs after items are assembled and priced, so the dust check has access to `valueUsd` when DefiLlama returned a price. Non-EVM (Solana / TRON base58) wallets early-return — vanity-suffix logic is hex-only.

Purely additive: existing clients ignore the new optional field.

## Test plan

- [x] `npm test` — 1145/1145 passing (93 files), including the new `test/tx-history-poisoning.test.ts` (7 cases).
- [x] `npm run build` — clean tsc.
- [x] Zero-amount USDC token_transfer flagged.
- [x] Vanity-suffix lookalike + legit recipient pair: dust tx flagged with `mimics`, normal-value tx untouched.
- [x] Self-suffix lookalike vs. the queried wallet flagged with `mimics: wallet`.
- [x] Negative: legit dust without a vanity match — no flag.
- [x] Negative: airdrop spam (non-zero token amount, unknown contract) — no flag (different rule class, out of scope).
- [x] Negative: vanity-suffix match but tx is NOT dust — no flag.
- [x] Negative: Solana wallet shape — early-return guard, no flags emitted.

Closes #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)