### PR TITLE
feat(swap): allow NEAR Intents via tamper-resistant intermediate-chain allowlist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1366,6 +1366,7 @@ async function main() {
         "Prepare an unsigned swap or bridge transaction via LiFi aggregator. Same-chain swaps use the best DEX route; cross-chain swaps use a bridge + DEX combo. Default is exact-in (`amount` = fromToken); set `amountSide: \"to\"` for exact-out (`amount` = target toToken output, e.g. \"I want 100 USDC out\"). " +
         "Source chain is always EVM. Destination can be any EVM chain, Solana, or TRON. For non-EVM destinations pass `toChain: \"solana\"` / `\"tron\"` + an explicit `toAddress` in the destination chain's format; the user signs an EVM tx and the bridge protocol delivers tokens to the destination after confirmation. The destination-side decimals cross-check is dropped for non-EVM destinations (we can't read SPL/TRC-20 via EVM RPC); LiFi's reported decimals are the source of truth there. Exact-out is not supported for cross-chain-to-non-EVM. For Solana-source swaps and bridges use `prepare_solana_lifi_swap`. TRON-source LiFi is not yet wired. " +
         "DECODING DEFENSE: every cross-chain bridge calldata is parsed into its `BridgeData` tuple and the encoded `destinationChainId` + `receiver` are cross-checked against what the user requested — refuses on mismatch. Catches a compromised MCP that returns calldata routing to a different chain or recipient than the prepare receipt advertises. " +
+        "INTERMEDIATE-CHAIN BRIDGES: NEAR Intents (notably for ETH→TRON USDT routes) settles on NEAR and releases on the final chain via an off-chain relayer, so its on-chain `destinationChainId` is NEAR's pseudo-id (1885080386571452) rather than the user's requested chain. The defense allows this ONLY for an explicit hardcoded (bridge name, intermediate chain ID) pair held as a source-code constant — not loaded from env / config / LiFi response — so a compromised aggregator can't claim arbitrary chains as 'intermediate'. Receiver-side checks (non-EVM sentinel, etc.) still apply unchanged. " +
         "The returned tx can be sent via `send_transaction`.",
       inputSchema: prepareSwapInput.shape,
     },
