### PR TITLE
feat(wc): probe for late broadcast on send_transaction timeout (#232)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2599,7 +2599,10 @@ export async function sendTransaction(args: SendTransactionArgs): Promise<{
     maxPriorityFeePerGas: stashed.maxPriorityFeePerGas,
     gas: stashed.gas,
   };
-  const hash = await requestSendTransaction(tx, pinned);
+  // Issue #232: thread the pinned pre-sign hash so a WC timeout can
+  // run a late-broadcast probe (find a tx that mined after our 120s
+  // timer fired) instead of surfacing a false-alarm timeout.
+  const hash = await requestSendTransaction(tx, pinned, stashed.preSignHash);
   // Only retire the handle after successful submission. If requestSendTransaction
   // throws (device disconnect, user rejection, relay timeout), the handle stays
   // valid and the caller can retry until the 15-minute TTL expires. The pin

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -3,6 +3,7 @@ import type { SessionTypes } from "@walletconnect/types";
 import { getSdkError } from "@walletconnect/utils";
 import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import type { PublicClient } from "viem";
 import { CHAIN_IDS, CHAIN_ID_TO_NAME, type SupportedChain, type UnsignedTx } from "../types/index.js";
 import { EVM_ADDRESS } from "../shared/address-patterns.js";
 import {
@@ -11,6 +12,8 @@ import {
   resolveWalletConnectProjectId,
   getConfigDir,
 } from "../config/user-config.js";
+import { getClient } from "../data/rpc.js";
+import { eip1559PreSignHash } from "./verification.js";
 
 /**
  * Recursively tighten permissions on the WalletConnect storage tree so the
@@ -507,10 +510,202 @@ export function timeoutMessage(args: {
   );
 }
 
+/**
+ * Compose the message thrown when the WC timer fires AND the pending
+ * nonce on chain has advanced past the pinned nonce, but no tx in the
+ * recent block window matched our pre-sign hash. Issue #232. This is
+ * an "ambiguous" outcome: someone consumed the slot, but we can't
+ * confirm it was our broadcast.
+ *
+ * Exported for test-side inspection.
+ */
+export function consumedUnmatchedMessage(args: {
+  from: `0x${string}` | string;
+  pinnedNonce: number;
+  pendingNonce: number;
+  chainId: number | string;
+  probeWindowBlocks: number;
+}): string {
+  return (
+    `WalletConnect signing request timed out AND the on-chain pending nonce for \`${args.from}\` ` +
+    `has advanced past the pinned nonce (pending=${args.pendingNonce}, pinned=${args.pinnedNonce}) ` +
+    `on chain id \`${args.chainId}\` — the slot was consumed by SOMETHING, but the last ${args.probeWindowBlocks} blocks ` +
+    `do NOT contain a tx whose pre-sign hash matches what we pinned. ` +
+    `Possible causes: (a) our tx mined further back than the probe window, ` +
+    `(b) a different tx with the same nonce got there first (rare unless the user has another tool driving the same wallet), ` +
+    `(c) RBF/cancel from another tooling path replaced our tx. ` +
+    `DO NOT retry — the nonce is consumed and a retry would either fail with "nonce too low" or land a duplicate at a higher nonce. ` +
+    `Direct the user to a block explorer for txs from \`${args.from}\` around the recent window to identify what landed. Issue #232.`
+  );
+}
+
+/**
+ * Compose the message thrown when the WC timer fires but the late-
+ * broadcast probe confirmed the pending nonce is still equal to the
+ * pinned nonce — i.e. NOTHING broadcast. Issue #232. Strict improvement
+ * over the legacy generic timeout: the agent (and user) now know with
+ * certainty that retrying the same handle is safe.
+ *
+ * Exported for test-side inspection.
+ */
+export function noBroadcastConfirmedMessage(args: {
+  from: `0x${string}` | string;
+  pinnedNonce: number;
+  chainId: number | string;
+  timeoutSeconds: number;
+}): string {
+  return (
+    `WalletConnect signing request did not complete within ${args.timeoutSeconds}s — and an automatic ` +
+    `on-chain probe confirmed that the pending nonce for \`${args.from}\` on chain id \`${args.chainId}\` ` +
+    `is still \`${args.pinnedNonce}\` (pinned), so no late broadcast is in flight. ` +
+    `Safe to retry: call \`send_transaction\` on the SAME handle within its 15-min TTL. ` +
+    `The user is most likely still reviewing the tx on the Ledger device — closing the WalletConnect ` +
+    `subapp on Ledger Live and reopening it before the retry can help if the device prompt got stale. Issue #232.`
+  );
+}
+
+/**
+ * How many recent blocks the late-broadcast probe walks back through to
+ * find a tx matching the pinned (from, nonce). Bounded so a probe on a
+ * fast-block chain (Arbitrum, Optimism, Base) doesn't fan out to dozens
+ * of `eth_getBlockByNumber` calls. The 120s WC timeout fires after the
+ * tx (if broadcast) has had time to mine — for Ethereum (~12s blocks)
+ * 16 blocks is ~3 min of headroom; for L2s with sub-second blocks the
+ * window is shorter in wall time but still covers the typical late-
+ * broadcast tail. Beyond this we surface a "consumed but not located"
+ * error and let the agent fall back to the existing on-chain check.
+ */
+const LATE_BROADCAST_PROBE_BLOCKS = 16;
+
+/**
+ * Outcome of `probeForLateBroadcast`. Three branches:
+ *   - `matched` → found an on-chain tx whose pre-sign hash equals the
+ *     server's pinned hash; the WC timeout was a false alarm and we can
+ *     return the tx hash to the caller.
+ *   - `no_broadcast` → the pending nonce on chain is still ≤ the pinned
+ *     nonce; the tx never left Ledger Live's side. Safe to retry.
+ *   - `consumed_unmatched` → the pinned nonce was consumed but no tx in
+ *     the recent block window had a matching pre-sign hash. Could be a
+ *     different tx (RBF replacement, parallel tooling) using the same
+ *     slot, or our tx mined further back than the probe window. Don't
+ *     retry; surface the pending nonce so the agent can guide the user
+ *     to a block explorer.
+ */
+export type LateBroadcastProbeResult =
+  | { status: "matched"; txHash: `0x${string}` }
+  | { status: "no_broadcast"; pendingNonce: number }
+  | { status: "consumed_unmatched"; pendingNonce: number };
+
+/**
+ * After a WC `eth_sendTransaction` times out, find out whether the tx
+ * actually broadcast (Ledger Live finished signing + relayed
+ * asynchronously after our 120s timer fired) before throwing. Issue
+ * #232.
+ *
+ * Strategy:
+ *   1. Read the pending nonce on chain. If it equals the pinned nonce,
+ *      nothing happened — return `no_broadcast`.
+ *   2. Otherwise (pending > pinned), the slot was consumed. Walk the
+ *      most-recent `LATE_BROADCAST_PROBE_BLOCKS` blocks, pull every tx
+ *      with `from === pinnedFrom && nonce === pinnedNonce`, and
+ *      recompute its EIP-1559 pre-sign hash. If it equals
+ *      `expectedPreSignHash`, that IS our tx; return `matched`.
+ *   3. If walked the full window without a hash match, return
+ *      `consumed_unmatched`.
+ *
+ * Errors during the probe (RPC failure, viem decoding failure) bubble
+ * up to the caller, which falls back to the existing timeout error
+ * rather than blocking. This is read-only — no chain mutations.
+ */
+export async function probeForLateBroadcast(args: {
+  client: Pick<
+    PublicClient,
+    "getTransactionCount" | "getBlockNumber" | "getBlock"
+  >;
+  from: `0x${string}`;
+  pinnedNonce: number;
+  expectedPreSignHash: `0x${string}`;
+  chainId: number;
+  /** Override the default block window (for tests). */
+  blockWindow?: number;
+}): Promise<LateBroadcastProbeResult> {
+  const pendingNonce = await args.client.getTransactionCount({
+    address: args.from,
+    blockTag: "pending",
+  });
+  if (pendingNonce <= args.pinnedNonce) {
+    return { status: "no_broadcast", pendingNonce };
+  }
+  const head = await args.client.getBlockNumber();
+  const window = args.blockWindow ?? LATE_BROADCAST_PROBE_BLOCKS;
+  const fromLower = args.from.toLowerCase();
+  for (let n = 0; n < window; n++) {
+    if (head < BigInt(n)) break;
+    const blockNumber = head - BigInt(n);
+    let block;
+    try {
+      block = await args.client.getBlock({
+        blockNumber,
+        includeTransactions: true,
+      });
+    } catch {
+      continue;
+    }
+    for (const tx of block.transactions) {
+      // includeTransactions:true → full objects; the `string` branch is
+      // never taken at runtime but viem's union type forces a guard.
+      if (typeof tx === "string") continue;
+      if (!tx.from || tx.from.toLowerCase() !== fromLower) continue;
+      if (tx.nonce !== args.pinnedNonce) continue;
+      // Pre-sign hash recomputation requires EIP-1559 fields. The pin
+      // path always emits eip1559 txs; legacy/2930 wouldn't match by
+      // construction. viem types these as a discriminated union via
+      // `tx.type`.
+      if (tx.type !== "eip1559") continue;
+      if (
+        tx.maxFeePerGas === undefined ||
+        tx.maxFeePerGas === null ||
+        tx.maxPriorityFeePerGas === undefined ||
+        tx.maxPriorityFeePerGas === null ||
+        tx.to === null
+      ) {
+        continue;
+      }
+      let computed: `0x${string}`;
+      try {
+        computed = eip1559PreSignHash({
+          chainId: args.chainId,
+          nonce: tx.nonce,
+          maxFeePerGas: tx.maxFeePerGas,
+          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+          gas: tx.gas,
+          to: tx.to as `0x${string}`,
+          value: tx.value,
+          data: tx.input,
+        });
+      } catch {
+        continue;
+      }
+      if (computed.toLowerCase() === args.expectedPreSignHash.toLowerCase()) {
+        return { status: "matched", txHash: tx.hash };
+      }
+    }
+  }
+  return { status: "consumed_unmatched", pendingNonce };
+}
+
 /** Send an `eth_sendTransaction` request. Ledger Live shows it, user signs on device, we get tx hash back. */
 export async function requestSendTransaction(
   tx: UnsignedTx,
   pinned?: PinnedGasFields,
+  /**
+   * EIP-1559 pre-sign hash the server pinned at preview time. When set,
+   * a WC timeout triggers a late-broadcast probe (issue #232): if the
+   * pinned tx mined while we were waiting, return its on-chain hash
+   * instead of throwing. Required to be present on the production send
+   * path; only test/legacy callers omit it.
+   */
+  expectedPreSignHash?: `0x${string}`,
 ): Promise<`0x${string}`> {
   const c = await getSignClient();
   if (!currentSession) {
@@ -603,10 +798,63 @@ export async function requestSendTransaction(
         );
       }, WC_SEND_REQUEST_TIMEOUT_MS),
     ),
