### PR TITLE
docs(claude-md): require per-feature worktrees in Git/PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 ## Git/PR Workflow
 - Always use PR-based workflow: never push directly to main, and never push feature work to the wrong branch. Open a PR and let CI run.
 - Before force-pushing or rebasing, confirm with user.
+- **Each new feature/fix must be implemented inside its own dedicated `git worktree` under `.claude/worktrees/<branch-name>`** — NEVER do feature work in the main worktree at `/home/szhygulin/dev/recon-mcp`. Multiple agents may work this repo in parallel; if two agents share a single worktree they will race on the working tree, the index, and the npm install state. Recipe: `git fetch origin main && git worktree add .claude/worktrees/<short-name> -b <branch-name> origin/main`. Worktrees are auto-cleaned on PR merge by `git worktree prune`. The main worktree stays on `main` and is for sync/inspection only — don't edit files there. Exception: cross-project `claude-work/` plan files (gitignored) and `~/.claude/projects/.../memory/` (per-user) can be edited from anywhere; they're not under git's control in this repo.
 
 ## Tool Usage Discipline
 - Do not repeat the same informational tool call (e.g., lending_positions, compound_positions) within a single turn. Cache results mentally and reuse.


### PR DESCRIPTION
Codifies the convention every recent PR has actually followed: each new branch lives in `.claude/worktrees/<branch-name>/`, NEVER in the main worktree at `/home/szhygulin/dev/recon-mcp`.

## Why

Multiple Claude Code agents may work this repo in parallel — different terminals, IDE windows, sessions. If two agents share the main worktree, they race on:

- the working tree (one agent's edits clobber the other's)
- the index (`git add` from agent A interleaves with agent B's commit)
- the branch HEAD (one checkout invalidates the other's context)
- `node_modules/` and the npm install lock (concurrent `npm i` corrupts)

Per-feature worktrees are filesystem-isolated copies; agents stop seeing each other's WIP.

## Recipe (added to CLAUDE.md)

```
git fetch origin main && \
  git worktree add .claude/worktrees/<short-name> -b <branch-name> origin/main
```

## Escape hatches (also documented)

- gitignored `claude-work/` plan files → editable from anywhere
- per-user memory at `~/.claude/projects/.../memory/` → editable from anywhere

Both are out of git's race domain.

## Dogfooding

This PR was made inside `.claude/worktrees/docs-worktree-convention/`. The matching memory entry lives at `~/.claude/projects/-home-szhygulin-dev-recon-mcp/memory/feedback_worktree_per_feature.md` (per-user, cross-session continuity for me / future-me).

## Test plan

- [x] Plain doc edit; no code changes; nothing to test.
- [x] Markdown renders correctly in CLAUDE.md (one new bullet under Git/PR Workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)