@@ -2103,7 +2104,10 @@ async function main() {
         "(TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt) and the owner_address is the user's wallet, " +
         "(3) decodes the inner ABI calldata's BridgeData tuple and cross-checks " +
         "destinationChainId + receiver against the user's request — refuses on any " +
-        "mismatch. TRC-20 source flows REQUIRE a prior approve to the LiFi Diamond — call " +
+        "mismatch. NEAR Intents routes (intermediate-chain settlement on NEAR's pseudo-chain " +
+        "1885080386571452) are allowlisted via a hardcoded source-code constant so a hostile " +
+        "aggregator cannot fabricate 'intermediate-chain' encodings; receiver-side checks still " +
+        "apply unchanged. TRC-20 source flows REQUIRE a prior approve to the LiFi Diamond — call " +
         "`prepare_tron_trc20_approve` first with `spender: \"TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt\"` " +
         "and the amount you intend to swap; insufficient allowance reverts the swap on-chain. " +
         "BLIND-SIGN on Ledger (LiFi Diamond not in TRON app's clear-sign allowlist) — " +

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -11,6 +11,7 @@ import {
   type DecodedLifiBridgeData,
 } from "../../signing/decode-calldata.js";
 import { NON_EVM_RECEIVER_SENTINEL } from "../../abis/lifi-diamond.js";
+import { matchIntermediateChainBridge } from "./intermediate-chain-bridges.js";
 import type { SupportedChain, UnsignedTx } from "../../types/index.js";
 
 /**
@@ -148,11 +149,39 @@ function verifyLifiBridgeIntent(
   }
   const expectedChainId = BigInt(LIFI_CHAIN_ID[args.toChain as keyof typeof LIFI_CHAIN_ID]);
   if (decoded.destinationChainId !== expectedChainId) {
-    throw new Error(
-      `LiFi bridge calldata destinationChainId mismatch: encoded ${decoded.destinationChainId.toString()} ` +
-        `but user requested toChain="${args.toChain}" (= ${expectedChainId.toString()}). ` +
-        `Refusing to return calldata — this would route funds to the wrong chain. Re-run get_swap_quote.`,
-    );
+    // Some bridges legitimately encode an intermediate settlement chain
+    // ID (NEAR Intents being the canonical case for ETH→TRON USDT —
+    // funds settle on NEAR and are released on TRON off-chain by a
+    // relayer). The match must satisfy BOTH the bridge name AND the
+    // intermediate chain ID, both of which are hardcoded source-code
+    // constants in INTERMEDIATE_CHAIN_BRIDGES — no env / userConfig /
+    // LiFi-response input is consulted, so neither value is tamperable
+    // by a compromised MCP / hostile aggregator within our threat
+    // model. Issue #237.
+    const intermediate = matchIntermediateChainBridge(decoded);
+    if (!intermediate) {
+      throw new Error(
+        `LiFi bridge calldata destinationChainId mismatch: encoded ${decoded.destinationChainId.toString()} ` +
+          `but user requested toChain="${args.toChain}" (= ${expectedChainId.toString()}). ` +
+          `Refusing to return calldata — this would route funds to the wrong chain. Re-run get_swap_quote.`,
+      );
+    }
+    // Intermediate-chain bridges only make sense for cross-chain
+    // requests. On a same-chain request the user wanted no bridging at
+    // all, so a NEAR-Intents-shaped calldata represents wrong intent
+    // (the swap-facet path is what handles same-chain swaps; bridge
+    // facets shouldn't fire there).
+    if (args.fromChain === args.toChain) {
+      throw new Error(
+        `LiFi quote returned ${intermediate.description} calldata for a same-chain ` +
+          `request (${args.fromChain} → ${args.toChain}). Intermediate-chain bridges ` +
+          `are only valid for cross-chain routes; refusing to return calldata.`,
+      );
+    }
+    // Allowed: fall through to receiver-side checks below. The
+    // receiver MUST still be the non-EVM sentinel for non-EVM final
+    // destinations, since the actual destination address is in the
+    // bridge-specific facet data we do not decode.
   }
 
   const toIsNonEvm = args.toChain === "solana" || args.toChain === "tron";

--- a/src/modules/swap/intermediate-chain-bridges.ts
+++ b/src/modules/swap/intermediate-chain-bridges.ts
@@ -1,0 +1,118 @@
+/**
+ * Hardcoded allowlist of LiFi bridge tools whose `BridgeData.destinationChainId`
+ * legitimately encodes an INTERMEDIATE settlement chain rather than the user's
+ * final destination chain.
+ *
+ * Background
+ * ----------
+ * The default chainId-mismatch defense in `verifyLifiBridgeIntent` refuses
+ * any cross-chain bridge calldata whose encoded `destinationChainId` doesn't
+ * equal the LiFi chain ID for the user's requested `toChain`. That's the
+ * right default — it's the layer that catches a compromised aggregator (or
+ * upstream MCP) returning calldata that secretly routes funds to an
+ * attacker-controlled chain.
+ *
+ * But some bridge protocols legitimately settle on an intermediate chain and
+ * release on the final chain off-chain. NEAR Intents is the canonical
+ * example: ETH→TRON USDT routes deposit into a NEAR-bridge contract on
+ * Ethereum, settle on NEAR, and a relayer releases USDT-TRC20 to the user's
+ * TRON address. The on-chain `destinationChainId` is NEAR's pseudo-id
+ * (`1885080386571452`, similar pattern to Solana's `1151111081099710`),
+ * even though the user's final destination is genuinely TRON.
+ *
+ * This module narrows the chainId-mismatch defense to permit ONLY
+ * specifically-allowlisted (bridge name, intermediate chain ID) pairs. The
+ * receiver-side checks in `verifyLifiBridgeIntent` still apply unchanged
+ * (non-EVM sentinel for non-EVM destinations, or matching toAddress for EVM
+ * destinations) — this allowlist only relaxes the chainId equality.
+ *
+ * Tamper resistance
+ * -----------------
+ * THE LITERAL CHAIN-ID VALUES BELOW ARE A SECURITY ANCHOR. They MUST be:
+ *
+ *   1. Hardcoded source-code constants — never loaded from env vars,
+ *      `userConfig`, MCP tool args, or LiFi response data. All of those
+ *      are within the compromised-MCP / hostile-aggregator threat model.
+ *      A literal source-code constant is the only tamper-resistant
+ *      location: an attacker cannot change it without rebuilding the
+ *      binary the user is running, at which point they own everything
+ *      anyway.
+ *   2. Compared with `===` against an externally-supplied `bigint` —
+ *      no arithmetic, no derivation. The decoded value either equals
+ *      the literal or it doesn't.
+ *   3. Pinned by a unit test (`intermediate-chain-bridges.test.ts`) so
+ *      a developer typo / merge mishap that drifts the value is caught
+ *      at CI time.
+ *
+ * Adding a new entry
+ * ------------------
+ * Adding a bridge to this allowlist materially expands the `prepare_swap`
+ * trust surface. Every entry must satisfy:
+ *
+ *   1. The bridge is a real third-party protocol with a publicly-verifiable
+ *      on-chain contract address and protocol docs.
+ *   2. The intermediate chain ID is the bridge's canonical settlement
+ *      chain ID as encoded by the bridge protocol itself — NOT inferred
+ *      from a single LiFi response. Cross-check against the bridge's own
+ *      docs and at least one independent route execution.
+ *   3. The bridge name string is exactly LiFi's lowercase label for that
+ *      tool (verified from a known-good LiFi response, NOT from the
+ *      quote we're about to sign).
+ *
+ * Trust trade-off (consistent with existing non-EVM destinations)
+ * ---------------------------------------------------------------
+ * When this allowlist matches, we still REQUIRE
+ * `receiver === NON_EVM_RECEIVER_SENTINEL` for non-EVM final destinations.
+ * The actual destination address lives in the bridge-specific facet data
+ * (which we do NOT decode), so we trust the bridge protocol to deliver to
+ * the address LiFi packed in there. This is the SAME trust boundary we
+ * already accept for ETH→Solana via Wormhole/Mayan and is documented in
+ * `SECURITY.md`'s second-LLM verification flow as the user-side defense.
+ */
+
+/**
+ * Allowlist entry shape. `as const` on the array literal forces the
+ * `bridgeName` strings to narrow to literal types so TypeScript catches
+ * accidental drift between this table and consumer code that branches on
+ * the bridge name.
+ */
+export interface IntermediateChainBridge {
+  /** Exact LiFi `BridgeData.bridge` label, case-insensitive on the wire. */
+  readonly bridgeName: string;
+  /** Hardcoded LiFi pseudo-chainId for the bridge's settlement chain. */
+  readonly intermediateChainId: bigint;
+  /** Human-friendly description for diagnostics + receipt text. */
+  readonly description: string;
+}
+
+export const INTERMEDIATE_CHAIN_BRIDGES: ReadonlyArray<IntermediateChainBridge> = [
+  {
+    bridgeName: "near",
+    intermediateChainId: 1885080386571452n,
+    description: "NEAR Intents (intermediate-chain settlement on NEAR)",
+  },
+] as const;
+
+/**
+ * Returns the matching allowlist entry when `decoded` corresponds to a
+ * known intermediate-chain bridge encoding, null otherwise. The caller
+ * must still enforce the receiver-side invariants (non-EVM sentinel for
+ * non-EVM final destinations, or matching `toAddress` for EVM final
+ * destinations) — this helper ONLY answers "is the destinationChainId
+ * mismatch explicable by a known intermediate-chain bridge?".
+ */
+export function matchIntermediateChainBridge(decoded: {
+  bridge: string;
+  destinationChainId: bigint;
+}): IntermediateChainBridge | null {
+  const bridgeLower = decoded.bridge.toLowerCase();
+  for (const entry of INTERMEDIATE_CHAIN_BRIDGES) {
+    if (
+      bridgeLower === entry.bridgeName &&
+      decoded.destinationChainId === entry.intermediateChainId
+    ) {
+      return entry;
+    }
+  }
+  return null;
+}

--- a/src/modules/tron/lifi-swap.ts
+++ b/src/modules/tron/lifi-swap.ts
@@ -12,6 +12,7 @@ import {
   type DecodedLifiBridgeData,
 } from "../../signing/decode-calldata.js";
 import { NON_EVM_RECEIVER_SENTINEL } from "../../abis/lifi-diamond.js";
+import { matchIntermediateChainBridge } from "../swap/intermediate-chain-bridges.js";
 import { SOLANA_ADDRESS } from "../../shared/address-patterns.js";
 import { getAddress } from "viem";
 import type { SupportedChain, UnsignedTronTx } from "../../types/index.js";
@@ -204,11 +205,22 @@ function verifyTronLifiBridgeIntent(
 
   const expectedChainId = BigInt(LIFI_CHAIN_ID[p.toChain]);
   if (decoded.destinationChainId !== expectedChainId) {
-    throw new Error(
-      `LiFi bridge calldata destinationChainId mismatch: encoded ` +
-        `${decoded.destinationChainId.toString()} but user requested toChain="${p.toChain}" ` +
-        `(= ${expectedChainId.toString()}). Refusing to sign.`,
-    );
+    // Intermediate-chain bridges (NEAR Intents) legitimately encode a
+    // settlement-chain ID instead of the user's final destination.
+    // Source-code-constant allowlist — see
+    // `src/modules/swap/intermediate-chain-bridges.ts`. Issue #237.
+    if (!matchIntermediateChainBridge(decoded)) {
+      throw new Error(
+        `LiFi bridge calldata destinationChainId mismatch: encoded ` +
+          `${decoded.destinationChainId.toString()} but user requested toChain="${p.toChain}" ` +
+          `(= ${expectedChainId.toString()}). Refusing to sign.`,
+      );
+    }
+    // TRON-source same-chain (tron → tron) is excluded by the type
+    // system: `PrepareTronLifiSwapParams.toChain` is `SupportedChain |
+    // "solana"`. So the cross-chain invariant the EVM-source path
+    // re-asserts is enforced upstream here. Fall through to
+    // receiver-side checks below.
   }
 
   if (p.toChain === "solana") {

--- a/test/intermediate-chain-bridges.test.ts
+++ b/test/intermediate-chain-bridges.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  INTERMEDIATE_CHAIN_BRIDGES,
+  matchIntermediateChainBridge,
+} from "../src/modules/swap/intermediate-chain-bridges.js";
+
+/**
+ * Pin the literal chain-ID values in INTERMEDIATE_CHAIN_BRIDGES so a
+ * developer typo, accidental rebase fixup, or merge-conflict
+ * mis-resolution that drifts the constant is caught at CI time.
+ *
+ * THIS IS A SECURITY TEST. The whole tamper-resistance argument for the
+ * chainId-mismatch defense's NEAR-Intents allowlist rests on the
+ * intermediate chain ID being a hardcoded literal. If this test goes
+ * red, do NOT update the expected value to make it pass — investigate
+ * what changed in the source and why.
+ */
+describe("INTERMEDIATE_CHAIN_BRIDGES — literal-value pin (security)", () => {
+  it("pins NEAR Intents at LiFi's published pseudo-chain ID (1885080386571452)", () => {
+    const near = INTERMEDIATE_CHAIN_BRIDGES.find(
+      (e) => e.bridgeName === "near",
+    );
+    expect(near).toBeDefined();
+    // If THIS literal needs to change, the bridge protocol changed
+    // identifiers — confirm against li.quest/v1/chains and update both
+    // this test and the source constant in the same commit.
+    expect(near?.intermediateChainId).toBe(1885080386571452n);
+  });
+
+  it("entries are immutable in shape — every entry has a non-empty lowercase bridge name and a positive bigint chain ID", () => {
+    expect(INTERMEDIATE_CHAIN_BRIDGES.length).toBeGreaterThan(0);
+    for (const entry of INTERMEDIATE_CHAIN_BRIDGES) {
+      expect(entry.bridgeName).toBe(entry.bridgeName.toLowerCase());
+      expect(entry.bridgeName.length).toBeGreaterThan(0);
+      expect(typeof entry.intermediateChainId).toBe("bigint");
+      expect(entry.intermediateChainId).toBeGreaterThan(0n);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("matchIntermediateChainBridge", () => {
+  it("matches a NEAR-bridge / NEAR-chain-ID pair (case-insensitive on bridge name)", () => {
+    const m = matchIntermediateChainBridge({
+      bridge: "near",
+      destinationChainId: 1885080386571452n,
+    });
+    expect(m).not.toBeNull();
+    expect(m?.bridgeName).toBe("near");
+
+    // Case-insensitive: real LiFi responses use "near" lowercase, but
+    // a bridge label arriving as "NEAR" or "Near" should still match
+    // — the `===` security boundary is on the chain ID, not on case.
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "NEAR",
+        destinationChainId: 1885080386571452n,
+      }),
+    ).not.toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "Near",
+        destinationChainId: 1885080386571452n,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("REJECTS bridge=NEAR with a non-NEAR chain ID (chain-ID tamper attempt)", () => {
+    // Attacker spoofs the bridge name "near" but encodes some other
+    // chain ID, hoping the allowlist match is name-only. Must be null.
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "near",
+        destinationChainId: 728126428n, // TRON
+      }),
+    ).toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "near",
+        destinationChainId: 99999999n, // arbitrary
+      }),
+    ).toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "near",
+        destinationChainId: 0n,
+      }),
+    ).toBeNull();
+  });
+
+  it("REJECTS the NEAR chain ID with a non-NEAR bridge name (bridge-name tamper attempt)", () => {
+    // Attacker uses NEAR's chain ID but labels the bridge as "across"
+    // — hoping the allowlist match is chain-ID-only. Must be null.
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "across",
+        destinationChainId: 1885080386571452n,
+      }),
+    ).toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "wormhole",
+        destinationChainId: 1885080386571452n,
+      }),
+    ).toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "",
+        destinationChainId: 1885080386571452n,
+      }),
+    ).toBeNull();
+  });
+
+  it("REJECTS unknown (bridge, chain) pairs entirely", () => {
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "across",
+        destinationChainId: 42161n, // arbitrum, a real chain
+      }),
+    ).toBeNull();
+    expect(
+      matchIntermediateChainBridge({
+        bridge: "made-up-bridge",
+        destinationChainId: 1n,
+      }),
+    ).toBeNull();
+  });
+});