-  ]).catch((e: unknown) => {
-    if (timedOut) throw e;
-    // Any other `c.request` rejection surfaces as-is.
-    throw e;
+  ]).catch(async (e: unknown) => {
+    if (!timedOut) {
+      // Any other `c.request` rejection surfaces as-is.
+      throw e;
+    }
+    // Issue #232: WC timeout doesn't necessarily mean nothing happened —
+    // Ledger Live can finish signing + broadcast asynchronously after
+    // our 120s timer aborts. Probe the chain before surfacing a scary
+    // error to the user. Only run when we have everything the probe
+    // needs (pinned nonce + expected pre-sign hash); otherwise fall
+    // through to the existing timeout error.
+    if (!pinned || !expectedPreSignHash) {
+      throw e;
+    }
+    let probe: LateBroadcastProbeResult;
+    try {
+      probe = await probeForLateBroadcast({
+        client: getClient(tx.chain),
+        from: from as `0x${string}`,
+        pinnedNonce: pinned.nonce,
+        expectedPreSignHash,
+        chainId,
+      });
+    } catch {
+      // Probe-internal failure (RPC down, decoder threw) → fall back
+      // to the existing timeout error. Better the conservative "DO NOT
+      // retry blindly" guidance than a silent partial result.
+      throw e;
+    }
+    if (probe.status === "matched") {
+      // The tx landed while we were waiting — return the on-chain
+      // hash and treat the timeout as a false alarm. The caller's
+      // happy-path post-broadcast block fires unchanged.
+      return probe.txHash;
+    }
+    if (probe.status === "consumed_unmatched") {
+      throw new WalletConnectRequestTimeoutError(
+        consumedUnmatchedMessage({
+          from,
+          pinnedNonce: pinned.nonce,
+          pendingNonce: probe.pendingNonce,
+          chainId,
+          probeWindowBlocks: LATE_BROADCAST_PROBE_BLOCKS,
+        }),
+      );
+    }
+    // probe.status === "no_broadcast" → safe to retry, surface the
+    // confirmed-no-broadcast variant so the agent doesn't fall back to
+    // the conservative original message.
+    throw new WalletConnectRequestTimeoutError(
+      noBroadcastConfirmedMessage({
+        from,
+        pinnedNonce: pinned.nonce,
+        chainId,
+        timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
+      }),
+    );
   });
   return hash;
 }

