### PR TITLE
fix(btc, ltc): route change to BIP-44 chain=1 + label as Change on-device

### DIFF
--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -5,6 +5,7 @@ import { selectInputs, type CoinSelectInput } from "./coin-select.js";
 import { issueBitcoinHandle } from "../../signing/btc-tx-store.js";
 import {
   getPairedBtcByAddress,
+  getPairedBtcAddresses,
   type BtcAddressType as PairedBtcAddressType,
 } from "../../signing/btc-usb-signer.js";
 import type { UnsignedBitcoinTx } from "../../types/index.js";
@@ -18,14 +19,20 @@ import { BTC_DECIMALS, SATS_PER_BTC } from "../../config/btc.js";
  * registered with the in-memory tx-store. The Ledger BTC app consumes
  * the PSBT bytes at signing time via `signPsbtBuffer`.
  *
- * Phase 1 simplification — change goes back to the source address.
- * Proper BIP-32 internal-chain change (`<purpose>'/0'/<account>'/1/<idx>`)
- * is a follow-up; deriving it requires either the account-level xpub
- * (which pairing doesn't currently cache) or an extra device round-trip
- * at prepare time. Sending change back to the source is functionally
- * correct and the Ledger still clear-signs every output — the user
- * recognizes their own address on the device. Trade-off documented in
- * the plan; the on-device review surface is unchanged.
+ * Change derivation (issue #254). Change goes to the BIP-44 internal
+ * chain (`<purpose>'/0'/<account>'/1/<idx>`), looked up from the
+ * pairings cache (`pair_ledger_btc` derives the first 20 chain=1
+ * addresses per account during the gap-limit scan). The change leaf's
+ * `path` and compressed `publicKey` are threaded onto the unsigned tx
+ * envelope so the signer can register the change output in
+ * `signPsbtBuffer.knownAddressDerivations` — the Ledger BTC app then
+ * recognizes it as a same-account change output, labels it "Change"
+ * on-screen, and skips the previous "unusual change path" warning.
+ *
+ * For now the lowest available `addressIndex` (= 0) is used. Address
+ * rotation across multiple sends in one session is out of scope for
+ * this PR (each send currently reuses the same chain=1 address; the
+ * Ledger app does not warn on address reuse).
  *
  * RBF — sequence `0xFFFFFFFD` on every input by default (BIP-125
  * replaceable). Pass `rbf: false` to set `0xFFFFFFFE` (final, not
@@ -99,6 +106,35 @@ function accountPathFromLeaf(leafPath: string): string {
 /** Estimate vbytes for a P2WPKH/P2TR tx — same shape coinselect uses. */
 function roughVbytes(inputCount: number, outputCount: number): number {
   return 10 + inputCount * 68 + outputCount * 31;
+}
+
+/**
+ * Pick the chain=1 (BIP-32 internal/change) entry from the pairings
+ * cache that matches the source's (accountIndex, addressType). Lowest
+ * `addressIndex` wins. Returns null when none is cached — caller
+ * surfaces a re-pair instruction (the gap-limit scan in
+ * `pair_ledger_btc` skips chain=1 when chain=0 has zero history, so
+ * fresh wallets need a re-pair after their first received tx).
+ *
+ * Issue #254.
+ */
+function pickChangeEntry(
+  paired: ReturnType<typeof getPairedBtcByAddress>,
+): { address: string; path: string; publicKey: string } | null {
+  if (!paired) return null;
+  const all = getPairedBtcAddresses();
+  const candidates = all
+    .filter(
+      (e) =>
+        e.accountIndex === paired.accountIndex &&
+        e.addressType === paired.addressType &&
+        e.chain === 1 &&
+        typeof e.addressIndex === "number",
+    )
+    .sort((a, b) => (a.addressIndex ?? 0) - (b.addressIndex ?? 0));
+  const c = candidates[0];
+  if (!c) return null;
+  return { address: c.address, path: c.path, publicKey: c.publicKey };
 }
 
 /** Format sats as a BTC decimal string (8-decimal padding, trailing-zero strip). */
@@ -188,6 +224,24 @@ export async function buildBitcoinNativeSend(
     );
   }
 
+  // Resolve the change address (BIP-32 chain=1) from the pairings
+  // cache. Same accountIndex + addressType as the source; lowest
+  // available addressIndex. `pair_ledger_btc` walks both chains and
+  // caches them — if the user paired before any chain=0 history, the
+  // change-chain walk was skipped (no UTXOs → no spends → no change
+  // can exist anyway). Once they have UTXOs to send, re-pairing
+  // populates chain=1 entries. Issue #254.
+  const changeEntry = pickChangeEntry(paired);
+  if (!changeEntry) {
+    throw new Error(
+      `No paired chain=1 (change) address found for ${args.wallet}'s account ` +
+        `(${paired.addressType}, accountIndex=${paired.accountIndex}). The pairings cache ` +
+        `was likely populated when the wallet had no on-chain history (the gap-limit scan ` +
+        `skips the change-chain walk in that case). Re-run \`pair_ledger_btc({ accountIndex: ` +
+        `${paired.accountIndex} })\` now that this address has UTXOs and retry.`,
+    );
+  }
+
   const indexer = getBitcoinIndexer();
 
   // 3. Resolve fee rate.
@@ -255,13 +309,13 @@ export async function buildBitcoinNativeSend(
     );
   }
 
-  // 6. Coin-selection. Phase-1 simplification: change goes back to the
-  //    source address (see file docstring for the reasoning).
+  // 6. Coin-selection. Change goes to the BIP-44 internal-chain address
+  //    we resolved above (issue #254).
   const selection = selectInputs({
     utxos: csUtxos,
     outputs: [{ address: args.to, value: Number(amountSats) }],
     feeRate,
-    changeAddress: args.wallet,
+    changeAddress: changeEntry.address,
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 
@@ -302,7 +356,7 @@ export async function buildBitcoinNativeSend(
   }
   for (const output of selection.outputs) {
     const outScript = bitcoinjs.address.toOutputScript(
-      output.address ?? args.wallet,
+      output.address ?? changeEntry.address,
       NETWORK,
     );
     psbt.addOutput({ script: outScript, value: output.value });
@@ -313,12 +367,20 @@ export async function buildBitcoinNativeSend(
   //    output gets a sats + BTC-decimal string + isChange flag. The
   //    Ledger walks every entry on-screen — this projection is what
   //    `render-verification.ts` mirrors for the user to cross-check.
-  const decodedOutputs = selection.outputs.map((o) => ({
-    address: o.address ?? args.wallet,
-    amountSats: o.value.toString(),
-    amountBtc: satsToBtcString(BigInt(o.value)),
-    isChange: o.isChange,
-  }));
+  //    For the change output (BIP-32 chain=1) we surface its full leaf
+  //    path so the user — and the second-LLM verifier — can see the
+  //    derivation that backs the on-screen "Change" label.
+  const decodedOutputs = selection.outputs.map((o) => {
+    const isChange = o.isChange;
+    const address = o.address ?? changeEntry.address;
+    return {
+      address,
+      amountSats: o.value.toString(),
+      amountBtc: satsToBtcString(BigInt(o.value)),
+      isChange,
+      ...(isChange ? { changePath: changeEntry.path } : {}),
+    };
+  });
 
   const accountPath = accountPathFromLeaf(paired.path);
   const vsize = roughVbytes(selection.inputs.length, selection.outputs.length);
@@ -331,6 +393,11 @@ export async function buildBitcoinNativeSend(
     psbtBase64,
     accountPath,
     addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    change: {
+      address: changeEntry.address,
+      path: changeEntry.path,
+      publicKey: changeEntry.publicKey,
+    },
     description,
     decoded: {
       functionName: "bitcoin.native_send",

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1881,6 +1881,7 @@ async function sendBitcoinTransaction(args: SendTransactionArgs): Promise<{
     path: paired.path,
     accountPath: tx.accountPath,
     addressFormat: tx.addressFormat,
+    ...(tx.change ? { change: tx.change } : {}),
   });
   const { getBitcoinIndexer } = await import("../btc/indexer.js");
   const txid = await getBitcoinIndexer().broadcastTx(rawTxHex);
@@ -1913,6 +1914,7 @@ async function sendLitecoinTransaction(args: SendTransactionArgs): Promise<{
     path: paired.path,
     accountPath: tx.accountPath,
     addressFormat: tx.addressFormat,
+    ...(tx.change ? { change: tx.change } : {}),
   });
   const { getLitecoinIndexer } = await import("../litecoin/indexer.js");
   const txid = await getLitecoinIndexer().broadcastTx(rawTxHex);

--- a/src/modules/litecoin/actions.ts
+++ b/src/modules/litecoin/actions.ts
@@ -5,6 +5,7 @@ import { selectInputs, type CoinSelectInput } from "./coin-select.js";
 import { issueLitecoinHandle } from "../../signing/ltc-tx-store.js";
 import {
   getPairedLtcByAddress,
+  getPairedLtcAddresses,
   type LtcAddressType as PairedLtcAddressType,
 } from "../../signing/ltc-usb-signer.js";
 import type { UnsignedLitecoinTx } from "../../types/index.js";
@@ -32,9 +33,14 @@ import { LTC_DECIMALS, LITOSHIS_PER_LTC } from "../../config/litecoin.js";
  * years ago); when one shows up, we surface a clear error pointing
  * the user to ask the recipient for an M-prefix address.
  *
- * Same Phase 1 simplification as BTC: change goes back to the source
- * address. Same RBF default (`0xFFFFFFFD`). Same nonWitnessUtxo
- * requirement on every input (Ledger BTC/LTC app 2.x — issue #213).
+ * Change derivation mirrors BTC's (issue #254): the change output goes
+ * to a BIP-44 internal-chain (`/1/<idx>`) address looked up from the
+ * pairings cache, and the change leaf's `path` + `publicKey` are
+ * threaded onto the unsigned tx so the signer can register the change
+ * in `signPsbtBuffer.knownAddressDerivations` (and, on the legacy
+ * `createPaymentTransaction` fallback path, populate `changePath`).
+ * Same RBF default (`0xFFFFFFFD`). Same nonWitnessUtxo requirement on
+ * every input (Ledger BTC/LTC app 2.x — issue #213).
  */
 
 const requireCjs = createRequire(import.meta.url);
@@ -103,6 +109,31 @@ function accountPathFromLeaf(leafPath: string): string {
 
 function roughVbytes(inputCount: number, outputCount: number): number {
   return 10 + inputCount * 68 + outputCount * 31;
+}
+
+/**
+ * Pick the chain=1 (BIP-32 internal/change) entry from the LTC pairings
+ * cache that matches the source's (accountIndex, addressType). Mirror
+ * of `pickChangeEntry` in btc/actions.ts. Returns null when none is
+ * cached. Issue #254.
+ */
+function pickChangeEntry(
+  paired: ReturnType<typeof getPairedLtcByAddress>,
+): { address: string; path: string; publicKey: string } | null {
+  if (!paired) return null;
+  const all = getPairedLtcAddresses();
+  const candidates = all
+    .filter(
+      (e) =>
+        e.accountIndex === paired.accountIndex &&
+        e.addressType === paired.addressType &&
+        e.chain === 1 &&
+        typeof e.addressIndex === "number",
+    )
+    .sort((a, b) => (a.addressIndex ?? 0) - (b.addressIndex ?? 0));
+  const c = candidates[0];
+  if (!c) return null;
+  return { address: c.address, path: c.path, publicKey: c.publicKey };
 }
 
 function litoshisToLtcString(litoshis: bigint): string {
@@ -180,6 +211,19 @@ export async function buildLitecoinNativeSend(
     );
   }
 
+  // Resolve the BIP-32 chain=1 change address from the pairings cache.
+  // Symmetric with the BTC builder. Issue #254.
+  const changeEntry = pickChangeEntry(paired);
+  if (!changeEntry) {
+    throw new Error(
+      `No paired chain=1 (change) address found for ${args.wallet}'s account ` +
+        `(${paired.addressType}, accountIndex=${paired.accountIndex}). The pairings cache ` +
+        `was likely populated when the wallet had no on-chain history (the gap-limit scan ` +
+        `skips the change-chain walk in that case). Re-run \`pair_ledger_ltc({ accountIndex: ` +
+        `${paired.accountIndex} })\` now that this address has UTXOs and retry.`,
+    );
+  }
+
   const indexer = getLitecoinIndexer();
 
   // 3. Resolve fee rate.
@@ -239,12 +283,13 @@ export async function buildLitecoinNativeSend(
     );
   }
 
-  // 6. Coin-selection.
+  // 6. Coin-selection. Change goes to the BIP-44 chain=1 address from
+  //    the pairings cache (issue #254).
   const selection = selectInputs({
     utxos: csUtxos,
     outputs: [{ address: args.to, value: Number(amountSats) }],
     feeRate,
-    changeAddress: args.wallet,
+    changeAddress: changeEntry.address,
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 
@@ -277,19 +322,24 @@ export async function buildLitecoinNativeSend(
   }
   for (const output of selection.outputs) {
     const outScript = bitcoinjs.address.toOutputScript(
-      output.address ?? args.wallet,
+      output.address ?? changeEntry.address,
       NETWORK,
     );
     psbt.addOutput({ script: outScript, value: output.value });
   }
   const psbtBase64 = psbt.toBase64();
 
-  const decodedOutputs = selection.outputs.map((o) => ({
-    address: o.address ?? args.wallet,
-    amountSats: o.value.toString(),
-    amountLtc: litoshisToLtcString(BigInt(o.value)),
-    isChange: o.isChange,
-  }));
+  const decodedOutputs = selection.outputs.map((o) => {
+    const isChange = o.isChange;
+    const address = o.address ?? changeEntry.address;
+    return {
+      address,
+      amountSats: o.value.toString(),
+      amountLtc: litoshisToLtcString(BigInt(o.value)),
+      isChange,
+      ...(isChange ? { changePath: changeEntry.path } : {}),
+    };
+  });
 
   const accountPath = accountPathFromLeaf(paired.path);
   const vsize = roughVbytes(selection.inputs.length, selection.outputs.length);
@@ -302,6 +352,11 @@ export async function buildLitecoinNativeSend(
     psbtBase64,
     accountPath,
     addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    change: {
+      address: changeEntry.address,
+      path: changeEntry.path,
+      publicKey: changeEntry.publicKey,
+    },
     description,
     decoded: {
       functionName: "litecoin.native_send",

--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -634,6 +634,22 @@ export async function signBtcPsbtOnLedger(args: {
   path: string;
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  /**
+   * BIP-32 chain=1 change-output derivation (issue #254). When set, the
+   * signer adds a second `knownAddressDerivations` entry so the SDK
+   * populates the change output's bip32Derivation, which the Ledger BTC
+   * app uses to recognize the address as same-account change and skip
+   * the "unusual change path" warning. The pairings cache is the source
+   * of truth — we trust it to point at a real device-derivable address;
+   * if the cache is stale the device's own derivation check (run inside
+   * the BTC app at sign time) will refuse before the user sees a wrong
+   * address.
+   */
+  change?: {
+    address: string;
+    path: string;
+    publicKey: string;
+  };
 }): Promise<{ rawTxHex: string }> {
   return withBtcUsbLock(async () => {
     const { app, transport, rawTransport } = await openLedger();
@@ -665,26 +681,37 @@ export async function signBtcPsbtOnLedger(args: {
         );
       }
 
-      // Build the knownAddressDerivations map. Phase 1 sends keep change
-      // on the source address, so a single entry covers both inputs and
-      // any same-address output. The SDK keys the map by the witness-
-      // program payload extracted from each scriptPubKey — bytes 2..22
-      // (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked x-only key)
-      // for P2TR. Mirrors @ledgerhq/psbtv2 `extractHashFromScriptPubKey`,
-      // which is what `populateMissingBip32Derivations` looks up against.
-      // Issue #206: an earlier sha256(scriptPubKey) key never matched, so
-      // the library left the PSBT without bip32Derivation and the Ledger
+      // Build the knownAddressDerivations map. The SDK keys the map by
+      // the witness-program payload extracted from each scriptPubKey —
+      // bytes 2..22 (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked
+      // x-only key) for P2TR. Mirrors @ledgerhq/psbtv2
+      // `extractHashFromScriptPubKey`, which is what
+      // `populateMissingBip32Derivations` looks up against. Issue #206:
+      // an earlier sha256(scriptPubKey) key never matched, so the
+      // library left the PSBT without bip32Derivation and the Ledger
       // BTC app v2.x rejected with 0x6a80 before any UI.
-      const scriptPubKey = bitcoinjs.address.toOutputScript(
+      //
+      // Two entries today: the source (input + same-address-as-recipient
+      // edge case) and the BIP-32 chain=1 change output (issue #254).
+      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
+      const sourceScript = bitcoinjs.address.toOutputScript(
         args.expectedFrom,
         bitcoinjs.networks.bitcoin,
       );
-      const lookupKey = extractWitnessProgramHex(scriptPubKey);
-      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
-      known.set(lookupKey, {
+      known.set(extractWitnessProgramHex(sourceScript), {
         pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
         path: pathStringToNumbers(args.path),
       });
+      if (args.change) {
+        const changeScript = bitcoinjs.address.toOutputScript(
+          args.change.address,
+          bitcoinjs.networks.bitcoin,
+        );
+        known.set(extractWitnessProgramHex(changeScript), {
+          pubkey: compressPubkey(Buffer.from(args.change.publicKey, "hex")),
+          path: pathStringToNumbers(args.change.path),
+        });
+      }
 
       const psbtBuffer = Buffer.from(args.psbtBase64, "base64");
       const result = await app.signPsbtBuffer(psbtBuffer, {

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -678,6 +678,15 @@ export async function signLtcPsbtOnLedger(args: {
   path: string;
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  /**
+   * BIP-32 chain=1 change-output derivation (issue #254). Mirror of the
+   * BTC signer's same-named field — see `signBtcPsbtOnLedger`.
+   */
+  change?: {
+    address: string;
+    path: string;
+    publicKey: string;
+  };
 }): Promise<{ rawTxHex: string }> {
   return withLtcUsbLock(async () => {
     const { app, transport, rawTransport } = await openLedger();
@@ -709,26 +718,37 @@ export async function signLtcPsbtOnLedger(args: {
         );
       }
 
-      // Build the knownAddressDerivations map. Phase 1 sends keep change
-      // on the source address, so a single entry covers both inputs and
-      // any same-address output. The SDK keys the map by the witness-
-      // program payload extracted from each scriptPubKey — bytes 2..22
-      // (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked x-only key)
-      // for P2TR. Mirrors @ledgerhq/psbtv2 `extractHashFromScriptPubKey`,
-      // which is what `populateMissingBip32Derivations` looks up against.
-      // Issue #206: an earlier sha256(scriptPubKey) key never matched, so
-      // the library left the PSBT without bip32Derivation and the Ledger
+      // Build the knownAddressDerivations map. The SDK keys the map by
+      // the witness-program payload extracted from each scriptPubKey —
+      // bytes 2..22 (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked
+      // x-only key) for P2TR. Mirrors @ledgerhq/psbtv2
+      // `extractHashFromScriptPubKey`, which is what
+      // `populateMissingBip32Derivations` looks up against. Issue #206:
+      // an earlier sha256(scriptPubKey) key never matched, so the
+      // library left the PSBT without bip32Derivation and the Ledger
       // Litecoin app v2.x rejected with 0x6a80 before any UI.
-      const scriptPubKey = bitcoinjs.address.toOutputScript(
+      //
+      // Two entries today: the source (input + same-address-as-recipient
+      // edge case) and the BIP-32 chain=1 change output (issue #254).
+      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
+      const sourceScript = bitcoinjs.address.toOutputScript(
         args.expectedFrom,
         LITECOIN_NETWORK,
       );
-      const lookupKey = extractWitnessProgramHex(scriptPubKey);
-      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
-      known.set(lookupKey, {
+      known.set(extractWitnessProgramHex(sourceScript), {
         pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
         path: pathStringToNumbers(args.path),
       });
+      if (args.change) {
+        const changeScript = bitcoinjs.address.toOutputScript(
+          args.change.address,
+          LITECOIN_NETWORK,
+        );
+        known.set(extractWitnessProgramHex(changeScript), {
+          pubkey: compressPubkey(Buffer.from(args.change.publicKey, "hex")),
+          path: pathStringToNumbers(args.change.path),
+        });
+      }
 
       const psbtBuffer = Buffer.from(args.psbtBase64, "base64");
       try {
@@ -842,6 +862,7 @@ async function signLtcPsbtViaLegacyApi(
     path: string;
     accountPath: string;
     addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+    change?: { address: string; path: string; publicKey: string };
   },
 ): Promise<string> {
   const psbt = bitcoinjs.Psbt.fromBase64(args.psbtBase64);
@@ -881,21 +902,29 @@ async function signLtcPsbtViaLegacyApi(
   // verbatim into the tx's outputs section before signing.
   const outChunks: Buffer[] = [encodeVarInt(psbt.txOutputs.length)];
   let changePath: string | undefined;
+  // Issue #254: detect change by matching the script either against the
+  // BIP-32 chain=1 change address (when supplied — modern path) or
+  // against the source script as a same-address-as-source fallback (so
+  // a legacy on-disk envelope without `change` still labels its change
+  // output to the device). Compare scripts byte-equal rather than
+  // addresses to handle the bech32/bech32m case where the same address
+  // renders identically on both sides.
   const sourceScript = bitcoinjs.address.toOutputScript(
     args.expectedFrom,
     LITECOIN_NETWORK,
   );
+  const changeScript = args.change
+    ? bitcoinjs.address.toOutputScript(args.change.address, LITECOIN_NETWORK)
+    : null;
   for (const o of psbt.txOutputs) {
     const value = Buffer.alloc(8);
     value.writeBigUInt64LE(BigInt(o.value), 0);
     outChunks.push(value);
     outChunks.push(encodeVarInt(o.script.length));
     outChunks.push(o.script);
-    // Phase 1 LTC sends keep change on the source address — flag that
-    // output to the device as "yours" via changePath. Compare scripts
-    // byte-equal rather than addresses to handle the bech32/bech32m
-    // case where the same address renders identically on both sides.
-    if (o.script.equals(sourceScript)) {
+    if (changeScript && o.script.equals(changeScript)) {
+      changePath = args.change!.path;
+    } else if (!changeScript && o.script.equals(sourceScript)) {
       changePath = args.path;
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1220,6 +1220,25 @@ export interface UnsignedBitcoinTx {
    * `signPsbtBuffer.addressFormat`. "bech32" for native segwit, etc.
    */
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  /**
+   * Internal-chain (BIP-32 chain=1) address the change output goes to,
+   * plus its derivation. Threaded to the signer so it can register the
+   * change output in `signPsbtBuffer.knownAddressDerivations` (and, for
+   * the legacy `createPaymentTransaction` fallback, populate
+   * `changePath`). Without this, the Ledger BTC app v2.x flags every
+   * change output as "unusual change path". Issue #254.
+   *
+   * Optional only for tx envelopes built by older code paths or by
+   * clients that pre-validated they want change-on-source — the modern
+   * Phase-1 builder always sets it.
+   */
+  change?: {
+    address: string;
+    /** Full leaf path of the change address, e.g. `84'/0'/0'/1/0`. */
+    path: string;
+    /** Compressed (or uncompressed; signer compresses) public key hex. */
+    publicKey: string;
+  };
   /** Human-readable description for the preview. */
   description: string;
   /** Decoded outputs + fee + RBF flag. The shape Ledger's screen mirrors. */
@@ -1267,6 +1286,12 @@ export interface UnsignedLitecoinTx {
   psbtBase64: string;
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
+  /** See `UnsignedBitcoinTx.change`. Issue #254. */
+  change?: {
+    address: string;
+    path: string;
+    publicKey: string;
+  };
   description: string;
   decoded: {
     functionName: string;
@@ -1383,6 +1408,13 @@ export interface UserConfig {
   etherscanApiKey?: string;
   /** Optional 1inch Developer Portal API key for intra-chain swap-quote comparison. */
   oneInchApiKey?: string;
+  /**
+   * Safe Transaction Service API key. Required to call `get_safe_positions` and
+   * the v2/v3 propose/execute Safe tools — modern `*.safe.global` endpoints
+   * authenticate every request. Get one at https://developer.safe.global/.
+   * Env var `SAFE_API_KEY` takes priority over this field.
+   */
+  safeApiKey?: string;
   /**
    * TronGrid API key (`TRON-PRO-API-KEY` header). Required to read TRX and
    * TRC-20 balances on the `tron` chain — TronGrid rate-limits unauthenticated

--- a/test/btc-pr3-send.test.ts
+++ b/test/btc-pr3-send.test.ts
@@ -73,6 +73,18 @@ const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
 // Ledger returned, so the SDK's downstream P2WPKH/P2TR derivation
 // arithmetic doesn't choke. Issue #211.
 const SEGWIT_PUBKEY = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+// Issue #254: BIP-32 chain=1 (internal/change) address that pair_ledger_btc
+// caches for the same account. The builder picks this when adding the
+// change output to the PSBT, and the signer registers it as a second
+// `knownAddressDerivations` entry so the Ledger BTC app labels the
+// output as "Change" instead of warning. Address + pubkey can be any
+// well-formed pair — the mock SDK doesn't device-validate them.
+// Derived with `bj.address.toBech32(ripemd160(sha256("…change-fixture")))`
+// so the bech32 checksum is genuine (bitcoinjs's address.toOutputScript
+// validates it).
+const CHANGE_ADDR = "bc1qr0p2usnskwqhupc2590l2skll0vzd84cdp3gly";
+const CHANGE_PUBKEY = SEGWIT_PUBKEY;
+const CHANGE_PATH = "84'/0'/0'/1/0";
 // Uncompressed (65-byte) form of the same on-curve point — what Ledger
 // `getWalletPublicKey` actually returns. Tests stub the device with this
 // to exercise the compress-on-the-way-in path.
@@ -183,6 +195,21 @@ beforeEach(async () => {
     appVersion: "2.2.0",
     addressType: "segwit",
     accountIndex: 0,
+    chain: 0,
+    addressIndex: 0,
+  });
+  // Issue #254: also pre-pair the BIP-32 chain=1 (change) address.
+  // `pair_ledger_btc`'s gap-limit scan caches both chains; the modern
+  // builder requires a chain=1 entry to construct the change output.
+  setPairedBtcAddress({
+    address: CHANGE_ADDR,
+    publicKey: CHANGE_PUBKEY,
+    path: CHANGE_PATH,
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 1,
+    addressIndex: 0,
   });
 });
 
@@ -311,6 +338,79 @@ describe("buildBitcoinNativeSend", () => {
     ).rejects.toThrow(/No UTXOs/);
   });
 
+  // Issue #254 regression: when the pairings cache has a chain=0 source
+  // entry but no chain=1 change entry (= the user paired before any
+  // history existed; gap-limit scan skipped chain=1 in that branch),
+  // the builder must refuse with a clear "re-pair" message rather than
+  // silently fall back to change-on-source.
+  it("refuses when the pairings cache has no chain=1 change entry for the account", async () => {
+    const { clearPairedBtcAddresses, setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    clearPairedBtcAddresses();
+    setPairedBtcAddress({
+      address: SEGWIT_ADDR,
+      publicKey: SEGWIT_PUBKEY,
+      path: "84'/0'/0'/0/0",
+      appVersion: "2.2.0",
+      addressType: "segwit",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+    // NOTE: no chain=1 entry inserted — mirrors a fresh-wallet pairing.
+    getUtxosMock.mockResolvedValueOnce([
+      { txid: FAKE_TXID, vout: 0, value: 100_000, unconfirmed: false },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinNativeSend({
+        wallet: SEGWIT_ADDR,
+        to: RECIPIENT,
+        amount: "0.0005",
+        feeRateSatPerVb: 10,
+      }),
+    ).rejects.toThrow(/No paired chain=1 \(change\) address found.*pair_ledger_btc/s);
+  });
+
+  // Issue #254 happy path: the builder routes change to the cached
+  // chain=1 address, threads it onto `tx.change`, and stamps the change
+  // output's `decoded` projection with `changePath` so the verification
+  // block (and second-LLM check) can show the BIP-44 internal-chain
+  // derivation that backs the on-screen "Change" label.
+  it("routes change to the cached chain=1 address and stamps decoded.outputs.changePath", async () => {
+    getUtxosMock.mockResolvedValueOnce([
+      { txid: FAKE_TXID, vout: 0, value: 1_000_000, unconfirmed: false },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: SEGWIT_ADDR,
+      to: RECIPIENT,
+      amount: "0.001",
+      feeRateSatPerVb: 10,
+    });
+    expect(tx.change).toEqual({
+      address: CHANGE_ADDR,
+      path: CHANGE_PATH,
+      publicKey: CHANGE_PUBKEY,
+    });
+    const changeOutput = tx.decoded.outputs.find((o) => o.isChange);
+    expect(changeOutput).toBeDefined();
+    expect(changeOutput!.address).toBe(CHANGE_ADDR);
+    expect(changeOutput!.changePath).toBe(CHANGE_PATH);
+    // Recipient output is unaffected.
+    const recipientOutput = tx.decoded.outputs.find(
+      (o) => o.address === RECIPIENT,
+    );
+    expect(recipientOutput).toBeDefined();
+    expect(recipientOutput!.isChange).toBe(false);
+    expect(recipientOutput!.changePath).toBeUndefined();
+  });
+
   it("supports rbf=false (sequence finality)", async () => {
     getUtxosMock.mockResolvedValueOnce([
       { txid: FAKE_TXID, vout: 0, value: 100_000, unconfirmed: false },
@@ -413,17 +513,40 @@ describe("sendBitcoinTransaction", () => {
       string,
       { pubkey: Buffer; path: number[] }
     >;
-    expect(known.size).toBe(1);
-    const [[lookupKey, entry]] = [...known.entries()];
-    expect(lookupKey).toMatch(/^[0-9a-f]{40}$/);
-    expect(lookupKey).not.toMatch(/^[0-9a-f]{64}$/);
-    expect(entry.pubkey.toString("hex")).toBe(SEGWIT_PUBKEY);
+    // Issue #254: the map now carries TWO entries — source (chain=0) and
+    // change (chain=1) — so the Ledger BTC app labels the change output
+    // as "Change" instead of warning "unusual change path".
+    expect(known.size).toBe(2);
+    for (const lookupKey of known.keys()) {
+      expect(lookupKey).toMatch(/^[0-9a-f]{40}$/);
+      expect(lookupKey).not.toMatch(/^[0-9a-f]{64}$/);
+    }
+    // Find each entry by matching the path's chain segment.
+    const entries = [...known.values()];
+    const sourceEntry = entries.find(
+      (e) => e.path[3] === 0,
+    );
+    const changeEntry = entries.find((e) => e.path[3] === 1);
+    expect(sourceEntry).toBeDefined();
+    expect(changeEntry).toBeDefined();
+    expect(sourceEntry!.pubkey.toString("hex")).toBe(SEGWIT_PUBKEY);
     // 84'/0'/0'/0/0 — three hardened segments + receive chain + index 0.
-    expect(entry.path).toEqual([
+    expect(sourceEntry!.path).toEqual([
       (84 | 0x80000000) >>> 0,
       (0 | 0x80000000) >>> 0,
       (0 | 0x80000000) >>> 0,
       0,
+      0,
+    ]);
+    // 84'/0'/0'/1/0 — same shape, change chain. The pubkey we threaded
+    // through is the same fixture for simplicity; in production each
+    // chain has its own derived leaf pubkey, which the device validates
+    // against its own derivation at sign time.
+    expect(changeEntry!.path).toEqual([
+      (84 | 0x80000000) >>> 0,
+      (0 | 0x80000000) >>> 0,
+      (0 | 0x80000000) >>> 0,
+      1,
       0,
     ]);
   });


### PR DESCRIPTION
Closes #254.

## Problem

Both `prepare_btc_send` and `prepare_litecoin_native_send` Phase-1 hardcode `changeAddress: args.wallet` (the source). Source addresses live on BIP-44's receiving branch (`<purpose>'/<coin>'/<account>'/0/N`); change MUST come from chain=1 (`/1/N`). The Ledger BTC/LTC apps correctly flag every change-on-source signing prompt with **\"the change path is unusual\"** — empirically confirmed during a 0.01 LTC self-send on Ledger Litecoin v2.4.11.

Privacy regression: every send collapses source + change into one on-chain footprint, defeating BIP-44's clustering-resistance. UX regression: training users to ignore Ledger warnings is the opposite of VaultPilot's security posture.

## Fix

- **Builder** (`src/modules/{btc,litecoin}/actions.ts`) looks up the BIP-32 chain=1 entry from the pairings cache (same `accountIndex` + `addressType`, lowest `addressIndex`) and uses it as the change address. Errors out clearly when no chain=1 entry is cached, telling the user to re-pair (the gap-limit scan skips chain=1 on never-funded accounts; once funds arrive, a re-pair populates them).
- **Unsigned-tx envelope** carries a new optional `change?: { address, path, publicKey }` field. `decoded.outputs[isChange=true].changePath` surfaces the internal-chain derivation in the verification block.
- **Signer** (`src/signing/{btc,ltc}-usb-signer.ts`) registers the change derivation as a **second** `signPsbtBuffer.knownAddressDerivations` entry. The Ledger SDK's `populateMissingBip32Derivations` populates the change output's `bip32Derivation` with the **device-derived** master fingerprint at sign time — no need to compute or fake it at build time. This is the core unblock: the BTC/LTC app then recognizes the output as same-account change and labels it \"Change\" on-screen instead of warning.
- **LTC legacy fallback** (`createPaymentTransaction`, issue #240): when `change` is supplied, match the change script for `changePath`; when omitted (legacy call shape), keep the source-script fallback for backward compat.

## Test plan

- [x] `npm run build` clean (the only TS errors in the working tree are in unrelated in-progress Safe-module files, not touched by this PR).
- [x] Focused suites: 49/49 pass across `btc-pr3-send.test.ts`, `litecoin-core.test.ts`, `ltc-message-prefix-and-legacy-app.test.ts`, `ltc-rescan-and-hydration.test.ts`.
- [x] Full suite: 1244/1244 (the one intermittent `send-hash-pin.test.ts` failure is the pre-existing flake — passes on isolated re-run).
- [x] New regression test: builder refuses with a clear \"re-pair\" message when the cache has chain=0 but no chain=1 for the account.
- [x] New happy-path test: `tx.change` envelope field is set, `decoded.outputs[isChange=true].changePath` surfaces the chain=1 leaf path, signer's `knownAddressDerivations` carries 2 entries (one chain=0, one chain=1), each pinned to the right path shape.
- [ ] Manual on-device retest: rerun the original 0.01 LTC self-send that triggered the issue and confirm the Ledger app no longer warns AND labels the change output as \"Change\".

## Out of scope

- Address rotation across multiple sends in one session — for now every send reuses chain=1 / addressIndex=0; the Ledger app doesn't warn on address reuse, so this is benign.
- Legacy / P2SH-wrapped source-address sends (still gated by the pre-existing Phase-1 source-type check).
- Account-aggregation logic that walks both chain=0 and chain=1 for balance / utxo discovery — orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)