### PR TITLE
feat(demo): VAULTPILOT_DEMO=true — try-before-install fixture mode

### DIFF
--- a/src/demo/fixtures.ts
+++ b/src/demo/fixtures.ts
@@ -1,0 +1,449 @@
+/**
+ * Deterministic fixture data for VAULTPILOT_DEMO=true. Same args → same
+ * response on every call so demo screenshots / videos / tutorials
+ * reproduce identically. Fixtures here mirror the *shape* of the real
+ * tool outputs but use values designed to look realistic at a glance to
+ * a prospective user — not to pass strict cross-tool consistency checks
+ * (the agent narrates each tool independently).
+ *
+ * Coverage policy:
+ *   - The handful of tools the demo-mode plan calls out by name (the
+ *     ones a user is most likely to hit in a 30-second walkthrough)
+ *     get explicit fixtures.
+ *   - Every other tool falls through to `getDemoFixture`'s
+ *     `not-implemented` payload, which echoes the tool name + args so
+ *     the user can see what's covered and what isn't.
+ *
+ * Demo-wallet choice: ONE EVM address, ONE TRON address, ONE Solana
+ * address, ONE Bitcoin address. A single self-consistent identity makes
+ * the demo narrative simpler ("this is your wallet across four chains")
+ * and avoids the multi-account UX complexity that would distract from
+ * the core read-only walkthrough.
+ */
+
+export const DEMO_WALLET = {
+  evm: "0xDeFa1212121212121212121212121212121212De" as const,
+  tron: "TDemoVAULTpilotxxxxxxxxxxxxxxxxxxxxx" as const,
+  solana: "DEMo1111111111111111111111111111111111111111" as const,
+  bitcoin: "bc1qdemo7xpyrkfsm7dl5kfjxgvm8azwj9c4yefzx0" as const,
+};
+
+/**
+ * Each fixture function takes the (already-validated by the wrapper at
+ * call time) tool args and returns a canned response. Args may be
+ * undefined for argless tools (e.g. `get_ledger_status`).
+ */
+type FixtureFn = (args: unknown) => unknown;
+
+export const DEMO_FIXTURES: Record<string, FixtureFn> = {
+  // -------- Identity / pairing -------------------------------------------------
+  get_ledger_status: () => ({
+    paired: true,
+    accounts: [DEMO_WALLET.evm],
+    accountDetails: [
+      {
+        address: DEMO_WALLET.evm,
+        chainIds: [1, 42161, 137, 8453],
+        chains: ["ethereum", "arbitrum", "polygon", "base"],
+      },
+    ],
+    topic: "demo0000000000000000000000000000000000000000000000000000000000",
+    expiresAt: 9_999_999_999_000,
+    wallet: "VaultPilot Demo Wallet",
+    peerUrl: "https://demo.vaultpilot.example/",
+    peerDescription: "Demo session — VAULTPILOT_DEMO=true (no real Ledger paired)",
+    tron: [
+      {
+        address: DEMO_WALLET.tron,
+        path: "44'/195'/0'/0/0",
+        appVersion: "0.7.4",
+        accountIndex: 0,
+      },
+    ],
+    solana: [
+      {
+        address: DEMO_WALLET.solana,
+        path: "44'/501'/0'",
+        appVersion: "1.12.1",
+        accountIndex: 0,
+      },
+    ],
+    bitcoin: [
+      {
+        address: DEMO_WALLET.bitcoin,
+        path: "84'/0'/0'/0/0",
+        appVersion: "2.4.6",
+        addressType: "segwit",
+        accountIndex: 0,
+        chain: 0,
+        addressIndex: 0,
+      },
+    ],
+  }),
+
+  get_ledger_device_info: () => ({
+    productName: "Nano X (demo)",
+    seVersion: "2.2.3",
+    mcuVersion: "2.30",
+    serialNumber: "DEMO-XXXX-XXXX",
+    isOnboarded: true,
+    flags: { isInRecoveryMode: false },
+  }),
+
+  // -------- Token balances -----------------------------------------------------
+  get_token_balance: (args) => {
+    const a = (args ?? {}) as { chain?: string; token?: string };
+    const chain = a.chain ?? "ethereum";
+    const token = (a.token ?? "native").toLowerCase();
+    const isNative = token === "native";
+    const lookupKey = `${chain}:${isNative ? "native" : token}`;
+    const slice = DEMO_TOKEN_BALANCES[lookupKey] ?? DEMO_TOKEN_BALANCES[`${chain}:native`];
+    if (!slice) {
+      return {
+        token: a.token ?? "native",
+        symbol: "DEMO",
+        decimals: 18,
+        amount: "0",
+        formatted: "0",
+        priceUsd: 0,
+        valueUsd: 0,
+      };
+    }
+    return slice;
+  },
+
+  // -------- Portfolio summary --------------------------------------------------
+  get_portfolio_summary: () => DEMO_PORTFOLIO_SUMMARY,
+
+  // -------- Lending / staking / LP --------------------------------------------
+  get_lending_positions: () => DEMO_AAVE_POSITIONS,
+  get_compound_positions: () => DEMO_COMPOUND_POSITIONS,
+  get_morpho_positions: () => DEMO_MORPHO_POSITIONS,
+  get_lp_positions: () => DEMO_UNIV3_POSITIONS,
+  get_staking_positions: () => DEMO_LIDO_POSITIONS,
+  get_solana_staking_positions: () => DEMO_SOLANA_STAKING,
+  get_marginfi_positions: () => DEMO_MARGINFI_POSITIONS,
+  get_kamino_positions: () => DEMO_KAMINO_POSITIONS,
+  get_tron_staking: () => DEMO_TRON_STAKING,
+
+  // -------- Bitcoin reads ------------------------------------------------------
+  get_btc_balance: () => DEMO_BTC_SINGLE_BALANCE,
+  get_btc_balances: () => ({
+    addresses: [DEMO_BTC_SINGLE_BALANCE],
+  }),
+  get_btc_account_balance: () => DEMO_BTC_ACCOUNT_BALANCE,
+  get_btc_block_tip: () => ({
+    height: 946_598,
+    hash: "0000000000000000000000000000000000000000000000000000demoabcdef1234",
+    timestamp: 1_745_625_600,
+    ageSeconds: 240,
+  }),
+  get_btc_fee_estimates: () => ({
+    fastestFee: 18,
+    halfHourFee: 9,
+    hourFee: 5,
+    economyFee: 2,
+    minimumFee: 1,
+  }),
+  get_btc_tx_history: () => ({
+    address: DEMO_WALLET.bitcoin,
+    txs: [
+      {
+        txid: "demo1111111111111111111111111111111111111111111111111111111111",
+        receivedSats: "7500000",
+        sentSats: "0",
+        feeSats: "0",
+        blockHeight: 946_500,
+        blockTime: 1_745_022_400,
+        rbfEligible: false,
+      },
+    ],
+  }),
+
+  // -------- Tx history ---------------------------------------------------------
+  get_transaction_history: () => DEMO_TX_HISTORY,
+
+  // -------- Read-only helpers (cheap to fixture) -------------------------------
+  get_token_metadata: (args) => {
+    const a = (args ?? {}) as { token?: string };
+    return {
+      address: a.token ?? "native",
+      symbol: "DEMO-TOKEN",
+      decimals: 18,
+      name: "Demo Token",
+      priceUsd: 1,
+    };
+  },
+  get_token_price: (args) => {
+    const a = (args ?? {}) as { token?: string };
+    return {
+      token: a.token ?? "native",
+      priceUsd: 1,
+      source: "demo-fixture",
+    };
+  },
+  get_market_incident_status: () => ({
+    overallStatus: "operational",
+    incidents: [],
+    lastChecked: "2026-04-26T00:00:00Z",
+  }),
+  get_health_alerts: () => ({
+    wallet: DEMO_WALLET.evm,
+    alerts: [],
+    summary: "All lending positions in the demo wallet are well above the liquidation threshold.",
+  }),
+};
+
+// ============================================================================
+// Demo-data tables
+// ============================================================================
+
+const DEMO_TOKEN_BALANCES: Record<string, unknown> = {
+  "ethereum:native": {
+    token: "0x0000000000000000000000000000000000000000",
+    symbol: "ETH",
+    decimals: 18,
+    amount: "2500000000000000000",
+    formatted: "2.5",
+    priceUsd: 2316.09,
+    valueUsd: 5790.23,
+  },
+  "ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
+    token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    symbol: "USDC",
+    decimals: 6,
+    amount: "0",
+    formatted: "0",
+    priceUsd: 1,
+    valueUsd: 0,
+  },
+  "arbitrum:native": {
+    token: "0x0000000000000000000000000000000000000000",
+    symbol: "ETH",
+    decimals: 18,
+    amount: "100000000000000000",
+    formatted: "0.1",
+    priceUsd: 2316.09,
+    valueUsd: 231.61,
+  },
+  "arbitrum:0xaf88d065e77c8cc2239327c5edb3a432268e5831": {
+    token: "0xaf88d065e77C8CC2239327C5EDb3A432268e5831",
+    symbol: "USDC",
+    decimals: 6,
+    amount: "1500000000",
+    formatted: "1500",
+    priceUsd: 1,
+    valueUsd: 1500,
+  },
+};
+
+const DEMO_AAVE_POSITIONS = {
+  wallet: DEMO_WALLET.evm,
+  positions: [
+    {
+      chain: "ethereum",
+      collateralUsd: 4_000,
+      debtUsd: 800,
+      healthFactor: 4.85,
+      ltv: 0.20,
+      liquidationThreshold: 0.83,
+      collateral: [{ symbol: "WETH", amount: "1.726", valueUsd: 4_000 }],
+      debt: [{ symbol: "USDC", amount: "800", valueUsd: 800 }],
+    },
+  ],
+  totals: { collateralUsd: 4_000, debtUsd: 800, netUsd: 3_200 },
+};
+
+const DEMO_COMPOUND_POSITIONS = {
+  wallet: DEMO_WALLET.evm,
+  positions: [],
+  totals: { collateralUsd: 0, debtUsd: 0, netUsd: 0 },
+};
+
+const DEMO_MORPHO_POSITIONS = {
+  wallet: DEMO_WALLET.evm,
+  positions: [],
+  totals: { collateralUsd: 0, debtUsd: 0, netUsd: 0 },
+};
+
+const DEMO_UNIV3_POSITIONS = {
+  wallet: DEMO_WALLET.evm,
+  positions: [
+    {
+      chain: "ethereum",
+      tokenId: "847291",
+      pair: "WETH/USDC",
+      feeTier: 0.0005,
+      inRange: true,
+      token0: { symbol: "WETH", amount: "0.215", valueUsd: 498 },
+      token1: { symbol: "USDC", amount: "498", valueUsd: 498 },
+      uncollectedFees: { token0: "0.0012", token1: "2.71", valueUsd: 5.49 },
+      approxImpermanentLossUsd: -3.2,
+      totalValueUsd: 996,
+    },
+  ],
+  totals: { positionValueUsd: 996, uncollectedFeesUsd: 5.49 },
+};
+
+const DEMO_LIDO_POSITIONS = {
+  wallet: DEMO_WALLET.evm,
+  positions: [
+    {
+      protocol: "lido",
+      chain: "ethereum",
+      stakedAsset: "stETH",
+      amount: "1.2",
+      valueUsd: 2_779.31,
+      currentApr: 0.0312,
+    },
+  ],
+  totals: { stakedUsd: 2_779.31, weightedApr: 0.0312 },
+};
+
+const DEMO_SOLANA_STAKING = {
+  wallet: DEMO_WALLET.solana,
+  marinade: { positions: [], totalMSolBalance: "0" },
+  jito: { positions: [], totalJitoSolBalance: "0" },
+  native: [],
+  summary: { totalStakedSol: "0", positionCount: 0 },
+};
+
+const DEMO_MARGINFI_POSITIONS = {
+  wallet: DEMO_WALLET.solana,
+  positions: [
+    {
+      bankAddress: "2s37akKDBoxKcvHm9DwWXGCHA6V3uPGrBiJP6gQAaEpD",
+      mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      symbol: "USDC",
+      depositedAmount: "800",
+      depositedValueUsd: 800,
+      borrowedAmount: "0",
+      borrowedValueUsd: 0,
+      currentApy: 0.062,
+    },
+  ],
+  totals: { suppliedUsd: 800, borrowedUsd: 0, netUsd: 800 },
+};
+
+const DEMO_KAMINO_POSITIONS = {
+  wallet: DEMO_WALLET.solana,
+  positions: [],
+  totals: { suppliedUsd: 0, borrowedUsd: 0, netUsd: 0 },
+};
+
+const DEMO_TRON_STAKING = {
+  address: DEMO_WALLET.tron,
+  trxBalance: "5000",
+  frozenForEnergy: { amount: "1000", expiresIn: "in 14 days" },
+  frozenForBandwidth: { amount: "0", expiresIn: null },
+  votes: [],
+  unclaimedRewards: { amount: "12.34", lastClaimedAt: "2026-04-19T10:00:00Z" },
+  resources: { energy: { used: 0, total: 152_000 }, bandwidth: { used: 145, total: 1_200 } },
+};
+
+const DEMO_BTC_SINGLE_BALANCE = {
+  address: DEMO_WALLET.bitcoin,
+  confirmedSats: "7500000",
+  mempoolSats: "0",
+  totalSats: "7500000",
+  txCount: 1,
+};
+
+const DEMO_BTC_ACCOUNT_BALANCE = {
+  accountIndex: 0,
+  addressesQueried: 1,
+  addressesCached: 1,
+  totalConfirmedSats: "7500000",
+  totalConfirmedBtc: "0.075",
+  totalMempoolSats: "0",
+  totalSats: "7500000",
+  breakdown: [
+    {
+      address: DEMO_WALLET.bitcoin,
+      addressType: "segwit",
+      chain: 0,
+      addressIndex: 0,
+      confirmedSats: "7500000",
+      mempoolSats: "0",
+      totalSats: "7500000",
+    },
+  ],
+};
+
+const DEMO_PORTFOLIO_SUMMARY = {
+  wallet: DEMO_WALLET.evm,
+  totalValueUsd: 14_098,
+  byChain: {
+    ethereum: {
+      nativeValueUsd: 5_790,
+      tokenValueUsd: 0,
+      defi: { lending: 3_200, staking: 2_779, lpUsd: 996 },
+      total: 12_765,
+    },
+    arbitrum: { nativeValueUsd: 232, tokenValueUsd: 1_500, total: 1_732 },
+  },
+  nonEvm: {
+    bitcoin: [{ address: DEMO_WALLET.bitcoin, totalSats: "7500000", valueUsd: 7_125 }],
+    solana: [
+      {
+        address: DEMO_WALLET.solana,
+        nativeSol: "12",
+        usdc: "800",
+        marginfi: { suppliedUsd: 800 },
+        valueUsd: 3_572,
+      },
+    ],
+    tron: [
+      {
+        address: DEMO_WALLET.tron,
+        trx: "5000",
+        usdt: "2000",
+        valueUsd: 2_675,
+      },
+    ],
+  },
+  generatedAt: "2026-04-26T00:00:00Z",
+};
+
+const DEMO_TX_HISTORY = {
+  wallet: DEMO_WALLET.evm,
+  txs: [
+    {
+      hash: "0xdemo1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      chain: "ethereum",
+      timestamp: "2026-04-22T11:42:11Z",
+      type: "swap",
+      summary: "Swapped 500 USDC → 0.215 WETH on Uniswap V3 (LP top-up)",
+      valueUsd: 500,
+      gasUsd: 1.21,
+    },
+    {
+      hash: "0xdemo2bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      chain: "ethereum",
+      timestamp: "2026-04-15T08:17:03Z",
+      type: "supply",
+      summary: "Supplied 1.726 WETH to Aave V3",
+      valueUsd: 4_000,
+      gasUsd: 2.04,
+    },
+    {
+      hash: "0xdemo3ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      chain: "ethereum",
+      timestamp: "2026-04-10T20:50:00Z",
+      type: "stake",
+      summary: "Staked 1.2 ETH → 1.2 stETH via Lido",
+      valueUsd: 2_779,
+      gasUsd: 1.62,
+    },
+    {
+      hash: "0xdemo4dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      chain: "arbitrum",
+      timestamp: "2026-04-02T15:33:21Z",
+      type: "bridge",
+      summary: "Bridged 1500 USDC from Ethereum → Arbitrum (LiFi)",
+      valueUsd: 1_500,
+      gasUsd: 0.42,
+    },
+  ],
+  hasMore: false,
+};