--- a/test/wc-late-broadcast-probe.test.ts
+++ b/test/wc-late-broadcast-probe.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Issue #232 — proactive late-broadcast detection on WalletConnect
+ * timeout. Unit tests for `probeForLateBroadcast` and the two new
+ * timeout-path message helpers.
+ *
+ * Scope: the probe helper itself (chain probe + recent-block walk).
+ * Exercising the full `requestSendTransaction` timeout integration
+ * needs a stubbed SignClient + session state and is intentionally NOT
+ * covered here; the wording and message helpers below pin the
+ * agent-facing contract that the integration relies on.
+ */
+import { describe, it, expect } from "vitest";
+import { keccak256, serializeTransaction } from "viem";
+import {
+  probeForLateBroadcast,
+  consumedUnmatchedMessage,
+  noBroadcastConfirmedMessage,
+} from "../src/signing/walletconnect.js";
+
+const FROM = "0x1111111111111111111111111111111111111111" as const;
+const RECIPIENT = "0x2222222222222222222222222222222222222222" as const;
+
+interface PinnedFields {
+  nonce: number;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  gas: bigint;
+  to: `0x${string}`;
+  value: bigint;
+  data: `0x${string}`;
+}
+
+const SAMPLE_TX_FIELDS: PinnedFields = {
+  nonce: 273,
+  maxFeePerGas: 50_000_000_000n,
+  maxPriorityFeePerGas: 1_000_000_000n,
+  gas: 100_000n,
+  to: RECIPIENT,
+  value: 0n,
+  data: "0x" as `0x${string}`,
+};
+
+const CHAIN_ID = 1;
+
+/** Compute the EIP-1559 pre-sign hash exactly the way the server pins it. */
+function preSignHashOf(fields: PinnedFields): `0x${string}` {
+  return keccak256(
+    serializeTransaction({
+      type: "eip1559",
+      chainId: CHAIN_ID,
+      nonce: fields.nonce,
+      maxFeePerGas: fields.maxFeePerGas,
+      maxPriorityFeePerGas: fields.maxPriorityFeePerGas,
+      gas: fields.gas,
+      to: fields.to,
+      value: fields.value,
+      data: fields.data,
+    }),
+  );
+}
+
+/**
+ * Build a viem-shaped EIP-1559 tx object as it would appear inside
+ * `client.getBlock({ includeTransactions: true })`. Adds the on-chain
+ * fields the probe doesn't read (hash, blockHash, gasPrice, etc.) so
+ * the type pins are realistic.
+ */
+function eip1559TxOnBlock(
+  fields: PinnedFields,
+  opts: { from?: `0x${string}`; hash?: `0x${string}` } = {},
+) {
+  return {
+    type: "eip1559" as const,
+    hash: opts.hash ?? ("0xabc" + "0".repeat(61)) as `0x${string}`,
+    from: opts.from ?? FROM,
+    to: fields.to,
+    nonce: fields.nonce,
+    maxFeePerGas: fields.maxFeePerGas,
+    maxPriorityFeePerGas: fields.maxPriorityFeePerGas,
+    gas: fields.gas,
+    value: fields.value,
+    input: fields.data,
+    blockHash: ("0x" + "1".repeat(64)) as `0x${string}`,
+    blockNumber: 24_961_478n,
+    transactionIndex: 0,
+    chainId: CHAIN_ID,
+    accessList: [],
+  };
+}
+
+describe("probeForLateBroadcast", () => {
+  it("returns no_broadcast when pending nonce equals the pinned nonce (nothing landed)", async () => {
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce,
+      getBlockNumber: async () => {
+        throw new Error("must not be called when pending=pinned");
+      },
+      getBlock: async () => {
+        throw new Error("must not be called when pending=pinned");
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+    });
+    expect(result.status).toBe("no_broadcast");
+    if (result.status === "no_broadcast") {
+      expect(result.pendingNonce).toBe(SAMPLE_TX_FIELDS.nonce);
+    }
+  });
+
+  it("returns matched + the on-chain hash when the recent-block walk finds the pinned tx", async () => {
+    const expectedHash = ("0xcee2a965b8e35a85dbce7b7389bc5ea2ffb1846c8abdaea676ee709d9d0f0165" as const);
+    const tx = eip1559TxOnBlock(SAMPLE_TX_FIELDS, { hash: expectedHash });
+    const client = {
+      // pendingNonce > pinned → slot consumed, walk required
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce + 1,
+      getBlockNumber: async () => 24_961_480n,
+      getBlock: async ({ blockNumber }: { blockNumber: bigint }) => {
+        // Put the matching tx in the latest block; lower blocks are empty.
+        if (blockNumber === 24_961_480n) {
+          return { number: blockNumber, transactions: [tx] };
+        }
+        return { number: blockNumber, transactions: [] };
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+    });
+    expect(result.status).toBe("matched");
+    if (result.status === "matched") {
+      expect(result.txHash).toBe(expectedHash);
+    }
+  });
+
+  it("returns consumed_unmatched when the slot is taken but no tx in the window matches the pre-sign hash", async () => {
+    // A different tx with the SAME (from, nonce) but DIFFERENT bytes —
+    // e.g. an RBF replacement, or a parallel-tooling submission. The
+    // pre-sign hash must NOT match.
+    const otherFields: PinnedFields = {
+      ...SAMPLE_TX_FIELDS,
+      // Different gas → different RLP → different pre-sign hash
+      gas: 200_000n,
+    };
+    const tx = eip1559TxOnBlock(otherFields, { hash: "0xdead000000000000000000000000000000000000000000000000000000000001" });
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce + 1,
+      getBlockNumber: async () => 24_961_480n,
+      getBlock: async () => ({ number: 24_961_480n, transactions: [tx] }),
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      blockWindow: 4,
+    });
+    expect(result.status).toBe("consumed_unmatched");
+    if (result.status === "consumed_unmatched") {
+      expect(result.pendingNonce).toBe(SAMPLE_TX_FIELDS.nonce + 1);
+    }
+  });
+
+  it("ignores txs that match nonce but are from a different sender", async () => {
+    // Sanity: `from` filter is applied. Same nonce + same hash bytes
+    // wouldn't really exist with a different `from` (RLP encodes the
+    // signer indirectly via signature recovery), but the filter must
+    // run BEFORE the hash compute either way.
+    const otherSender = "0x9999999999999999999999999999999999999999" as const;
+    const tx = eip1559TxOnBlock(SAMPLE_TX_FIELDS, { from: otherSender });
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce + 1,
+      getBlockNumber: async () => 24_961_480n,
+      getBlock: async () => ({ number: 24_961_480n, transactions: [tx] }),
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      blockWindow: 4,
+    });
+    expect(result.status).toBe("consumed_unmatched");
+  });
+
+  it("survives a per-block getBlock failure and continues walking", async () => {
+    // A flaky block fetch in the middle of the window must not abort
+    // the probe — it should skip the block and keep walking.
+    const tx = eip1559TxOnBlock(SAMPLE_TX_FIELDS);
+    const expectedHash = tx.hash;
+    let callCount = 0;
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce + 1,
+      getBlockNumber: async () => 24_961_482n,
+      getBlock: async ({ blockNumber }: { blockNumber: bigint }) => {
+        callCount++;
+        // First two block fetches throw; third returns the matching tx.
+        if (callCount <= 2) throw new Error("rpc-temporarily-unavailable");
+        if (blockNumber === 24_961_480n) {
+          return { number: blockNumber, transactions: [tx] };
+        }
+        return { number: blockNumber, transactions: [] };
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      blockWindow: 8,
+    });
+    expect(result.status).toBe("matched");
+    if (result.status === "matched") expect(result.txHash).toBe(expectedHash);
+  });
+});
+
+describe("noBroadcastConfirmedMessage — issue #232 wording lock", () => {
+  it("tells the agent it's safe to retry the same handle", async () => {
+    const msg = noBroadcastConfirmedMessage({
+      from: FROM,
+      pinnedNonce: 273,
+      chainId: 1,
+      timeoutSeconds: 120,
+    });
+    expect(msg).toContain("did not complete within 120s");
+    expect(msg).toContain("Safe to retry");
+    expect(msg).toContain("SAME handle");
+    expect(msg).toContain(FROM);
+    expect(msg).toContain("273");
+    expect(msg).toContain("Issue #232");
+  });
+});
+
+describe("consumedUnmatchedMessage — issue #232 wording lock", () => {
+  it("tells the agent NOT to retry and points at a block explorer", async () => {
+    const msg = consumedUnmatchedMessage({
+      from: FROM,
+      pinnedNonce: 273,
+      pendingNonce: 274,
+      chainId: 1,
+      probeWindowBlocks: 16,
+    });
+    expect(msg).toContain("DO NOT retry");
+    expect(msg).toContain("nonce is consumed");
+    expect(msg).toContain("block explorer");
+    expect(msg).toContain("pending=274");
+    expect(msg).toContain("pinned=273");
+    expect(msg).toContain("16 blocks");
+    expect(msg).toContain("Issue #232");
+  });
+});


