### PR TITLE
fix(ltc): hydrate pairing cache from litecoin + add rescan_ltc_account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ import {
   getLitecoinBalance,
   prepareLitecoinNativeSend,
   signLtcMessage,
+  rescanLitecoinAccount,
   getMarginfiPositions,
   getSolanaStakingPositions,
   getMarginfiDiagnostics,
@@ -166,6 +167,7 @@ import {
   getLitecoinBalanceInput,
   prepareLitecoinNativeSendInput,
   signLtcMessageInput,
+  rescanLitecoinAccountInput,
   getMarginfiPositionsInput,
   getSolanaStakingPositionsInput,
   getMarginfiDiagnosticsInput,
@@ -2055,6 +2057,32 @@ async function main() {
       inputSchema: signLtcMessageInput.shape,
     },
     handler(signLtcMessage, { toolName: "sign_message_ltc" })
+  );
+
+  server.registerTool(
+    "rescan_ltc_account",
+    {
+      description:
+        "READ-ONLY — refresh the cached on-chain `txCount` for every paired " +
+        "Litecoin address under one Ledger account by re-querying the indexer. " +
+        "Pure indexer-side: NO Ledger / USB interaction. Use this after the " +
+        "user has received funds (so a previously-empty cached address now " +
+        "has history) or when the indexer was stale at the original " +
+        "`pair_ledger_ltc` scan time. Updates the persisted cache, so " +
+        "subsequent `get_ltc_balance` reflects the refresh without another " +
+        "rescan. Three-state extend signal: `needsExtend: true` (trailing " +
+        "buffer address on any cached chain has on-chain history — re-run " +
+        "`pair_ledger_ltc` to extend the walked window); `unverifiedChains: " +
+        "[...]` (tail probe REJECTED for that chain — indeterminate, usually " +
+        "a transient indexer hiccup, re-run `rescan_ltc_account` rather than " +
+        "re-pairing); neither field present → all walked chains confirmed " +
+        "healthy. Indexer fan-out is bounded to `LITECOIN_INDEXER_PARALLELISM` " +
+        "concurrent requests (default 8) to stay under litecoinspace.org's " +
+        "free-tier rate limits; transient 429s and network errors are retried " +
+        "once internally.",
+      inputSchema: rescanLitecoinAccountInput.shape,
+    },
+    handler(rescanLitecoinAccount, { toolName: "rescan_ltc_account" })
   );
 
   server.registerTool(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -144,6 +144,7 @@ import type {
   GetLitecoinBalanceArgs,
   PrepareLitecoinNativeSendArgs,
   SignLtcMessageArgs,
+  RescanLitecoinAccountArgs,
   GetMarginfiPositionsArgs,
   GetSolanaStakingPositionsArgs,
   PreviewSendArgs,
@@ -1199,6 +1200,159 @@ export async function prepareLitecoinNativeSend(
 export async function signLtcMessage(args: SignLtcMessageArgs) {
   const { signLitecoinMessage } = await import("../litecoin/actions.js");
   return signLitecoinMessage({ wallet: args.wallet, message: args.message });
+}
+
+/**
+ * Refresh the cached `txCount` for every paired Litecoin address under
+ * one Ledger account by re-querying the indexer. Pure indexer fan-out:
+ * no Ledger / USB interaction. Mirror of `rescanBitcoinAccount` for
+ * Litecoin — same three-state extend signal, same persistence side
+ * effects, same parallelism cap (`LITECOIN_INDEXER_PARALLELISM`).
+ *
+ * Issue #229.
+ */
+export async function rescanLitecoinAccount(args: RescanLitecoinAccountArgs) {
+  const { getPairedLtcAddresses, setPairedLtcAddress } = await import(
+    "../../signing/ltc-usb-signer.js"
+  );
+  const all = getPairedLtcAddresses();
+  const forAccount = all.filter(
+    (e) => e.accountIndex === args.accountIndex,
+  );
+  if (forAccount.length === 0) {
+    throw new Error(
+      `No paired Litecoin entries cached for accountIndex=${args.accountIndex}. ` +
+        `Run \`pair_ledger_ltc({ accountIndex: ${args.accountIndex} })\` first ` +
+        `to populate the cache. \`rescan_ltc_account\` only refreshes existing ` +
+        `entries — it cannot derive new addresses (that needs the Ledger device).`,
+    );
+  }
+  const { getLitecoinIndexer } = await import("../litecoin/indexer.js");
+  const indexer = getLitecoinIndexer();
+  const { pLimitMap } = await import("../../data/http.js");
+  const { resolveLitecoinIndexerParallelism } = await import(
+    "../../config/litecoin.js"
+  );
+  // Same rationale as the BTC twin: cap fan-out under litecoinspace.org's
+  // free-tier rate limit. Self-hosted Esplora users with no rate concerns
+  // can override via `LITECOIN_INDEXER_PARALLELISM`.
+  const parallelism = resolveLitecoinIndexerParallelism();
+  const probes = await pLimitMap(forAccount, parallelism, (e) =>
+    indexer.getBalance(e.address),
+  );
+
+  type LTCEntry = (typeof forAccount)[number];
+  type ChainKey = `${LTCEntry["addressType"]}:${0 | 1}`;
+  const chainBuckets = new Map<ChainKey, LTCEntry[]>();
+  const refreshed: Array<{
+    address: string;
+    addressType: LTCEntry["addressType"];
+    chain: 0 | 1 | null;
+    addressIndex: number | null;
+    path: string;
+    previousTxCount: number;
+    txCount: number;
+    delta: number;
+    fetchOk: boolean;
+  }> = [];
+  for (let i = 0; i < forAccount.length; i++) {
+    const entry = forAccount[i];
+    const probe = probes[i];
+    const previousTxCount = entry.txCount ?? 0;
+    let liveTxCount = previousTxCount;
+    let fetchOk = false;
+    if (probe.status === "fulfilled") {
+      liveTxCount = probe.value.txCount;
+      fetchOk = true;
+      if (liveTxCount !== previousTxCount) {
+        setPairedLtcAddress({ ...entry, txCount: liveTxCount });
+      }
+    }
+    refreshed.push({
+      address: entry.address,
+      addressType: entry.addressType,
+      chain: entry.chain ?? null,
+      addressIndex: entry.addressIndex ?? null,
+      path: entry.path,
+      previousTxCount,
+      txCount: liveTxCount,
+      delta: liveTxCount - previousTxCount,
+      fetchOk,
+    });
+    if (entry.chain === 0 || entry.chain === 1) {
+      const key: ChainKey = `${entry.addressType}:${entry.chain}`;
+      const bucket = chainBuckets.get(key);
+      if (bucket) bucket.push(entry);
+      else chainBuckets.set(key, [entry]);
+    }
+  }
+
+  let needsExtend = false;
+  const extendChains: Array<{
+    addressType: LTCEntry["addressType"];
+    chain: 0 | 1;
+    lastAddressIndex: number;
+  }> = [];
+  const unverifiedChains: Array<{
+    addressType: LTCEntry["addressType"];
+    chain: 0 | 1;
+    lastAddressIndex: number;
+  }> = [];
+  for (const [key, bucket] of chainBuckets) {
+    const tail = bucket.reduce((max, e) =>
+      (e.addressIndex ?? -1) > (max.addressIndex ?? -1) ? e : max,
+    );
+    const i = forAccount.indexOf(tail);
+    const probe = probes[i];
+    const [addressTypeStr, chainStr] = key.split(":");
+    const chainEntry = {
+      addressType: addressTypeStr as LTCEntry["addressType"],
+      chain: Number(chainStr) as 0 | 1,
+      lastAddressIndex: tail.addressIndex ?? -1,
+    };
+    if (probe.status === "rejected") {
+      unverifiedChains.push(chainEntry);
+      continue;
+    }
+    if (probe.value.txCount > 0) {
+      needsExtend = true;
+      extendChains.push(chainEntry);
+    }
+  }
+
+  const fetchFailures = refreshed.filter((r) => !r.fetchOk).length;
+  const txCountChanges = refreshed.filter((r) => r.delta !== 0).length;
+  let note: string | undefined;
+  if (needsExtend) {
+    note =
+      "The trailing empty address on at least one cached chain now has " +
+      "on-chain history. The original gap-limit window may miss funds " +
+      "past it. Run `pair_ledger_ltc({ accountIndex: " +
+      args.accountIndex +
+      " })` to extend the scan with fresh on-device derivations." +
+      (unverifiedChains.length > 0
+        ? " (Some other chains' tail probes failed and are reported as " +
+          "`unverifiedChains` — those are independent of the extend signal.)"
+        : "");
+  } else if (unverifiedChains.length > 0) {
+    note =
+      "Some chains' tail probes failed this run, so we can't confirm the " +
+      "gap window is still healthy for them — see `unverifiedChains`. " +
+      "This is usually a transient indexer hiccup (rate limit / 5xx); " +
+      "re-run `rescan_ltc_account` after a moment. Don't re-pair on this " +
+      "alone — `needsExtend: true` is the signal for that.";
+  }
+  return {
+    accountIndex: args.accountIndex,
+    addressesScanned: refreshed.length,
+    txCountChanges,
+    fetchFailures,
+    needsExtend,
+    ...(needsExtend ? { extendChains } : {}),
+    ...(unverifiedChains.length > 0 ? { unverifiedChains } : {}),
+    refreshed,
+    ...(note ? { note } : {}),
+  };
 }
 
 export async function getMarginfiPositions(args: GetMarginfiPositionsArgs) {

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1305,7 +1305,28 @@ export const signLtcMessageInput = z.object({
     .describe("UTF-8 message to sign."),
 });
 
+export const rescanLitecoinAccountInput = z.object({
+  accountIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe(
+      "Ledger Litecoin account slot to rescan. Must already be paired (call " +
+        "`pair_ledger_ltc` first). Re-queries the indexer for the live " +
+        "`txCount` of every cached address under this account and updates " +
+        "the persisted cache — useful after the user has received funds or " +
+        "the indexer was stale at original scan time. Pure indexer-side: no " +
+        "Ledger / USB interaction. Returns: `needsExtend: true` when the " +
+        "trailing empty address on any cached chain now has history (re-pair " +
+        "to extend the walked window); `unverifiedChains: [...]` when the " +
+        "tail probe ITSELF rejected (transient indexer hiccup, status " +
+        "indeterminate — re-run `rescan_ltc_account` rather than re-pairing)."
+    ),
+});
+
 export type PairLedgerLitecoinArgs = z.infer<typeof pairLedgerLitecoinInput>;
 export type GetLitecoinBalanceArgs = z.infer<typeof getLitecoinBalanceInput>;
 export type PrepareLitecoinNativeSendArgs = z.infer<typeof prepareLitecoinNativeSendInput>;
 export type SignLtcMessageArgs = z.infer<typeof signLtcMessageInput>;
+export type RescanLitecoinAccountArgs = z.infer<typeof rescanLitecoinAccountInput>;

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -13,6 +13,7 @@ import {
   type AccountNode,
 } from "./ltc-bip32-derive.js";
 import { getConfigPath, patchUserConfig, readUserConfig } from "../config/user-config.js";
+import { isLitecoinAddress } from "../modules/litecoin/address.js";
 import type { PairedLitecoinEntry } from "../types/index.js";
 
 const requireCjs = createRequire(import.meta.url);
@@ -825,8 +826,19 @@ let pairedLtcHydrated = false;
 function ensurePairedLtcHydrated(): void {
   if (pairedLtcHydrated) return;
   pairedLtcHydrated = true;
-  const persisted = readUserConfig()?.pairings?.bitcoin ?? [];
+  const persisted = readUserConfig()?.pairings?.litecoin ?? [];
+  let polluted = false;
   for (const entry of persisted) {
+    // Defensive filter: drop any entry whose address isn't a valid LTC
+    // mainnet format. Issue #228 silently overwrote `pairings.litecoin`
+    // with bitcoin entries; the persisted JSON on affected installs
+    // still holds those rows. Filtering at hydrate time auto-recovers
+    // those users without forcing them to hand-edit user-config.json
+    // (and re-persists the cleaned list on the next mutation).
+    if (!isLitecoinAddress(entry.address)) {
+      polluted = true;
+      continue;
+    }
     // Backfill chain/addressIndex from the path for pre-#189 entries
     // (which only ever had chain=0, addressIndex=0). Keeps callers
     // from having to handle the absence at every read site.
@@ -842,6 +854,7 @@ function ensurePairedLtcHydrated(): void {
     }
     pairedLtcByPath.set(entry.path, entry);
   }
+  if (polluted) persistPairedLtc();
 }
 
 function persistPairedLtc(): void {

--- a/test/ltc-rescan-and-hydration.test.ts
+++ b/test/ltc-rescan-and-hydration.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { setConfigDirForTesting, getConfigPath } from "../src/config/user-config.js";
+
+/**
+ * Tests for issues #228 (LTC pairing cache hydrating from `pairings.bitcoin`)
+ * and #229 (rescan_ltc_account — read-only Litecoin pairing-cache refresh).
+ */
+
+const LTC_SEGWIT = "ltc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck";
+const LTC_SEGWIT_TAIL = "ltc1qttxxttxttxttxttxttxttxttxttxttxttxxqxx55h";
+const FAKE_PUBKEY = "00".repeat(33);
+
+const indexerGetBalanceMock = vi.fn();
+vi.mock("../src/modules/litecoin/indexer.ts", () => ({
+  getLitecoinIndexer: () => ({ getBalance: indexerGetBalanceMock }),
+  resetLitecoinIndexer: () => {},
+}));
+
+vi.mock("../src/signing/ltc-usb-loader.js", () => ({
+  openLedger: async () => {
+    throw new Error("test: openLedger should not be called from rescan");
+  },
+  getAppAndVersion: async () => {
+    throw new Error("test: getAppAndVersion should not be called");
+  },
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-ltc-rescan-"));
+  setConfigDirForTesting(pjoin(tmpHome, ".vaultpilot-mcp"));
+  indexerGetBalanceMock.mockReset();
+  const { clearPairedLtcAddresses } = await import(
+    "../src/signing/ltc-usb-signer.js"
+  );
+  clearPairedLtcAddresses();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.LITECOIN_INDEXER_PARALLELISM;
+  vi.resetModules();
+});
+
+// ---- Issue #228: hydration source + pollution recovery -------------------
+
+describe("LTC pairing cache hydration (issue #228)", () => {
+  it("reads from pairings.litecoin (NOT pairings.bitcoin)", async () => {
+    // Seed the on-disk config with both lists. If the hydrator reads
+    // from `bitcoin`, the LTC cache would surface a `bc1q...` entry —
+    // exactly the bug from #228. Correct behavior: only the LTC entry
+    // appears.
+    const cfgPath = getConfigPath();
+    mkdirSync(pjoin(cfgPath, ".."), { recursive: true });
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        pairings: {
+          bitcoin: [
+            {
+              address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+              publicKey: FAKE_PUBKEY,
+              path: "84'/0'/0'/0/0",
+              appVersion: "2.2.3",
+              addressType: "segwit",
+              accountIndex: 0,
+              chain: 0,
+              addressIndex: 0,
+              txCount: 0,
+            },
+          ],
+          litecoin: [
+            {
+              address: LTC_SEGWIT,
+              publicKey: FAKE_PUBKEY,
+              path: "84'/2'/0'/0/0",
+              appVersion: "2.4.6",
+              addressType: "segwit",
+              accountIndex: 0,
+              chain: 0,
+              addressIndex: 0,
+              txCount: 0,
+            },
+          ],
+        },
+      }) + "\n",
+    );
+
+    // Reset the in-memory hydration latch so the read above takes effect.
+    vi.resetModules();
+    const { getPairedLtcAddresses } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const entries = getPairedLtcAddresses();
+    expect(entries.length).toBe(1);
+    expect(entries[0].address).toBe(LTC_SEGWIT);
+    expect(entries[0].path).toBe("84'/2'/0'/0/0");
+  });
+
+  it("filters out bitcoin-shaped entries that earlier polluted pairings.litecoin", async () => {
+    // Affected installs from #228 ended up with bitcoin entries inside
+    // `pairings.litecoin` on disk. The hydrate-time filter drops them
+    // and re-persists the cleaned list so users don't have to hand-edit
+    // user-config.json.
+    const cfgPath = getConfigPath();
+    mkdirSync(pjoin(cfgPath, ".."), { recursive: true });
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        pairings: {
+          litecoin: [
+            // Polluted: BTC mainnet bech32 on coin_type=0 path.
+            {
+              address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+              publicKey: FAKE_PUBKEY,
+              path: "84'/0'/0'/0/0",
+              appVersion: "2.2.3",
+              addressType: "segwit",
+              accountIndex: 0,
+              chain: 0,
+              addressIndex: 0,
+              txCount: 0,
+            },
+            // Polluted: BTC legacy `1...` on coin_type=0 path.
+            {
+              address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+              publicKey: FAKE_PUBKEY,
+              path: "44'/0'/0'/0/0",
+              appVersion: "2.2.3",
+              addressType: "legacy",
+              accountIndex: 0,
+              chain: 0,
+              addressIndex: 0,
+              txCount: 0,
+            },
+            // Genuine LTC entry — the only one that should survive.
+            {
+              address: LTC_SEGWIT,
+              publicKey: FAKE_PUBKEY,
+              path: "84'/2'/0'/0/0",
+              appVersion: "2.4.6",
+              addressType: "segwit",
+              accountIndex: 0,
+              chain: 0,
+              addressIndex: 0,
+              txCount: 0,
+            },
+          ],
+        },
+      }) + "\n",
+    );
+
+    vi.resetModules();
+    const { getPairedLtcAddresses } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const entries = getPairedLtcAddresses();
+    expect(entries.length).toBe(1);
+    expect(entries[0].address).toBe(LTC_SEGWIT);
+
+    // The cleaned list is persisted back to disk so subsequent loads
+    // also see only the genuine entry (and to recover the user's
+    // config without manual editing).
+    const { readFileSync } = await import("node:fs");
+    const onDisk = JSON.parse(readFileSync(cfgPath, "utf8")) as {
+      pairings: { litecoin: Array<{ address: string }> };
+    };
+    expect(onDisk.pairings.litecoin.length).toBe(1);
+    expect(onDisk.pairings.litecoin[0].address).toBe(LTC_SEGWIT);
+  });
+});
+
+// ---- Issue #229: rescan_ltc_account ---------------------------------------
+
+describe("rescan_ltc_account (issue #229)", () => {
+  async function seedSegwitReceiveChain(
+    addresses: Array<{ idx: number; addr: string; txCount: number }>,
+  ) {
+    const { setPairedLtcAddress } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    for (const e of addresses) {
+      setPairedLtcAddress({
+        address: e.addr,
+        publicKey: FAKE_PUBKEY,
+        path: `84'/2'/0'/0/${e.idx}`,
+        appVersion: "2.4.6",
+        addressType: "segwit",
+        accountIndex: 0,
+        chain: 0,
+        addressIndex: e.idx,
+        txCount: e.txCount,
+      });
+    }
+  }
+
+  it("throws when no entries are paired for the requested account", async () => {
+    const { rescanLitecoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(rescanLitecoinAccount({ accountIndex: 0 })).rejects.toThrow(
+      /No paired Litecoin entries cached/,
+    );
+  });
+
+  it("flags needsExtend when the trailing empty cached address now has history", async () => {
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: LTC_SEGWIT, txCount: 5 },
+      { idx: 1, addr: LTC_SEGWIT_TAIL, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockImplementation(async (address: string) => ({
+      address,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: address === LTC_SEGWIT_TAIL ? 1 : 5,
+    }));
+    const { rescanLitecoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanLitecoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(true);
+    expect(out.extendChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 1 },
+    ]);
+    expect(out.unverifiedChains).toBeUndefined();
+    expect(out.note).toMatch(/pair_ledger_ltc/);
+  });
+
+  it("surfaces unverifiedChains (NOT needsExtend) when the tail probe rejects", async () => {
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: LTC_SEGWIT, txCount: 5 },
+      { idx: 1, addr: LTC_SEGWIT_TAIL, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockImplementation(async (address: string) => {
+      if (address === LTC_SEGWIT_TAIL) {
+        throw new Error("simulated 502 on the tail");
+      }
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 5,
+      };
+    });
+    const { rescanLitecoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanLitecoinAccount({ accountIndex: 0 });
+    expect(out.needsExtend).toBe(false);
+    expect(out.extendChains).toBeUndefined();
+    expect(out.unverifiedChains).toEqual([
+      { addressType: "segwit", chain: 0, lastAddressIndex: 1 },
+    ]);
+    expect(out.note).toMatch(/unverifiedChains/);
+    expect(out.note).toMatch(/transient/);
+  });
+
+  it("persists txCount changes back to the pairing cache", async () => {
+    await seedSegwitReceiveChain([
+      { idx: 0, addr: LTC_SEGWIT, txCount: 0 },
+    ]);
+    indexerGetBalanceMock.mockResolvedValue({
+      address: LTC_SEGWIT,
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: 7,
+    });
+    const { rescanLitecoinAccount } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const out = await rescanLitecoinAccount({ accountIndex: 0 });
+    expect(out.txCountChanges).toBe(1);
+    expect(out.refreshed[0].previousTxCount).toBe(0);
+    expect(out.refreshed[0].txCount).toBe(7);
+    expect(out.refreshed[0].delta).toBe(7);
+
+    const { getPairedLtcByAddress } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    expect(getPairedLtcByAddress(LTC_SEGWIT)?.txCount).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- **#228** — `ensurePairedLtcHydrated` read from `pairings.bitcoin`, so the LTC cache filled with BTC entries on the first restart after `pair_ledger_ltc` and `persistPairedLtc` then wrote them back into `pairings.litecoin`. Switch to `pairings.litecoin`; also add a hydrate-time `isLitecoinAddress` filter that drops any non-LTC entry and re-persists the cleaned list, so already-polluted installs auto-recover without hand-editing user-config.json.
- **#229** — Add `rescan_ltc_account`, a read-only mirror of `rescan_btc_account`: indexer fan-out across every paired LTC address under one account, same three-state extend signal (`needsExtend` / `unverifiedChains` / clean), parallelism capped via `LITECOIN_INDEXER_PARALLELISM` (default 8), persists refreshed `txCount` back into the cache.

## Test plan
- [x] `npm run build` — clean.
- [x] `npm test` — 1144 tests pass (was 1138; +6 from the new file).
- [x] New `test/ltc-rescan-and-hydration.test.ts` covers: hydration source (LTC vs BTC), pollution recovery (filter + re-persist), empty-account error, `needsExtend`, `unverifiedChains`, `txCount` persistence.
- [ ] Manual: on an install with the polluted on-disk config, restart MCP and call `get_ledger_status` — `litecoin: [...]` should drop the bitcoin-shaped rows; `pairings.litecoin` on disk reflects the cleaned list.
- [ ] Manual: after receiving funds on a previously-empty cached LTC address, run `rescan_ltc_account({accountIndex: 0})` and verify `txCountChanges > 0` + the next `get_ltc_balance` reflects the refresh without a re-pair.

Closes #228, closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)