### PR TITLE
fix(ltc): legacy createPaymentTransaction fallback + correct LTC prefixes (#235 #240)

### DIFF
--- a/src/signing/ltc-usb-loader.ts
+++ b/src/signing/ltc-usb-loader.ts
@@ -63,6 +63,38 @@ export interface LtcLedgerApp {
       knownAddressDerivations: Map<string, { pubkey: Buffer; path: number[] }>;
     },
   ): Promise<{ psbt: Buffer; tx?: string }>;
+  /**
+   * Legacy `createPaymentTransaction` API. Required for the Ledger
+   * Litecoin app v2.4.x which still ships the legacy signing surface
+   * (issue #240) — the modern `signPsbtBuffer` rejects with "is not
+   * supported with the legacy Bitcoin app" against this app build, so
+   * the LTC PSBT signer falls back to this path. The opaque return is
+   * the signed transaction hex ready to broadcast.
+   */
+  createPaymentTransaction(arg: {
+    inputs: Array<
+      [unknown, number, string | null | undefined, number | null | undefined]
+    >;
+    associatedKeysets: string[];
+    changePath?: string;
+    outputScriptHex: string;
+    lockTime?: number;
+    segwit?: boolean;
+    additionals: string[];
+  }): Promise<string>;
+  /**
+   * Parse a raw transaction hex into the SDK's internal `Transaction`
+   * shape so it can be passed back into `createPaymentTransaction` as
+   * an input. The legacy signing path needs the previous transaction
+   * for every input it signs (BIP-143 amount commitment is the same as
+   * issue #213's nonWitnessUtxo requirement, just rebuilt via this API).
+   */
+  splitTransaction(
+    transactionHex: string,
+    isSegwitSupported?: boolean | null,
+    hasExtraData?: boolean,
+    additionals?: string[],
+  ): unknown;
 }
 
 export interface LtcAppAndVersion {

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -19,6 +19,19 @@ import type { PairedLitecoinEntry } from "../types/index.js";
 const requireCjs = createRequire(import.meta.url);
 const bitcoinjs = requireCjs("bitcoinjs-lib") as {
   address: { toOutputScript(addr: string, network?: unknown): Buffer };
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          nonWitnessUtxo?: Buffer;
+          witnessUtxo?: { script: Buffer; value: number };
+        }>;
+      };
+      txInputs: Array<{ hash: Buffer; index: number; sequence: number }>;
+      txOutputs: Array<{ address?: string; script: Buffer; value: number }>;
+      locktime: number;
+    };
+  };
 };
 
 /**
@@ -718,23 +731,184 @@ export async function signLtcPsbtOnLedger(args: {
       });
 
       const psbtBuffer = Buffer.from(args.psbtBase64, "base64");
-      const result = await app.signPsbtBuffer(psbtBuffer, {
-        finalizePsbt: true,
-        accountPath: args.accountPath,
-        addressFormat: args.addressFormat,
-        knownAddressDerivations: known,
-      });
-      if (!result.tx) {
-        throw new Error(
-          `Ledger Litecoin app returned no finalized tx hex from signPsbtBuffer. ` +
-            `The PSBT may have been signed but not finalized — check the device for an ` +
-            `unexpected approval state and retry.`,
-        );
+      try {
+        const result = await app.signPsbtBuffer(psbtBuffer, {
+          finalizePsbt: true,
+          accountPath: args.accountPath,
+          addressFormat: args.addressFormat,
+          knownAddressDerivations: known,
+        });
+        if (!result.tx) {
+          throw new Error(
+            `Ledger Litecoin app returned no finalized tx hex from signPsbtBuffer. ` +
+              `The PSBT may have been signed but not finalized — check the device for an ` +
+              `unexpected approval state and retry.`,
+          );
+        }
+        return { rawTxHex: result.tx };
+      } catch (err) {
+        // Issue #240: the Ledger Litecoin app at v2.4.11 still exposes the
+        // LEGACY signing API (`createPaymentTransaction`); the modern
+        // `signPsbtBuffer` path the BTC app uses isn't implemented and
+        // hw-app-btc raises this exact string when it detects the legacy
+        // surface. Fall back to the legacy API rebuilt from the PSBT.
+        // The error message is stable across hw-app-btc 10.x versions
+        // and is the cleanest signal we have without a separate getApp
+        // capability probe.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (
+          msg.includes("signPsbtBuffer is not supported with the legacy Bitcoin app")
+        ) {
+          return { rawTxHex: await signLtcPsbtViaLegacyApi(app, args) };
+        }
+        throw err;
       }
-      return { rawTxHex: result.tx };
     } finally {
       await (transport as LtcLedgerTransport).close().catch(() => {});
     }
+  });
+}
+
+/**
+ * Encode a single varint per Bitcoin's `serialize.h`: 1 / 3 / 5 / 9 bytes
+ * depending on magnitude. Used to assemble the `outputScriptHex` payload
+ * the legacy `createPaymentTransaction` API expects.
+ */
+function encodeVarInt(n: number | bigint): Buffer {
+  const v = typeof n === "bigint" ? n : BigInt(n);
+  if (v < 0xfdn) {
+    const b = Buffer.alloc(1);
+    b.writeUInt8(Number(v), 0);
+    return b;
+  }
+  if (v <= 0xffffn) {
+    const b = Buffer.alloc(3);
+    b.writeUInt8(0xfd, 0);
+    b.writeUInt16LE(Number(v), 1);
+    return b;
+  }
+  if (v <= 0xffffffffn) {
+    const b = Buffer.alloc(5);
+    b.writeUInt8(0xfe, 0);
+    b.writeUInt32LE(Number(v), 1);
+    return b;
+  }
+  const b = Buffer.alloc(9);
+  b.writeUInt8(0xff, 0);
+  b.writeBigUInt64LE(v, 1);
+  return b;
+}
+
+/** Map our internal addressFormat → the legacy API's `additionals` flags. */
+function additionalsForAddressFormat(
+  format: "legacy" | "p2sh" | "bech32" | "bech32m",
+): string[] {
+  if (format === "bech32") return ["bech32"];
+  if (format === "bech32m") return ["bech32m"];
+  return [];
+}
+
+/**
+ * Issue #240 fallback path. Re-issues the same signing intent against
+ * the Ledger Litecoin app's legacy `createPaymentTransaction` API,
+ * rebuilding the inputs + outputs from the PSBT.
+ *
+ *   - Each PSBT input has `nonWitnessUtxo` populated (issue #213's fix
+ *     made that mandatory) — we feed that hex into `app.splitTransaction`
+ *     to get the legacy-API `Transaction` object.
+ *   - The `associatedKeysets` array carries one path per input. Phase 1
+ *     LTC sends are single-source-address, so every input shares
+ *     `args.path`.
+ *   - `outputScriptHex` is constructed manually as varint(N) ||
+ *     foreach( uint64LE(value) || varint(scriptLen) || script ) — the
+ *     exact serialization the BTC tx format expects in the outputs
+ *     section.
+ *   - `changePath` is set when an output's address matches the source
+ *     (Phase 1 LTC keeps change on the source address); the legacy API
+ *     uses this to render the change output as "yours" on the device
+ *     screen instead of as a second external recipient.
+ *
+ * Restricted to native segwit / taproot for now (matches the build-side
+ * Phase 1 scope in `actions.ts`). Legacy / P2SH-wrapped sends are
+ * rejected upstream, so we never reach here with `addressFormat` outside
+ * the `bech32`/`bech32m` set in practice — but the `additionals` map
+ * handles the four formats anyway in case future scope expands.
+ */
+async function signLtcPsbtViaLegacyApi(
+  app: LtcLedgerApp,
+  args: {
+    psbtBase64: string;
+    expectedFrom: string;
+    path: string;
+    accountPath: string;
+    addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  },
+): Promise<string> {
+  const psbt = bitcoinjs.Psbt.fromBase64(args.psbtBase64);
+  if (psbt.data.inputs.length === 0) {
+    throw new Error("Litecoin legacy-API fallback: PSBT has zero inputs.");
+  }
+  const additionals = additionalsForAddressFormat(args.addressFormat);
+  const segwit =
+    args.addressFormat === "bech32" || args.addressFormat === "bech32m";
+
+  // Build the legacy-API input tuples from the PSBT.
+  const inputs: Array<
+    [
+      ReturnType<LtcLedgerApp["splitTransaction"]>,
+      number,
+      string | null,
+      number | null,
+    ]
+  > = [];
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const inputData = psbt.data.inputs[i];
+    if (!inputData.nonWitnessUtxo) {
+      throw new Error(
+        `Litecoin legacy-API fallback: PSBT input ${i} has no nonWitnessUtxo. ` +
+          `Issue #213's fix should have populated this on every input — was the PSBT ` +
+          `built by an older version of vaultpilot-mcp?`,
+      );
+    }
+    const prevHex = inputData.nonWitnessUtxo.toString("hex");
+    const prevTx = app.splitTransaction(prevHex, true, false, additionals);
+    const txInput = psbt.txInputs[i];
+    inputs.push([prevTx, txInput.index, null, txInput.sequence]);
+  }
+
+  // Build outputScriptHex manually: varint(N) || (uint64LE(value) ||
+  // varint(scriptLen) || script) per output. The legacy API parses this
+  // verbatim into the tx's outputs section before signing.
+  const outChunks: Buffer[] = [encodeVarInt(psbt.txOutputs.length)];
+  let changePath: string | undefined;
+  const sourceScript = bitcoinjs.address.toOutputScript(
+    args.expectedFrom,
+    LITECOIN_NETWORK,
+  );
+  for (const o of psbt.txOutputs) {
+    const value = Buffer.alloc(8);
+    value.writeBigUInt64LE(BigInt(o.value), 0);
+    outChunks.push(value);
+    outChunks.push(encodeVarInt(o.script.length));
+    outChunks.push(o.script);
+    // Phase 1 LTC sends keep change on the source address — flag that
+    // output to the device as "yours" via changePath. Compare scripts
+    // byte-equal rather than addresses to handle the bech32/bech32m
+    // case where the same address renders identically on both sides.
+    if (o.script.equals(sourceScript)) {
+      changePath = args.path;
+    }
+  }
+  const outputScriptHex = Buffer.concat(outChunks).toString("hex");
+
+  return app.createPaymentTransaction({
+    inputs,
+    associatedKeysets: psbt.txInputs.map(() => args.path),
+    ...(changePath !== undefined ? { changePath } : {}),
+    outputScriptHex,
+    lockTime: psbt.locktime,
+    segwit,
+    additionals,
   });
 }
 
