### PR TITLE
fix(ltc): per-type fault-tolerant pairing — taproot bech32m no longer breaks the whole scan

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2002,13 +2002,18 @@ async function main() {
         "app open on-screen. Ledger Live's WalletConnect relay does not expose " +
         "Litecoin accounts to dApps, so signing goes over USB HID via " +
         "`@ledgerhq/hw-app-btc` (the same SDK as Bitcoin, with `currency:'litecoin'` " +
-        "selecting Litecoin-specific encoding). One call enumerates all four " +
-        "address types (legacy `L…`, p2sh-segwit `M…`, native segwit `ltc1q…`, " +
-        "taproot `ltc1p…`) for the given account index. BIP-44 coin_type 2. " +
+        "selecting Litecoin-specific encoding). One call enumerates the four " +
+        "BIP-44 address types (legacy `L…`, p2sh-segwit `M…`, native segwit " +
+        "`ltc1q…`, taproot `ltc1p…`) for the given account index. BIP-44 coin_type 2. " +
+        "Per-type fault-tolerant: each address-type walk runs independently, so " +
+        "one type's failure (e.g. the Ledger Litecoin app currently rejects " +
+        "`bech32m`/taproot with 'Unsupported address format bech32m') does NOT " +
+        "abort the others — the failed type is recorded under `skipped[]` in " +
+        "the response and the remaining three are paired and persisted. " +
         "Note: Litecoin Core has not activated Taproot on mainnet, so `ltc1p…` " +
-        "outputs are not yet spendable — the address is derived for forward " +
-        "compat. All paired entries surface under the `litecoin: [...]` section " +
-        "of `get_ledger_status`.",
+        "outputs would not be spendable anyway — taproot pairing is effectively " +
+        "forward-compat only. All paired entries surface under the `litecoin: " +
+        "[...]` section of `get_ledger_status`.",
       inputSchema: pairLedgerLitecoinInput.shape,
     },
     handler(pairLedgerLitecoin, { toolName: "pair_ledger_ltc" })

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1098,6 +1098,10 @@ export async function pairLedgerLitecoin(
     addressIndex: number;
     txCount: number;
   }>;
+  skipped: Array<{
+    addressType: "legacy" | "p2sh-segwit" | "segwit" | "taproot";
+    reason: string;
+  }>;
   summary: { totalDerived: number; used: number; unused: number };
   instructions: string;
 }> {
@@ -1131,6 +1135,19 @@ export async function pairLedgerLitecoin(
     }
     throw e;
   }
+  // Issue #231: scanLtcAccount is per-type fault-tolerant — a single
+  // type's failure (e.g. taproot's bech32m on the current Ledger LTC
+  // app) records into `skipped` rather than aborting. If EVERY type
+  // failed, treat that as a real pairing failure: don't drop the
+  // existing cache and don't claim success.
+  if (derived.entries.length === 0) {
+    const reasons = derived.skipped
+      .map((s) => `${s.addressType}: ${s.reason}`)
+      .join("; ");
+    throw new Error(
+      `pair_ledger_ltc: every address-type walk failed. ${reasons || "no per-type errors recorded"}`,
+    );
+  }
   clearPairedLtcAccount(accountIndex);
   for (const entry of derived.entries) {
     setPairedLtcAddress({
@@ -1146,6 +1163,11 @@ export async function pairLedgerLitecoin(
     });
   }
   const used = derived.entries.filter((e) => e.txCount > 0).length;
+  const succeededTypes = new Set(derived.entries.map((e) => e.addressType)).size;
+  const totalTypes = succeededTypes + derived.skipped.length;
+  const skippedNote = derived.skipped.length
+    ? ` Skipped ${derived.skipped.length}/${totalTypes} address types (${derived.skipped.map((s) => s.addressType).join(", ")}) — see \`skipped[]\` for per-type reasons. Common case: the Ledger Litecoin app does not support bech32m, so taproot (\`ltc1p…\`) derivation throws "Unsupported address format bech32m". Litecoin Core has not activated Taproot on mainnet anyway, so taproot pairing is effectively forward-compat only.`
+    : "";
   return {
     accountIndex,
     gapLimit,
@@ -1158,6 +1180,7 @@ export async function pairLedgerLitecoin(
       addressIndex: e.addressIndex,
       txCount: e.txCount,
     })),
