### PR TITLE
feat(safe): add get_safe_positions read-only tool (v1 of 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@mrgnlabs/marginfi-client-v2": "^6.4.1",
         "@noble/hashes": "^1.5.0",
+        "@safe-global/api-kit": "^4.1.0",
         "@scure/base": "^1.2.6",
         "@scure/bip32": "^1.7.0",
         "@solana/kit": "^2.3.0",
@@ -2144,6 +2145,25 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@protobuf-ts/grpcweb-transport": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz",
@@ -2563,6 +2583,60 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@safe-global/api-kit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/api-kit/-/api-kit-4.1.0.tgz",
+      "integrity": "sha512-UlLG5bY1dR3zKKJxv0/d4bsR0zkFiC52aXJDg4/BTXGge51CZdG/d/5Z+V/IQX6fC09QiLPT1D3VquO0oc9Ecg==",
+      "license": "MIT",
+      "dependencies": {
+        "@safe-global/protocol-kit": "^7.0.0",
+        "@safe-global/types-kit": "^3.1.0",
+        "node-fetch": "^2.7.0",
+        "viem": "^2.21.8"
+      }
+    },
+    "node_modules/@safe-global/protocol-kit": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/protocol-kit/-/protocol-kit-7.1.0.tgz",
+      "integrity": "sha512-eFJ6SwxF9TIDpQkQj8bTP9ma1zpf1C1nhdhAwx16rUX749CWT6styg7e9dSmeV40zSleWFeQUWcqgLOaRnxj1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@safe-global/safe-deployments": "^1.37.54",
+        "@safe-global/safe-modules-deployments": "^3.0.2",
+        "@safe-global/types-kit": "^3.1.0",
+        "abitype": "^1.0.2",
+        "semver": "^7.7.2",
+        "viem": "^2.21.8"
+      },
+      "optionalDependencies": {
+        "@noble/curves": "^1.6.0",
+        "@peculiar/asn1-schema": "^2.3.13"
+      }
+    },
+    "node_modules/@safe-global/safe-deployments": {
+      "version": "1.37.55",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-deployments/-/safe-deployments-1.37.55.tgz",
+      "integrity": "sha512-vI7jgwV4XukOniAziybjoXzw9lYFXqNF4NVU7ytKCymnjzfNSnzCIJgM2kaGmA+eKlMm8XbIbdMRHtKTwIAzUw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.2"
+      }
+    },
+    "node_modules/@safe-global/safe-modules-deployments": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-modules-deployments/-/safe-modules-deployments-3.0.3.tgz",
+      "integrity": "sha512-buagqAbogvJp7WLJNV2t3/QrSEDlOdyIMiOuEY1TOR3Q+BTDhFcrolQ30tBqohj6pdojOW6NNcv6ITzpUz/X4w==",
+      "license": "MIT"
+    },
+    "node_modules/@safe-global/types-kit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/types-kit/-/types-kit-3.1.0.tgz",
+      "integrity": "sha512-uI6lFV8wOji4rb7juu0/LRMND0rq2NWaqH4zFzE2FUjO8lTvbCT+/5W/+flUUfkcaqyLDlJ1OPjasa2bEakrbw==",
+      "license": "MIT",
+      "dependencies": {
+        "abitype": "^1.0.2"
+      }
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
@@ -4294,21 +4368,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -4793,6 +4852,28 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -6303,13 +6384,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7185,21 +7259,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
-      }
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/jayson/node_modules/ws": {
@@ -8596,6 +8655,33 @@
         "bitcoin-ops": "^1.3.0"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -9719,6 +9805,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@mrgnlabs/marginfi-client-v2": "^6.4.1",
     "@noble/hashes": "^1.5.0",
+    "@safe-global/api-kit": "^4.1.0",
     "@scure/base": "^1.2.6",
     "@scure/bip32": "^1.7.0",
     "@solana/kit": "^2.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ import {
   simulatePositionChangeInput,
 } from "./modules/positions/schemas.js";
 