### PR DESCRIPTION
Closes #232.

## Problem

Part (a) of #218 reworded the WC timeout error to discourage blind retries. Part (b) — proactive late-broadcast detection — was never shipped, so the user still sees a scary timeout error before the agent self-corrects with `get_transaction_history`.

Live repro on 2026-04-26: ETH mainnet Uniswap V3 swap, user reviewed >120s on Ledger, server threw the timeout error, agent then queried history and found the swap landed at `0xcee2a965b8e3...` ~10s later. A failure that wasn't a failure.

## Fix

On a 120s WC timeout in `send_transaction`, before throwing, the server now probes the chain itself.

1. **`getTransactionCount(from, "pending")`** — if pending nonce equals pinned nonce, nothing broadcast. Throw a new `noBroadcastConfirmedMessage` that says explicitly "safe to retry the same handle" (strict improvement over the legacy "DO NOT retry blindly").
2. **Pending > pinned**: walk the most-recent 16 blocks for a tx with `from === pinnedFrom && nonce === pinnedNonce`. For each candidate, recompute its EIP-1559 pre-sign hash and compare to the server-pinned value. **Match → return the on-chain tx hash** as if the WC request had succeeded; the user sees the happy-path post-broadcast block.
3. **Slot consumed but no hash match**: throw a new `consumedUnmatchedMessage` flagging an ambiguous outcome (RBF/cancel from another tooling path, parallel tooling, or our tx mined further back than the probe window). Tells the agent NOT to retry and to point the user at a block explorer.