+    skipped: derived.skipped,
     summary: {
       totalDerived: derived.entries.length,
       used,
@@ -1170,7 +1193,8 @@ export async function pairLedgerLitecoin(
       gapLimit +
       " consecutive empty addresses were observed. Use `get_ltc_balance` against " +
       "any cached address. Re-run `pair_ledger_ltc` to refresh; previously-cached " +
-      "entries for this accountIndex are dropped before the new scan persists.",
+      "entries for this accountIndex are dropped before the new scan persists." +
+      skippedNote,
   };
 }
 

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -331,6 +331,7 @@ export async function scanLtcAccount(args: {
 }): Promise<{
   appVersion: string;
   entries: Array<DerivedAddress & { txCount: number }>;
+  skipped: Array<{ addressType: LtcAddressType; reason: string }>;
 }> {
   const accountIndex = args.accountIndex;
   const gapLimit = args.gapLimit ?? DEFAULT_LTC_GAP_LIMIT;
@@ -359,50 +360,65 @@ export async function scanLtcAccount(args: {
       }
 
       const all: Array<DerivedAddress & { txCount: number }> = [];
+      const skipped: Array<{ addressType: LtcAddressType; reason: string }> = [];
       for (const addressType of LTC_ADDRESS_TYPES) {
-        // ONE device call per type — pull the account-level (publicKey,
-        // chainCode). Everything below this in the BIP-44 tree is
-        // non-hardened and host-derivable.
-        const accountPath = ltcAccountLevelPath(accountIndex, addressType);
-        const { format } = TYPE_META[addressType];
-        const accountResp = await app.getWalletPublicKey(accountPath, {
-          format,
-        });
-        const node: AccountNode = accountNodeFromLedgerResponse({
-          publicKeyHex: accountResp.publicKey,
-          chainCodeHex: accountResp.chainCode,
-          addressFormat: format,
-        });
+        // Per-type fault tolerance (issue #231): the Ledger Litecoin app
+        // throws unconditionally on `format: "bech32m"` (taproot), and
+        // pre-#231 a single bech32m throw aborted the entire scan,
+        // leaving even legacy/p2sh/segwit unpaired. Wrap each type's
+        // device call + chain walks in try/catch so one type's failure
+        // is recorded as `skipped` and the rest of the address-types
+        // still pair. When Litecoin Core activates Taproot AND the
+        // Ledger LTC app gains bech32m support, this loop becomes a
+        // no-op skip-recording pass — no code change needed.
+        try {
+          // ONE device call per type — pull the account-level (publicKey,
+          // chainCode). Everything below this in the BIP-44 tree is
+          // non-hardened and host-derivable.
+          const accountPath = ltcAccountLevelPath(accountIndex, addressType);
+          const { format } = TYPE_META[addressType];
+          const accountResp = await app.getWalletPublicKey(accountPath, {
+            format,
+          });
+          const node: AccountNode = accountNodeFromLedgerResponse({
+            publicKeyHex: accountResp.publicKey,
+            chainCodeHex: accountResp.chainCode,
+            addressFormat: format,
+          });
 
-        const receive = await scanChainHostSide({
-          node,
-          accountIndex,
-          addressType,
-          chain: 0,
-          gapLimit,
-          appVersion: appVer.version,
-          fetchTxCount: args.fetchTxCount,
-        });
-        for (let i = 0; i < receive.addresses.length; i++) {
-          all.push({ ...receive.addresses[i], txCount: receive.txCounts[i] });
-        }
-        // No receives ever → no change can exist. Skip the change-chain
-        // walk entirely (saves the entire change-chain HTTP round).
-        if (receive.empty) continue;
-        const change = await scanChainHostSide({
-          node,
-          accountIndex,
-          addressType,
-          chain: 1,
-          gapLimit,
-          appVersion: appVer.version,
-          fetchTxCount: args.fetchTxCount,
-        });
-        for (let i = 0; i < change.addresses.length; i++) {
-          all.push({ ...change.addresses[i], txCount: change.txCounts[i] });
+          const receive = await scanChainHostSide({
+            node,
+            accountIndex,
+            addressType,
+            chain: 0,
+            gapLimit,
+            appVersion: appVer.version,
+            fetchTxCount: args.fetchTxCount,
+          });
+          for (let i = 0; i < receive.addresses.length; i++) {
+            all.push({ ...receive.addresses[i], txCount: receive.txCounts[i] });
+          }
+          // No receives ever → no change can exist. Skip the change-chain
+          // walk entirely (saves the entire change-chain HTTP round).
+          if (receive.empty) continue;
+          const change = await scanChainHostSide({
+            node,
+            accountIndex,
+            addressType,
+            chain: 1,
+            gapLimit,
+            appVersion: appVer.version,
+            fetchTxCount: args.fetchTxCount,
+          });
+          for (let i = 0; i < change.addresses.length; i++) {
+            all.push({ ...change.addresses[i], txCount: change.txCounts[i] });
+          }
+        } catch (e) {
+          const reason = e instanceof Error ? e.message : String(e);
+          skipped.push({ addressType, reason });
         }
       }
-      return { appVersion: appVer.version, entries: all };
+      return { appVersion: appVer.version, entries: all, skipped };
     } finally {
       await (transport as LtcLedgerTransport).close().catch(() => {});
     }

--- a/test/litecoin-core.test.ts
+++ b/test/litecoin-core.test.ts
@@ -264,6 +264,91 @@ describe("pair_ledger_ltc", () => {
       /Litecoin is required/,
     );
   });
+
+  // Issue #231 regression: the Ledger Litecoin app throws unconditionally
+  // on `format: "bech32m"` (taproot). Pre-fix, this took out the entire
+  // pairing call and left legacy/p2sh/segwit unpaired. Fix: per-type
+  // fault tolerance — record taproot under `skipped[]`, persist the
+  // other three, return success.
+  it("survives taproot's bech32m rejection — pairs the other three types and records taproot under skipped[]", async () => {
+    const fixturesByPurpose = new Map<number, ReturnType<typeof makeAccountFixture>>();
+    for (const purpose of [44, 49, 84, 86]) {
+      fixturesByPurpose.set(purpose, makeAccountFixture(purpose, 0));
+    }
+    getWalletPublicKeyMock.mockImplementation(
+      (path: string, opts?: { format?: string }) => {
+        // Mirror the real Ledger LTC app behavior at
+        // node_modules/@ledgerhq/hw-app-btc/src/BtcOld.ts:93.
+        if (opts?.format === "bech32m") {
+          throw new Error("Unsupported address format bech32m");
+        }
+        const m = /^(\d+)'\/2'\/(\d+)'$/.exec(path);
+        if (!m) {
+          throw new Error(`unexpected non-account path: ${path}`);
+        }
+        const purpose = Number(m[1]);
+        const fixture = fixturesByPurpose.get(purpose);
+        if (!fixture) throw new Error(`no fixture for purpose ${purpose}`);
+        return Promise.resolve({
+          publicKey: fixture.publicKeyHex,
+          bitcoinAddress: "irrelevant-at-account-level",
+          chainCode: fixture.chainCodeHex,
+        });
+      },
+    );
+
+    const { pairLedgerLitecoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const { getLitecoinIndexer } = await import(
+      "../src/modules/litecoin/indexer.js"
+    );
+    const indexer = getLitecoinIndexer();
+    vi.spyOn(indexer, "getBalance").mockResolvedValue({
+      address: "any",
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: 0,
+    });
+
+    const result = await pairLedgerLitecoin({ accountIndex: 0, gapLimit: 1 });
+    // Three types succeed (legacy / p2sh-segwit / segwit), taproot is
+    // skipped — pre-fix this whole call threw "Unsupported address
+    // format bech32m" with zero entries persisted.
+    expect(result.addresses.length).toBe(3);
+    const types = result.addresses.map((a) => a.addressType).sort();
+    expect(types).toEqual(["legacy", "p2sh-segwit", "segwit"]);
+    expect(result.skipped.length).toBe(1);
+    expect(result.skipped[0].addressType).toBe("taproot");
+    expect(result.skipped[0].reason).toMatch(/bech32m/);
+    expect(result.instructions).toMatch(/Skipped 1\/4 address types \(taproot\)/);
+
+    // The persisted cache must reflect the same shape — three entries,
+    // no taproot.
+    const { getPairedLtcAddresses } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const cached = getPairedLtcAddresses();
+    expect(cached.length).toBe(3);
+    expect(cached.some((c) => c.addressType === "taproot")).toBe(false);
+  });
+
+  // If EVERY type fails (e.g. wrong app version blocking all paths), we
+  // should not silently "succeed" with zero entries — that would clear
+  // the existing cache and leave the user worse off. Throw with the
+  // collected per-type reasons so the caller can diagnose.
+  it("throws when every address-type walk fails (does not wipe the cache)", async () => {
+    getWalletPublicKeyMock.mockImplementation(() => {
+      throw new Error("device disconnected mid-call");
+    });
+    const { pairLedgerLitecoin } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      pairLedgerLitecoin({ accountIndex: 0, gapLimit: 1 }),
+    ).rejects.toThrow(/every address-type walk failed/);
+  });
 });
 
 // ---- Send-side rejection of legacy 3-prefix recipients ----------------