+import { getSafePositions } from "./modules/safe/index.js";
+import { getSafePositionsInput } from "./modules/safe/schemas.js";
+
 import {
   checkContractSecurityHandler,
   checkPermissionRisksHandler,
@@ -1311,7 +1314,7 @@ async function main() {
     handler(getHealthAlerts)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "simulate_position_change",
     {
       description:
@@ -1319,6 +1322,16 @@ async function main() {
       inputSchema: simulatePositionChangeInput.shape,
     },
     handler(simulatePositionChange)
+  );
+
+  registerTool(server,
+    "get_safe_positions",
+    {
+      description:
+        "Fetch Safe (Gnosis Safe) multisig accounts for an EVM owner address and/or by Safe address. Returns per-Safe threshold, owners, contract version, native balance, pending and recently-executed transactions, and risk notes (single-signer threshold, all-required threshold, Safe Modules, Safe Guards). Pass `signerAddress` to discover every Safe the wallet is an owner on, OR `safeAddress` to look up one Safe directly (or both — results are unioned and deduped). `chains` defaults to `[\"ethereum\"]`; pass an explicit array to query other supported EVM chains. Requires SAFE_API_KEY (https://developer.safe.global/) — Safe Transaction Service authenticates every request. ERC-20 balances are NOT enumerated here; pair with `get_token_balance` per token or `get_portfolio_summary` against the Safe address.",
+      inputSchema: getSafePositionsInput.shape,
+    },
+    handler(getSafePositions)
   );
 
   // ---- Module 2: Security ----

--- a/src/modules/safe/index.ts
+++ b/src/modules/safe/index.ts
@@ -1,0 +1,343 @@
+import { getAddress, getContract } from "viem";
+import { getSafeApiKit, type SafeServiceMultisigTx } from "./sdk.js";
+import { getClient } from "../../data/rpc.js";
+import { gnosisSafeAbi } from "../../abis/access-control.js";
+import { getTokenBalance } from "../balances/index.js";
+import type { SupportedChain, TokenAmount } from "../../types/index.js";
+import type { GetSafePositionsArgs } from "./schemas.js";
+
+/**
+ * Compact summary of one Safe pending or recently-executed transaction. The
+ * Safe Transaction Service returns a fat record per tx (~30 fields, decoded
+ * calldata, paginated confirmation list); we surface the load-bearing fields
+ * for an agent and let callers fetch the full record by `safeTxHash` if they
+ * need calldata-level detail.
+ */
+export interface SafeTxSummary {
+  safeTxHash: string;
+  nonce: number;
+  to: string;
+  value: string;
+  /** True when the call carries calldata (i.e. is a contract call, not a plain transfer). */
+  hasData: boolean;
+  /** 0 = CALL, 1 = DELEGATECALL. DELEGATECALL is high-risk; agents should flag it loudly. */
+  operation: number;
+  confirmations: number;
+  confirmationsRequired: number;
+  proposer: string | null;
+  submissionDate: string;
+  /** Only set for executed txs — the on-chain transaction hash. */
+  executionTxHash?: string;
+  /** Only set for executed txs — date the multisig tx landed on-chain. */
+  executionDate?: string;
+}
+
+/** Result for a single Safe — one entry in the response list. */
+export interface SafeAccount {
+  address: `0x${string}`;
+  chain: SupportedChain;
+  /** Safe contract version (e.g. "1.4.1"). Useful for compat checks. */
+  version: string;
+  threshold: number;
+  owners: `0x${string}`[];
+  /** Native coin balance on this chain. ERC20 balances are not enumerated here — query `get_token_balance` per token. */
+  nativeBalance: TokenAmount;
+  /** Number of Safe Modules currently enabled. >0 is a notable risk surface — modules can bypass owner consent. */
+  moduleCount: number;
+  /** True when a Safe Guard is configured (extra checks on every tx). */
+  hasGuard: boolean;
+  pendingTxs: SafeTxSummary[];
+  /** Most-recent first; capped at `RECENT_EXECUTED_LIMIT`. */
+  recentExecutedTxs: SafeTxSummary[];
+  /** Plain-English risk notes derived from the config above. Empty array when nothing notable. */
+  riskNotes: string[];
+}
+
+export interface GetSafePositionsResult {
+  /** What the caller asked about, echoed back so multi-Safe responses are easy to match up. */
+  query: {
+    signerAddress?: `0x${string}`;
+    safeAddress?: `0x${string}`;
+    chains: SupportedChain[];
+  };
+  safes: SafeAccount[];
+  /**
+   * Per-chain coverage. `errored: true` means the Safe Transaction Service
+   * call failed for that chain (network, auth, or upstream error). Mirrors
+   * the `coverage` shape used by `get_portfolio_summary` so agents can
+   * distinguish "no Safes here" from "fetch failed".
+   */
+  coverage: Array<{ chain: SupportedChain; errored: boolean; error?: string }>;
+}
+
+/**
+ * Cap on `recentExecutedTxs`. Five is enough for "what did this Safe do
+ * recently" without ballooning the response payload — the tx-service paginates
+ * at 100/page, but agents almost never need more than the most recent few.
+ */
+const RECENT_EXECUTED_LIMIT = 5;
+
+/**
+ * Cap on `pendingTxs`. Pending is usually 0–3 txs in real treasuries; setting
+ * the limit at 20 leaves headroom for the rare DAO with a queue without
+ * producing a 200-item dump.
+ */
+const PENDING_LIMIT = 20;
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function summarizeTx(tx: SafeServiceMultisigTx): SafeTxSummary {
+  const summary: SafeTxSummary = {
+    safeTxHash: tx.safeTxHash,
+    nonce: Number(tx.nonce),
+    to: tx.to,
+    value: tx.value,
+    hasData: !!tx.data && tx.data !== "0x",
+    operation: tx.operation,
+    confirmations: tx.confirmations?.length ?? 0,
+    confirmationsRequired: tx.confirmationsRequired,
+    proposer: tx.proposer,
+    submissionDate: tx.submissionDate,
+  };
+  if (tx.isExecuted && tx.transactionHash) {
+    summary.executionTxHash = tx.transactionHash;
+  }
+  if (tx.isExecuted && tx.executionDate) {
+    summary.executionDate = tx.executionDate;
+  }
+  return summary;
+}
+
+function deriveRiskNotes(safe: {
+  threshold: number;
+  owners: string[];
+  moduleCount: number;
+  hasGuard: boolean;
+}): string[] {
+  const notes: string[] = [];
+  if (safe.threshold === 1) {
+    notes.push(
+      "Threshold is 1 — this Safe is signed by any single owner, equivalent to an EOA in terms of multisig protection.",
+    );
+  }
+  if (safe.threshold > 1 && safe.threshold === safe.owners.length) {
+    notes.push(
+      `Threshold equals owner count (${safe.threshold}/${safe.owners.length}) — losing any single owner permanently locks the Safe.`,
+    );
+  }
+  if (safe.moduleCount > 0) {
+    notes.push(
+      `${safe.moduleCount} Safe Module(s) enabled — modules can move funds without owner signatures. Verify each one before trusting this Safe.`,
+    );
+  }
+  if (safe.hasGuard) {
+    // Guards can be either a SAFER posture (e.g. one that blocks DELEGATECALL)
+    // or a brick risk (a malicious guard rejects every legit tx). We just flag
+    // the presence and let the user investigate the guard contract.
+    notes.push(
+      "A Safe Guard is configured — every tx goes through extra checks. Verify the guard contract before relying on this Safe.",
+    );
+  }
+  return notes;
+}
+
+/**
+ * Read on-chain Safe state directly. `getSafeInfo` from the tx-service
+ * already exposes threshold/owners/version, so this is currently a fallback
+ * path; we keep it because the on-chain reads are the source of truth and
+ * v2/v3 will need to compute the next nonce locally without round-tripping
+ * through the tx-service.
+ */
+async function readSafeOnChain(
+  chain: SupportedChain,
+  address: `0x${string}`,
+): Promise<{ threshold: number; owners: `0x${string}`[]; version: string }> {
+  const client = getClient(chain);
+  const safe = getContract({
+    address,
+    abi: [
+      ...gnosisSafeAbi,
+      {
+        type: "function",
+        name: "VERSION",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [{ type: "string" }],
+      },
+    ] as const,
+    client,
+  });
+  const [threshold, owners, version] = await Promise.all([
+    safe.read.getThreshold() as Promise<bigint>,
+    safe.read.getOwners() as Promise<readonly `0x${string}`[]>,
+    safe.read.VERSION() as Promise<string>,
+  ]);
+  return { threshold: Number(threshold), owners: [...owners], version };
+}
+
+/**
+ * Fetch one Safe's full state (config + balance + tx queue) on a given chain.
+ * Splits the work between the Safe Transaction Service (config, tx queue) and
+ * direct RPC (native balance) so a tx-service hiccup doesn't block balance
+ * reads and vice-versa.
+ */
+async function loadSafe(
+  chain: SupportedChain,
+  safeAddress: `0x${string}`,
+): Promise<SafeAccount> {
+  const kit = getSafeApiKit(chain);
+
+  const [info, pending, executed, nativeBalance] = await Promise.all([
+    kit.getSafeInfo(safeAddress),
+    kit.getPendingTransactions(safeAddress, { limit: PENDING_LIMIT }),
+    kit.getMultisigTransactions(safeAddress, { executed: true, limit: RECENT_EXECUTED_LIMIT }),
+    getTokenBalance({ wallet: safeAddress, token: "native", chain }) as Promise<TokenAmount>,
+  ]);
+
+  const moduleCount = info.modules?.length ?? 0;
+  const hasGuard = !!info.guard && info.guard.toLowerCase() !== ZERO_ADDRESS;
+  const owners = info.owners.map((o: string) => getAddress(o) as `0x${string}`);
+
+  return {
+    address: getAddress(safeAddress) as `0x${string}`,
+    chain,
+    version: info.version,
+    threshold: info.threshold,
+    owners,
+    nativeBalance,
+    moduleCount,
+    hasGuard,
+    pendingTxs: pending.results.map(summarizeTx),
+    recentExecutedTxs: executed.results.map(summarizeTx),
+    riskNotes: deriveRiskNotes({
+      threshold: info.threshold,
+      owners,
+      moduleCount,
+      hasGuard,
+    }),
+  };
+}
+
+/**
+ * Discover all Safes a given owner is a signer on, then load each one in
+ * parallel. Per-Safe failures are surfaced via `coverage` rather than tanking
+ * the whole call — losing one Safe to a transient tx-service blip shouldn't
+ * black out the user's view of their other Safes.
+ */
+async function loadSafesForOwner(
+  chain: SupportedChain,
+  ownerAddress: `0x${string}`,
+): Promise<{ safes: SafeAccount[]; perSafeErrors: string[] }> {
+  const kit = getSafeApiKit(chain);
+  const { safes: safeAddresses } = await kit.getSafesByOwner(ownerAddress);
+  const perSafeErrors: string[] = [];
+  const settled = await Promise.allSettled(
+    safeAddresses.map((addr: string) =>
+      loadSafe(chain, getAddress(addr) as `0x${string}`),
+    ),
+  );
+  const safes: SafeAccount[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const r = settled[i];
+    if (r.status === "fulfilled") {
+      safes.push(r.value);
+    } else {
+      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      perSafeErrors.push(`${safeAddresses[i]}: ${reason}`);
+    }
+  }
+  return { safes, perSafeErrors };
+}
+
+/**
+ * Top-level handler for `get_safe_positions`. Discovery rules:
+ *
+ *  - At least one of `signerAddress` / `safeAddress` must be supplied.
+ *  - When both are supplied, results union (`safeAddress` is loaded directly
+ *    on every requested chain, plus all Safes the signer is on per chain),
+ *    de-duplicated by `chain:address`.
+ *  - `chains` defaults to `["ethereum"]` (see schema rationale).
+ *
+ * The handler never throws on a single-chain failure — those land in
+ * `coverage[i].errored`. It DOES throw `SafeApiKeyMissingError` synchronously
+ * when SAFE_API_KEY is unset, since the request can't proceed at all.
+ */
+export async function getSafePositions(
+  args: GetSafePositionsArgs,
+): Promise<GetSafePositionsResult> {
+  if (!args.signerAddress && !args.safeAddress) {
+    throw new Error("Provide at least one of `signerAddress` or `safeAddress`.");
+  }
+  const chains: SupportedChain[] = (args.chains as SupportedChain[] | undefined) ?? ["ethereum"];
+  const signerAddress = args.signerAddress ? (getAddress(args.signerAddress) as `0x${string}`) : undefined;
+  const safeAddress = args.safeAddress ? (getAddress(args.safeAddress) as `0x${string}`) : undefined;
+
+  const coverage: GetSafePositionsResult["coverage"] = [];
+  // Map keyed by `${chain}:${address}` to dedupe when a direct safeAddress
+  // also shows up under signerAddress's owner-list.
+  const collected = new Map<string, SafeAccount>();
+
+  await Promise.all(
+    chains.map(async (chain) => {
+      try {
+        const tasks: Promise<unknown>[] = [];
+        if (safeAddress) {
+          tasks.push(
+            loadSafe(chain, safeAddress).then((s) => {
+              collected.set(`${chain}:${s.address.toLowerCase()}`, s);
+            }),
+          );
+        }
+        if (signerAddress) {
+          tasks.push(
+            loadSafesForOwner(chain, signerAddress).then(({ safes, perSafeErrors }) => {
+              for (const s of safes) {
+                collected.set(`${chain}:${s.address.toLowerCase()}`, s);
+              }
+              if (perSafeErrors.length > 0) {
+                // Surface partial failure as an error string on coverage —
+                // the safes that DID load are still in `collected`.
+                coverage.push({
+                  chain,
+                  errored: true,
+                  error: `partial failure: ${perSafeErrors.join("; ")}`,
+                });
+              }
+            }),
+          );
+        }
+        await Promise.all(tasks);
+        if (!coverage.find((c) => c.chain === chain)) {
+          coverage.push({ chain, errored: false });
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        coverage.push({ chain, errored: true, error: message });
+      }
+    }),
+  );
+
+  // Stable ordering: chain first (in user-supplied order), then address.
+  const chainOrder = new Map(chains.map((c, i) => [c, i]));
+  const safes = [...collected.values()].sort((a, b) => {
+    const ci = (chainOrder.get(a.chain) ?? 0) - (chainOrder.get(b.chain) ?? 0);
+    if (ci !== 0) return ci;
+    return a.address.localeCompare(b.address);
+  });
+
+  coverage.sort((a, b) => (chainOrder.get(a.chain) ?? 0) - (chainOrder.get(b.chain) ?? 0));
+
+  return {
+    query: {
+      ...(signerAddress ? { signerAddress } : {}),
+      ...(safeAddress ? { safeAddress } : {}),
+      chains,
+    },
+    safes,
+    coverage,
+  };
+}
+
+// readSafeOnChain is exported for v2 (where we need on-chain nonce + version
+// reads independent of the tx-service).
+export { readSafeOnChain };

--- a/src/modules/safe/schemas.ts
+++ b/src/modules/safe/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+
+const evmChainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
+/**
+ * `get_safe_positions` accepts at least one of `signerAddress` (discover all
+ * Safes the address is an owner of via Safe Transaction Service) or
+ * `safeAddress` (direct lookup of one Safe). The "at least one" rule is
+ * enforced inside the handler — MCP requires the raw ZodObject here, so we
+ * can't `.refine` at the schema root.
+ *
+ * `chains` defaults to `["ethereum"]` rather than fanning out across all five
+ * EVM chains. The Safe Transaction Service is a per-chain authenticated API:
+ * fanning out by default would 5x the API-key request budget and surface a
+ * pile of "no Safes here" empty results for users who only use mainnet.
+ */
+export const getSafePositionsInput = z.object({
+  signerAddress: z.string().regex(EVM_ADDRESS).optional(),
+  safeAddress: z.string().regex(EVM_ADDRESS).optional(),
+  chains: z.array(evmChainEnum).min(1).optional(),
+});
+
+export type GetSafePositionsArgs = z.infer<typeof getSafePositionsInput>;

--- a/src/modules/safe/sdk.ts
+++ b/src/modules/safe/sdk.ts
@@ -1,0 +1,115 @@
+// `@safe-global/api-kit` ships a dual ESM/CJS bundle whose package.json
+// `exports` map advertises a single top-level `types` field (no per-condition
+// types) and whose runtime ESM bundle re-exports only `default`. Under
+// Node16 module resolution, both `import SafeApiKit from "..."` and
+// `import * as Mod` paths confuse TS into binding the class identifier to
+// the entire module namespace — `new X(...)` fails with "no construct
+// signatures" and `InstanceType<typeof X>` fails the constraint check.
+// Pulling the class through `createRequire` matches the runtime CJS shape
+// (`module.exports = SafeApiKit`) and gives TS a real constructor to type
+// against. Same workaround already used by `src/modules/btc/actions.ts` for
+// `bitcoinjs-lib`.
+import { createRequire } from "node:module";
+import { CHAIN_IDS, type SupportedChain } from "../../types/index.js";
+import { readUserConfig } from "../../config/user-config.js";
+
+const requireCjs = createRequire(import.meta.url);
+const SafeApiKit = requireCjs("@safe-global/api-kit").default as new (config: {
+  chainId: bigint;
+  txServiceUrl?: string;
+  apiKey?: string;
+}) => {
+  getSafeInfo(safeAddress: string): Promise<{
+    address: string;
+    nonce: string;
+    threshold: number;
+    owners: string[];
+    modules: string[];
+    fallbackHandler: string;
+    guard: string;
+    version: string;
+  }>;
+  getSafesByOwner(ownerAddress: string): Promise<{ safes: string[] }>;
+  getPendingTransactions(
+    safeAddress: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ count: number; results: SafeServiceMultisigTx[] }>;
+  getMultisigTransactions(
+    safeAddress: string,
+    options?: { executed?: boolean; limit?: number; offset?: number; ordering?: string },
+  ): Promise<{ count: number; results: SafeServiceMultisigTx[] }>;
+};
+type SafeApiKitInstance = InstanceType<typeof SafeApiKit>;
+
+/**
+ * Subset of `SafeMultisigTransactionResponse` (from `@safe-global/types-kit`)
+ * that we actually consume. Mirrors the runtime fields the tx-service
+ * returns; the full type has ~30 fields and pulling it via the CJS require
+ * path would defeat the type isolation we get above.
+ */
+export interface SafeServiceMultisigTx {
+  safeTxHash: string;
+  nonce: string;
+  to: string;
+  value: string;
+  data?: string;
+  operation: number;
+  confirmations?: { owner: string }[];
+  confirmationsRequired: number;
+  proposer: string | null;
+  submissionDate: string;
+  transactionHash: string | null;
+  executionDate: string | null;
+  isExecuted: boolean;
+}
+
+/**
+ * Thrown when SAFE_API_KEY is not configured. Modern Safe Transaction Service
+ * (`*.safe.global`) requires a per-org API key — the SDK enforces this at
+ * `SafeApiKit` construction time, so we surface a friendlier error before the
+ * SDK throws its generic "apiKey is required" message. Get a key from
+ * https://developer.safe.global/.
+ */
+export class SafeApiKeyMissingError extends Error {
+  constructor() {
+    super(
+      "SAFE_API_KEY is not configured. Safe Transaction Service requires an API key " +
+        "(see https://developer.safe.global/). Set the SAFE_API_KEY env var or run " +
+        "`vaultpilot-mcp-setup`.",
+    );
+    this.name = "SafeApiKeyMissingError";
+  }
+}
+
+/** Pull the Safe API key from env (highest priority) or user config. */
+export function resolveSafeApiKey(): string | undefined {
+  const fromEnv = process.env.SAFE_API_KEY;
+  if (fromEnv) return fromEnv;
+  return readUserConfig()?.safeApiKey;
+}
+
+/**
+ * Per-chain `SafeApiKit` cache. The kit holds the chainId + apiKey and a
+ * resolved txServiceUrl; instantiating one is cheap, but reusing avoids the
+ * URL-resolution work on every call. Cleared by tests via
+ * `clearSafeApiKitCacheForTesting`.
+ */
+const apiKitCache = new Map<SupportedChain, SafeApiKitInstance>();
+
+export function getSafeApiKit(chain: SupportedChain): SafeApiKitInstance {
+  const cached = apiKitCache.get(chain);
+  if (cached) return cached;
+  const apiKey = resolveSafeApiKey();
+  if (!apiKey) throw new SafeApiKeyMissingError();
+  const kit = new SafeApiKit({
+    chainId: BigInt(CHAIN_IDS[chain]),
+    apiKey,
+  });
+  apiKitCache.set(chain, kit);
+  return kit;
+}
+
+/** Test-only: drop the cached kits so a re-read of SAFE_API_KEY takes effect. */
+export function clearSafeApiKitCacheForTesting(): void {
+  apiKitCache.clear();
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -246,6 +246,23 @@ async function configureOneInch(p: Prompt): Promise<string | undefined> {
   return answer || undefined;
 }
 
+async function configureSafe(p: Prompt): Promise<string | undefined> {
+  console.log("\n--- Safe (optional — enables Safe / Gnosis Safe multisig tools) ---");
+  console.log("Required for `get_safe_positions` and the propose/execute Safe tools.");
+  console.log("The modern `*.safe.global` Transaction Service authenticates every request,");
+  console.log("so portfolio reads against a Safe are gated on this key. Skip if you don't");
+  console.log("use Safe.");
+  console.log("Create a free key at https://developer.safe.global/.");
+  const existing = readUserConfig()?.safeApiKey;
+  const answer = await p.ask(
+    existing
+      ? "Safe API key [press enter to keep existing]: "
+      : "Safe API key (or blank to skip): "
+  );
+  if (!answer && existing) return existing;
+  return answer || undefined;
+}
+
 async function validateTronApiKey(apiKey: string): Promise<void> {
   // USDT-TRC20 address — well-known, always returns 200 on a healthy grid.
   const url = "https://api.trongrid.io/v1/accounts/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
@@ -500,6 +517,7 @@ function summarizeConfig(cfg: UserConfig): void {
   }
   console.log(`  Etherscan API key:   ${cfg.etherscanApiKey ? "set" : "not set"}`);
   console.log(`  1inch API key:       ${cfg.oneInchApiKey ? "set" : "not set"}`);
+  console.log(`  Safe API key:        ${cfg.safeApiKey ? "set" : "not set"}`);
   console.log(`  TronGrid API key:    ${cfg.tronApiKey ? "set" : "not set"}`);
   console.log(
     `  Solana RPC URL:      ${
@@ -527,6 +545,7 @@ async function editSectionMenu(p: Prompt): Promise<void> {
     { label: "RPC provider / API key", action: "rpc" as const },
     { label: "Etherscan API key", action: "etherscan" as const },
     { label: "1inch API key", action: "oneinch" as const },
+    { label: "Safe API key", action: "safe" as const },
     { label: "TronGrid API key", action: "tron" as const },
     { label: "Solana RPC URL", action: "solana" as const },
     { label: "WalletConnect project ID", action: "wc" as const },
@@ -555,6 +574,11 @@ async function editSectionMenu(p: Prompt): Promise<void> {
       case "oneinch": {
         const k = await configureOneInch(p);
         if (k !== undefined) patchUserConfig({ oneInchApiKey: k });
+        break;
+      }
+      case "safe": {
+        const k = await configureSafe(p);
+        if (k !== undefined) patchUserConfig({ safeApiKey: k });
         break;
       }
       case "tron": {
@@ -597,6 +621,11 @@ async function runFullWizard(p: Prompt): Promise<void> {
   const oneInchApiKey = await configureOneInch(p);
   if (oneInchApiKey !== undefined) {
     patchUserConfig({ oneInchApiKey });
+  }
+
+  const safeApiKey = await configureSafe(p);
+  if (safeApiKey !== undefined) {
+    patchUserConfig({ safeApiKey });
   }
 
   const tronApiKey = await configureTron(p);


### PR DESCRIPTION
## Summary

First stage of Safe / Gnosis Safe support per `claude-work/HIGH-plan-safe-multisig.md`. Adds `get_safe_positions` — the read-only entry point. v2 (propose) and v3 (execute) ship in follow-up PRs.

- **Discovery**: pass `signerAddress` (returns every Safe the wallet is an owner on), `safeAddress` (direct lookup), or both (unioned + deduped).
- **Per-Safe data**: threshold, owners, contract version, native balance, module count, guard presence, pending tx queue, recent executed txs, plain-English risk notes.
- **Coverage**: per-chain status entries mirror `get_portfolio_summary` so agents distinguish "no Safes here" from "tx-service fetch failed".

## Design choices

- `chains` defaults to `["ethereum"]`, NOT all five EVM chains. Safe Tx Service is per-chain authenticated; fanning out by default 5x's the API-key budget for the most common case (mainnet-only treasuries). Explicit array supported for multi-chain users.
- ERC-20 balances NOT enumerated. Only native balance is read on-chain; full balance reads stay with `get_token_balance` / `get_portfolio_summary` against the Safe address.
- `SAFE_API_KEY` is required at handler entry. Modern `*.safe.global` endpoints authenticate every request — the SDK enforces this at construction. Wired through env, `~/.vaultpilot-mcp/config.json` (`safeApiKey`), and the setup wizard.
- Per-Safe failures during owner-list expansion surface in `coverage` rather than tanking the whole call.

## Implementation notes

- `@safe-global/api-kit` v4 + `protocol-kit` v7 are pure viem (no ethers v6 in the dep tree) — confirmed via `npm view`.
- Class loaded via `createRequire` (same pattern as `bitcoinjs-lib` in `src/modules/btc/actions.ts`). Under Node16 module resolution + the package's dual ESM/CJS bundle with no per-condition `types` mapping, both `import X from` and `import * as Mod` paths confuse TS into binding the class identifier to the entire module namespace.
- `SafeServiceMultisigTx` is a typed subset (we only consume ~13 of the ~30 fields tx-service returns); pulling the full type from `types-kit` would defeat the createRequire-based type isolation.

## Out of scope (deferred to follow-up PRs)

- **PR 2**: `prepare_safe_tx` — wraps an inner `prepare_*` action into a Safe-format tx and proposes it via Safe Tx Service. Sign path uses on-chain `approveHash` per signer, NOT off-chain `eth_signTypedData_v4` — preserves the anti-Permit2-phishing posture in `src/signing/walletconnect.ts:70-89`.
- **PR 3**: `execute_safe_tx` — pulls collected signatures, encodes `execTransaction` calldata, returns as a prepare receipt for the existing `send_transaction` flow.
- ERC-20 balance enumeration and Safe Modules / Safe Apps integration.

## Test plan

- [ ] `npm run build` passes.
- [ ] `npm test -- test/send-hash-pin.test.ts` passes (full suite has unrelated TRON/preview flakes; see issue tracker).
- [ ] `SAFE_API_KEY` unset → `get_safe_positions` throws `SafeApiKeyMissingError` with installer link.
- [ ] `SAFE_API_KEY` set → query a known DAO multisig signer (e.g. an Aave or Lido governor) → returns Safes they're on with correct owners + threshold.
- [ ] Direct `safeAddress` lookup against a known mainnet Safe → returns config + native balance + pending/executed tx summaries.
- [ ] `chains: ["arbitrum"]` overrides the default and queries the Arbitrum tx-service host.
- [ ] Threshold-1 Safe → `riskNotes` includes the single-signer warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)