Probe RPC failures fall back to the existing `timeoutMessage` — better the conservative "DO NOT retry blindly" guidance than a silent partial result.

## Implementation

- New exported helper `probeForLateBroadcast` in `src/signing/walletconnect.ts`. Pure function — takes a viem client + `(from, pinnedNonce, expectedPreSignHash, chainId)`, returns one of three structured outcomes. No side effects.
- `requestSendTransaction` accepts an optional third `expectedPreSignHash` arg; on timeout, runs the probe with `getClient(tx.chain)` and decides which message to throw.
- `sendTransaction` in `execution/index.ts` threads the stashed `preSignHash` through.
- 16-block probe window: ~3min on Ethereum (12s blocks), shorter on L2s. Bounded so `eth_getBlockByNumber` fan-out stays cheap.

## Test plan

- [x] `npm run build` clean
- [x] New `test/wc-late-broadcast-probe.test.ts`, 7 cases:
  - All three probe outcomes (`no_broadcast`, `matched`, `consumed_unmatched`)
  - `from`-mismatch filter
  - Mid-walk RPC-flake survival
  - Wording locks for both new message helpers
- [x] Full suite: 1283/1283 pass
- [ ] Manual: trigger a timeout in a real WC session and verify the probe outcome surfaces correctly when (a) the user signs late (matched), (b) the user rejects (no_broadcast), (c) parallel tooling consumes the slot (consumed_unmatched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)