--- a/test/swap-evm-to-tron.test.ts
+++ b/test/swap-evm-to-tron.test.ts
@@ -465,3 +465,199 @@ describe("verifyLifiBridgeIntent — chain-id swap detection", () => {
     expect(tx.description).toContain("Bridge");
   });
 });
+
+/**
+ * Issue #237: NEAR Intents legitimately encodes its own pseudo-chain-id
+ * (1885080386571452) in BridgeData.destinationChainId because the route
+ * settles on NEAR and a relayer releases on the final chain off-chain.
+ * The chainId-mismatch defense must allow this — but ONLY for a
+ * hardcoded (bridge name, intermediate chain ID) pair that cannot be
+ * tampered with by a compromised MCP / hostile aggregator at runtime.
+ */
+describe("verifyLifiBridgeIntent — NEAR Intents intermediate-chain allowlist", () => {
+  const NEAR_INTERMEDIATE_CHAIN_ID = 1885080386571452n;
+
+  it("ALLOWS ETH→TRON USDT via NEAR Intents — bridge='near' + chainId=NEAR pseudo-id + receiver=non-EVM sentinel", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "77".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: NEAR_INTERMEDIATE_CHAIN_ID,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "tron",
+      fromToken: ETH_USDT,
+      toToken: TRON_USDT,
+      toAddress: TRON_RECIPIENT,
+      amount: "10",
+    });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to).toBe(LIFI_DIAMOND);
+    expect(tx.description).toContain("tron");
+  });
+
+  // Tamper-attempt 1: spoofed bridge name. An attacker-controlled
+  // aggregator could try labelling any bridge as "near" hoping the
+  // chainId-mismatch defense was relaxed by name alone. The (bridge,
+  // chainId) pair is the security boundary, so chainId NOT matching the
+  // hardcoded literal must still be rejected.
+  it("REJECTS bridge='near' with a non-NEAR chainId (chain-ID tamper attempt)", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "88".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: 99999999n, // not NEAR's pseudo-id, not TRON
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: TRON_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/destinationChainId mismatch/);
+  });
+
+  // Tamper-attempt 2: spoofed bridge label on a NEAR chain ID. An
+  // attacker could try encoding NEAR's chain ID under a different bridge
+  // name (e.g. "across") to slip past a chainId-only allowlist. Both
+  // halves are required.
+  it("REJECTS NEAR chainId encoded under a non-'near' bridge name (bridge-name tamper attempt)", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "99".repeat(32)) as `0x${string}`,
+          bridge: "across",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: NEAR_INTERMEDIATE_CHAIN_ID,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: TRON_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/destinationChainId mismatch/);
+  });
+
+  // Even when bridge=near + chainId=NEAR match, the non-EVM destination
+  // case still requires the receiver to be the non-EVM sentinel. The
+  // intermediate-chain allowlist relaxes ONLY the chainId equality, not
+  // the receiver-side checks — so an attacker can't pair a legit-looking
+  // (bridge, chainId) with an EVM receiver to exfiltrate funds.
+  it("REJECTS NEAR-bridge route with a real EVM receiver (receiver-side check still applies)", async () => {
+    const attackerEvmReceiver = "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead" as `0x${string}`;
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "aa".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: attackerEvmReceiver,
+          minAmount: 9_900_000n,
+          destinationChainId: NEAR_INTERMEDIATE_CHAIN_ID,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "tron",
+        fromToken: ETH_USDT,
+        toToken: TRON_USDT,
+        toAddress: TRON_RECIPIENT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/receiver mismatch for non-EVM destination tron/);
+  });
+
+  // Same-chain requests should never produce intermediate-chain calldata.
+  // If LiFi (or a tampered MCP) hands us a NEAR-shaped bridge tx for a
+  // same-chain swap, refuse — the user wanted no bridging at all.
+  it("REJECTS NEAR-shaped calldata for a same-chain request (cross-chain-only invariant)", async () => {
+    fetchQuoteMock.mockResolvedValue(
+      makeBridgeQuote({
+        bridgeData: {
+          transactionId: ("0x" + "bb".repeat(32)) as `0x${string}`,
+          bridge: "near",
+          integrator: "vaultpilot-mcp",
+          referrer: "0x0000000000000000000000000000000000000000",
+          sendingAssetId: ETH_USDT.toLowerCase() as `0x${string}`,
+          receiver: NON_EVM_RECEIVER_SENTINEL as `0x${string}`,
+          minAmount: 9_900_000n,
+          destinationChainId: NEAR_INTERMEDIATE_CHAIN_ID,
+          hasSourceSwaps: false,
+          hasDestinationCall: false,
+        },
+        toAsset: {
+          address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          symbol: "USDC",
+          decimals: 6,
+          priceUSD: "1",
+        },
+      }),
+    );
+
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    await expect(
+      prepareSwap({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: ETH_USDT,
+        toToken: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+        amount: "10",
+      }),
+    ).rejects.toThrow(/Intermediate-chain bridges are only valid for cross-chain/);
+  });
+});