### PR DESCRIPTION
## Summary

Fixes #231. `pair_ledger_ltc` was completely blocked because the Ledger Litecoin app throws unconditionally on taproot's `bech32m` format, which short-circuited the entire four-type pairing walk (legacy / p2sh-segwit / segwit / taproot) — zero entries cached, every downstream LTC tool unusable.

- Wraps each address-type walk in `scanLtcAccount` with try/catch; failures get recorded into a new `skipped: Array<{ addressType, reason }>` rather than aborting the call.
- `pairLedgerLitecoin` surfaces `skipped[]` in the response shape and notes it in `instructions`.
- If EVERY type fails (e.g. wrong app version blocking all paths), throws with the collected per-type reasons so the existing cache isn't silently wiped.
- Forward-compat: when Litecoin Core activates Taproot AND the Ledger LTC app gains bech32m support, the loop becomes a no-op skip-recording pass with no further code change.

## Test plan

- [x] `npm test` — all 1161 tests pass (94 files)
- [x] `npm run build` — clean
- [x] New regression test: `survives taproot's bech32m rejection — pairs the other three types and records taproot under skipped[]` (mirrors the real Ledger LTC app's `format: "bech32m"` throw)
- [x] New regression test: `throws when every address-type walk fails (does not wipe the cache)`
- [ ] Manual: `pair_ledger_ltc({ accountIndex: 0 })` against a real Ledger with the Litecoin app open — verify legacy + p2sh-segwit + segwit appear in `get_ledger_status`, taproot under `skipped[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)