--- a/src/demo/fixtures.ts
+++ b/src/demo/fixtures.ts
@@ -29,6 +29,80 @@ export const DEMO_WALLET = {
 };
 
 /**
+ * Known DeFi contract addresses, recognized by `check_contract_security`,
+ * `check_permission_risks`, and `get_protocol_risk_score` so the same
+ * contract gets a consistent risk verdict across all three tools (and
+ * users see "Aave V3 Pool — verified, timelock-governed" rather than
+ * generic "established protocol" hand-waving). Real mainnet addresses
+ * — keys are lowercase for case-insensitive lookup, since the wire
+ * format varies (EIP-55 in user input, lowercase in some indexers).
+ */
+const KNOWN_DEFI_ADDRESSES: Record<
+  string,
+  { name: string; protocol: string; kind: string; chain: string; isProxy: boolean }
+> = {
+  // Aave V3 Pool (mainnet)
+  "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2": {
+    name: "Aave V3 Pool",
+    protocol: "aave-v3",
+    kind: "lending-pool",
+    chain: "ethereum",
+    isProxy: true,
+  },
+  // Compound V3 USDC Comet (Base)
+  "0xb125e6687d4313864e53df431d5425969c15eb2f": {
+    name: "Compound V3 USDC (Base)",
+    protocol: "compound-v3",
+    kind: "comet",
+    chain: "base",
+    isProxy: true,
+  },
+  // Lido stETH (mainnet)
+  "0xae7ab96520de3a18e5e111b5eaab095312d7fe84": {
+    name: "Lido stETH",
+    protocol: "lido",
+    kind: "liquid-staking-token",
+    chain: "ethereum",
+    isProxy: true,
+  },
+  // Uniswap V3 NonfungiblePositionManager (mainnet)
+  "0xc36442b4a4522e871399cd717abdd847ab11fe88": {
+    name: "Uniswap V3 NonfungiblePositionManager",
+    protocol: "uniswap-v3",
+    kind: "lp-nft",
+    chain: "ethereum",
+    isProxy: false,
+  },
+  // LiFi diamond (multichain)
+  "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae": {
+    name: "LiFi Diamond",
+    protocol: "lifi",
+    kind: "swap-bridge-aggregator",
+    chain: "ethereum",
+    isProxy: false,
+  },
+};
+
+function lookupKnownDefi(addr: string | undefined) {
+  if (!addr || typeof addr !== "string") return undefined;
+  return KNOWN_DEFI_ADDRESSES[addr.toLowerCase()];
+}
+
+/**
+ * The four `0xdemo*` tx hashes from `get_transaction_history`'s v1
+ * fixture. `get_transaction_status` recognizes these and reports them
+ * as confirmed (so the agent's narrative — "you swapped, supplied,
+ * staked, bridged last month" — survives a follow-up "did the swap
+ * confirm?" probe). Any other hash returns `pending`.
+ */
+const KNOWN_TX_HASHES: Set<string> = new Set([
+  "0xdemo1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "0xdemo2bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "0xdemo3ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "0xdemo4dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+]);
+
+/**
  * Each fixture function takes the (already-validated by the wrapper at
  * call time) tool args and returns a canned response. Args may be
  * undefined for argless tools (e.g. `get_ledger_status`).
@@ -192,7 +266,554 @@ export const DEMO_FIXTURES: Record<string, FixtureFn> = {
     alerts: [],
     summary: "All lending positions in the demo wallet are well above the liquidation threshold.",
   }),
+
+  // -------- v2: swap & quote ---------------------------------------------------
+  get_swap_quote: (args) => {
+    const a = (args ?? {}) as {
+      fromChain?: string;
+      toChain?: string;
+      fromToken?: string;
+      toToken?: string;
+      amount?: string;
+      amountSide?: "from" | "to";
+    };
+    const fromChain = a.fromChain ?? "ethereum";
+    const toChain = a.toChain ?? "ethereum";
+    const amountIn = parseFloat(a.amount ?? "0") || 0;
+    const exactOut = a.amountSide === "to";
+    // Stable→stable on mainnet matches the live exact-out shape from
+    // the session: SushiSwap routing, ~0.28% effective haircut.
+    const isStablePair =
+      isStableMint(a.fromToken) && isStableMint(a.toToken) && fromChain === toChain;
+    if (isStablePair) {
+      const expected = exactOut ? amountIn * 1.001 : amountIn * 0.999;
+      const fromAmount = exactOut ? amountIn * 1.0039 : amountIn;
+      const toAmount = exactOut ? amountIn : amountIn * 0.9971;
+      return {
+        fromChain,
+        toChain,
+        fromToken: { address: a.fromToken, symbol: "USDC", decimals: 6, priceUSD: "1.0" },
+        toToken: { address: a.toToken, symbol: "USDT", decimals: 6, priceUSD: "1.0" },
+        fromAmount: fromAmount.toFixed(6),
+        toAmountMin: toAmount.toFixed(6),
+        toAmountExpected: expected.toFixed(6),
+        fromAmountUsd: fromAmount,
+        toAmountUsd: toAmount,
+        tool: "sushiswap",
+        executionDurationSeconds: 0,
+        feeCostsUsd: amountIn * 0.0025,
+        gasCostsUsd: 0.21,
+        crossChain: false,
+      };
+    }
+    const isCrossChain = fromChain !== toChain;
+    const out = exactOut ? amountIn : amountIn * 0.997;
+    return {
+      fromChain,
+      toChain,
+      fromToken: { address: a.fromToken, symbol: "DEMO-IN", decimals: 18 },
+      toToken: { address: a.toToken, symbol: "DEMO-OUT", decimals: 18 },
+      fromAmount: (exactOut ? amountIn * 1.003 : amountIn).toString(),
+      toAmountMin: (out * 0.995).toString(),
+      toAmountExpected: out.toString(),
+      tool: isCrossChain ? "across" : "1inch",
+      executionDurationSeconds: isCrossChain ? 480 : 0,
+      feeCostsUsd: isCrossChain ? 4.5 : 0.6,
+      gasCostsUsd: 0.18,
+      crossChain: isCrossChain,
+    };
+  },
+
+  get_solana_swap_quote: (args) => {
+    const a = (args ?? {}) as { inputMint?: string; outputMint?: string; amount?: string };
+    const amount = parseFloat(a.amount ?? "0") || 0;
+    return {
+      inputMint: a.inputMint ?? "So11111111111111111111111111111111111111112",
+      outputMint: a.outputMint ?? "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      inAmount: amount.toString(),
+      outAmount: (amount * 0.995).toString(),
+      otherAmountThreshold: (amount * 0.99).toString(),
+      swapMode: "ExactIn",
+      slippageBps: 50,
+      priceImpactPct: 0.0012,
+      platformFee: null,
+      routePlan: [
+        {
+          swapInfo: {
+            ammKey: "DemoOrcaWhirlpoolxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            label: "Orca (Whirlpool)",
+            inputMint: a.inputMint ?? "So11111111111111111111111111111111111111112",
+            outputMint: a.outputMint ?? "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            inAmount: amount.toString(),
+            outAmount: (amount * 0.995).toString(),
+            feeAmount: (amount * 0.0025).toString(),
+            feeMint: a.inputMint ?? "So11111111111111111111111111111111111111112",
+          },
+          percent: 100,
+        },
+      ],
+      contextSlot: 287_654_321,
+      timeTaken: 0.082,
+    };
+  },
+
+  simulate_transaction: (args) => {
+    const a = (args ?? {}) as { data?: string };
+    const data = a.data ?? "0x";
+    // A specific marker calldata triggers the synthetic-revert demo so
+    // the security narrative ("simulate said REVERT — don't sign") shows
+    // up in the demo walkthrough; everything else returns ok.
+    if (typeof data === "string" && data.toLowerCase().includes("dead")) {
+      return {
+        chain: "ethereum",
+        ok: false,
+        revertReason: "transfer amount exceeds balance",
+        revert: {
+          errorName: "ERC20InsufficientBalance",
+          args: ["sender", "0", "1000000"],
+          data: "0xfb8f41b2",
+          source: "demo-fixture",
+        },
+      };
+    }
+    return { chain: "ethereum", ok: true, returnData: "0x" };
+  },
+
+  // -------- v2: status & diagnostics ------------------------------------------
+  get_transaction_status: (args) => {
+    const a = (args ?? {}) as { txHash?: string; chain?: string };
+    const hash = (a.txHash ?? "").toLowerCase();
+    if (KNOWN_TX_HASHES.has(hash)) {
+      return {
+        chain: a.chain ?? "ethereum",
+        txHash: a.txHash,
+        status: "success",
+        confirmations: 142,
+        blockHeight: 19_843_002,
+        gasUsed: "73214",
+      };
+    }
+    return {
+      chain: a.chain ?? "ethereum",
+      txHash: a.txHash,
+      status: "pending",
+      confirmations: 0,
+      note: "demo fixture — only the four `0xdemo*` hashes from get_transaction_history are recognized as confirmed",
+    };
+  },
+
+  get_vaultpilot_config_status: () => ({
+    configPath: "~/.vaultpilot-mcp/config.json",
+    configExists: true,
+    version: "0.8.2",
+    rpc: {
+      ethereum: { source: "demo-fixture" },
+      arbitrum: { source: "demo-fixture" },
+      polygon: { source: "demo-fixture" },
+      base: { source: "demo-fixture" },
+      optimism: { source: "demo-fixture" },
+    },
+    apiKeys: {
+      etherscan: { exists: true, source: "demo-fixture" },
+      oneinch: { exists: true, source: "demo-fixture" },
+      tronGrid: { exists: true, source: "demo-fixture" },
+      walletConnect: { exists: true, source: "demo-fixture" },
+    },
+    pairedLedger: { solana: 1, tron: 1, bitcoin: 1 },
+    wcTopic: "...demo0000",
+    demoMode: true,
+  }),
+
+  get_marginfi_diagnostics: () => ({
+    totalBanks: 188,
+    decoded: 188,
+    skipped: [],
+    note: "demo fixture — all banks hydrated cleanly (no SDK drift in demo mode)",
+  }),
+
+  get_solana_setup_status: () => ({
+    durableNonce: {
+      exists: true,
+      address: "DEMo11111111111111111111111111111111nonce0",
+      lamports: 1_500_000,
+      currentNonce: "DEMo11111111111111111111111111111nonceVal0",
+      authority: DEMO_WALLET.solana,
+    },
+    marginfiAccounts: [
+      { accountIndex: 0, address: "DEMo111111111111111111111111111111111mfi0" },
+    ],
+    note: "demo fixture — both Solana setup steps already complete",
+  }),
+
+  rescan_btc_account: (args) => {
+    const a = (args ?? {}) as { accountIndex?: number };
+    const idx = a.accountIndex ?? 0;
+    if (idx !== 0) {
+      return {
+        accountIndex: idx,
+        addressesQueried: 0,
+        addressesCached: 0,
+        totalConfirmedSats: "0",
+        totalConfirmedBtc: "0",
+        totalMempoolSats: "0",
+        totalSats: "0",
+        breakdown: [],
+        note: `demo fixture — only accountIndex 0 has data; got ${idx}`,
+      };
+    }
+    return {
+      ...DEMO_BTC_ACCOUNT_BALANCE,
+      note: "demo fixture — rescanned at 2026-04-26T00:00:00Z (no on-chain delta vs cache)",
+    };
+  },
+
+  // -------- v2: DeFi protocol reads -------------------------------------------
+  get_compound_market_info: (args) => {
+    const a = (args ?? {}) as { chain?: string; market?: string };
+    return {
+      chain: a.chain ?? "base",
+      market: a.market ?? "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+      baseToken: {
+        address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        symbol: "USDC",
+        decimals: 6,
+      },
+      totalSupply: "12450000.00",
+      totalBorrow: "8230000.00",
+      utilization: 0.661,
+      supplyApr: 0.041,
+      borrowApr: 0.063,
+      pausedActions: [],
+      collateralAssets: [
+        { symbol: "WETH", liquidationFactor: 0.83, supplyCap: "10000" },
+        { symbol: "cbETH", liquidationFactor: 0.83, supplyCap: "5000" },
+      ],
+    };
+  },
+
+  simulate_position_change: (args) => {
+    const a = (args ?? {}) as {
+      protocol?: string;
+      action?: "borrow" | "repay" | "supply" | "withdraw";
+      asset?: string;
+      amount?: string;
+    };
+    const proto = a.protocol ?? "aave-v3";
+    if (proto !== "aave-v3") {
+      return {
+        ok: false,
+        note: "demo fixture only models the v1 Aave V3 demo position; got protocol=" + proto,
+      };
+    }
+    // v1 demo Aave numbers: 4000 collateral (1.726 WETH), 800 USDC debt.
+    // Aave HF formula approximated as collateral × liqThreshold (0.83) / debt.
+    const liqThreshold = 0.83;
+    const baseCollateralUsd = 4_000;
+    const baseDebtUsd = 800;
+    const amount = parseFloat(a.amount ?? "0") || 0;
+    let collateralUsd = baseCollateralUsd;
+    let debtUsd = baseDebtUsd;
+    if (a.action === "borrow") debtUsd += amount;
+    else if (a.action === "repay") debtUsd = Math.max(0, debtUsd - amount);
+    else if (a.action === "supply") collateralUsd += amount;
+    else if (a.action === "withdraw") collateralUsd = Math.max(0, collateralUsd - amount);
+    const healthFactor = debtUsd > 0 ? (collateralUsd * liqThreshold) / debtUsd : Infinity;
+    return {
+      protocol: "aave-v3",
+      chain: "ethereum",
+      action: a.action,
+      asset: a.asset,
+      amount: a.amount,
+      projected: {
+        collateralUsd,
+        debtUsd,
+        healthFactor: isFinite(healthFactor) ? Number(healthFactor.toFixed(2)) : null,
+        liquidationThreshold: liqThreshold,
+      },
+      baseline: {
+        collateralUsd: baseCollateralUsd,
+        debtUsd: baseDebtUsd,
+        healthFactor: 4.15,
+      },
+    };
+  },
+
+  get_staking_rewards: () => ({
+    wallet: DEMO_WALLET.evm,
+    period: "30d",
+    estimated: [
+      {
+        protocol: "lido",
+        asset: "stETH",
+        amount: "0.0030",
+        valueUsd: 6.94,
+        note: "1.2 stETH × ~3.12% APR × 30d",
+      },
+      {
+        protocol: "marginfi",
+        asset: "USDC",
+        amount: "4.07",
+        valueUsd: 4.07,
+        note: "800 USDC supply × ~6.2% APY × 30d",
+      },
+    ],
+    totalUsd: 11.01,
+    disclaimer: "demo fixture — values are deterministic projections, not realized rewards",
+  }),
+
+  estimate_staking_yield: (args) => {
+    const a = (args ?? {}) as { protocol?: string; amount?: string };
+    const amount = parseFloat(a.amount ?? "1.0") || 1.0;
+    const known: Record<string, number> = {
+      lido: 0.0312,
+      "rocket-pool": 0.0298,
+      marinade: 0.072,
+      "jito-stake-pool": 0.078,
+      eigenlayer: 0.041,
+    };
+    const apr = known[a.protocol ?? "lido"] ?? 0.05;
+    const annualValueUsd = amount * 2316.09 * apr;
+    return {
+      protocol: a.protocol ?? "lido",
+      amount: a.amount ?? "1.0",
+      apr,
+      estimatedAnnualYield: (amount * apr).toFixed(4),
+      valueUsd: Number(annualValueUsd.toFixed(2)),
+      note: "demo fixture — APR is a 30-day rolling estimate",
+    };
+  },
+
+  // -------- v2: security advisory ---------------------------------------------
+  check_contract_security: (args) => {
+    const a = (args ?? {}) as { address?: string; chain?: string };
+    const known = lookupKnownDefi(a.address);
+    if (known) {
+      return {
+        address: a.address,
+        chain: a.chain ?? known.chain,
+        isVerified: true,
+        isProxy: known.isProxy,
+        ...(known.isProxy
+          ? {
+              implementation: "0xDemoImpl000000000000000000000000000000000",
+              admin: { type: "TimelockController", delay: 86_400 },
+            }
+          : {}),
+        dangerousFunctions: [],
+        notes: [
+          `${known.name} — established protocol (${known.protocol}), audited multiple times.`,
+          "demo fixture — recognized as a well-known DeFi contract.",
+        ],
+        proxyPattern: known.isProxy ? "transparent-proxy" : null,
+      };
+    }
+    return {
+      address: a.address,
+      chain: a.chain ?? "ethereum",
+      isVerified: false,
+      isProxy: false,
+      dangerousFunctions: ["selfdestruct", "delegatecall to unverified target"],
+      notes: [
+        "Unverified contract — proceed with caution.",
+        "demo fixture — any address NOT in the known-DeFi table returns this cautionary verdict so the demo walkthrough shows both safe and risky outcomes.",
+      ],
+    };
+  },
+
+  check_permission_risks: (args) => {
+    const a = (args ?? {}) as { address?: string; chain?: string };
+    const known = lookupKnownDefi(a.address);
+    if (known) {
+      return {
+        address: a.address,
+        chain: a.chain ?? known.chain,
+        roles: [
+          {
+            function: "pause",
+            holder: "0xDemoTimelock0000000000000000000000000000",
+            holderType: "TimelockController",
+            note: "24h timelock — well-protected",
+          },
+          {
+            function: "upgrade",
+            holder: "0xDemoTimelock0000000000000000000000000000",
+            holderType: "TimelockController",
+            note: "Same timelock as pause — single governance path",
+          },
+        ],
+        notes: [
+          `${known.name} — governance is on-chain timelock.`,
+          "demo fixture — known DeFi contract with mature governance.",
+        ],
+      };
+    }
+    return {
+      address: a.address,
+      chain: a.chain ?? "ethereum",
+      roles: [
+        {
+          function: "owner",
+          holder: "0xDemoUnknownEOA000000000000000000000000000",
+          holderType: "EOA",
+          note: "Single EOA owner — high admin risk; can pause/upgrade unilaterally.",
+        },
+      ],
+      notes: [
+        "Unknown contract with EOA admin.",
+        "demo fixture — any address NOT in the known-DeFi table returns this high-risk verdict.",
+      ],
+    };
+  },
+
+  get_protocol_risk_score: (args) => {
+    const a = (args ?? {}) as { protocol?: string };
+    const protocol = (a.protocol ?? "aave-v3").toLowerCase();
+    const known: Record<string, { score: number; tvlUsd: number; ageDays: number }> = {
+      "aave-v3": { score: 92, tvlUsd: 11_000_000_000, ageDays: 1095 },
+      "compound-v3": { score: 88, tvlUsd: 3_200_000_000, ageDays: 870 },
+      lido: { score: 90, tvlUsd: 28_000_000_000, ageDays: 1450 },
+      "uniswap-v3": { score: 95, tvlUsd: 4_500_000_000, ageDays: 1310 },
+      lifi: { score: 80, tvlUsd: 350_000_000, ageDays: 600 },
+      "morpho-blue": { score: 84, tvlUsd: 2_100_000_000, ageDays: 540 },
+      marginfi: { score: 76, tvlUsd: 420_000_000, ageDays: 730 },
+    };
+    const k = known[protocol];
+    if (k) {
+      return {
+        protocol: a.protocol,
+        score: k.score,
+        breakdown: {
+          tvl: 18,
+          trend30d: 16,
+          contractAge: 20,
+          audit: 22,
+          bugBounty: 16,
+        },
+        raw: {
+          tvlUsd: k.tvlUsd,
+          tvlTrend30d: 0.04,
+          contractAgeDays: k.ageDays,
+          hasBugBounty: true,
+        },
+      };
+    }
+    return {
+      protocol: a.protocol,
+      score: 35,
+      breakdown: {
+        tvl: 5,
+        trend30d: 5,
+        contractAge: 5,
+        audit: 10,
+        bugBounty: 10,
+      },
+      raw: { hasBugBounty: false },
+      notes: [
+        "Unknown protocol — low confidence demo fallback.",
+        "demo fixture — any protocol NOT in the known-DeFi table scores 35 by default.",
+      ],
+    };
+  },
+
+  // -------- v2: ENS resolution ------------------------------------------------
+  resolve_ens_name: (args) => {
+    const a = (args ?? {}) as { name?: string };
+    const name = (a.name ?? "").toLowerCase();
+    if (name === "demo.eth" || name === "vaultpilot.eth") {
+      return { name: a.name, address: DEMO_WALLET.evm };
+    }
+    return {
+      name: a.name,
+      address: null,
+      note: "demo fixture — only resolves `demo.eth` and `vaultpilot.eth`",
+    };
+  },
+
+  reverse_resolve_ens: (args) => {
+    const a = (args ?? {}) as { address?: string };
+    if (a.address && a.address.toLowerCase() === DEMO_WALLET.evm.toLowerCase()) {
+      return { address: a.address, name: "demo.eth" };
+    }
+    return { address: a.address, name: null };
+  },
+
+  // -------- v2: portfolio diff ------------------------------------------------
+  get_portfolio_diff: () => ({
+    wallet: DEMO_WALLET.evm,
+    startIso: "2026-04-19T00:00:00Z",
+    endIso: "2026-04-26T00:00:00Z",
+    byChain: {
+      ethereum: {
+        diffs: {
+          ETH: {
+            delta: "0",
+            deltaUsd: 0,
+            price: ["2289.00", "2316.09"],
+          },
+          stETH: {
+            delta: "+0.0030",
+            deltaUsd: 6.95,
+            price: ["2289.00", "2316.09"],
+          },
+        },
+        totals: {
+          netUsd: 12,
+          balUsdStart: 12_753,
+          balUsdEnd: 12_765,
+        },
+      },
+      arbitrum: {
+        diffs: {},
+        totals: { netUsd: 0, balUsdStart: 1_732, balUsdEnd: 1_732 },
+      },
+    },
+    notes: [
+      "~$12 net change driven by stETH yield + ETH price drift; cross-references the v1 Lido stETH position.",
+    ],
+  }),
+
+  // -------- v2: TRON witnesses ------------------------------------------------
+  list_tron_witnesses: () => ({
+    witnesses: Array.from({ length: 27 }, (_, i) => ({
+      address: `TVoteDemoSR${(i + 1).toString().padStart(2, "0")}xxxxxxxxxxxxxxxxxxxx`,
+      rank: i + 1,
+      totalVotes: ((420_000_000 - i * 5_000_000)).toString(),
+      isActive: true,
+      estVoterApr: Number((0.058 - i * 0.0003).toFixed(4)),
+    })),
+    userVotes: {},
+    totalTronPower: 0,
+    totalVotesCast: 0,
+    availableVotes: 0,
+    note: "demo fixture — user has no votes cast (matches get_tron_staking which has votes: [])",
+  }),
 };
+
+/**
+ * Stable-mint heuristic for `get_swap_quote`'s SushiSwap-routing branch.
+ * Recognizes the most common stables across chains (USDC native +
+ * bridged, USDT, DAI, USDS, FRAX) by lowercased address; anything else
+ * falls through to the generic LiFi / 1inch branch.
+ */
+function isStableMint(addr: string | undefined): boolean {
+  if (!addr || typeof addr !== "string") return false;
+  return STABLE_MINTS.has(addr.toLowerCase());
+}
+
+const STABLE_MINTS = new Set([
+  // USDC variants
+  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // mainnet USDC
+  "0xaf88d065e77c8cc2239327c5edb3a432268e5831", // arb USDC
+  "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // base USDC
+  "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359", // polygon USDC
+  // USDT variants
+  "0xdac17f958d2ee523a2206206994597c13d831ec7", // mainnet USDT
+  "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9", // arb USDT
+  // DAI / USDS / FRAX
+  "0x6b175474e89094c44da98b954eedeac495271d0f", // mainnet DAI
+  "0xdc035d45d973e3ec169d2276ddab16f1e407384f", // mainnet USDS
+  "0x853d955acef822db058eb8505911ed77f175b99e", // mainnet FRAX
+]);
 
 // ============================================================================
 // Demo-data tables

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Demo / try-before-install mode. Switches read tools to fixture mode and
+ * gates every signing tool with a structured refusal — `VAULTPILOT_DEMO=true`
+ * is the single env-var gate. Goal: a prospective user can `npx vaultpilot-mcp`
+ * with the env var set and get a coherent multi-chain portfolio walkthrough
+ * in 30 seconds, no Ledger required.
+ *
+ * Determinism: fixtures are static — no random variation, no time-of-day
+ * drift. Demo screenshots / videos / tutorials reproduce identically across
+ * runs.
+ */
+
+import { DEMO_FIXTURES } from "./fixtures.js";
+
+/**
+ * True when `VAULTPILOT_DEMO=true` is set in the environment. Read at
+ * tool-call time (not module load) so a single process can be flipped via
+ * env mutation in tests without re-imports.
+ */
+export function isDemoMode(): boolean {
+  return process.env.VAULTPILOT_DEMO === "true";
+}
+
+/**
+ * Tools that produce or forward signable transactions. In demo mode every
+ * one of these refuses with a structured error rather than fabricating a
+ * fake signature — fake-sign would be misleading and fake-broadcast would
+ * be impossible (no chain to receive). Pattern-matched so newly added
+ * `prepare_*` / `pair_ledger_*` tools are gated automatically.
+ */
+export function isSigningTool(toolName: string): boolean {
+  if (toolName.startsWith("prepare_")) return true;
+  if (toolName.startsWith("pair_ledger_")) return true;
+  if (toolName.startsWith("sign_message_")) return true;
+  return EXPLICIT_SIGNING_TOOLS.has(toolName);
+}
+
+const EXPLICIT_SIGNING_TOOLS = new Set([
+  "send_transaction",
+  "preview_send",
+  "preview_solana_send",
+  "verify_tx_decode",
+  "get_verification_artifact",
+  "request_capability", // network write to GH; not a chain tx but disruptive in demo
+]);
+
+/**
+ * Structured refusal for signing tools in demo mode. Single source of
+ * truth so the message is consistent across every blocked tool — agents
+ * pattern-matching the prefix can branch on it cleanly.
+ */
+export function demoSigningRefusalMessage(toolName: string): string {
+  return (
+    `[VAULTPILOT_DEMO] '${toolName}' is a signing / device-pairing tool and is disabled in demo mode. ` +
+    `Demo mode ships fixture data for read tools so you can try the read-only UX without a Ledger. ` +
+    `To sign real transactions: unset VAULTPILOT_DEMO (or restart with it absent), run \`vaultpilot-mcp-setup\`, plug in your Ledger, and pair Ledger Live.`
+  );
+}
+
+/**
+ * Lookup-or-default for read tools. Returns the deterministic fixture
+ * registered for `toolName` if one exists; otherwise returns a structured
+ * "fixture not yet implemented" payload so the agent can tell the user
+ * which tools have demo coverage and which don't (instead of either
+ * silently falling through to the real tool — which would 404 / time
+ * out without a Ledger paired — or crashing).
+ *
+ * The fixture function receives the parsed args so per-(chain, wallet,
+ * token) lookups can vary the response without losing determinism: same
+ * args → same fixture.
+ */
+export function getDemoFixture(toolName: string, args: unknown): unknown {
+  const fixture = DEMO_FIXTURES[toolName];
+  if (fixture === undefined) {
+    return {
+      _demoFixture: "not-implemented",
+      _toolName: toolName,
+      _message:
+        `Demo mode is active and a fixture for '${toolName}' has not been added yet. ` +
+        `Implemented fixtures: ${Object.keys(DEMO_FIXTURES).sort().join(", ")}. ` +
+        `Tool arguments received (echoed for inspection): ${JSON.stringify(args)}.`,
+    };
+  }
+  return fixture(args);
+}
+
+/**
+ * Used by the setup wizard to refuse writing real config in demo mode —
+ * a user who runs `vaultpilot-mcp-setup` while VAULTPILOT_DEMO=true is
+ * almost certainly experimenting and shouldn't be silently writing
+ * Ledger pairing state to disk. Throws with an actionable error.
+ */
+export function assertNotDemoForSetup(): void {
+  if (isDemoMode()) {
+    throw new Error(
+      "[VAULTPILOT_DEMO] Setup is disabled in demo mode — running `vaultpilot-mcp-setup` " +
+        "would write a real config (pairing state, indexer URLs) to disk while the server " +
+        "is operating against fake fixture data. Unset VAULTPILOT_DEMO and re-run setup.",
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,12 @@ import { join } from "node:path";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  isDemoMode,
+  isSigningTool,
+  getDemoFixture,
+  demoSigningRefusalMessage,
+} from "./demo/index.js";
 
 import {
   getLendingPositions,
@@ -630,6 +636,62 @@ function txHandler<T>(toolName: string, fn: (args: T) => Promise<UnsignedTx> | U
 }
 
 /**
+ * Demo-mode-aware wrapper around `server.registerTool`. When
+ * `VAULTPILOT_DEMO=true` is set in the environment AT REQUEST TIME (not
+ * at startup), every tool call is intercepted before reaching its real
+ * handler:
+ *
+ *   - signing tools (prepare_*, send_transaction, pair_ledger_*, etc.)
+ *     refuse with a structured demo-mode error (`isSigningTool` decides);
+ *   - read tools return a deterministic fixture from `DEMO_FIXTURES`,
+ *     or — for tools without a fixture — a `_demoFixture: "not-implemented"`
+ *     payload so the user sees what's covered.
+ *
+ * When the env var is unset, this function is a transparent pass-through
+ * to the real `server.registerTool` — zero runtime cost on the hot path.
+ *
+ * Single point of demo enforcement so adding a new tool only requires
+ * (a) registering it through `registerTool(server, ...)` like every
+ * other tool and optionally (b) adding a fixture entry. The signing-vs-
+ * read classification is pattern-based so new prepare_* / pair_ledger_*
+ * tools are gated automatically.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function registerTool(
+  server: InstanceType<typeof McpServer>,
+  name: string,
+  // `opts` mirrors the shape `server.registerTool` accepts (description +
+  // optional zod inputSchema); the SDK's parameter type is overloaded and
+  // doesn't infer cleanly through a generic wrapper, so we cast through
+  // `any` at the delegation point. Call-site type-safety is preserved by
+  // the SDK's own validation of the registered schema.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  opts: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  realHandler: (args: any) => Promise<{ content: unknown[]; isError?: boolean }> | { content: unknown[]; isError?: boolean },
+): ReturnType<InstanceType<typeof McpServer>["registerTool"]> {
+  // Pre-build the demo handler at registration time; it's only invoked
+  // when `isDemoMode()` is true at request time, but allocating it once
+  // up front keeps the request-path branch trivial.
+  const demoHandler = handler<unknown, unknown>(
+    (args: unknown) => {
+      if (isSigningTool(name)) {
+        throw new Error(demoSigningRefusalMessage(name));
+      }
+      return getDemoFixture(name, args);
+    },
+    { toolName: name },
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dispatch = async (args: any) => {
+    if (isDemoMode()) return demoHandler(args);
+    return realHandler(args);
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return server.registerTool(name, opts, dispatch as any);
+}
+
+/**
  * Handler wrapper for `get_vaultpilot_config_status`. Tacks on the
  * setup-skill missing-notice (once per session) AFTER the standard handler
  * has emitted the preflight notice and JSON result. This is the canonical
@@ -1197,7 +1259,7 @@ async function main() {
   );
 
   // ---- Module 1: Positions ----
-  server.registerTool(
+  registerTool(server, 
     "get_lending_positions",
     {
       description:
@@ -1207,7 +1269,7 @@ async function main() {
     handler(getLendingPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_lp_positions",
     {
       description:
@@ -1217,7 +1279,7 @@ async function main() {
     handler(getLpPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_health_alerts",
     {
       description:
@@ -1227,7 +1289,7 @@ async function main() {
     handler(getHealthAlerts)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "simulate_position_change",
     {
       description:
@@ -1238,7 +1300,7 @@ async function main() {
   );
 
   // ---- Module 2: Security ----
-  server.registerTool(
+  registerTool(server, 
     "check_contract_security",
     {
       description:
@@ -1248,7 +1310,7 @@ async function main() {
     handler((a) => checkContractSecurityHandler(a))
   );
 
-  server.registerTool(
+  registerTool(server, 
     "check_permission_risks",
     {
       description:
@@ -1258,7 +1320,7 @@ async function main() {
     handler((a) => checkPermissionRisksHandler(a))
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_protocol_risk_score",
     {
       description:
@@ -1269,7 +1331,7 @@ async function main() {
   );
 
   // ---- Module 3: Staking ----
-  server.registerTool(
+  registerTool(server, 
     "get_staking_positions",
     {
       description:
@@ -1279,7 +1341,7 @@ async function main() {
     handler(getStakingPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_staking_rewards",
     {
       description:
@@ -1289,7 +1351,7 @@ async function main() {
     handler(getStakingRewards)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "estimate_staking_yield",
     {
       description:
@@ -1300,7 +1362,7 @@ async function main() {
   );
 
   // ---- Module 4: Portfolio ----
-  server.registerTool(
+  registerTool(server, 
     "get_portfolio_summary",
     {
       description:
@@ -1310,7 +1372,7 @@ async function main() {
     handler(getPortfolioSummary)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_portfolio_diff",
     {
       description:
@@ -1320,7 +1382,7 @@ async function main() {
     handler(getPortfolioDiff)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_transaction_history",
     {
       description:
@@ -1331,7 +1393,7 @@ async function main() {
   );
 
   // ---- Module 5: Swap/Bridge (LiFi) ----
-  server.registerTool(
+  registerTool(server, 
     "get_swap_quote",
     {
       description:
@@ -1343,7 +1405,7 @@ async function main() {
     handler(getSwapQuote)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_swap",
     {
       description:
@@ -1356,7 +1418,7 @@ async function main() {
     txHandler("prepare_swap", prepareSwap)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_uniswap_swap",
     {
       description:
@@ -1375,7 +1437,7 @@ async function main() {
   );
 
   // ---- Module 6: Execution (Ledger Live) ----
-  server.registerTool(
+  registerTool(server, 
     "pair_ledger_live",
     {
       description:
@@ -1385,7 +1447,7 @@ async function main() {
     handler(pairLedgerLive)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "pair_ledger_tron",
     {
       description:
@@ -1395,7 +1457,7 @@ async function main() {
     handler(pairLedgerTron)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "pair_ledger_solana",
     {
       description:
@@ -1405,7 +1467,7 @@ async function main() {
     handler(pairLedgerSolana)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "pair_ledger_btc",
     {
       description:
@@ -1420,7 +1482,7 @@ async function main() {
     handler(pairLedgerBitcoin)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_native_send",
     {
       description:
@@ -1430,7 +1492,7 @@ async function main() {
     handler(prepareSolanaNativeSend)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_spl_send",
     {
       description:
@@ -1440,7 +1502,7 @@ async function main() {
     handler(prepareSolanaSplSend)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_nonce_init",
     {
       description:
@@ -1459,7 +1521,7 @@ async function main() {
     handler(prepareSolanaNonceInit)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_nonce_close",
     {
       description:
@@ -1474,7 +1536,7 @@ async function main() {
     handler(prepareSolanaNonceClose)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_solana_swap_quote",
     {
       description:
@@ -1490,7 +1552,7 @@ async function main() {
     handler(getSolanaSwapQuote)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_swap",
     {
       description:
@@ -1510,7 +1572,7 @@ async function main() {
     handler(prepareSolanaSwap)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marginfi_init",
     {
       description:
@@ -1536,7 +1598,7 @@ async function main() {
     handler(prepareMarginfiInit)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marginfi_supply",
     {
       description:
@@ -1552,7 +1614,7 @@ async function main() {
     handler(prepareMarginfiSupply)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marginfi_withdraw",
     {
       description:
@@ -1567,7 +1629,7 @@ async function main() {
     handler(prepareMarginfiWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marginfi_borrow",
     {
       description:
@@ -1582,7 +1644,7 @@ async function main() {
     handler(prepareMarginfiBorrow)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marginfi_repay",
     {
       description:
@@ -1595,7 +1657,7 @@ async function main() {
     handler(prepareMarginfiRepay)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marinade_stake",
     {
       description:
@@ -1612,7 +1674,7 @@ async function main() {
     handler(prepareMarinadeStake)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_jito_stake",
     {
       description:
@@ -1635,7 +1697,7 @@ async function main() {
     handler(prepareJitoStake)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_marinade_unstake_immediate",
     {
       description:
@@ -1651,7 +1713,7 @@ async function main() {
     handler(prepareMarinadeUnstakeImmediate)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_native_stake_delegate",
     {
       description:
@@ -1669,7 +1731,7 @@ async function main() {
     handler(prepareNativeStakeDelegate)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_native_stake_deactivate",
     {
       description:
@@ -1685,7 +1747,7 @@ async function main() {
     handler(prepareNativeStakeDeactivate)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_native_stake_withdraw",
     {
       description:
@@ -1700,7 +1762,7 @@ async function main() {
     handler(prepareNativeStakeWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_solana_lifi_swap",
     {
       description:
@@ -1722,7 +1784,7 @@ async function main() {
     handler(prepareSolanaLifiSwap)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_kamino_init_user",
     {
       description:
@@ -1739,7 +1801,7 @@ async function main() {
     handler(prepareKaminoInitUser)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_kamino_supply",
     {
       description:
@@ -1756,7 +1818,7 @@ async function main() {
     handler(prepareKaminoSupply)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_kamino_borrow",
     {
       description:
@@ -1771,7 +1833,7 @@ async function main() {
     handler(prepareKaminoBorrow)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_kamino_withdraw",
     {
       description:
@@ -1785,7 +1847,7 @@ async function main() {
     handler(prepareKaminoWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_kamino_repay",
     {
       description:
@@ -1799,7 +1861,7 @@ async function main() {
     handler(prepareKaminoRepay)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_kamino_positions",
     {
       description:
@@ -1816,7 +1878,7 @@ async function main() {
   );
 
   // ---- Module: Bitcoin (Phase 1 — read-only) ----
-  server.registerTool(
+  registerTool(server, 
     "get_btc_balance",
     {
       description:
@@ -1831,7 +1893,7 @@ async function main() {
     handler(getBitcoinBalance)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_btc_balances",
     {
       description:
@@ -1844,7 +1906,7 @@ async function main() {
     handler(getBitcoinBalances)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_btc_fee_estimates",
     {
       description:
@@ -1859,7 +1921,7 @@ async function main() {
     handler(getBitcoinFeeEstimates)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "rescan_btc_account",
     {
       description:
@@ -1885,7 +1947,7 @@ async function main() {
     handler(rescanBitcoinAccount)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_btc_account_balance",
     {
       description:
@@ -1907,7 +1969,7 @@ async function main() {
     handler(getBitcoinAccountBalance)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_btc_block_tip",
     {
       description:
@@ -1926,7 +1988,7 @@ async function main() {
     handler(getBitcoinBlockTip)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_btc_tx_history",
     {
       description:
@@ -1940,7 +2002,7 @@ async function main() {
     handler(getBitcoinTxHistory)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_btc_send",
     {
       description:
@@ -1959,7 +2021,7 @@ async function main() {
     handler(prepareBitcoinNativeSend, { toolName: "prepare_btc_send" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "sign_message_btc",
     {
       description:
@@ -1977,7 +2039,7 @@ async function main() {
     handler(signBtcMessage, { toolName: "sign_message_btc" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_lifi_swap",
     {
       description:
@@ -2004,7 +2066,7 @@ async function main() {
     handler(prepareTronLifiSwap, { toolName: "prepare_tron_lifi_swap" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_solana_setup_status",
     {
       description:
@@ -2021,7 +2083,7 @@ async function main() {
     handler(getSolanaSetupStatus)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_vaultpilot_config_status",
     {
       description:
@@ -2040,7 +2102,7 @@ async function main() {
     configStatusHandler(getVaultPilotConfigStatus),
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_ledger_device_info",
     {
       description:
@@ -2060,7 +2122,7 @@ async function main() {
     handler(getLedgerDeviceInfo)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_marginfi_positions",
     {
       description:
@@ -2076,7 +2138,7 @@ async function main() {
     handler(getMarginfiPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_solana_staking_positions",
     {
       description:
@@ -2094,7 +2156,7 @@ async function main() {
     handler(getSolanaStakingPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_marginfi_diagnostics",
     {
       description:
@@ -2112,7 +2174,7 @@ async function main() {
     handler(getMarginfiDiagnostics)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_ledger_status",
     {
       description:
@@ -2135,7 +2197,7 @@ async function main() {
     handler(getLedgerStatus)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_aave_supply",
     {
       description:
@@ -2145,7 +2207,7 @@ async function main() {
     txHandler("prepare_aave_supply", prepareAaveSupply)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_aave_withdraw",
     {
       description:
@@ -2155,7 +2217,7 @@ async function main() {
     txHandler("prepare_aave_withdraw", prepareAaveWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_aave_borrow",
     {
       description:
@@ -2165,7 +2227,7 @@ async function main() {
     txHandler("prepare_aave_borrow", prepareAaveBorrow)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_aave_repay",
     {
       description:
@@ -2175,7 +2237,7 @@ async function main() {
     txHandler("prepare_aave_repay", prepareAaveRepay)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_lido_stake",
     {
       description:
@@ -2185,7 +2247,7 @@ async function main() {
     txHandler("prepare_lido_stake", prepareLidoStake)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_lido_unstake",
     {
       description:
@@ -2195,7 +2257,7 @@ async function main() {
     txHandler("prepare_lido_unstake", prepareLidoUnstake)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_eigenlayer_deposit",
     {
       description:
@@ -2205,7 +2267,7 @@ async function main() {
     txHandler("prepare_eigenlayer_deposit", prepareEigenLayerDeposit)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "preview_send",
     {
       description:
@@ -2225,7 +2287,7 @@ async function main() {
     previewSendHandler(previewSend),
   );
 
-  server.registerTool(
+  registerTool(server, 
     "preview_solana_send",
     {
       description:
@@ -2247,7 +2309,7 @@ async function main() {
     previewSolanaSendHandler(previewSolanaSend),
   );
 
-  server.registerTool(
+  registerTool(server, 
     "send_transaction",
     {
       description:
@@ -2261,7 +2323,7 @@ async function main() {
     sendTransactionHandler(sendTransaction)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_transaction_status",
     {
       description:
@@ -2271,7 +2333,7 @@ async function main() {
     handler(getTransactionStatus)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_tx_verification",
     {
       description:
@@ -2281,7 +2343,7 @@ async function main() {
     handler(getTxVerification)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_verification_artifact",
     {
       description:
@@ -2301,7 +2363,7 @@ async function main() {
     handler(getVerificationArtifact)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "verify_tx_decode",
     {
       description:
@@ -2323,7 +2385,7 @@ async function main() {
     handler(verifyTxDecode)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "simulate_transaction",
     {
       description:
@@ -2342,7 +2404,7 @@ async function main() {
   );
 
   // ---- Module 7: Balances & ENS ----
-  server.registerTool(
+  registerTool(server, 
     "get_token_balance",
     {
       description:
@@ -2352,7 +2414,7 @@ async function main() {
     handler(getTokenBalance)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_token_price",
     {
       description:
@@ -2362,7 +2424,7 @@ async function main() {
     handler(getTokenPriceTool)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_token_metadata",
     {
       description:
@@ -2372,7 +2434,7 @@ async function main() {
     handler(getTokenMetadata)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "resolve_ens_name",
     {
       description:
@@ -2382,7 +2444,7 @@ async function main() {
     handler(resolveName)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "reverse_resolve_ens",
     {
       description:
@@ -2392,7 +2454,7 @@ async function main() {
     handler(reverseResolve)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_tron_staking",
     {
       description:
@@ -2402,7 +2464,7 @@ async function main() {
     handler((args: { address: string }) => getTronStaking(args.address))
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_native_send",
     {
       description:
@@ -2412,7 +2474,7 @@ async function main() {
     handler(buildTronNativeSend, { toolName: "prepare_tron_native_send" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_token_send",
     {
       description:
@@ -2422,7 +2484,7 @@ async function main() {
     handler(buildTronTokenSend, { toolName: "prepare_tron_token_send" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_trc20_approve",
     {
       description:
@@ -2434,7 +2496,7 @@ async function main() {
     handler(buildTronTrc20Approve, { toolName: "prepare_tron_trc20_approve" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_claim_rewards",
     {
       description:
@@ -2444,7 +2506,7 @@ async function main() {
     handler(buildTronClaimRewards, { toolName: "prepare_tron_claim_rewards" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_freeze",
     {
       description:
@@ -2454,7 +2516,7 @@ async function main() {
     handler(buildTronFreeze, { toolName: "prepare_tron_freeze" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_unfreeze",
     {
       description:
@@ -2464,7 +2526,7 @@ async function main() {
     handler(buildTronUnfreeze, { toolName: "prepare_tron_unfreeze" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_withdraw_expire_unfreeze",
     {
       description:
@@ -2474,7 +2536,7 @@ async function main() {
     handler(buildTronWithdrawExpireUnfreeze, { toolName: "prepare_tron_withdraw_expire_unfreeze" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "list_tron_witnesses",
     {
       description:
@@ -2486,7 +2548,7 @@ async function main() {
     )
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_tron_vote",
     {
       description:
@@ -2496,7 +2558,7 @@ async function main() {
     handler(buildTronVote, { toolName: "prepare_tron_vote" })
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_native_send",
     {
       description:
@@ -2506,7 +2568,7 @@ async function main() {
     txHandler("prepare_native_send", prepareNativeSend)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_weth_unwrap",
     {
       description:
@@ -2516,7 +2578,7 @@ async function main() {
     txHandler("prepare_weth_unwrap", prepareWethUnwrap)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_token_send",
     {
       description:
@@ -2527,7 +2589,7 @@ async function main() {
   );
 
   // ---- Module 8: Compound V3 ----
-  server.registerTool(
+  registerTool(server, 
     "get_compound_positions",
     {
       description:
@@ -2537,7 +2599,7 @@ async function main() {
     handler(getCompoundPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_compound_market_info",
     {
       description:
@@ -2547,7 +2609,7 @@ async function main() {
     handler(getCompoundMarketInfo)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "get_market_incident_status",
     {
       description:
@@ -2557,7 +2619,7 @@ async function main() {
     handler(getMarketIncidentStatus)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_compound_supply",
     {
       description:
@@ -2567,7 +2629,7 @@ async function main() {
     txHandler("prepare_compound_supply", buildCompoundSupply)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_compound_withdraw",
     {
       description:
@@ -2577,7 +2639,7 @@ async function main() {
     txHandler("prepare_compound_withdraw", buildCompoundWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_compound_borrow",
     {
       description:
@@ -2587,7 +2649,7 @@ async function main() {
     txHandler("prepare_compound_borrow", buildCompoundBorrow)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_compound_repay",
     {
       description:
@@ -2598,7 +2660,7 @@ async function main() {
   );
 
   // ---- Module 9: Morpho Blue ----
-  server.registerTool(
+  registerTool(server, 
     "get_morpho_positions",
     {
       description:
@@ -2608,7 +2670,7 @@ async function main() {
     handler(getMorphoPositions)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_supply",
     {
       description:
@@ -2618,7 +2680,7 @@ async function main() {
     txHandler("prepare_morpho_supply", buildMorphoSupply)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_withdraw",
     {
       description:
@@ -2628,7 +2690,7 @@ async function main() {
     txHandler("prepare_morpho_withdraw", buildMorphoWithdraw)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_borrow",
     {
       description:
@@ -2638,7 +2700,7 @@ async function main() {
     txHandler("prepare_morpho_borrow", buildMorphoBorrow)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_repay",
     {
       description:
@@ -2648,7 +2710,7 @@ async function main() {
     txHandler("prepare_morpho_repay", buildMorphoRepay)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_supply_collateral",
     {
       description:
@@ -2658,7 +2720,7 @@ async function main() {
     txHandler("prepare_morpho_supply_collateral", buildMorphoSupplyCollateral)
   );
 
-  server.registerTool(
+  registerTool(server, 
     "prepare_morpho_withdraw_collateral",
     {
       description:
@@ -2669,7 +2731,7 @@ async function main() {
   );
 
   // ---- Module 10: Capability requests (agent → maintainers) ----
-  server.registerTool(
+  registerTool(server, 
     "request_capability",
     {
       description:

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -674,6 +674,21 @@ async function offerSkillInstall(p: Prompt): Promise<void> {
 }
 
 async function main() {
+  // Demo mode is a try-before-install switch — the server runs against
+  // fixture data and never touches a real Ledger or RPC. Running the
+  // setup wizard while VAULTPILOT_DEMO is active would write real config
+  // (Ledger pairing state, API keys, indexer URLs) to disk and silently
+  // create a misleading mismatch between what the user sees in chat
+  // (fixture data) and what's actually configured. Refuse with a clear
+  // message instead.
+  const { assertNotDemoForSetup } = await import("./demo/index.js");
+  try {
+    assertNotDemoForSetup();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
   console.log("VaultPilot MCP — interactive setup\n");
   console.log(`Config path: ${getConfigPath()}`);
 

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Demo-mode unit tests. Covers:
+ *
+ *   - `isDemoMode()` reads VAULTPILOT_DEMO at call time (not module load),
+ *     so a single process can flip behavior between calls;
+ *   - `isSigningTool()` pattern-matches the prepare_, pair_ledger_,
+ *     sign_message_ prefixes and the explicit signing-tool list;
+ *   - `getDemoFixture()` returns a deterministic, non-empty payload for
+ *     every fixtured tool, and the structured `not-implemented` echo for
+ *     anything else;
+ *   - `demoSigningRefusalMessage()` is stable for agents that pattern-
+ *     match the prefix;
+ *   - `assertNotDemoForSetup()` throws when demo is on, no-ops otherwise.
+ *
+ * The end-to-end behavior of the registerTool wrapper (signing tools
+ * actually refused, read tools actually return fixtures through the
+ * MCP content shape) is exercised indirectly: spinning up the full
+ * server in a unit test is heavy; the wrapper is a thin composition
+ * over already-tested primitives (`handler` + `getDemoFixture` +
+ * `isSigningTool`), so we check those primitives directly.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const ENV_KEY = "VAULTPILOT_DEMO";
+
+describe("isDemoMode — reads env at call time", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("returns true only when VAULTPILOT_DEMO is exactly 'true'", async () => {
+    const { isDemoMode } = await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    expect(isDemoMode()).toBe(false);
+    process.env[ENV_KEY] = "true";
+    expect(isDemoMode()).toBe(true);
+    process.env[ENV_KEY] = "TRUE"; // strictly case-sensitive — opt-in must be exact
+    expect(isDemoMode()).toBe(false);
+    process.env[ENV_KEY] = "1";
+    expect(isDemoMode()).toBe(false);
+    process.env[ENV_KEY] = "yes";
+    expect(isDemoMode()).toBe(false);
+  });
+});
+
+describe("isSigningTool — pattern + explicit-list classification", () => {
+  it("classifies prepare_, pair_ledger_, sign_message_ prefixes as signing", async () => {
+    const { isSigningTool } = await import("../src/demo/index.js");
+    expect(isSigningTool("prepare_native_send")).toBe(true);
+    expect(isSigningTool("prepare_aave_supply")).toBe(true);
+    expect(isSigningTool("prepare_swap")).toBe(true);
+    expect(isSigningTool("prepare_btc_send")).toBe(true);
+    expect(isSigningTool("pair_ledger_live")).toBe(true);
+    expect(isSigningTool("pair_ledger_btc")).toBe(true);
+    expect(isSigningTool("pair_ledger_solana")).toBe(true);
+    expect(isSigningTool("pair_ledger_tron")).toBe(true);
+    expect(isSigningTool("sign_message_btc")).toBe(true);
+  });
+
+  it("classifies the explicit-list tools as signing", async () => {
+    const { isSigningTool } = await import("../src/demo/index.js");
+    expect(isSigningTool("send_transaction")).toBe(true);
+    expect(isSigningTool("preview_send")).toBe(true);
+    expect(isSigningTool("preview_solana_send")).toBe(true);
+    expect(isSigningTool("verify_tx_decode")).toBe(true);
+    expect(isSigningTool("get_verification_artifact")).toBe(true);
+    expect(isSigningTool("request_capability")).toBe(true);
+  });
+
+  it("classifies read tools as non-signing", async () => {
+    const { isSigningTool } = await import("../src/demo/index.js");
+    expect(isSigningTool("get_token_balance")).toBe(false);
+    expect(isSigningTool("get_portfolio_summary")).toBe(false);
+    expect(isSigningTool("get_lending_positions")).toBe(false);
+    expect(isSigningTool("get_btc_balance")).toBe(false);
+    expect(isSigningTool("get_ledger_status")).toBe(false);
+    expect(isSigningTool("get_marginfi_positions")).toBe(false);
+    expect(isSigningTool("get_swap_quote")).toBe(false);
+  });
+});
+
+describe("getDemoFixture — deterministic, non-empty for fixtured tools", () => {
+  it("returns the same payload twice for the same args", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const a = getDemoFixture("get_ledger_status", undefined);
+    const b = getDemoFixture("get_ledger_status", undefined);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("returns the demo wallet identity from get_ledger_status", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const result = getDemoFixture("get_ledger_status", undefined) as {
+      paired: boolean;
+      accounts: string[];
+      bitcoin: { address: string }[];
+    };
+    expect(result.paired).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts[0]).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(result.bitcoin[0].address).toMatch(/^bc1q/);
+  });
+
+  it("returns realistic balance + USD value for get_token_balance", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const ethMainnet = getDemoFixture("get_token_balance", {
+      chain: "ethereum",
+      token: "native",
+    }) as { symbol: string; valueUsd: number };
+    expect(ethMainnet.symbol).toBe("ETH");
+    expect(ethMainnet.valueUsd).toBeGreaterThan(0);
+
+    // Per-(chain, token) variation: USDC on Arbitrum should differ from
+    // ETH on Ethereum — tests that the lookup key is composite.
+    const usdcArb = getDemoFixture("get_token_balance", {
+      chain: "arbitrum",
+      token: "0xaf88d065e77C8CC2239327C5EDb3A432268e5831",
+    }) as { symbol: string; valueUsd: number };
+    expect(usdcArb.symbol).toBe("USDC");
+    expect(usdcArb.valueUsd).toBeGreaterThan(0);
+  });
+
+  it("returns the not-implemented payload for tools without a fixture", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const result = getDemoFixture("get_definitely_not_a_real_tool", { foo: 1 }) as {
+      _demoFixture: string;
+      _toolName: string;
+      _message: string;
+    };
+    expect(result._demoFixture).toBe("not-implemented");
+    expect(result._toolName).toBe("get_definitely_not_a_real_tool");
+    expect(result._message).toContain("Demo mode is active");
+    // Args must be echoed so the user knows what hit the tool.
+    expect(result._message).toContain('"foo":1');
+    // List of implemented fixtures is surfaced — helps the user discover
+    // what's covered without grepping the source.
+    expect(result._message).toContain("get_ledger_status");
+    expect(result._message).toContain("get_portfolio_summary");
+  });
+
+  it("covers the priority tools the demo-mode plan calls out by name", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    // The plan names these as the headline fixtures for v1 — locking
+    // them so a future fixture-table refactor can't silently drop one.
+    for (const tool of [
+      "get_ledger_status",
+      "get_token_balance",
+      "get_portfolio_summary",
+      "get_lending_positions",
+      "get_lp_positions",
+      "get_staking_positions",
+      "get_solana_staking_positions",
+      "get_marginfi_positions",
+      "get_tron_staking",
+      "get_btc_balance",
+      "get_btc_balances",
+      "get_btc_account_balance",
+      "get_transaction_history",
+    ]) {
+      const result = getDemoFixture(tool, undefined) as Record<string, unknown>;
+      expect(result, `expected fixture for ${tool}`).toBeDefined();
+      // A real fixture, not the not-implemented echo:
+      expect(result._demoFixture, `${tool} fell through to not-implemented`).toBeUndefined();
+    }
+  });
+});
+
+describe("demoSigningRefusalMessage — stable for pattern-matching agents", () => {
+  it("starts with [VAULTPILOT_DEMO] and names the blocked tool", async () => {
+    const { demoSigningRefusalMessage } = await import("../src/demo/index.js");
+    const msg = demoSigningRefusalMessage("prepare_swap");
+    expect(msg.startsWith("[VAULTPILOT_DEMO]")).toBe(true);
+    expect(msg).toContain("'prepare_swap'");
+    expect(msg).toContain("disabled in demo mode");
+    expect(msg).toContain("vaultpilot-mcp-setup");
+  });
+});
+
+describe("assertNotDemoForSetup — refuses to write real config in demo mode", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("throws when demo is active", async () => {
+    const { assertNotDemoForSetup } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "true";
+    expect(() => assertNotDemoForSetup()).toThrow(/disabled in demo mode/);
+  });
+
+  it("no-ops when demo is off", async () => {
+    const { assertNotDemoForSetup } = await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    expect(() => assertNotDemoForSetup()).not.toThrow();
+  });
+});

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -142,30 +142,256 @@ describe("getDemoFixture — deterministic, non-empty for fixtured tools", () =>
     expect(result._message).toContain("get_portfolio_summary");
   });
 
-  it("covers the priority tools the demo-mode plan calls out by name", async () => {
+  it("covers all priority tools the demo-mode plan calls out by name (v1 + v2)", async () => {
     const { getDemoFixture } = await import("../src/demo/index.js");
-    // The plan names these as the headline fixtures for v1 — locking
-    // them so a future fixture-table refactor can't silently drop one.
-    for (const tool of [
+    // v1 (24) + v2 (19) = 43 fixtured read tools. Locking them so a
+    // future fixture-table refactor can't silently drop one. If a tool
+    // here falls through to the `not-implemented` echo, the test fails
+    // with the offending tool name in the message.
+    const fixturedTools = [
+      // v1
       "get_ledger_status",
+      "get_ledger_device_info",
       "get_token_balance",
+      "get_token_metadata",
+      "get_token_price",
       "get_portfolio_summary",
+      "get_transaction_history",
       "get_lending_positions",
+      "get_compound_positions",
+      "get_morpho_positions",
       "get_lp_positions",
       "get_staking_positions",
       "get_solana_staking_positions",
       "get_marginfi_positions",
+      "get_kamino_positions",
       "get_tron_staking",
       "get_btc_balance",
       "get_btc_balances",
       "get_btc_account_balance",
-      "get_transaction_history",
-    ]) {
+      "get_btc_block_tip",
+      "get_btc_fee_estimates",
+      "get_btc_tx_history",
+      "get_market_incident_status",
+      "get_health_alerts",
+      // v2
+      "get_swap_quote",
+      "get_solana_swap_quote",
+      "simulate_transaction",
+      "get_transaction_status",
+      "get_vaultpilot_config_status",
+      "get_marginfi_diagnostics",
+      "get_solana_setup_status",
+      "rescan_btc_account",
+      "get_compound_market_info",
+      "simulate_position_change",
+      "get_staking_rewards",
+      "estimate_staking_yield",
+      "check_contract_security",
+      "check_permission_risks",
+      "get_protocol_risk_score",
+      "resolve_ens_name",
+      "reverse_resolve_ens",
+      "get_portfolio_diff",
+      "list_tron_witnesses",
+    ];
+    expect(fixturedTools.length).toBe(43);
+    for (const tool of fixturedTools) {
       const result = getDemoFixture(tool, undefined) as Record<string, unknown>;
       expect(result, `expected fixture for ${tool}`).toBeDefined();
-      // A real fixture, not the not-implemented echo:
       expect(result._demoFixture, `${tool} fell through to not-implemented`).toBeUndefined();
     }
+  });
+});
+
+// v2 narrative-consistency tests. Fixtures are richer when they cite
+// each other — a follow-up "did the swap from history confirm?" should
+// return success because get_transaction_status recognizes the history
+// fixture's hashes; a position-change simulation should project from
+// the same Aave numbers get_lending_positions returned; etc. Lock these
+// links so a future fixture refactor can't silently break the demo
+// narrative.
+describe("v2 fixtures — cross-fixture narrative consistency", () => {
+  it("ENS round-trip: resolve(demo.eth) → DEMO_WALLET.evm; reverse(...) → demo.eth", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const { DEMO_WALLET } = await import("../src/demo/fixtures.js");
+    const forward = getDemoFixture("resolve_ens_name", { name: "demo.eth" }) as {
+      address: string | null;
+    };
+    expect(forward.address).toBe(DEMO_WALLET.evm);
+    // vaultpilot.eth also resolves to the same wallet
+    const alt = getDemoFixture("resolve_ens_name", { name: "vaultpilot.eth" }) as {
+      address: string | null;
+    };
+    expect(alt.address).toBe(DEMO_WALLET.evm);
+    const reverse = getDemoFixture("reverse_resolve_ens", {
+      address: DEMO_WALLET.evm,
+    }) as { name: string | null };
+    expect(reverse.name).toBe("demo.eth");
+    // Unknown names / addresses return null
+    const unknownFwd = getDemoFixture("resolve_ens_name", { name: "vitalik.eth" }) as {
+      address: string | null;
+    };
+    expect(unknownFwd.address).toBeNull();
+    const unknownRev = getDemoFixture("reverse_resolve_ens", {
+      address: "0x0000000000000000000000000000000000000001",
+    }) as { name: string | null };
+    expect(unknownRev.name).toBeNull();
+  });
+
+  it("get_transaction_status recognizes hashes from get_transaction_history", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const history = getDemoFixture("get_transaction_history", undefined) as {
+      txs: { hash: string }[];
+    };
+    expect(history.txs.length).toBeGreaterThan(0);
+    for (const tx of history.txs) {
+      const status = getDemoFixture("get_transaction_status", {
+        chain: "ethereum",
+        txHash: tx.hash,
+      }) as { status: string; confirmations: number };
+      expect(status.status, `${tx.hash} should resolve as success`).toBe("success");
+      expect(status.confirmations).toBeGreaterThan(0);
+    }
+    // Any other hash → pending
+    const unknown = getDemoFixture("get_transaction_status", {
+      chain: "ethereum",
+      txHash: "0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface",
+    }) as { status: string };
+    expect(unknown.status).toBe("pending");
+  });
+
+  it("simulate_position_change projects from the v1 Aave numbers", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const aave = getDemoFixture("get_lending_positions", undefined) as {
+      positions: { collateralUsd: number; debtUsd: number; healthFactor: number }[];
+    };
+    expect(aave.positions[0].collateralUsd).toBe(4_000);
+    expect(aave.positions[0].debtUsd).toBe(800);
+    // Borrow another 500 USDC against the same position → debt becomes
+    // 1300, HF should be (4000 × 0.83) / 1300 ≈ 2.55.
+    const sim = getDemoFixture("simulate_position_change", {
+      protocol: "aave-v3",
+      action: "borrow",
+      asset: "USDC",
+      amount: "500",
+    }) as { projected: { collateralUsd: number; debtUsd: number; healthFactor: number } };
+    expect(sim.projected.collateralUsd).toBe(4_000);
+    expect(sim.projected.debtUsd).toBe(1_300);
+    expect(sim.projected.healthFactor).toBeCloseTo(2.55, 1);
+    // Repay 300 USDC → debt becomes 500, HF should be (4000 × 0.83) / 500 ≈ 6.64.
+    const repay = getDemoFixture("simulate_position_change", {
+      protocol: "aave-v3",
+      action: "repay",
+      asset: "USDC",
+      amount: "300",
+    }) as { projected: { healthFactor: number } };
+    expect(repay.projected.healthFactor).toBeCloseTo(6.64, 1);
+  });
+});
+
+describe("v2 fixtures — args-aware branching", () => {
+  it("check_contract_security: known DeFi → verified; unknown → cautionary", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    // Aave V3 Pool — known
+    const aave = getDemoFixture("check_contract_security", {
+      address: "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      chain: "ethereum",
+    }) as {
+      isVerified: boolean;
+      dangerousFunctions: string[];
+      notes: string[];
+    };
+    expect(aave.isVerified).toBe(true);
+    expect(aave.dangerousFunctions).toEqual([]);
+    expect(aave.notes.some((n) => n.includes("Aave V3 Pool"))).toBe(true);
+    // Random address — unknown
+    const unknown = getDemoFixture("check_contract_security", {
+      address: "0xCafeBabe000000000000000000000000DeadBeef",
+      chain: "ethereum",
+    }) as { isVerified: boolean; dangerousFunctions: string[] };
+    expect(unknown.isVerified).toBe(false);
+    expect(unknown.dangerousFunctions.length).toBeGreaterThan(0);
+  });
+
+  it("check_permission_risks: same known-vs-unknown branching as security check", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const aave = getDemoFixture("check_permission_risks", {
+      address: "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      chain: "ethereum",
+    }) as { roles: { holderType: string }[] };
+    expect(aave.roles.every((r) => r.holderType === "TimelockController")).toBe(true);
+    const unknown = getDemoFixture("check_permission_risks", {
+      address: "0xCafeBabe000000000000000000000000DeadBeef",
+      chain: "ethereum",
+    }) as { roles: { holderType: string }[] };
+    expect(unknown.roles.some((r) => r.holderType === "EOA")).toBe(true);
+  });
+
+  it("get_swap_quote: stable→stable on mainnet returns SushiSwap-routed exact-out shape", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    // Live exact-out shape from this session: 6000 USDT for USDC →
+    // SushiSwap routing, fromAmount > 6000.
+    const quote = getDemoFixture("get_swap_quote", {
+      wallet: "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075",
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      toToken: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      amount: "6000",
+      amountSide: "to",
+    }) as {
+      tool: string;
+      crossChain: boolean;
+      fromAmount: string;
+      toAmountMin: string;
+    };
+    expect(quote.tool).toBe("sushiswap");
+    expect(quote.crossChain).toBe(false);
+    expect(parseFloat(quote.fromAmount)).toBeGreaterThan(6_000);
+    expect(parseFloat(quote.toAmountMin)).toBeGreaterThanOrEqual(6_000);
+  });
+
+  it("get_swap_quote: cross-chain bridges go through `across`, not sushiswap", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const quote = getDemoFixture("get_swap_quote", {
+      fromChain: "ethereum",
+      toChain: "base",
+      fromToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      toToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      amount: "1000",
+    }) as { tool: string; crossChain: boolean };
+    expect(quote.tool).toBe("across");
+    expect(quote.crossChain).toBe(true);
+  });
+
+  it("rescan_btc_account: only accountIndex 0 has data; others return empty + note", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const idx0 = getDemoFixture("rescan_btc_account", { accountIndex: 0 }) as {
+      totalConfirmedBtc: string;
+      note?: string;
+    };
+    expect(parseFloat(idx0.totalConfirmedBtc)).toBeGreaterThan(0);
+    const idx5 = getDemoFixture("rescan_btc_account", { accountIndex: 5 }) as {
+      totalConfirmedSats: string;
+      note?: string;
+    };
+    expect(idx5.totalConfirmedSats).toBe("0");
+    expect(idx5.note).toContain("only accountIndex 0 has data");
+  });
+
+  it("get_protocol_risk_score: known DeFi protocols score 70+; unknown defaults to 35", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    for (const protocol of ["aave-v3", "compound-v3", "lido", "uniswap-v3", "lifi"]) {
+      const r = getDemoFixture("get_protocol_risk_score", { protocol }) as {
+        score: number;
+      };
+      expect(r.score, `${protocol} should score 70+`).toBeGreaterThanOrEqual(70);
+    }
+    const unknown = getDemoFixture("get_protocol_risk_score", { protocol: "rugpull-v1" }) as {
+      score: number;
+    };
+    expect(unknown.score).toBe(35);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements [claude-work/HIGH-plan-demo-mode.md](claude-work/HIGH-plan-demo-mode.md). \`VAULTPILOT_DEMO=true\` ships a fake wallet with realistic positions across EVM / TRON / Solana / Bitcoin — no Ledger, no setup, no API keys. Bloggers, YouTubers, prospective users can try the read-only UX in 30 seconds.

## Architecture

- **Single point of demo enforcement.** A thin \`registerTool(server, name, opts, handler)\` wrapper sits in front of \`server.registerTool\`. When demo is off, it's a transparent pass-through (zero hot-path cost). When demo is on, the request routes to the demo handler instead of the real one. All 109 tool registrations in \`src/index.ts\` now go through the wrapper (mechanical sed).
- **Pattern-based signing-tool gate.** \`isSigningTool()\` matches the \`prepare_\`, \`pair_ledger_\`, \`sign_message_\` prefixes plus an explicit list (\`send_transaction\`, \`preview_send\`, \`preview_solana_send\`, \`verify_tx_decode\`, \`get_verification_artifact\`, \`request_capability\`). New \`prepare_*\` / \`pair_ledger_*\` tools are gated automatically without code changes.
- **Determinism.** Same args → same fixture on every call. Demo screenshots / videos / tutorials reproduce identically across runs.
- **Setup-wizard guard.** \`vaultpilot-mcp-setup\` refuses to run when demo is active — prevents the silent-mismatch case where the wizard writes real pairing state to disk while the server is serving fixture data.
- **Discoverability.** Tools without a fixture return a structured \`_demoFixture: "not-implemented"\` payload that echoes the tool name + args + the list of fixtured tools, so users can see what's done vs. not without grepping the source.

## Fixtures (priority tools the plan calls out by name)

- **Identity**: \`get_ledger_status\`, \`get_ledger_device_info\` — single demo wallet across EVM/TRON/Solana/BTC
- **Balances**: \`get_token_balance\` per (chain, token) — 2.5 ETH on Ethereum, 1500 USDC on Arbitrum, 0.075 BTC, 12 SOL, 5000 TRX
- **DeFi**: \`get_lending_positions\` (Aave V3 supply, HF 4.85), \`get_lp_positions\` (Uniswap V3 WETH/USDC LP), \`get_staking_positions\` (Lido stETH 1.2), \`get_marginfi_positions\` (USDC supply 6.2% APY), \`get_tron_staking\` (frozen for energy + reward)
- **Bitcoin**: \`get_btc_balance\` / \`get_btc_balances\` / \`get_btc_account_balance\`, \`get_btc_block_tip\`, \`get_btc_fee_estimates\`, \`get_btc_tx_history\`
- **Aggregate**: \`get_portfolio_summary\` (coherent multi-chain breakdown summing ~\$14k), \`get_transaction_history\` (4-tx timeline showing the swap → supply → stake narrative)

Out of v1 (per the plan): per-tool fixture overrides, tutorial branching, write-side fixtures.

## Test plan

- [x] 12 new tests in \`test/demo.test.ts\`:
  - \`isDemoMode\` reads env at call time and is strictly case-sensitive
  - \`isSigningTool\` classifies prefixes + explicit list correctly, and read tools as non-signing
  - \`getDemoFixture\` is deterministic + non-empty for every priority tool
  - The not-implemented echo includes tool name + args + discoverable list of fixtured tools
  - \`demoSigningRefusalMessage\` starts with the agent-greppable \`[VAULTPILOT_DEMO]\` prefix and names the blocked tool
  - \`assertNotDemoForSetup\` throws when demo is on, no-ops otherwise
- [x] Targeted: \`npx vitest run test/demo.test.ts\` — 12/12 pass
- [x] Full suite: \`npm test\` — 1135/1135 pass (1123 prior + 12 new)
- [ ] **Live verification post-merge**:
  - \`VAULTPILOT_DEMO=true npx vaultpilot-mcp\` — server boots without a Ledger
  - In an MCP client, ask the agent "show me my crypto portfolio" → coherent multi-chain answer
  - Try \`prepare_native_send\` — should refuse with \`[VAULTPILOT_DEMO]\` prefix, no signing attempt
  - \`VAULTPILOT_DEMO=true npx vaultpilot-mcp-setup\` — wizard refuses with the explicit "disabled in demo mode" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)