### PR DESCRIPTION
Closes #237.

## Problem

`prepare_swap({ fromChain: \"ethereum\", toChain: \"tron\", fromToken: USDT-ETH, toToken: USDT-TRC20, ... })` was failing with:

> LiFi bridge calldata destinationChainId mismatch: encoded 1885080386571452 but user requested toChain=\"tron\" (= 728126428).

LiFi only offers NEAR Intents for the ETH→TRON USDT pair today. NEAR Intents settles on NEAR (pseudo-chain-id `1885080386571452`) and a relayer releases USDT-TRC20 on TRON off-chain — so the on-chain `destinationChainId` is genuinely NEAR's id, even though the user's final destination is TRON. The default chainId-mismatch defense couldn't tell legit-intermediate from malicious-wrong-chain and refused everything.

## Solution

Add a hardcoded **source-code-constant** allowlist of `(bridge name, intermediate chain ID)` pairs in [`src/modules/swap/intermediate-chain-bridges.ts`](src/modules/swap/intermediate-chain-bridges.ts). Both halves must match for the chainId mismatch to be tolerated. Receiver-side checks (non-EVM sentinel for non-EVM destinations, etc.) still apply unchanged.

Hooked into both the EVM-source path (`verifyLifiBridgeIntent` in `src/modules/swap/index.ts`) and the TRON-source path (`verifyTronLifiBridgeIntent` in `src/modules/tron/lifi-swap.ts`).

