### PR TITLE
feat(install): add install.sh + install.ps1 bootstrap scripts (agent-driven install)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -151,3 +151,50 @@ jobs:
             release/${{ matrix.server_asset }}
             release/${{ matrix.setup_asset }}
           fail_on_unmatched_files: true
+
+  # OS-agnostic install scripts — uploaded once per release, not per
+  # matrix leg. Hosted at the well-known path
+  # `https://github.com/<repo>/releases/latest/download/install.sh`
+  # (and `.ps1`) so an LLM-coding agent can run a single command:
+  #
+  #   curl -fsSL .../install.sh | bash
+  #   iwr .../install.ps1 -UseBasicParsing | iex
+  #
+  # The scripts download the OS+arch-specific server/setup binaries
+  # from the same release tag, place them in ~/.local/bin (or
+  # %LOCALAPPDATA%\Programs\vaultpilot-mcp), and run the wizard in
+  # --non-interactive --json mode. See scripts/install.sh for details.
+  #
+  # Runs on ubuntu-latest because the scripts are plain text — no
+  # cross-OS build needed. Independent of the `build` job (no `needs:`)
+  # so a binary-build failure on one OS doesn't suppress the install-
+  # script upload; the script is useful even with partial-platform
+  # binary coverage (it'll just 404 on the missing target's binary,
+  # which is the user's signal that build is in flight).
+  upload-install-scripts:
+    name: Upload install scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            scripts/install.sh
+            scripts/install.ps1
+          fail_on_unmatched_files: true
+
+      - name: Upload to existing release (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            scripts/install.sh
+            scripts/install.ps1
+          fail_on_unmatched_files: true

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,201 @@
+# vaultpilot-mcp installer for Windows.
+#
+# Hosted at:
+#   https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.ps1
+#
+# Designed for the agent-driven install path
+# (claude-work/HIGH-plan-agent-driven-install.md). An LLM-coding agent
+# can run this in one PowerShell call:
+#
+#   iwr https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.ps1 -UseBasicParsing | iex
+#
+# What it does:
+#   1. Detect arch (x64 only at the moment — the release pipeline
+#      doesn't ship Windows arm64 yet).
+#   2. Download the matching server.exe + setup.exe binaries from the
+#      latest GitHub Release into %LOCALAPPDATA%\Programs\vaultpilot-mcp\
+#      (or $env:VAULTPILOT_INSTALL_DIR).
+#   3. Run `vaultpilot-mcp-setup --non-interactive --json` which
+#      registers MCP clients (Claude Desktop / Claude Code / Cursor)
+#      and clones the companion skills.
+#   4. Print the setup wizard's JSON envelope so the calling agent
+#      can parse `next_steps` and relay them to the user.
+#
+# What it does NOT do:
+#   - Collect API keys (zero-config defaults — PublicNode RPC).
+#   - Pair a Ledger (requires hardware presence; user-only step).
+#   - Auto-restart MCP clients (tell the user via `next_steps`).
+#   - Persistently modify the user's PATH (a session-scope `$env:PATH`
+#     update lets the wizard run; a permanent edit is suggested as a
+#     one-liner the user can run themselves).
+#
+# Behavior is idempotent: re-running re-downloads and re-runs the
+# wizard, which is itself idempotent. This is also the update path.
+
+#Requires -Version 5.1
+
+# Strict mode + stop on any error so a bad download or 404 surfaces
+# immediately rather than continuing and emitting confusing later
+# failures.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Modern TLS — older PS5.1 defaults to TLS 1.0 which GitHub's CDN
+# rejects. Idempotent assignment.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# ----------------------------------------------------------------------
+# Config — overridable via env, sensible defaults otherwise.
+# ----------------------------------------------------------------------
+
+$Repo = if ($env:VAULTPILOT_REPO) { $env:VAULTPILOT_REPO } else { 'szhygulin/vaultpilot-mcp' }
+$InstallDir = if ($env:VAULTPILOT_INSTALL_DIR) {
+  $env:VAULTPILOT_INSTALL_DIR
+} else {
+  Join-Path $env:LOCALAPPDATA 'Programs\vaultpilot-mcp'
+}
+$ReleaseBaseUrl = if ($env:VAULTPILOT_RELEASE_URL) {
+  $env:VAULTPILOT_RELEASE_URL
+} else {
+  "https://github.com/$Repo/releases/latest/download"
+}
+
+# ----------------------------------------------------------------------
+# Pretty output. Use Write-Host with colors so messages render in the
+# integrated terminal of VS Code / Cursor / Claude Code on Windows.
+# ----------------------------------------------------------------------
+
+function Log     { param([string]$msg) Write-Host "[vaultpilot] $msg" -ForegroundColor Blue }
+function Ok      { param([string]$msg) Write-Host "[vaultpilot] $msg" -ForegroundColor Green }
+function WarnMsg { param([string]$msg) Write-Host "[vaultpilot] $msg" -ForegroundColor Yellow }
+function Fatal   { param([string]$msg) Write-Host "[vaultpilot] ERROR: $msg" -ForegroundColor Red; exit 1 }
+
+# ----------------------------------------------------------------------
+# Arch detection → asset name pair.
+#
+# Matches the release pipeline (.github/workflows/release-binaries.yml).
+# Windows is x64-only at present.
+# ----------------------------------------------------------------------
+
+function Detect-Target {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  if ($arch -ne 'AMD64' -and $arch -ne 'x64') {
+    Fatal "Unsupported Windows arch '$arch'. Only x64 is published; install from npm: ``npm i -g vaultpilot-mcp`` (requires Node 22+)."
+  }
+  $script:ServerAsset = 'vaultpilot-mcp-windows-x64-server.exe'
+  $script:SetupAsset  = 'vaultpilot-mcp-windows-x64-setup.exe'
+  $script:TargetArch  = 'x64'
+}
+
+# ----------------------------------------------------------------------
+# Atomic download: write to .partial then rename, so a partial download
+# never leaves a corrupt binary at the final path.
+# ----------------------------------------------------------------------
+
+function Download-File {
+  param(
+    [Parameter(Mandatory)] [string] $Url,
+    [Parameter(Mandatory)] [string] $Dest
+  )
+  $tmp = "$Dest.partial"
+  if (Test-Path $tmp) { Remove-Item $tmp -Force }
+  # -UseBasicParsing matters on Windows PowerShell 5.1 (avoids loading
+  # the legacy IE engine which can hang on machines without IE
+  # configured). Implicit on PS Core 6+ but harmless there.
+  Invoke-WebRequest -Uri $Url -OutFile $tmp -UseBasicParsing
+  if (Test-Path $Dest) { Remove-Item $Dest -Force }
+  Move-Item $tmp $Dest
+}
+
+# ----------------------------------------------------------------------
+# Install binaries.
+# ----------------------------------------------------------------------
+
+function Install-Binaries {
+  if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  }
+
+  $serverPath = Join-Path $InstallDir 'vaultpilot-mcp.exe'
+  $setupPath  = Join-Path $InstallDir 'vaultpilot-mcp-setup.exe'
+
+  Log "Downloading server binary..."
+  Log "  $ReleaseBaseUrl/$ServerAsset"
+  Download-File -Url "$ReleaseBaseUrl/$ServerAsset" -Dest $serverPath
+
+  Log "Downloading setup wizard binary..."
+  Log "  $ReleaseBaseUrl/$SetupAsset"
+  Download-File -Url "$ReleaseBaseUrl/$SetupAsset" -Dest $setupPath
+
+  Ok "Installed binaries to $InstallDir"
+  $script:SetupPath  = $setupPath
+  $script:ServerPath = $serverPath
+}
+
+# ----------------------------------------------------------------------
+# PATH advisory. Don't permanently modify the user's PATH from a script
+# piped into iex — that's the kind of action this server's CLAUDE.md
+# warns against ("hard-to-reverse" / "shared state"). Update the
+# session-scope PATH so the wizard finds the binary, and print a
+# one-liner the user can run themselves to make it permanent.
+# ----------------------------------------------------------------------
+
+function Advise-Path {
+  $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+  $pathEntries = if ($userPath) { $userPath.Split(';') } else { @() }
+  if ($pathEntries -contains $InstallDir) {
+    Ok "$InstallDir is on your User PATH."
+    return
+  }
+  WarnMsg "$InstallDir is NOT on your User PATH."
+  WarnMsg "  Updated this PowerShell session's PATH so the wizard can run."
+  WarnMsg "  To make this permanent, run (once, in any PowerShell):"
+  WarnMsg ""
+  WarnMsg "    [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`" + [Environment]::GetEnvironmentVariable('PATH','User'), 'User')"
+  WarnMsg ""
+  # Update the in-process PATH so `Run-Setup` below can find the binary
+  # on the script's own search path. This is process-scope only.
+  $env:PATH = "$InstallDir;$env:PATH"
+}
+
+# ----------------------------------------------------------------------
+# Run the setup wizard in --non-interactive --json mode and print the
+# envelope verbatim. The wizard registers MCP clients + installs
+# companion skills. Zero-config defaults; no API keys; no Ledger
+# pairing.
+# ----------------------------------------------------------------------
+
+function Run-Setup {
+  Log "Running setup wizard (non-interactive, JSON output)..."
+  Write-Host ""
+  # Invoke directly via the absolute path so we don't depend on the
+  # PATH advisory branch having succeeded.
+  & $SetupPath '--non-interactive' '--json'
+  $exitCode = $LASTEXITCODE
+  Write-Host ""
+  if ($exitCode -ne 0) {
+    Fatal "Setup wizard exited with code $exitCode. See the JSON envelope above for the structured error."
+  }
+  Ok "Setup completed."
+}
+
+# ----------------------------------------------------------------------
+# Main.
+# ----------------------------------------------------------------------
+
+Log "VaultPilot MCP installer"
+Detect-Target
+Log "Target: windows/$TargetArch"
+Log "Install dir: $InstallDir"
+Write-Host ""
+
+Install-Binaries
+Advise-Path
+Write-Host ""
+Run-Setup
+
+Write-Host ""
+Log "Done. The JSON envelope above lists which MCP clients were registered (or"
+Log "already-present), and a 'next_steps' array — usually 'restart your MCP"
+Log "client' so vaultpilot-mcp's tools become visible. To pair your Ledger or"
+Log "set provider API keys, run 'vaultpilot-mcp-setup' interactively."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# vaultpilot-mcp installer for Linux + macOS.
+#
+# Hosted at:
+#   https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh
+#
+# Designed for the agent-driven install path
+# (claude-work/HIGH-plan-agent-driven-install.md). An LLM-coding agent
+# can run this in one Bash call:
+#
+#   curl -fsSL https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh | bash
+#
+# What it does:
+#   1. Detect OS + arch.
+#   2. Download the matching server + setup binaries from the latest
+#      GitHub Release into ~/.local/bin (or $VAULTPILOT_INSTALL_DIR).
+#   3. Run `vaultpilot-mcp-setup --non-interactive --json`, which
+#      registers MCP clients (Claude Desktop / Claude Code / Cursor)
+#      and clones the companion skills.
+#   4. Print the setup wizard's JSON envelope so the calling agent
+#      can parse `next_steps` and relay them to the user.
+#
+# What it does NOT do:
+#   - Collect API keys (zero-config defaults — PublicNode RPC).
+#   - Pair a Ledger (requires hardware presence; user-only step).
+#   - Auto-restart MCP clients (no portable way; envelope tells the
+#     agent which client to ask the user to restart).
+#   - Modify the user's shell rc (PATH suggestion is printed for the
+#     user to add manually if needed; we never `>>` rc files).
+#
+# Behavior is idempotent: re-running re-downloads the binaries and
+# re-runs the wizard, which is itself idempotent (already-present
+# clients / skills are no-ops). This is also the update path.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------
+# Config — overridable via env, sensible defaults otherwise.
+# ----------------------------------------------------------------------
+
+REPO="${VAULTPILOT_REPO:-szhygulin/vaultpilot-mcp}"
+INSTALL_DIR="${VAULTPILOT_INSTALL_DIR:-$HOME/.local/bin}"
+RELEASE_BASE_URL="${VAULTPILOT_RELEASE_URL:-https://github.com/${REPO}/releases/latest/download}"
+
+# ----------------------------------------------------------------------
+# Pretty output (no color when stdout is not a TTY — script may be
+# parsed by an agent or piped into `tee`).
+# ----------------------------------------------------------------------
+
+if [ -t 1 ]; then
+  C_RESET="$(printf '\033[0m')"
+  C_DIM="$(printf '\033[2m')"
+  C_BLUE="$(printf '\033[34m')"
+  C_GREEN="$(printf '\033[32m')"
+  C_RED="$(printf '\033[31m')"
+  C_YELLOW="$(printf '\033[33m')"
+else
+  C_RESET=""
+  C_DIM=""
+  C_BLUE=""
+  C_GREEN=""
+  C_RED=""
+  C_YELLOW=""
+fi
+
+log()    { printf "%s[vaultpilot]%s %s\n" "$C_BLUE" "$C_RESET" "$*"; }
+ok()     { printf "%s[vaultpilot]%s %s%s%s\n" "$C_BLUE" "$C_RESET" "$C_GREEN" "$*" "$C_RESET"; }
+warn()   { printf "%s[vaultpilot]%s %s%s%s\n" "$C_BLUE" "$C_RESET" "$C_YELLOW" "$*" "$C_RESET" >&2; }
+fatal()  { printf "%s[vaultpilot]%s %sERROR:%s %s\n" "$C_BLUE" "$C_RESET" "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+dim()    { printf "%s%s%s" "$C_DIM" "$*" "$C_RESET"; }
+
+# ----------------------------------------------------------------------
+# OS + arch detection → asset name pair.
+#
+# Asset names match the release pipeline (.github/workflows/
+# release-binaries.yml). Linux is x64-only at present; macOS has
+# x64 + arm64. Windows is handled by install.ps1, not this script.
+# ----------------------------------------------------------------------
+
+detect_target() {
+  local uname_s uname_m os arch
+  uname_s="$(uname -s)"
+  uname_m="$(uname -m)"
+
+  case "$uname_s" in
+    Linux)  os="linux" ;;
+    Darwin) os="macos" ;;
+    *)
+      fatal "Unsupported OS '$uname_s'. This installer supports Linux and macOS. For Windows, use install.ps1. For other OSes, install from npm: \`npm i -g vaultpilot-mcp\`."
+      ;;
+  esac
+
+  case "$uname_m" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      fatal "Unsupported CPU arch '$uname_m'. Supported: x86_64 / amd64, arm64 / aarch64. Install from npm instead: \`npm i -g vaultpilot-mcp\`."
+      ;;
+  esac
+
+  # The release pipeline ships Linux as x64 only — Linux arm64 binary
+  # isn't built. Fall back to the npm install instructions in that
+  # case rather than 404'ing the asset download below.
+  if [ "$os" = "linux" ] && [ "$arch" = "arm64" ]; then
+    fatal "Linux arm64 binaries are not published. Install from npm: \`npm i -g vaultpilot-mcp\` (requires Node 22+)."
+  fi
+
+  TARGET_OS="$os"
+  TARGET_ARCH="$arch"
+  SERVER_ASSET="vaultpilot-mcp-${os}-${arch}-server"
+  SETUP_ASSET="vaultpilot-mcp-${os}-${arch}-setup"
+}
+
+# ----------------------------------------------------------------------
+# Tool checks. We need curl (or wget) and a writable install dir.
+# ----------------------------------------------------------------------
+
+require_downloader() {
+  if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+  elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+  else
+    fatal "Neither \`curl\` nor \`wget\` is installed. Install one and retry."
+  fi
+}
+
+# Download $1 (URL) → $2 (path), atomically (write to .tmp then mv) so
+# a partial download never leaves a corrupt binary at the final path.
+download() {
+  local url="$1" dest="$2" tmp="$2.partial"
+  if [ "$DOWNLOADER" = "curl" ]; then
+    # -f: fail on HTTP error (4xx/5xx); -L: follow redirects (GH
+    # Releases /latest/download/ is a redirect); -o: output path.
+    # We do NOT pin --proto "=https" here — the default URL is HTTPS,
+    # and an attacker controlling the env-overridden VAULTPILOT_RELEASE_URL
+    # would just use HTTPS too. Restricting the scheme would block
+    # local smoke tests against http://127.0.0.1 without buying real
+    # safety.
+    curl -fL -o "$tmp" "$url"
+  else
+    wget -O "$tmp" "$url"
+  fi
+  mv "$tmp" "$dest"
+}
+
+# ----------------------------------------------------------------------
+# Install binaries.
+# ----------------------------------------------------------------------
+
+install_binaries() {
+  mkdir -p "$INSTALL_DIR"
+
+  local server_path="$INSTALL_DIR/vaultpilot-mcp"
+  local setup_path="$INSTALL_DIR/vaultpilot-mcp-setup"
+
+  log "Downloading server binary…"
+  log "  $(dim "$RELEASE_BASE_URL/$SERVER_ASSET")"
+  download "$RELEASE_BASE_URL/$SERVER_ASSET" "$server_path"
+  chmod +x "$server_path"
+
+  log "Downloading setup wizard binary…"
+  log "  $(dim "$RELEASE_BASE_URL/$SETUP_ASSET")"
+  download "$RELEASE_BASE_URL/$SETUP_ASSET" "$setup_path"
+  chmod +x "$setup_path"
+
+  # macOS: strip the quarantine xattr so Gatekeeper doesn't refuse to
+  # run the unsigned binary on first launch. `xattr -d` exits non-zero
+  # if the attribute isn't there — that's fine, we silence it.
+  if [ "$TARGET_OS" = "macos" ] && command -v xattr >/dev/null 2>&1; then
+    xattr -d com.apple.quarantine "$server_path" 2>/dev/null || true
+    xattr -d com.apple.quarantine "$setup_path"  2>/dev/null || true
+  fi
+
+  ok "Installed binaries to $INSTALL_DIR"
+  SETUP_PATH="$setup_path"
+  SERVER_PATH="$server_path"
+}
+
+# ----------------------------------------------------------------------
+# PATH check. Don't auto-edit shell rc — print the one-liner instead so
+# the user (or agent) can decide. Touching ~/.bashrc / ~/.zshrc without
+# explicit consent is the kind of action this server's CLAUDE.md
+# warns against ("hard-to-reverse" / "shared state").
+# ----------------------------------------------------------------------
+
+advise_path() {
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*)
+      ok "$INSTALL_DIR is on your PATH."
+      return
+      ;;
+  esac
+  warn "$INSTALL_DIR is NOT on your PATH."
+  warn "  Add it by appending this line to your shell rc:"
+  warn ""
+  warn "    export PATH=\"$INSTALL_DIR:\$PATH\""
+  warn ""
+  warn "  Then reopen your terminal (or \`source\` the rc file)."
+}
+
+# ----------------------------------------------------------------------
+# Run the setup wizard in --non-interactive --json mode and print the
+# envelope. The wizard registers MCP clients + installs companion
+# skills. Zero-config defaults; no API keys collected; no Ledger
+# pairing.
+# ----------------------------------------------------------------------
+
+run_setup() {
+  log "Running setup wizard (non-interactive, JSON output)…"
+  printf "\n"
+  # The wizard emits the InstallEnvelope on stdout. We pass it through
+  # verbatim so the calling agent can parse it.
+  if "$SETUP_PATH" --non-interactive --json; then
+    printf "\n"
+    ok "Setup completed."
+  else
+    fatal "Setup wizard exited with a non-zero status. See the JSON envelope above for the structured error."
+  fi
+}
+
+# ----------------------------------------------------------------------
+# Main.
+# ----------------------------------------------------------------------
+
+main() {
+  log "VaultPilot MCP installer"
+  detect_target
+  log "Target: $TARGET_OS/$TARGET_ARCH"
+  log "Install dir: $INSTALL_DIR"
+  printf "\n"
+
+  require_downloader
+  install_binaries
+  advise_path
+  printf "\n"
+  run_setup
+
+  printf "\n"
+  log "Done. The JSON envelope above lists which MCP clients were registered (or"
+  log "already-present), and a \`next_steps\` array — usually 'restart your MCP"
+  log "client' so vaultpilot-mcp's tools become visible. To pair your Ledger or"
+  log "set provider API keys, run \`vaultpilot-mcp-setup\` interactively."
+}
+
+main "$@"