@@ -771,7 +945,7 @@ export async function signLtcMessageOnLedger(args: {
     throw new Error(
       "Taproot (P2TR) message signing requires BIP-322, which the Ledger Litecoin app " +
         "does not yet expose. Sign with a paired segwit (`ltc1q…`), P2SH-wrapped " +
-        "(`3…`), or legacy (`1…`) address instead. The 4 address types share a " +
+        "(`M…`), or legacy (`L…`) address instead. The 4 address types share a " +
         "Ledger account — `pair_ledger_ltc` derives all four — so picking a " +
         "non-taproot address from the same Ledger wallet is one tool call away.",
     );

--- a/test/ltc-message-prefix-and-legacy-app.test.ts
+++ b/test/ltc-message-prefix-and-legacy-app.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Regression tests for the two LTC fixes shipped together:
+ *
+ * - **Issue #235**: `signLtcMessageOnLedger` taproot-rejection error must
+ *   reference Litecoin address prefixes (`L…` / `M…` / `ltc1q…`), NOT
+ *   the BTC prefixes (`1…` / `3…`) that leaked in via copy-paste from
+ *   the BTC twin.
+ *
+ * - **Issue #240**: `signLtcPsbtOnLedger` must fall back to the legacy
+ *   `createPaymentTransaction` API when `signPsbtBuffer` rejects with
+ *   "is not supported with the legacy Bitcoin app" — the Ledger Litecoin
+ *   app v2.4.x still ships only the legacy signing surface, while the
+ *   BTC app on the same device is on the modern surface.
+ *
+ * The grep-guard at the top is the broader hedge against #235's class of
+ * regression — any future copy-paste from BTC code that brings BTC
+ * address prefixes into LTC paths fails the build instead of leaking to
+ * the user mid-flow.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(import.meta.url);
+
+// Use bitcoinjs-lib to construct realistic PSBT + prev-tx fixtures.
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: new (opts: { network: unknown }) => {
+    addInput(input: {
+      hash: string;
+      index: number;
+      sequence?: number;
+      witnessUtxo: { script: Buffer; value: number };
+      nonWitnessUtxo: Buffer;
+    }): unknown;
+    addOutput(output: { script: Buffer; value: number }): unknown;
+    toBase64(): string;
+  };
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+};
+
+// Litecoin mainnet network params (mirror of the constant in
+// src/signing/ltc-usb-signer.ts) — bitcoinjs-lib doesn't ship a preset.
+const LITECOIN_NETWORK = {
+  messagePrefix: "\x19Litecoin Signed Message:\n",
+  bech32: "ltc",
+  bip32: { public: 0x0488b21e, private: 0x0488ade4 },
+  pubKeyHash: 0x30,
+  scriptHash: 0x32,
+  wif: 0xb0,
+};
+
+// ---------------------------------------------------------------------------
+// Issue #235 — message-prefix correctness + grep guard against future drift
+// ---------------------------------------------------------------------------
+
+describe("issue #235 — LTC code paths must not leak BTC address prefixes", () => {
+  it("the taproot-rejection error in ltc-usb-signer.ts uses LTC prefixes", () => {
+    const src = readFileSync(
+      new URL("../src/signing/ltc-usb-signer.ts", import.meta.url),
+      "utf8",
+    );
+    // Find the specific error message and assert it references LTC prefixes.
+    const m = src.match(
+      /Taproot \(P2TR\) message signing requires BIP-322[\s\S]*?one tool call away/,
+    );
+    expect(m, "expected taproot-reject message not found").toBeTruthy();
+    const msg = m![0];
+    expect(msg).toContain("`L…`");
+    expect(msg).toContain("`M…`");
+    expect(msg).toContain("`ltc1q…`");
+    // Negative regression — the BTC prefixes from the original copy-paste must NOT appear.
+    expect(msg).not.toContain("`1…`");
+    expect(msg).not.toContain("`3…`");
+  });
+
+  it("LTC source files do NOT contain BTC address-prefix literals (grep guard)", () => {
+    // Walk every .ts under src/signing/ltc-* and src/modules/litecoin/.
+    const roots = [
+      new URL("../src/signing/", import.meta.url),
+      new URL("../src/modules/litecoin/", import.meta.url),
+    ];
+    const offenders: string[] = [];
+    for (const root of roots) {
+      const dir = root.pathname;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const f of entries) {
+        // Only LTC-specific files in src/signing/ — BTC files there share
+        // the directory and legitimately use BTC prefixes.
+        if (
+          root.pathname.endsWith("/signing/") &&
+          !f.startsWith("ltc-")
+        ) {
+          continue;
+        }
+        if (!f.endsWith(".ts")) continue;
+        const path = join(dir, f);
+        const src = readFileSync(path, "utf8");
+        // The single legitimate `3...` mention in litecoin/address.ts
+        // documents Litecoin's deprecated 0x05 P2SH form. Allow-list
+        // by file-and-substring pair; everything else is a bug.
+        const allowlist: Array<[string, RegExp]> = [
+          // address.ts documents the legacy 0x05 form for backward-compat reads
+          [
+            "litecoin/address.ts",
+            /(legacy 0x05.*P2SH|deprecated.*P2SH|0x05.*scriptHash|3-prefix.*legacy)/,
+          ],
+        ];
+        // Patterns that indicate BTC prefix leakage when used as a
+        // user-facing example. Match `\`1…\`` / `\`3…\`` / `\`bc1q\`` /
+        // `\`bc1p\`` literals (the message format with backticks +
+        // ellipsis).
+        const badPatterns = [/`1…`/, /`3…`/, /`bc1q`/i, /`bc1p`/i];
+        for (const re of badPatterns) {
+          if (re.test(src)) {
+            // Check allowlist
+            const allowed = allowlist.some(
+              ([fileSuffix, allowRe]) =>
+                path.endsWith(fileSuffix) && allowRe.test(src),
+            );
+            if (!allowed) {
+              offenders.push(`${path}: matches ${re.source}`);
+            }
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      `BTC prefix literal(s) found in LTC code paths:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #240 — legacy createPaymentTransaction fallback when signPsbtBuffer
+// rejects with the specific "is not supported with the legacy Bitcoin app"
+// error
+// ---------------------------------------------------------------------------
+
+// Build P2WPKH scripts directly from constructed hash160s rather than
+// going through address parsing — this test only needs script bytes
+// to round-trip through the legacy-API fallback's varint serialization,
+// not real network-validatable addresses. Format: OP_0 (0x00) ||
+// PUSH_20 (0x14) || 20-byte hash160.
+const SOURCE_HASH160 = Buffer.alloc(20, 0xab);
+const RECIPIENT_HASH160 = Buffer.alloc(20, 0xcd);
+const SOURCE_SCRIPT = Buffer.concat([Buffer.from([0x00, 0x14]), SOURCE_HASH160]);
+const RECIPIENT_SCRIPT = Buffer.concat([Buffer.from([0x00, 0x14]), RECIPIENT_HASH160]);
+
+// Address strings — only used as the `expectedFrom` arg passed into the
+// signer, where it's compared by-script (not parsed). bitcoinjs.address.
+// toOutputScript runs inside the signer against this string and against
+// the same LITECOIN_NETWORK constant to derive the script for change-
+// path matching, so we need a real bech32-encoded ltc1... address. Use
+// bech32 encoding of SOURCE_HASH160 under hrp "ltc".
+const LTC_SEGWIT_ADDR = encodeBech32("ltc", 0, SOURCE_HASH160);
+const LTC_SEGWIT_PUBKEY =
+  "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+
+/** Minimal bech32 (BIP-173) encoder for v0 segwit addresses. */
+function encodeBech32(hrp: string, witnessVersion: number, program: Buffer): string {
+  const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  // Convert program from 8-bit to 5-bit groups
+  const data: number[] = [witnessVersion];
+  let acc = 0;
+  let bits = 0;
+  for (const v of program) {
+    acc = (acc << 8) | v;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      data.push((acc >> bits) & 31);
+    }
+  }
+  if (bits > 0) data.push((acc << (5 - bits)) & 31);
+  // Compute checksum
+  function hrpExpand(s: string): number[] {
+    const out: number[] = [];
+    for (let i = 0; i < s.length; i++) out.push(s.charCodeAt(i) >> 5);
+    out.push(0);
+    for (let i = 0; i < s.length; i++) out.push(s.charCodeAt(i) & 31);
+    return out;
+  }
+  function polymod(values: number[]): number {
+    const GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+    let chk = 1;
+    for (const v of values) {
+      const top = chk >> 25;
+      chk = ((chk & 0x1ffffff) << 5) ^ v;
+      for (let i = 0; i < 5; i++) {
+        if ((top >> i) & 1) chk ^= GEN[i];
+      }
+    }
+    return chk;
+  }
+  // BIP-173 uses constant 1 for v0; BIP-350 (bech32m) uses 0x2bc830a3.
+  const checksum = polymod([...hrpExpand(hrp), ...data, 0, 0, 0, 0, 0, 0]) ^ 1;
+  const checksumWords: number[] = [];
+  for (let i = 0; i < 6; i++) checksumWords.push((checksum >> (5 * (5 - i))) & 31);
+  return (
+    hrp +
+    "1" +
+    [...data, ...checksumWords].map((w) => CHARSET[w]).join("")
+  );
+}
+
+function buildPrevTxHex(value: number): string {
+  const tx = new bitcoinjs.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  tx.addOutput(SOURCE_SCRIPT, value);
+  return tx.toHex();
+}
+
+function buildPsbtB64(): string {
+  const psbt = new bitcoinjs.Psbt({ network: LITECOIN_NETWORK });
+  const prevHex = buildPrevTxHex(1_000_000);
+  psbt.addInput({
+    hash: "1".repeat(64),
+    index: 0,
+    sequence: 0xfffffffd,
+    witnessUtxo: { script: SOURCE_SCRIPT, value: 1_000_000 },
+    nonWitnessUtxo: Buffer.from(prevHex, "hex"),
+  });
+  // Recipient + change-to-source split
+  psbt.addOutput({ script: RECIPIENT_SCRIPT, value: 100_000 });
+  psbt.addOutput({ script: SOURCE_SCRIPT, value: 899_500 });
+  return psbt.toBase64();
+}
+
+const getWalletPublicKeyMock = vi.fn();
+const getAppAndVersionMock = vi.fn();
+const signPsbtBufferMock = vi.fn();
+const createPaymentTransactionMock = vi.fn();
+const splitTransactionMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+
+vi.mock("../src/signing/ltc-usb-loader.js", () => ({
+  openLedger: async () => ({
+    app: {
+      getWalletPublicKey: getWalletPublicKeyMock,
+      signPsbtBuffer: signPsbtBufferMock,
+      createPaymentTransaction: createPaymentTransactionMock,
+      splitTransaction: splitTransactionMock,
+    },
+    transport: { close: transportCloseMock },
+    rawTransport: {},
+  }),
+  getAppAndVersion: () => getAppAndVersionMock(),
+}));
+
+describe("issue #240 — legacy createPaymentTransaction fallback", () => {
+  beforeEach(() => {
+    getWalletPublicKeyMock.mockReset();
+    getAppAndVersionMock.mockReset();
+    signPsbtBufferMock.mockReset();
+    createPaymentTransactionMock.mockReset();
+    splitTransactionMock.mockReset();
+    transportCloseMock.mockClear();
+
+    getAppAndVersionMock.mockResolvedValue({
+      name: "Litecoin",
+      version: "2.4.11",
+    });
+    getWalletPublicKeyMock.mockResolvedValue({
+      bitcoinAddress: LTC_SEGWIT_ADDR,
+      publicKey: LTC_SEGWIT_PUBKEY,
+      chainCode: "0".repeat(64),
+    });
+  });
+
+  it("falls back to createPaymentTransaction on the SDK's legacy-app error", async () => {
+    signPsbtBufferMock.mockRejectedValueOnce(
+      new Error(
+        "signPsbtBuffer is not supported with the legacy Bitcoin app",
+      ),
+    );
+    splitTransactionMock.mockReturnValue({ marker: "split-tx" });
+    createPaymentTransactionMock.mockResolvedValueOnce("0200000001abcd_signed_hex");
+
+    const { signLtcPsbtOnLedger } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const result = await signLtcPsbtOnLedger({
+      psbtBase64: buildPsbtB64(),
+      expectedFrom: LTC_SEGWIT_ADDR,
+      path: "84'/2'/0'/0/0",
+      accountPath: "84'/2'/0'",
+      addressFormat: "bech32",
+    });
+    expect(result.rawTxHex).toBe("0200000001abcd_signed_hex");
+    expect(signPsbtBufferMock).toHaveBeenCalledTimes(1);
+    expect(createPaymentTransactionMock).toHaveBeenCalledTimes(1);
+    const call = createPaymentTransactionMock.mock.calls[0][0];
+    expect(call.segwit).toBe(true);
+    expect(call.additionals).toEqual(["bech32"]);
+    // One input → one entry in associatedKeysets, with the source path
+    expect(call.associatedKeysets).toEqual(["84'/2'/0'/0/0"]);
+    expect(call.inputs).toHaveLength(1);
+    // changePath is set because output[1] goes back to source
+    expect(call.changePath).toBe("84'/2'/0'/0/0");
+    // outputScriptHex: 2 outputs encoded as varint(2) + ...
+    // varint(2) is just 0x02 = "02"
+    expect(call.outputScriptHex.startsWith("02")).toBe(true);
+    // Should encode both output values; quick sanity check on length
+    // (8 bytes value + varint scriptLen + script per output)
+    expect(call.outputScriptHex.length).toBeGreaterThan(40);
+  });
+
+  it("does NOT fall back when signPsbtBuffer rejects with an unrelated error", async () => {
+    signPsbtBufferMock.mockRejectedValueOnce(
+      new Error("Ledger device: Invalid data received (0x6a80)"),
+    );
+    const { signLtcPsbtOnLedger } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    await expect(
+      signLtcPsbtOnLedger({
+        psbtBase64: buildPsbtB64(),
+        expectedFrom: LTC_SEGWIT_ADDR,
+        path: "84'/2'/0'/0/0",
+        accountPath: "84'/2'/0'",
+        addressFormat: "bech32",
+      }),
+    ).rejects.toThrow(/0x6a80/);
+    expect(createPaymentTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("succeeds via signPsbtBuffer when it works (no fallback fired)", async () => {
+    signPsbtBufferMock.mockResolvedValueOnce({
+      psbt: Buffer.alloc(0),
+      tx: "0200000001happypath_signed_hex",
+    });
+    const { signLtcPsbtOnLedger } = await import(
+      "../src/signing/ltc-usb-signer.js"
+    );
+    const result = await signLtcPsbtOnLedger({
+      psbtBase64: buildPsbtB64(),
+      expectedFrom: LTC_SEGWIT_ADDR,
+      path: "84'/2'/0'/0/0",
+      accountPath: "84'/2'/0'",
+      addressFormat: "bech32",
+    });
+    expect(result.rawTxHex).toBe("0200000001happypath_signed_hex");
+    expect(createPaymentTransactionMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two clean LTC bugs in one PR — both copy-paste leaks from the BTC twin where the underlying SDK / app behavior diverges between the two chains.

### #240 — LTC sends fail before reaching the device

\`signLtcPsbtOnLedger\` was unconditionally calling the modern \`signPsbtBuffer\` API. The Ledger Litecoin app at v2.4.11 still ships the **legacy** signing surface (\`createPaymentTransaction\`); the hw-app-btc library detects this and rejects with \`signPsbtBuffer is not supported with the legacy Bitcoin app\` before any device prompt. Bitcoin works on the same device because the BTC app shipped the modern API in 2.x.

**Fix**: try \`signPsbtBuffer\` first; on the specific legacy-app error, fall back to \`signLtcPsbtViaLegacyApi\` which:

- parses the PSBT via bitcoinjs-lib
- splits each input's \`nonWitnessUtxo\` (always populated post #213) via \`app.splitTransaction(prevHex, true, false, additionals)\` to get the legacy-API \`Transaction\` object
- builds \`outputScriptHex\` manually as \`varint(N) || foreach( uint64LE(value) || varint(scriptLen) || script )\` via a small \`encodeVarInt\` helper (1/3/5/9-byte forms per Bitcoin's \`serialize.h\`)
- sets \`changePath\` when an output script equals the source script (Phase 1 LTC keeps change on source — same as BTC) so the device shows it as "yours" instead of as a second external recipient
- threads \`additionals: ["bech32" | "bech32m" | (none for legacy/p2sh)]\` through to the SDK
- calls \`app.createPaymentTransaction(...)\` and returns the signed tx hex

### #235 — taproot-rejection error referenced BTC address prefixes

\`signLtcMessageOnLedger\`'s taproot-rejection error told users to "sign with a paired segwit (\`ltc1q…\`), P2SH-wrapped (\`3…\`), or legacy (\`1…\`) address instead". \`1…\` is BTC P2PKH; LTC P2PKH is \`L…\` (version byte 0x30). \`3…\` is BTC P2SH; modern LTC P2SH is \`M…\` (version byte 0x32) — and \`pair_ledger_ltc\` always derives \`M…\`. The hint sent users on a wild-goose chase for an LTC wallet they don't have, with worst case being signature-verification confusion if they signed with their BTC \`1…\`/\`3…\` address by mistake.

**Fix**: one-line text change to use \`M…\` and \`L…\`. Plus a CI grep guard test that asserts no BTC prefix literals (\`\\\`1…\\\`\`, \`\\\`3…\\\`\`, \`\\\`bc1q\\\`\`, \`\\\`bc1p\\\`\`) appear in any LTC source file (\`src/signing/ltc-*.ts\` and \`src/modules/litecoin/*.ts\`) — catches the next copy-paste regression at build time instead of in user-facing chat. The single legitimate \`3-prefix\` mention in \`litecoin/address.ts\` (documenting LTC's deprecated 0x05 P2SH form for read-side compat) is allowlisted explicitly.

## Test plan

5 new tests in \`test/ltc-message-prefix-and-legacy-app.test.ts\`:

- **#235 source-anchored**: assert the taproot-reject message contains LTC prefixes (\`L…\`, \`M…\`, \`ltc1q…\`) and NOT the old BTC ones (\`1…\`, \`3…\`)
- **#235 grep guard**: walk every \`.ts\` under \`src/signing/ltc-*\` and \`src/modules/litecoin/\`; assert no BTC-prefix literals leak (with the documented allowlist for the LTC address-decode read path)
- **#240 fallback fires**: \`signPsbtBuffer\` rejected with the SDK's exact legacy-app error string → \`createPaymentTransaction\` invoked with the right args (\`segwit: true\`, \`additionals: ["bech32"]\`, one \`associatedKeysets\` entry, \`changePath\` set because output[1] returns to source, varint-encoded \`outputScriptHex\` of correct shape and length)
- **#240 fallback scoped**: unrelated rejection (the 0x6a80 from #206) does NOT trigger the fallback — re-throws verbatim so the user sees the real error
- **#240 happy path**: \`signPsbtBuffer\` succeeds → \`createPaymentTransaction\` is NOT called (confirms the modern path still wins on the BTC app where it works)

\`npm test\` — 1166/1166 (1161 baseline + 5 new). Build clean.

## Live verification post-merge

- Real LTC self-send via \`pair_ledger_ltc\` → \`prepare_litecoin_native_send\` → \`send_transaction\` should now reach the Ledger device prompt and complete signing instead of throwing the legacy-app error
- \`sign_message_ltc\` on a paired taproot (\`ltc1p…\`) entry should reject with a message that names \`L…\` / \`M…\` / \`ltc1q…\` as the recovery options (not BTC prefixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)