## Tamper resistance

The user explicitly asked: *make sure that whitelisted near chain ID is not tampered.*

The literal chain-ID values live as TypeScript `const bigint` in source — never loaded from env vars, `userConfig`, MCP tool args, or LiFi response data. All of those are within the compromised-aggregator / hostile-MCP threat model; a literal source-code constant is the only tamper-resistant location:

- Bound at module load and never re-assigned (TypeScript `const`).
- Compared with `===` against an externally-supplied `bigint` — no arithmetic, no derivation.
- Both bridge name AND chain ID must match — an attacker can't bypass by spoofing one half.
- A unit test pins the literal `1885080386571452n` so a developer typo or merge-conflict mishap that drifts the value gets caught at CI time. The test comments explicitly forbid \"update the expected value to make it pass\".
- File header has \"DO NOT MOVE TO CONFIG\" / \"DO NOT load from LiFi response\" guidance for future contributors.

## Test plan

- [x] `npm test` — 1172/1172 pass (95 files)
- [x] `npm run build` — clean
- [x] New file `test/intermediate-chain-bridges.test.ts` — pins the literal chain ID + exhaustive `matchIntermediateChainBridge` cases (case-insensitive bridge match; rejects chain-ID tamper; rejects bridge-name tamper; rejects unknown pairs)
- [x] New cases in `test/swap-evm-to-tron.test.ts`:
  - Allows ETH→TRON USDT via NEAR with NEAR's pseudo-chain-id + non-EVM-sentinel receiver
  - Rejects `bridge=\"near\"` with a non-NEAR chain ID (chain-ID tamper attempt)
  - Rejects NEAR's chain ID under a non-`\"near\"` bridge name (bridge-name tamper attempt)
  - Rejects NEAR-bridge route paired with a real EVM receiver (receiver-side check still applies)
  - Rejects intermediate-chain calldata for a same-chain request (cross-chain-only invariant)
- [ ] Manual: rerun the original ETH→TRON USDT repro from the issue against a real LiFi quote and verify the prepare succeeds, the prepare receipt shows the bridge as NEAR Intents, and signing the bytes on Ledger results in TRC-20 USDT delivered to the paired TRON address

🤖 Generated with [Claude Code](https://claude.com/claude-code)