### PR DESCRIPTION
PR3 of the agent-driven-install plan ([`claude-work/HIGH-plan-agent-driven-install.md`](claude-work/HIGH-plan-agent-driven-install.md)). Builds on PR1+2 (the non-interactive `--json` setup wizard, merged in #227): hooks the release-pipeline binaries up to a one-line installer an LLM-coding agent can run for the user.

## Target flow

1. User asks the agent to "help me manage my crypto".
2. Agent suggests vaultpilot-mcp and asks consent.
3. Agent runs (in a single Bash call):
   ```
   curl -fsSL https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh | bash
   ```
   Or on Windows:
   ```
   iwr https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.ps1 -UseBasicParsing | iex
   ```
4. Script detects OS+arch → downloads `vaultpilot-mcp` + `vaultpilot-mcp-setup` → places in `~/.local/bin` (or `%LOCALAPPDATA%\Programs\vaultpilot-mcp`) → runs `vaultpilot-mcp-setup --non-interactive --json`.
5. JSON envelope's `next_steps` tell the user to restart their MCP client; the agent relays that.

## Behavior

- **Idempotent.** Re-runs re-download (this is also the update path) and the wizard's own already-present detection covers MCP-client + skills state.
- **Zero-config.** PublicNode RPC at runtime, no API keys collected, no Ledger pairing (the user does that interactively when they're ready).
- **Non-destructive PATH.** Never edits `~/.bashrc` / `~/.zshrc`; if the install dir isn't on PATH, prints the one-liner to add it manually. PS1 equivalent: session-scope `$env:PATH` update so the wizard runs, plus a printed one-liner to make it permanent.
- **macOS-friendly.** Strips the Gatekeeper quarantine xattr so first launch works without manual `xattr -d`.

## Smoke test (local)

Stood up `python3 -m http.server` with thin shell shims that exec `node dist/{index,setup}.js` instead of real binaries:

```
HOME=/tmp/vaultpilot-fakehome \
VAULTPILOT_RELEASE_URL=http://127.0.0.1:8765/release \
VAULTPILOT_INSTALL_DIR=/tmp/vaultpilot-install-target \
bash scripts/install.sh
```

Result: clean run end-to-end. Binaries placed; PATH advisory printed (since /tmp dirs aren't on PATH); wizard ran; emitted the full `InstallEnvelope` with `status: "installed"`, `clients_registered: ["Claude Code"]`, `skills_installed: ["vaultpilot-preflight", "vaultpilot-setup"]`, correct next_steps.

## Design notes

- **Dropped `--proto "=https"` from curl.** The default URL is HTTPS, an attacker controlling the env override would just use HTTPS too, and the restriction blocks local smoke tests against `http://127.0.0.1`. Belt-and-suspenders that costs more than it earns.
- **`upload-install-scripts` job is independent of the per-OS `build` matrix.** No `needs:` so a binary-build failure doesn't suppress the install-script upload — the scripts are useful even with partial-platform binary coverage.

## Test plan

- [x] `bash -n scripts/install.sh` clean.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean on the workflow file.
- [x] Local end-to-end smoke (above) — InstallEnvelope emitted, binaries placed, wizard ran, skills cloned in fake HOME.
- [x] `npm test` — 1194 / 97 green (no source code touched).
- [ ] **Cannot test from this dev box**: actual `install.sh | bash` against the live GH Releases CDN (the script's URL is templated to the latest tag; first real test will be after this PR merges and a release tag goes out).
- [ ] **Cannot test from this dev box**: Windows PowerShell run. The script reads as-equivalent to install.sh; PS5.1+ syntax verified by structure but not executed. Will surface in Windows users' first install attempt; mitigated by the script being a small inspectable text file (`fail closed` on errors thanks to `Set-StrictMode -Version Latest` + `$ErrorActionPreference = 'Stop'`).

## Out of scope (subsequent PRs in the plan)

- **PR4**: `AGENTS.md` + README elevator paragraph — agent-discovery surface.
- **PR5**: `server.json` keywords + awesome-mcp submissions — MCP-registry surface.
- **PR6** (added per user request): rate-limit-detect → suggest API keys with provider-specific dashboard links. Separate runtime concern (touches RPC client / chains.ts / Solana RPC / TronGrid surface area), so cleaner as its own PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)