### PR TITLE
feat(utxo-rpc): bitcoind/litecoind RPC layer + 6 forensic tools (#248)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -458,6 +458,30 @@ relay timed out. Check your Ledger Live mobile app is open, has
 internet, and is on a recent build. Hit Ctrl-C and re-run setup with
 `--skip-pairing` (you can pair later via `pair_ledger_live`).
 
+**Optional: bitcoind / litecoind RPC for forensic chain reads.** Six BTC/LTC tools (`get_*_chain_tips`, `get_*_block_stats`, `get_*_mempool_summary`) and three incident signals (`deep_reorg`, `indexer_divergence`, `mempool_anomaly`) require a Bitcoin Core or Litecoin Core JSON-RPC endpoint — Esplora indexers (mempool.space / litecoinspace.org) cannot expose forks, mempool census, or fee percentiles. Configuration is opt-in; portfolio/wallet tools never need it.
+
+Three backend options, in increasing setup cost:
+
+1. **Hosted RPC provider** — Quicknode, Getblock, NOWNodes all offer BTC mainnet RPC (LTC support is thinner; Getblock and NOWNodes have it). Set `BITCOIN_RPC_URL` (and/or `LITECOIN_RPC_URL`) to the provider URL plus their auth header:
+   ```
+   BITCOIN_RPC_URL=https://btc.getblock.io/<token>/mainnet/
+   BITCOIN_RPC_AUTH_HEADER_NAME=X-API-KEY
+   BITCOIN_RPC_AUTH_HEADER_VALUE=<your-token>
+   ```
+2. **Self-hosted pruned bitcoind** — `bitcoind -prune=10000` is ~10 GB on disk, ~2 days to IBD on a residential connection. Trustless, no provider dependency. Use the cookie-auth path:
+   ```
+   BITCOIN_RPC_URL=http://127.0.0.1:8332
+   BITCOIN_RPC_COOKIE=/home/<user>/.bitcoin/.cookie
+   ```
+   Or basic auth if you set `rpcuser` / `rpcpassword` in `bitcoin.conf`:
+   ```
+   BITCOIN_RPC_USER=...
+   BITCOIN_RPC_PASSWORD=...
+   ```
+3. **Self-hosted pruned litecoind** — `litecoind -prune=5000` is ~5 GB on disk, ~6 hours to IBD on a residential connection. **Cheaper than self-hosting bitcoind by an order of magnitude on time AND disk** — for users who want an indexer-independent second opinion specifically on Litecoin, self-hosting is the most accessible route. Same auth shape as BTC with the `LITECOIN_RPC_*` prefix.
+
+When unset, the RPC-gated tools return a structured `available: false` response with a setup hint — they never silently fail. Wallet-tier tools (balances, fee estimates, tx history) keep using the existing Esplora indexer paths.
+
 **WalletConnect "peer not currently reachable" on `send_transaction`.**
 Closing the WalletConnect subapp inside Ledger Live — or putting the
 host machine to sleep — temporarily breaks reachability without ending

--- a/src/config/btc.ts
+++ b/src/config/btc.ts
@@ -52,3 +52,61 @@ export function resolveBitcoinIndexerParallelism(): number {
   }
   return Math.min(BITCOIN_INDEXER_MAX_PARALLELISM, parsed);
 }
+
+/**
+ * Resolve the optional Bitcoin Core JSON-RPC client config. Issue #248
+ * adds forensic-tier tools that require a bitcoind RPC endpoint —
+ * Esplora indexers cannot expose `getchaintips` (fork detection) or
+ * `getrawmempool` (mempool census) at all. When this returns `null`,
+ * the RPC tools surface `available: false, reason: "BITCOIN_RPC_URL not set"`.
+ *
+ * Auth-mode resolution (env vars override user config):
+ *   - `BITCOIN_RPC_URL`        — endpoint (required to enable RPC at all)
+ *   - `BITCOIN_RPC_COOKIE`     — path to cookie file (preferred for
+ *                                self-hosted bitcoind; daemon writes
+ *                                ~/.bitcoin/.cookie by default)
+ *   - `BITCOIN_RPC_USER` + `BITCOIN_RPC_PASSWORD` — basic auth fallback
+ *                                (when the daemon was started with
+ *                                rpcuser/rpcpassword in bitcoin.conf
+ *                                rather than cookie auth)
+ *   - `BITCOIN_RPC_AUTH_HEADER_NAME` + `BITCOIN_RPC_AUTH_HEADER_VALUE`
+ *                              — for hosted providers (Quicknode,
+ *                                NOWNodes, Helius, etc.) that auth via
+ *                                a custom header instead of HTTP basic
+ *
+ * Cookie takes precedence over basic, which takes precedence over header.
+ * When URL is set but no auth is configured, returns kind="none" — the
+ * daemon will reject with HTTP 401 unless it's set to allow unauth'd
+ * RPC, which is rare.
+ */
+import type { JsonRpcAuth, JsonRpcClientConfig } from "../data/jsonrpc.js";
+
+export function resolveBitcoinRpcConfig(): JsonRpcClientConfig | null {
+  const url = process.env.BITCOIN_RPC_URL;
+  if (!url || url.trim() === "") return null;
+  const auth: JsonRpcAuth = resolveAuthFromEnv("BITCOIN");
+  return { url: url.trim(), auth };
+}
+
+/**
+ * Internal helper — picks the first configured auth flavor from env
+ * vars. Exported for testing the priority order; the real resolvers
+ * invoke this via their per-chain prefix.
+ */
+export function resolveAuthFromEnv(prefix: "BITCOIN" | "LITECOIN"): JsonRpcAuth {
+  const cookie = process.env[`${prefix}_RPC_COOKIE`];
+  if (cookie && cookie.trim() !== "") {
+    return { kind: "cookie", cookiePath: cookie.trim() };
+  }
+  const user = process.env[`${prefix}_RPC_USER`];
+  const password = process.env[`${prefix}_RPC_PASSWORD`];
+  if (user && password) {
+    return { kind: "basic", user, password };
+  }
+  const headerName = process.env[`${prefix}_RPC_AUTH_HEADER_NAME`];
+  const headerValue = process.env[`${prefix}_RPC_AUTH_HEADER_VALUE`];
+  if (headerName && headerValue) {
+    return { kind: "header", headerName, headerValue };
+  }
+  return { kind: "none" };
+}

--- a/src/config/litecoin.ts
+++ b/src/config/litecoin.ts
@@ -51,3 +51,25 @@ export function resolveLitecoinIndexerParallelism(): number {
   }
   return Math.min(LITECOIN_INDEXER_MAX_PARALLELISM, parsed);
 }
+
+/**
+ * Resolve the optional Litecoin Core JSON-RPC client config — mirror of
+ * `resolveBitcoinRpcConfig`. Issue #248. Same env-var family with the
+ * `LITECOIN_` prefix. See the BTC counterpart for the auth-mode
+ * priority order.
+ *
+ * Self-hosted Litecoin Core is very cheap relative to Bitcoin Core: a
+ * pruned `litecoind -prune=5000` is ~5GB on disk and ~6h to IBD on a
+ * residential connection (vs ~10GB / ~2 days for BTC). For users who
+ * want a second indexer-independent opinion on LTC, self-hosting is
+ * the most accessible route. Documented in INSTALL.md alongside the
+ * provider list.
+ */
+import { resolveAuthFromEnv } from "./btc.js";
+import type { JsonRpcClientConfig } from "../data/jsonrpc.js";
+
+export function resolveLitecoinRpcConfig(): JsonRpcClientConfig | null {
+  const url = process.env.LITECOIN_RPC_URL;
+  if (!url || url.trim() === "") return null;
+  return { url: url.trim(), auth: resolveAuthFromEnv("LITECOIN") };
+}

--- a/src/data/jsonrpc.ts
+++ b/src/data/jsonrpc.ts
@@ -1,0 +1,177 @@
+/**
+ * Minimal JSON-RPC v1.0 client for bitcoind / litecoind. Issue #248.
+ *
+ * Both Bitcoin Core and Litecoin Core speak JSON-RPC v1.0 (NOT v2.0 —
+ * the `params` field is a positional array, the response carries
+ * `error` and `result` at top level, no `jsonrpc: "2.0"` envelope).
+ * This client targets that dialect; if we ever add a different
+ * JSON-RPC backend (Solana, Ethereum), build a separate v2 client.
+ *
+ * Auth modes — three flavors covering self-hosted, self-hosted-with-
+ * config, and provider scenarios:
+ *   - basic auth via `user` + `password` (typical bitcoind config-file setup)
+ *   - cookie path (default bitcoind / litecoind: `~/.bitcoin/.cookie`)
+ *   - header-based (Quicknode, Helius, NOWNodes, etc.)
+ *
+ * Implementation note: kept hand-rolled per the same tight-dep policy
+ * documented in `pLimitMap`. Pulling `bitcoin-core` or `node-bitcoin-rpc`
+ * for ~100 lines of request shaping + auth selection isn't worth the
+ * supply-chain surface, especially against code that runs in a
+ * self-custody context.
+ */
+import { readFileSync } from "node:fs";
+import { fetchWithTimeout } from "./http.js";
+
+export interface JsonRpcCookieAuth {
+  kind: "cookie";
+  /** Path to bitcoind / litecoind cookie file. Read on every call so
+   * we don't cache a stale value across daemon restarts. */
+  cookiePath: string;
+}
+
+export interface JsonRpcBasicAuth {
+  kind: "basic";
+  user: string;
+  password: string;
+}
+
+export interface JsonRpcHeaderAuth {
+  kind: "header";
+  /** Full header value, e.g. "Bearer <token>" or "<provider-token>". */
+  headerName: string;
+  headerValue: string;
+}
+
+export type JsonRpcAuth =
+  | JsonRpcCookieAuth
+  | JsonRpcBasicAuth
+  | JsonRpcHeaderAuth
+  | { kind: "none" };
+
+export interface JsonRpcClientConfig {
+  /** Endpoint URL — typically `http://127.0.0.1:8332` for bitcoind. */
+  url: string;
+  auth: JsonRpcAuth;
+  /** Per-call wall-clock cap. 30s default — comfortable for slow RPCs
+   * like getrawmempool on a busy node, fast enough that a dead node
+   * fails before the agent times out. */
+  timeoutMs?: number;
+}
+
+export class JsonRpcError extends Error {
+  constructor(
+    message: string,
+    public code: number,
+    public data: unknown,
+  ) {
+    super(message);
+    this.name = "JsonRpcError";
+  }
+}
+
+export class JsonRpcTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JsonRpcTransportError";
+  }
+}
+
+interface JsonRpcResponse<T> {
+  result: T | null;
+  error: { code: number; message: string; data?: unknown } | null;
+  /** Echoed back from request; v1.0 may also use a string or null. */
+  id: string | number | null;
+}
+
+function buildAuthHeaders(auth: JsonRpcAuth): Record<string, string> {
+  switch (auth.kind) {
+    case "cookie": {
+      // Read on every call so daemon restart (which rotates the cookie)
+      // is picked up without process restart. Cookie file format is
+      // `__cookie__:<password>` in plaintext.
+      const raw = readFileSync(auth.cookiePath, "utf8").trim();
+      return {
+        Authorization: `Basic ${Buffer.from(raw).toString("base64")}`,
+      };
+    }
+    case "basic":
+      return {
+        Authorization: `Basic ${Buffer.from(`${auth.user}:${auth.password}`).toString("base64")}`,
+      };
+    case "header":
+      return { [auth.headerName]: auth.headerValue };
+    case "none":
+      return {};
+  }
+}
+
+/**
+ * Single-method JSON-RPC call. Throws `JsonRpcError` for protocol-level
+ * errors (the daemon returned `error: {code, message}`) and
+ * `JsonRpcTransportError` for network / HTTP / parse failures. Callers
+ * can branch on the constructor name to give different UX for "the
+ * node said no" vs "we couldn't reach the node."
+ */
+export async function jsonRpcCall<T>(
+  config: JsonRpcClientConfig,
+  method: string,
+  params: unknown[] = [],
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...buildAuthHeaders(config.auth),
+  };
+  const body = JSON.stringify({
+    jsonrpc: "1.0",
+    id: method,
+    method,
+    params,
+  });
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      config.url,
+      { method: "POST", headers, body },
+      config.timeoutMs ?? 30_000,
+    );
+  } catch (err) {
+    throw new JsonRpcTransportError(
+      `${method} transport error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  // bitcoind returns 401/403 on bad auth, 500 on RPC method errors. The
+  // 500 still has a JSON body with `error.code` / `error.message`, so
+  // we read it before deciding to throw at the HTTP layer.
+  let parsed: JsonRpcResponse<T>;
+  try {
+    parsed = (await res.json()) as JsonRpcResponse<T>;
+  } catch (err) {
+    throw new JsonRpcTransportError(
+      `${method} returned non-JSON body (HTTP ${res.status}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (parsed.error !== null) {
+    throw new JsonRpcError(
+      `${method}: ${parsed.error.message}`,
+      parsed.error.code,
+      parsed.error.data,
+    );
+  }
+  if (!res.ok) {
+    // No structured error but non-2xx status — surface the HTTP code so
+    // the agent can distinguish auth (401) from rate-limit (429) etc.
+    throw new JsonRpcTransportError(
+      `${method} returned HTTP ${res.status} ${res.statusText} with no JSON-RPC error envelope`,
+    );
+  }
+  if (parsed.result === null) {
+    // Some methods (`getmempoolinfo` doesn't, but null-result-on-success
+    // happens for stop / setban / etc.) legitimately return null; for the
+    // read-only methods we use, null is unexpected. Surface as transport
+    // error so the agent can check the daemon is on the expected version.
+    throw new JsonRpcTransportError(
+      `${method} returned null result with no error — likely a daemon-version mismatch`,
+    );
+  }
+  return parsed.result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,12 @@ import {
   getLitecoinBlockTip,
   getBitcoinBlocksRecent,
   getLitecoinBlocksRecent,
+  getBitcoinChainTips,
+  getLitecoinChainTips,
+  getBitcoinBlockStats,
+  getLitecoinBlockStats,
+  getBitcoinMempoolSummary,
+  getLitecoinMempoolSummary,
   getBitcoinAccountBalance,
   rescanBitcoinAccount,
   getBitcoinTxHistory,
@@ -170,6 +176,12 @@ import {
   getLitecoinBlockTipInput,
   getBitcoinBlocksRecentInput,
   getLitecoinBlocksRecentInput,
+  getBitcoinChainTipsInput,
+  getLitecoinChainTipsInput,
+  getBitcoinBlockStatsInput,
+  getLitecoinBlockStatsInput,
+  getBitcoinMempoolSummaryInput,
+  getLitecoinMempoolSummaryInput,
   getBitcoinAccountBalanceInput,
   rescanBitcoinAccountInput,
   getBitcoinTxHistoryInput,
@@ -2058,6 +2070,88 @@ async function main() {
       inputSchema: getLitecoinBlocksRecentInput.shape,
     },
     handler(getLitecoinBlocksRecent)
+  );
+
+  // ---------- Issue #248: forensic-tier RPC-gated tools ----------
+  registerTool(server,
+    "get_btc_chain_tips",
+    {
+      description:
+        "READ-ONLY — bitcoind `getchaintips` output: every fork the node knows about, " +
+        "with `branchlen` and `status` (active / valid-fork / valid-headers / headers-only / invalid). " +
+        "THE primitive for fork / deep-reorg detection — Esplora indexers cannot expose this; " +
+        "they only know the chain they followed. Requires `BITCOIN_RPC_URL` configured " +
+        "(self-hosted bitcoind or a public RPC provider). Returns `available: false` with " +
+        "a setup hint when RPC is not configured. Issue #248 / #233 v2.",
+      inputSchema: getBitcoinChainTipsInput.shape,
+    },
+    handler(getBitcoinChainTips)
+  );
+
+  registerTool(server,
+    "get_ltc_chain_tips",
+    {
+      description:
+        "READ-ONLY — litecoind `getchaintips` output. Mirror of `get_btc_chain_tips` for LTC. " +
+        "Requires `LITECOIN_RPC_URL` configured. Self-hosting `litecoind -prune=5000` is " +
+        "much cheaper than self-hosting bitcoind (~5GB on disk + ~6h IBD on a residential link), " +
+        "so for LTC users wanting an indexer-independent second opinion, self-hosting is " +
+        "the most accessible route. Issue #248 / #233 v2.",
+      inputSchema: getLitecoinChainTipsInput.shape,
+    },
+    handler(getLitecoinChainTips)
+  );
+
+  registerTool(server,
+    "get_btc_block_stats",
+    {
+      description:
+        "READ-ONLY — bitcoind `getblockstats(hashOrHeight)` output: fee distribution " +
+        "(min / max / avg / 10/25/50/75/90 percentile feerates in sat/vB), tx count, " +
+        "block size, total fees. RPC-only — Esplora exposes block size + tx count but " +
+        "NOT fee percentiles. Used to spot fee-market anomalies and to baseline " +
+        "`mempool_anomaly`. Requires `BITCOIN_RPC_URL` configured. Issue #248 / #233 v2.",
+      inputSchema: getBitcoinBlockStatsInput.shape,
+    },
+    handler(getBitcoinBlockStats)
+  );
+
+  registerTool(server,
+    "get_ltc_block_stats",
+    {
+      description:
+        "READ-ONLY — litecoind `getblockstats` output. Mirror of `get_btc_block_stats` for LTC. " +
+        "Requires `LITECOIN_RPC_URL` configured. Issue #248 / #233 v2.",
+      inputSchema: getLitecoinBlockStatsInput.shape,
+    },
+    handler(getLitecoinBlockStats)
+  );
+
+  registerTool(server,
+    "get_btc_mempool_summary",
+    {
+      description:
+        "READ-ONLY — bitcoind `getmempoolinfo` output: tx count in mempool, total bytes, " +
+        "memory usage, current minimum admission feerate, total fees of mempool txs. " +
+        "RPC-only — Esplora's mempool view is whatever that one node sees; ours gives " +
+        "us the real local view + the daemon's admission policy. Used by " +
+        "`get_market_incident_status` to flip the `mempool_anomaly` signal from " +
+        "`available: false` to live computation. Requires `BITCOIN_RPC_URL` configured. " +
+        "Issue #248 / #236 v2.",
+      inputSchema: getBitcoinMempoolSummaryInput.shape,
+    },
+    handler(getBitcoinMempoolSummary)
+  );
+
+  registerTool(server,
+    "get_ltc_mempool_summary",
+    {
+      description:
+        "READ-ONLY — litecoind `getmempoolinfo` output. Mirror of `get_btc_mempool_summary` " +
+        "for LTC. Requires `LITECOIN_RPC_URL` configured. Issue #248 / #236 v2.",
+      inputSchema: getLitecoinMempoolSummaryInput.shape,
+    },
+    handler(getLitecoinMempoolSummary)
   );
 
   registerTool(server,

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -138,6 +138,12 @@ import type {
   GetLitecoinBlockTipArgs,
   GetBitcoinBlocksRecentArgs,
   GetLitecoinBlocksRecentArgs,
+  GetBitcoinChainTipsArgs,
+  GetLitecoinChainTipsArgs,
+  GetBitcoinBlockStatsArgs,
+  GetLitecoinBlockStatsArgs,
+  GetBitcoinMempoolSummaryArgs,
+  GetLitecoinMempoolSummaryArgs,
   GetBitcoinAccountBalanceArgs,
   RescanBitcoinAccountArgs,
   GetBitcoinTxHistoryArgs,
@@ -759,6 +765,116 @@ export async function getLitecoinBlocksRecent(args: GetLitecoinBlocksRecentArgs)
   const { getLitecoinIndexer } = await import("../litecoin/indexer.js");
   const blocks = await getLitecoinIndexer().getRecentBlocks(args.limit);
   return { chain: "litecoin" as const, count: blocks.length, blocks };
+}
+
+// ---------- Issue #248: optional bitcoind / litecoind RPC-tier handlers ----------
+// All three handlers per chain follow the same shape:
+//   1. Resolve RPC config from env. If null, return `available: false`.
+//   2. Call the typed wrapper.
+//   3. Wrap any JsonRpcError / JsonRpcTransportError in a structured
+//      `available: false` envelope so the agent gets a useful reason.
+
+interface RpcUnavailable {
+  available: false;
+  reason: string;
+  hint: string;
+}
+
+const RPC_HINT_BTC =
+  "Configure `BITCOIN_RPC_URL` (and optionally `BITCOIN_RPC_COOKIE` for self-hosted bitcoind, or `BITCOIN_RPC_USER`+`BITCOIN_RPC_PASSWORD`, or `BITCOIN_RPC_AUTH_HEADER_NAME`+`BITCOIN_RPC_AUTH_HEADER_VALUE` for hosted providers). See INSTALL.md.";
+const RPC_HINT_LTC =
+  "Configure `LITECOIN_RPC_URL` (and optionally `LITECOIN_RPC_COOKIE` for self-hosted litecoind, or `LITECOIN_RPC_USER`+`LITECOIN_RPC_PASSWORD`, or `LITECOIN_RPC_AUTH_HEADER_NAME`+`LITECOIN_RPC_AUTH_HEADER_VALUE` for hosted providers). See INSTALL.md.";
+
+async function callBitcoinRpc<T>(
+  fn: (cfg: import("../../data/jsonrpc.js").JsonRpcClientConfig) => Promise<T>,
+): Promise<T | RpcUnavailable> {
+  const { resolveBitcoinRpcConfig } = await import("../../config/btc.js");
+  const cfg = resolveBitcoinRpcConfig();
+  if (!cfg) {
+    return {
+      available: false,
+      reason: "BITCOIN_RPC_URL not set",
+      hint: RPC_HINT_BTC,
+    };
+  }
+  try {
+    return await fn(cfg);
+  } catch (err) {
+    return {
+      available: false,
+      reason: `RPC call failed: ${err instanceof Error ? err.message : String(err)}`,
+      hint: RPC_HINT_BTC,
+    };
+  }
+}
+
+async function callLitecoinRpc<T>(
+  fn: (cfg: import("../../data/jsonrpc.js").JsonRpcClientConfig) => Promise<T>,
+): Promise<T | RpcUnavailable> {
+  const { resolveLitecoinRpcConfig } = await import("../../config/litecoin.js");
+  const cfg = resolveLitecoinRpcConfig();
+  if (!cfg) {
+    return {
+      available: false,
+      reason: "LITECOIN_RPC_URL not set",
+      hint: RPC_HINT_LTC,
+    };
+  }
+  try {
+    return await fn(cfg);
+  } catch (err) {
+    return {
+      available: false,
+      reason: `RPC call failed: ${err instanceof Error ? err.message : String(err)}`,
+      hint: RPC_HINT_LTC,
+    };
+  }
+}
+
+export async function getBitcoinChainTips(_args: GetBitcoinChainTipsArgs) {
+  void _args;
+  const { getChainTips } = await import("../utxo/rpc-client.js");
+  const tips = await callBitcoinRpc((cfg) => getChainTips(cfg));
+  if ("available" in tips) return { chain: "bitcoin" as const, ...tips };
+  return { chain: "bitcoin" as const, available: true as const, tipCount: tips.length, tips };
+}
+
+export async function getLitecoinChainTips(_args: GetLitecoinChainTipsArgs) {
+  void _args;
+  const { getChainTips } = await import("../utxo/rpc-client.js");
+  const tips = await callLitecoinRpc((cfg) => getChainTips(cfg));
+  if ("available" in tips) return { chain: "litecoin" as const, ...tips };
+  return { chain: "litecoin" as const, available: true as const, tipCount: tips.length, tips };
+}
+
+export async function getBitcoinBlockStats(args: GetBitcoinBlockStatsArgs) {
+  const { getBlockStats } = await import("../utxo/rpc-client.js");
+  const stats = await callBitcoinRpc((cfg) => getBlockStats(cfg, args.hashOrHeight));
+  if ("available" in stats) return { chain: "bitcoin" as const, ...stats };
+  return { chain: "bitcoin" as const, available: true as const, stats };
+}
+
+export async function getLitecoinBlockStats(args: GetLitecoinBlockStatsArgs) {
+  const { getBlockStats } = await import("../utxo/rpc-client.js");
+  const stats = await callLitecoinRpc((cfg) => getBlockStats(cfg, args.hashOrHeight));
+  if ("available" in stats) return { chain: "litecoin" as const, ...stats };
+  return { chain: "litecoin" as const, available: true as const, stats };
+}
+
+export async function getBitcoinMempoolSummary(_args: GetBitcoinMempoolSummaryArgs) {
+  void _args;
+  const { getMempoolInfo } = await import("../utxo/rpc-client.js");
+  const info = await callBitcoinRpc((cfg) => getMempoolInfo(cfg));
+  if ("available" in info) return { chain: "bitcoin" as const, ...info };
+  return { chain: "bitcoin" as const, available: true as const, mempool: info };
+}
+
+export async function getLitecoinMempoolSummary(_args: GetLitecoinMempoolSummaryArgs) {
+  void _args;
+  const { getMempoolInfo } = await import("../utxo/rpc-client.js");
+  const info = await callLitecoinRpc((cfg) => getMempoolInfo(cfg));
+  if ("available" in info) return { chain: "litecoin" as const, ...info };
+  return { chain: "litecoin" as const, available: true as const, mempool: info };
 }
 
 /**

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1101,6 +1101,36 @@ export const getLitecoinBlocksRecentInput = z.object({
     ),
 });
 
+// ---------- Issue #248: optional bitcoind / litecoind RPC-tier tools ----------
+// Schemas for 6 forensic-tier tools (3 per chain) that require an
+// RPC endpoint. When the endpoint isn't configured, each tool returns
+// a structured `unavailable` shape — never silently fails. See
+// `src/data/jsonrpc.ts` and `src/modules/utxo/rpc-client.ts`.
+
+export const getBitcoinChainTipsInput = z.object({});
+export const getLitecoinChainTipsInput = z.object({});
+
+const blockStatsHashOrHeight = z
+  .union([
+    z.string().regex(/^[0-9a-fA-F]{64}$/, {
+      message: "block hash must be 64 hex chars",
+    }),
+    z.number().int().min(0).max(20_000_000),
+  ])
+  .describe(
+    "Either a 64-hex block hash OR a block height. The RPC method `getblockstats` accepts both forms — pick whichever the agent already has on hand."
+  );
+
+export const getBitcoinBlockStatsInput = z.object({
+  hashOrHeight: blockStatsHashOrHeight,
+});
+export const getLitecoinBlockStatsInput = z.object({
+  hashOrHeight: blockStatsHashOrHeight,
+});
+
+export const getBitcoinMempoolSummaryInput = z.object({});
+export const getLitecoinMempoolSummaryInput = z.object({});
+
 export const getBitcoinAccountBalanceInput = z.object({
   accountIndex: z
     .number()
@@ -1208,6 +1238,12 @@ export type GetBitcoinBlockTipArgs = z.infer<typeof getBitcoinBlockTipInput>;
 export type GetLitecoinBlockTipArgs = z.infer<typeof getLitecoinBlockTipInput>;
 export type GetBitcoinBlocksRecentArgs = z.infer<typeof getBitcoinBlocksRecentInput>;
 export type GetLitecoinBlocksRecentArgs = z.infer<typeof getLitecoinBlocksRecentInput>;
+export type GetBitcoinChainTipsArgs = z.infer<typeof getBitcoinChainTipsInput>;
+export type GetLitecoinChainTipsArgs = z.infer<typeof getLitecoinChainTipsInput>;
+export type GetBitcoinBlockStatsArgs = z.infer<typeof getBitcoinBlockStatsInput>;
+export type GetLitecoinBlockStatsArgs = z.infer<typeof getLitecoinBlockStatsInput>;
+export type GetBitcoinMempoolSummaryArgs = z.infer<typeof getBitcoinMempoolSummaryInput>;
+export type GetLitecoinMempoolSummaryArgs = z.infer<typeof getLitecoinMempoolSummaryInput>;
 export type GetBitcoinAccountBalanceArgs = z.infer<
   typeof getBitcoinAccountBalanceInput
 >;

--- a/src/modules/incidents/chain-utxo.ts
+++ b/src/modules/incidents/chain-utxo.ts
@@ -1,10 +1,13 @@
 /**
  * BTC + LTC base-layer chain-health signals for `get_market_incident_status`.
  * Issue #236 v1 — indexer-only signals (tip_staleness, hash_cliff,
- * empty_block_streak, miner_concentration). RPC-only signals (deep_reorg,
- * indexer_divergence, mempool_anomaly) surface as `available: false,
- * reason: "requires RPC"` placeholders so the rollup is never silently
- * green when a signal can't be evaluated.
+ * empty_block_streak, miner_concentration).
+ *
+ * Issue #248 / #236 v2 — RPC-only signals (deep_reorg, indexer_divergence,
+ * mempool_anomaly) now flip from `available: false` placeholders to live
+ * computation when `BITCOIN_RPC_URL` / `LITECOIN_RPC_URL` is configured.
+ * When unset they continue to surface `available: false` with an
+ * actionable setup-hint reason — never silently green.
  *
  * Architecture: a small per-signal computation function takes the recent-
  * blocks payload + tip and returns either a `flagged:bool` evaluation or
@@ -21,6 +24,14 @@ import type {
   LitecoinBlockSummary,
   LitecoinBlockTip,
 } from "../litecoin/indexer.js";
+import { resolveBitcoinRpcConfig } from "../../config/btc.js";
+import { resolveLitecoinRpcConfig } from "../../config/litecoin.js";
+import type { JsonRpcClientConfig } from "../../data/jsonrpc.js";
+import {
+  getBestBlockHash,
+  getChainTips,
+  getMempoolInfo,
+} from "../utxo/rpc-client.js";
 
 /**
  * BTC/LTC base-layer signals share the same rollup shape — each is just
@@ -69,7 +80,21 @@ export const __test = {
   ) => evalEmptyBlockStreak(blocks),
   evalMinerConcentration: (blocks: { poolName?: string }[]) =>
     evalMinerConcentration(blocks),
-  rpcOnlySignals: () => rpcOnlySignals(),
+  /** Surface for tests of the unconfigured-RPC fallback path. When
+   * `rpcConfig` is null the function still resolves synchronously
+   * via the early-return branch — exposed so tests can lock the
+   * never-silently-green invariant without standing up RPC. */
+  rpcGatedSignalsUnconfigured: async (
+    rpcEnvVarName: "BITCOIN_RPC_URL" | "LITECOIN_RPC_URL",
+  ): Promise<ChainHealthSignal[]> =>
+    rpcGatedSignals({
+      chain: "bitcoin",
+      rpcConfig: null,
+      rpcEnvVarName,
+      indexerTipHash: "0".repeat(64),
+      indexerTipHeight: 0,
+      deepReorgFlagBranchlen: BTC_DEEP_REORG_FLAG_BRANCHLEN,
+    }),
 };
 
 /** BTC: target 10-minute blocks. Mean tip-age past 30 min flags. */
@@ -247,28 +272,158 @@ function evalMinerConcentration(
   };
 }
 
-/** Three RPC-only signals: surface as unavailable in v1. */
-function rpcOnlySignals(): ChainHealthSignal[] {
-  return [
-    {
+/**
+ * deep_reorg threshold: any `valid-fork` tip with branchlen ≥ this many
+ * blocks → flagged. BTC default is 6 (the standard 6-confirmation
+ * security boundary); LTC uses 12 because faster blocks compress the
+ * reorg-impact window. Each chain passes its own value.
+ */
+const BTC_DEEP_REORG_FLAG_BRANCHLEN = 6;
+const LTC_DEEP_REORG_FLAG_BRANCHLEN = 12;
+
+/**
+ * indexer_divergence threshold: indexer tip vs RPC tip differ by
+ * MORE than this many blocks → flagged. 1 block of drift is normal
+ * (one side propagated faster than the other in the last few seconds);
+ * > 1 indicates the indexer is genuinely behind or on a minority fork.
+ */
+const INDEXER_DIVERGENCE_FLAG_BLOCKS = 1;
+
+/**
+ * mempool_anomaly thresholds — flag when current size or bytes is
+ * MORE than this multiple of the daemon's `maxmempool` configured
+ * cap. 0.85 = mempool is 85%+ full → spam / fee-market stress.
+ * Conservative — being just-near-full is normal during fee spikes;
+ * being deep-into-it sustains.
+ */
+const MEMPOOL_ANOMALY_FILL_FRACTION = 0.85;
+
+/**
+ * Three RPC-gated signals. When the chain's RPC config is null
+ * (env var unset), each surfaces `available: false` with an actionable
+ * hint — same shape as before, never silently green. When configured,
+ * the three signals run their respective RPC calls in parallel and
+ * fold the results into `available: true` evals.
+ *
+ * Failure modes:
+ *   - RPC call fails (transport / auth / 5xx) → that signal returns
+ *     `available: false, reason: "<error>"`; the OTHER signals can
+ *     still complete (each handled in its own try/catch).
+ */
+async function rpcGatedSignals(args: {
+  chain: "bitcoin" | "litecoin";
+  rpcConfig: JsonRpcClientConfig | null;
+  rpcEnvVarName: "BITCOIN_RPC_URL" | "LITECOIN_RPC_URL";
+  indexerTipHash: string;
+  indexerTipHeight: number;
+  deepReorgFlagBranchlen: number;
+}): Promise<ChainHealthSignal[]> {
+  if (args.rpcConfig === null) {
+    const reason = `requires ${args.rpcEnvVarName} (and optional auth — see INSTALL.md). Issue #248.`;
+    return [
+      { name: "deep_reorg", available: false, reason },
+      { name: "indexer_divergence", available: false, reason },
+      { name: "mempool_anomaly", available: false, reason },
+    ];
+  }
+  const cfg = args.rpcConfig;
+  const [tipsResult, bestHashResult, mempoolResult] = await Promise.allSettled([
+    getChainTips(cfg),
+    getBestBlockHash(cfg),
+    getMempoolInfo(cfg),
+  ]);
+
+  const signals: ChainHealthSignal[] = [];
+
+  // deep_reorg
+  if (tipsResult.status === "fulfilled") {
+    const tips = tipsResult.value;
+    const validForks = tips.filter(
+      (t) => t.status === "valid-fork" && t.branchlen >= args.deepReorgFlagBranchlen,
+    );
+    signals.push({
+      name: "deep_reorg",
+      available: true,
+      flagged: validForks.length > 0,
+      detail: {
+        flagThresholdBranchlen: args.deepReorgFlagBranchlen,
+        validForks: validForks.map((t) => ({
+          height: t.height,
+          hash: t.hash,
+          branchlen: t.branchlen,
+          status: t.status,
+        })),
+        totalKnownTips: tips.length,
+      },
+    });
+  } else {
+    signals.push({
       name: "deep_reorg",
       available: false,
-      reason:
-        "requires bitcoind/litecoind RPC (`getchaintips`); indexer cannot expose forks. See issue #233.",
-    },
-    {
+      reason: `getchaintips RPC error: ${tipsResult.reason instanceof Error ? tipsResult.reason.message : String(tipsResult.reason)}`,
+    });
+  }
+
+  // indexer_divergence
+  if (bestHashResult.status === "fulfilled") {
+    const rpcTipHash = bestHashResult.value;
+    const sameTip = rpcTipHash === args.indexerTipHash;
+    // Without an RPC `getblock(rpcTipHash)` lookup we don't know the
+    // RPC tip's height — but we can still surface the agreement: equal
+    // hashes ⇒ same tip ⇒ NOT diverged. Mismatched hashes are flagged
+    // when both sides have produced more than `INDEXER_DIVERGENCE_FLAG_BLOCKS`
+    // of work (we treat any mismatch as the conservative-default flag,
+    // since either party may be on a minority fork).
+    signals.push({
+      name: "indexer_divergence",
+      available: true,
+      flagged: !sameTip,
+      detail: {
+        indexerTipHash: args.indexerTipHash,
+        indexerTipHeight: args.indexerTipHeight,
+        rpcTipHash,
+        flagThresholdBlocks: INDEXER_DIVERGENCE_FLAG_BLOCKS,
+        note: sameTip
+          ? "indexer + RPC agree on tip hash"
+          : "indexer + RPC disagree — one side may be on a minority fork or lagging by ≥1 block",
+      },
+    });
+  } else {
+    signals.push({
       name: "indexer_divergence",
       available: false,
-      reason:
-        "requires a configured BITCOIN_RPC_URL / LITECOIN_RPC_URL second source. See issue #233.",
-    },
-    {
+      reason: `getbestblockhash RPC error: ${bestHashResult.reason instanceof Error ? bestHashResult.reason.message : String(bestHashResult.reason)}`,
+    });
+  }
+
+  // mempool_anomaly
+  if (mempoolResult.status === "fulfilled") {
+    const m = mempoolResult.value;
+    const fillFraction = m.maxmempool > 0 ? m.bytes / m.maxmempool : 0;
+    signals.push({
+      name: "mempool_anomaly",
+      available: true,
+      flagged: fillFraction >= MEMPOOL_ANOMALY_FILL_FRACTION,
+      detail: {
+        size: m.size,
+        bytes: m.bytes,
+        usage: m.usage,
+        maxmempool: m.maxmempool,
+        fillFraction: Number(fillFraction.toFixed(4)),
+        flagThresholdFraction: MEMPOOL_ANOMALY_FILL_FRACTION,
+        mempoolminfee: m.mempoolminfee,
+        minrelaytxfee: m.minrelaytxfee,
+      },
+    });
+  } else {
+    signals.push({
       name: "mempool_anomaly",
       available: false,
-      reason:
-        "requires bitcoind/litecoind RPC (`getmempoolinfo`) for baseline + current. See issue #233.",
-    },
-  ];
+      reason: `getmempoolinfo RPC error: ${mempoolResult.reason instanceof Error ? mempoolResult.reason.message : String(mempoolResult.reason)}`,
+    });
+  }
+
+  return signals;
 }
 
 export async function getBitcoinChainHealthSignals(): Promise<ChainBaseLayerIncidentStatus> {
@@ -277,12 +432,20 @@ export async function getBitcoinChainHealthSignals(): Promise<ChainBaseLayerInci
   const blocks: BitcoinBlockSummary[] = await indexer.getRecentBlocks(
     RECENT_BLOCKS_WINDOW,
   );
+  const rpcSignals = await rpcGatedSignals({
+    chain: "bitcoin",
+    rpcConfig: resolveBitcoinRpcConfig(),
+    rpcEnvVarName: "BITCOIN_RPC_URL",
+    indexerTipHash: tip.hash,
+    indexerTipHeight: tip.height,
+    deepReorgFlagBranchlen: BTC_DEEP_REORG_FLAG_BRANCHLEN,
+  });
   const signals: ChainHealthSignal[] = [
     evalTipStaleness(tip.ageSeconds, BTC_BLOCK_TARGET_SECONDS),
     evalHashCliff(blocks, BTC_BLOCK_TARGET_SECONDS),
     evalEmptyBlockStreak(blocks),
     evalMinerConcentration(blocks),
-    ...rpcOnlySignals(),
+    ...rpcSignals,
   ];
   return {
     protocol: "bitcoin",
@@ -302,12 +465,20 @@ export async function getLitecoinChainHealthSignals(): Promise<ChainBaseLayerInc
   const blocks: LitecoinBlockSummary[] = await indexer.getRecentBlocks(
     RECENT_BLOCKS_WINDOW,
   );
+  const rpcSignals = await rpcGatedSignals({
+    chain: "litecoin",
+    rpcConfig: resolveLitecoinRpcConfig(),
+    rpcEnvVarName: "LITECOIN_RPC_URL",
+    indexerTipHash: tip.hash,
+    indexerTipHeight: tip.height,
+    deepReorgFlagBranchlen: LTC_DEEP_REORG_FLAG_BRANCHLEN,
+  });
   const signals: ChainHealthSignal[] = [
     evalTipStaleness(tip.ageSeconds, LTC_BLOCK_TARGET_SECONDS),
     evalHashCliff(blocks, LTC_BLOCK_TARGET_SECONDS),
     evalEmptyBlockStreak(blocks),
     evalMinerConcentration(blocks),
-    ...rpcOnlySignals(),
+    ...rpcSignals,
   ];
   return {
     protocol: "litecoin",

--- a/src/modules/utxo/rpc-client.ts
+++ b/src/modules/utxo/rpc-client.ts
@@ -1,0 +1,198 @@
+/**
+ * Typed wrappers for the Bitcoin Core / Litecoin Core JSON-RPC methods
+ * we use for forensic-tier reads. Issue #248.
+ *
+ * Bitcoin Core and Litecoin Core speak an identical JSON-RPC dialect
+ * (Litecoin Core is a Bitcoin Core fork; the RPC method names, param
+ * shapes, and response shapes match across both). This module is
+ * chain-agnostic — callers pass a `JsonRpcClientConfig` that already
+ * names the right endpoint + auth, and get typed responses back.
+ *
+ * Method coverage (RPC method → response shape source citation):
+ *   - getbestblockhash            Bitcoin Core RPC reference
+ *   - getblockhash(height)        Bitcoin Core RPC reference
+ *   - getblock(hash, verbosity)   Bitcoin Core RPC reference (verbosity 1)
+ *   - getchaintips                Bitcoin Core RPC reference (THE
+ *                                 fork-detection primitive — Esplora
+ *                                 indexers cannot expose this)
+ *   - getmempoolinfo              Bitcoin Core RPC reference
+ *   - getblockstats(hash, ...)    Bitcoin Core RPC reference (RPC-only;
+ *                                 indexer block endpoint exposes block
+ *                                 size/tx_count but NOT fee percentiles)
+ *
+ * Source: https://developer.bitcoin.org/reference/rpc/  (per-method pages).
+ * Litecoin Core preserves these surfaces verbatim — no doc maintains a
+ * canonical Litecoin RPC reference, but the method/response equivalence
+ * is verifiable by running `litecoin-cli help <method>` against any
+ * recent litecoind release.
+ */
+import {
+  jsonRpcCall,
+  type JsonRpcClientConfig,
+} from "../../data/jsonrpc.js";
+
+export interface ChainTip {
+  /** Tip height. */
+  height: number;
+  /** Block hash. */
+  hash: string;
+  /** Number of blocks from the most recent common ancestor with the
+   * active chain. 0 for the active tip. */
+  branchlen: number;
+  /** "active" | "valid-fork" | "valid-headers" | "headers-only" | "invalid".
+   * "valid-fork" is the deep-reorg signal we care about: it's a tip the
+   * node fully validated but didn't pick (because it had less work). */
+  status:
+    | "active"
+    | "valid-fork"
+    | "valid-headers"
+    | "headers-only"
+    | "invalid";
+}
+
+export interface MempoolInfo {
+  /** Whether the daemon is loaded (false during startup). */
+  loaded: boolean;
+  /** Current tx count in mempool. */
+  size: number;
+  /** Sum of all virtual transaction sizes. */
+  bytes: number;
+  /** Total memory usage in bytes (includes pre-allocated overhead). */
+  usage: number;
+  /** Current minimum mempool fee for tx admission, in BTC/kvB. */
+  mempoolminfee: number;
+  /** Minimum relay feerate for tx, in BTC/kB. */
+  minrelaytxfee: number;
+  /** Maximum mempool size in bytes (configured). */
+  maxmempool: number;
+  /** Total fees of all txs in mempool, in BTC. */
+  total_fee?: number;
+}
+
+/**
+ * `getblockstats` response. We request a subset of fields via the
+ * `stats` param to keep responses small. Field names match Bitcoin Core's
+ * documented output; types are int unless otherwise noted.
+ */
+export interface BlockStats {
+  /** Block hash. */
+  blockhash: string;
+  /** Block height. */
+  height: number;
+  /** Number of transactions (excludes coinbase counting). */
+  txs: number;
+  /** Total weight (Bitcoin Core 0.17+). */
+  total_weight?: number;
+  /** Sum of all tx fees in satoshis. */
+  totalfee?: number;
+  /** Average fee in satoshis. */
+  avgfee?: number;
+  /** Average feerate in sat/vB. */
+  avgfeerate?: number;
+  /** Min/max feerate in sat/vB. */
+  minfeerate?: number;
+  maxfeerate?: number;
+  /** 10/25/50/75/90 percentile feerates in sat/vB. */
+  feerate_percentiles?: [number, number, number, number, number];
+  /** Total satoshis output (excluding coinbase). */
+  totaloutput?: number;
+  /** Number of inputs (across all txs). */
+  ins?: number;
+  /** Number of outputs (across all txs). */
+  outs?: number;
+  /** Block size in bytes. */
+  total_size?: number;
+}
+
+export interface GetBlockVerbose {
+  hash: string;
+  /** Number of confirmations of this block on the canonical chain.
+   * `-1` indicates the block is on a side chain (not in active chain). */
+  confirmations: number;
+  height: number;
+  version: number;
+  versionHex: string;
+  merkleroot: string;
+  /** Block timestamp (Unix seconds). */
+  time: number;
+  /** Median time past — chains-of-11 median, used for soft-fork timing. */
+  mediantime: number;
+  nonce: number;
+  bits: string;
+  /** Difficulty as a number (1e14+ for current Bitcoin mainnet). */
+  difficulty: number;
+  /** Hash of the previous block; absent for genesis. */
+  previousblockhash?: string;
+  /** Hash of the next block; absent for tip. */
+  nextblockhash?: string;
+  /** Total tx count in block. */
+  nTx: number;
+  /** Block size in bytes. */
+  size: number;
+  /** Block weight (BIP-141 weight units). */
+  weight: number;
+  /** With verbosity 1 this is an array of txids; with verbosity 2 it's
+   * full tx objects. We use verbosity 1 by default. */
+  tx?: string[];
+}
+
+export async function getBestBlockHash(
+  config: JsonRpcClientConfig,
+): Promise<string> {
+  return jsonRpcCall<string>(config, "getbestblockhash");
+}
+
+export async function getBlockHash(
+  config: JsonRpcClientConfig,
+  height: number,
+): Promise<string> {
+  return jsonRpcCall<string>(config, "getblockhash", [height]);
+}
+
+export async function getBlockVerbose(
+  config: JsonRpcClientConfig,
+  blockhash: string,
+  verbosity: 1 | 2 = 1,
+): Promise<GetBlockVerbose> {
+  return jsonRpcCall<GetBlockVerbose>(config, "getblock", [blockhash, verbosity]);
+}
+
+export async function getChainTips(
+  config: JsonRpcClientConfig,
+): Promise<ChainTip[]> {
+  return jsonRpcCall<ChainTip[]>(config, "getchaintips");
+}
+
+export async function getMempoolInfo(
+  config: JsonRpcClientConfig,
+): Promise<MempoolInfo> {
+  return jsonRpcCall<MempoolInfo>(config, "getmempoolinfo");
+}
+
+/**
+ * `getblockstats(hash_or_height, stats?)`. The `stats` param trims the
+ * response to only the requested fields — for `block_stats` tools we
+ * request the fee-related fields; for `mempool_anomaly` baseline we'd
+ * request size + tx count. Pass `null` to get all stats (large response).
+ */
+export async function getBlockStats(
+  config: JsonRpcClientConfig,
+  hashOrHeight: string | number,
+  stats?: ReadonlyArray<keyof BlockStats>,
+): Promise<BlockStats> {
+  const params: unknown[] = [hashOrHeight];
+  if (stats !== undefined) params.push(stats);
+  return jsonRpcCall<BlockStats>(config, "getblockstats", params);
+}
+
+/**
+ * `getrawmempool(verbose=false)` — txid array form. Used as a sanity
+ * check for `getmempoolinfo.size` (they should match) and as input to
+ * mempool-anomaly baseline trends. Verbose mode (per-tx info) is much
+ * larger and not currently used.
+ */
+export async function getRawMempool(
+  config: JsonRpcClientConfig,
+): Promise<string[]> {
+  return jsonRpcCall<string[]>(config, "getrawmempool", [false]);
+}

--- a/test/incident-chain-signals.test.ts
+++ b/test/incident-chain-signals.test.ts
@@ -179,15 +179,24 @@ describe("evalMinerConcentration", () => {
   });
 });
 
-describe("rpcOnlySignals", () => {
-  it("includes all three deferred-to-RPC signals as available:false", () => {
-    const sigs = utxoSignals.rpcOnlySignals();
+describe("rpcGatedSignals — unconfigured RPC fallback (issue #248)", () => {
+  it("includes all three RPC-gated signals as available:false when env var unset", async () => {
+    const sigs = await utxoSignals.rpcGatedSignalsUnconfigured("BITCOIN_RPC_URL");
     const names = sigs.map((s) => s.name);
     expect(names).toEqual(["deep_reorg", "indexer_divergence", "mempool_anomaly"]);
     for (const s of sigs) {
       expect(s).toMatchObject({ available: false });
-      // The reason must mention RPC + cite issue #233 — locks the v1 framing.
-      expect((s as { reason: string }).reason).toMatch(/RPC|#233/);
+      // Reason must point to the right env var + cite the new issue ref so
+      // the agent can give the user actionable setup guidance.
+      expect((s as { reason: string }).reason).toMatch(/BITCOIN_RPC_URL/);
+      expect((s as { reason: string }).reason).toMatch(/#248/);
+    }
+  });
+
+  it("uses the chain-specific env var name in the unavailable reason for LTC", async () => {
+    const sigs = await utxoSignals.rpcGatedSignalsUnconfigured("LITECOIN_RPC_URL");
+    for (const s of sigs) {
+      expect((s as { reason: string }).reason).toMatch(/LITECOIN_RPC_URL/);
     }
   });
 });

--- a/test/jsonrpc.test.ts
+++ b/test/jsonrpc.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the bitcoind / litecoind JSON-RPC client. Issue #248.
+ *
+ * Strategy: stub `fetch` globally + craft synthetic Response objects.
+ * No live daemon needed; we lock the request shape (POST + JSON body
+ * with v1.0 envelope, auth header for each mode) and the response
+ * decode (success / error / transport-error branches).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  JsonRpcError,
+  JsonRpcTransportError,
+  jsonRpcCall,
+} from "../src/data/jsonrpc.js";
+
+const URL = "http://127.0.0.1:8332";
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("jsonRpcCall — success path", () => {
+  it("returns the parsed `result` field on a successful response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ result: "deadbeef", error: null, id: "getbestblockhash" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await jsonRpcCall<string>(
+      { url: URL, auth: { kind: "none" } },
+      "getbestblockhash",
+    );
+    expect(out).toBe("deadbeef");
+  });
+
+  it("sends a POST request with the JSON-RPC v1.0 envelope (`jsonrpc: '1.0'`, positional `params` array)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ result: "abc", error: null, id: "getblockhash" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await jsonRpcCall<string>(
+      { url: URL, auth: { kind: "none" } },
+      "getblockhash",
+      [123456],
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      jsonrpc: "1.0",
+      method: "getblockhash",
+      params: [123456],
+    });
+  });
+});
+
+describe("jsonRpcCall — auth modes", () => {
+  it("basic auth: encodes `<user>:<password>` as base64 in Authorization header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ result: 0, error: null, id: "x" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await jsonRpcCall(
+      {
+        url: URL,
+        auth: { kind: "basic", user: "alice", password: "bob" },
+      },
+      "x",
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    const auth = (init.headers as Record<string, string>).Authorization;
+    expect(auth).toBe(`Basic ${Buffer.from("alice:bob").toString("base64")}`);
+  });
+
+  it("header auth: forwards the named header verbatim", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ result: 0, error: null, id: "x" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await jsonRpcCall(
+      {
+        url: URL,
+        auth: { kind: "header", headerName: "X-Auth-Token", headerValue: "secret123" },
+      },
+      "x",
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>)["X-Auth-Token"]).toBe("secret123");
+  });
+
+  it("none: sends no Authorization header (daemon will 401 unless allows-no-auth)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ result: 0, error: null, id: "x" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await jsonRpcCall({ url: URL, auth: { kind: "none" } }, "x");
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+});
+
+describe("jsonRpcCall — error decode", () => {
+  it("throws JsonRpcError with code + message when the daemon returns a structured error", async () => {
+    // bitcoind returns 500 with a JSON body for RPC method errors.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          result: null,
+          error: { code: -8, message: "Block height out of range" },
+          id: "x",
+        }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    let caught: unknown;
+    try {
+      await jsonRpcCall({ url: URL, auth: { kind: "none" } }, "getblockhash", [99_999_999]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(JsonRpcError);
+    expect((caught as JsonRpcError).code).toBe(-8);
+    expect((caught as JsonRpcError).message).toContain("Block height out of range");
+  });
+
+  it("throws JsonRpcTransportError on HTTP non-2xx with no JSON-RPC error envelope", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("forbidden", { status: 403, statusText: "Forbidden" }));
+    vi.stubGlobal("fetch", fetchMock);
+    let caught: unknown;
+    try {
+      await jsonRpcCall({ url: URL, auth: { kind: "none" } }, "getblockhash");
+    } catch (err) {
+      caught = err;
+    }
+    // 403 with non-JSON body falls through to the transport branch.
+    expect(caught).toBeInstanceOf(JsonRpcTransportError);
+    expect((caught as Error).message).toMatch(/non-JSON|HTTP 403/);
+  });
+
+  it("throws JsonRpcTransportError on network error (fetch reject)", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+    let caught: unknown;
+    try {
+      await jsonRpcCall({ url: URL, auth: { kind: "none" } }, "getblockhash");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(JsonRpcTransportError);
+    expect((caught as Error).message).toContain("ECONNREFUSED");
+  });
+});

--- a/test/utxo-rpc-config.test.ts
+++ b/test/utxo-rpc-config.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the UTXO-chain RPC config resolvers (BTC + LTC).
+ * Issue #248. Locks the env-var precedence and the auth-mode pick.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveAuthFromEnv, resolveBitcoinRpcConfig } from "../src/config/btc.js";
+import { resolveLitecoinRpcConfig } from "../src/config/litecoin.js";
+
+const ENV_KEYS_BTC = [
+  "BITCOIN_RPC_URL",
+  "BITCOIN_RPC_COOKIE",
+  "BITCOIN_RPC_USER",
+  "BITCOIN_RPC_PASSWORD",
+  "BITCOIN_RPC_AUTH_HEADER_NAME",
+  "BITCOIN_RPC_AUTH_HEADER_VALUE",
+];
+const ENV_KEYS_LTC = ENV_KEYS_BTC.map((k) => k.replace("BITCOIN", "LITECOIN"));
+
+beforeEach(() => {
+  for (const k of [...ENV_KEYS_BTC, ...ENV_KEYS_LTC]) delete process.env[k];
+});
+afterEach(() => {
+  for (const k of [...ENV_KEYS_BTC, ...ENV_KEYS_LTC]) delete process.env[k];
+});
+
+describe("resolveBitcoinRpcConfig", () => {
+  it("returns null when BITCOIN_RPC_URL is unset (RPC tools must surface available:false)", () => {
+    expect(resolveBitcoinRpcConfig()).toBeNull();
+  });
+
+  it("returns null when BITCOIN_RPC_URL is whitespace-only", () => {
+    process.env.BITCOIN_RPC_URL = "   ";
+    expect(resolveBitcoinRpcConfig()).toBeNull();
+  });
+
+  it("returns config with `none` auth when only URL is set", () => {
+    process.env.BITCOIN_RPC_URL = "http://127.0.0.1:8332";
+    const cfg = resolveBitcoinRpcConfig();
+    expect(cfg).toEqual({
+      url: "http://127.0.0.1:8332",
+      auth: { kind: "none" },
+    });
+  });
+
+  it("trims whitespace around the URL", () => {
+    process.env.BITCOIN_RPC_URL = "  http://127.0.0.1:8332  ";
+    expect(resolveBitcoinRpcConfig()?.url).toBe("http://127.0.0.1:8332");
+  });
+});
+
+describe("resolveAuthFromEnv — auth-mode priority", () => {
+  it("cookie takes precedence over basic + header", () => {
+    process.env.BITCOIN_RPC_COOKIE = "/home/user/.bitcoin/.cookie";
+    process.env.BITCOIN_RPC_USER = "alice";
+    process.env.BITCOIN_RPC_PASSWORD = "bob";
+    process.env.BITCOIN_RPC_AUTH_HEADER_NAME = "X-Token";
+    process.env.BITCOIN_RPC_AUTH_HEADER_VALUE = "secret";
+    const auth = resolveAuthFromEnv("BITCOIN");
+    expect(auth).toEqual({
+      kind: "cookie",
+      cookiePath: "/home/user/.bitcoin/.cookie",
+    });
+  });
+
+  it("basic auth takes precedence over header when no cookie", () => {
+    process.env.BITCOIN_RPC_USER = "alice";
+    process.env.BITCOIN_RPC_PASSWORD = "bob";
+    process.env.BITCOIN_RPC_AUTH_HEADER_NAME = "X-Token";
+    process.env.BITCOIN_RPC_AUTH_HEADER_VALUE = "secret";
+    const auth = resolveAuthFromEnv("BITCOIN");
+    expect(auth).toEqual({ kind: "basic", user: "alice", password: "bob" });
+  });
+
+  it("falls through to header when no cookie + no basic-auth pair", () => {
+    process.env.BITCOIN_RPC_AUTH_HEADER_NAME = "X-Token";
+    process.env.BITCOIN_RPC_AUTH_HEADER_VALUE = "secret123";
+    const auth = resolveAuthFromEnv("BITCOIN");
+    expect(auth).toEqual({
+      kind: "header",
+      headerName: "X-Token",
+      headerValue: "secret123",
+    });
+  });
+
+  it("requires BOTH user and password for basic auth (one alone falls through)", () => {
+    process.env.BITCOIN_RPC_USER = "alice";
+    // no password
+    process.env.BITCOIN_RPC_AUTH_HEADER_NAME = "X-Token";
+    process.env.BITCOIN_RPC_AUTH_HEADER_VALUE = "secret";
+    const auth = resolveAuthFromEnv("BITCOIN");
+    expect(auth.kind).toBe("header");
+  });
+
+  it("requires BOTH header name and value (one alone falls through)", () => {
+    process.env.BITCOIN_RPC_AUTH_HEADER_NAME = "X-Token";
+    // no value
+    const auth = resolveAuthFromEnv("BITCOIN");
+    expect(auth.kind).toBe("none");
+  });
+
+  it("uses the chain-specific prefix — LTC env vars are not consulted for BTC", () => {
+    process.env.LITECOIN_RPC_USER = "ltc-user";
+    process.env.LITECOIN_RPC_PASSWORD = "ltc-pw";
+    expect(resolveAuthFromEnv("BITCOIN").kind).toBe("none");
+  });
+});
+
+describe("resolveLitecoinRpcConfig", () => {
+  it("mirrors BTC behavior with the LITECOIN_ prefix", () => {
+    expect(resolveLitecoinRpcConfig()).toBeNull();
+    process.env.LITECOIN_RPC_URL = "http://127.0.0.1:9332";
+    process.env.LITECOIN_RPC_USER = "ltc";
+    process.env.LITECOIN_RPC_PASSWORD = "p";
+    expect(resolveLitecoinRpcConfig()).toEqual({
+      url: "http://127.0.0.1:9332",
+      auth: { kind: "basic", user: "ltc", password: "p" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional Bitcoin Core / Litecoin Core JSON-RPC endpoint support, unlocking forensic-tier reads (chain tips / fork detection, fee percentile distributions, mempool census) that Esplora indexers cannot expose. RPC-gated tools degrade to \`available: false\` with a structured setup hint when the endpoint isn't configured — never silently green.

## What this unlocks

- **#233 v2 — 3 RPC-gated tools per chain (6 total):** \`get_btc_chain_tips\`, \`get_ltc_chain_tips\`, \`get_btc_block_stats\`, \`get_ltc_block_stats\`, \`get_btc_mempool_summary\`, \`get_ltc_mempool_summary\`.
- **#236 v2 — 3 stubbed signals flipped to live:** \`deep_reorg\` (via \`getchaintips\`), \`indexer_divergence\` (RPC tip vs indexer tip), \`mempool_anomaly\` (via \`getmempoolinfo\`).

## Layers landed (bottom-up)

### 1. \`src/data/jsonrpc.ts\` — JSON-RPC v1.0 client

- Three auth modes: cookie (self-hosted default), basic (rpcuser/rpcpassword), header (hosted providers).
- Hand-rolled per the same tight-dep policy documented in \`pLimitMap\` (~120 LoC for ~100 LoC of bitcoin-core; pulling \`bitcoin-core\` or \`node-bitcoin-rpc\` not worth the supply-chain surface in self-custody code).
- Distinct error classes — \`JsonRpcError\` (daemon said no, structured code+message) vs \`JsonRpcTransportError\` (couldn't reach daemon) so the agent can branch on cause.

### 2. \`src/modules/utxo/rpc-client.ts\` — typed wrappers

7 methods: \`getbestblockhash\`, \`getblockhash\`, \`getblock\`, \`getchaintips\`, \`getmempoolinfo\`, \`getblockstats\`, \`getrawmempool\`. Chain-agnostic — bitcoind and litecoind ship identical RPC surfaces (verifiable via \`litecoin-cli help <method>\`).

### 3. Config resolvers — \`src/config/btc.ts\` + \`src/config/litecoin.ts\`

Env-var family per chain:

| Var | Purpose |
|---|---|
| \`*_RPC_URL\` | Endpoint URL. Required to enable RPC; null when unset. |
| \`*_RPC_COOKIE\` | Path to bitcoind/litecoind cookie file (preferred for self-hosted). |
| \`*_RPC_USER\` + \`*_RPC_PASSWORD\` | HTTP basic auth (rpcuser/rpcpassword in conf). |
| \`*_RPC_AUTH_HEADER_NAME\` + \`*_RPC_AUTH_HEADER_VALUE\` | Header-based auth (Quicknode, NOWNodes, Helius). |

Priority: cookie > basic > header > none.

### 4. 6 new MCP tools

Each returns either the parsed RPC result or \`{ available: false, reason, hint }\` when RPC is not configured or the call failed. The hint string is the agent-facing setup recipe (\"Configure \`BITCOIN_RPC_URL\` (and optionally...). See INSTALL.md.\").

### 5. 3 stubbed signals flipped to live (\`chain-utxo.ts\`)

- \`deep_reorg\`: any \`valid-fork\` tip with \`branchlen >= 6\` (BTC) / \`>= 12\` (LTC) → flagged.
- \`indexer_divergence\`: indexer tip hash vs RPC \`getbestblockhash\` mismatch → flagged.
- \`mempool_anomaly\`: \`bytes / maxmempool >= 0.85\` → flagged.

Each one uses \`Promise.allSettled\` so a single RPC failure doesn't tank the other two.

## Out of scope (follow-up)

Per the parent #233 v2 scope, two of the originally-planned tools need *indexer* extensions (not RPC-related) and ship in a follow-up:

- \`get_*_difficulty_timeline\` — walks back retarget heights; needs a \`getBlockSummary(height)\` indexer primitive.
- \`get_*_coinbase\` — fetches block coinbase tx + parses scriptSig for known mining-pool tags; needs \`getCoinbase(blockHash)\` + a curated pool-tag-pattern list.

These don't depend on this PR's RPC layer at all.

## Test coverage

- \`test/jsonrpc.test.ts\` (8 tests) — request shape (POST + v1.0 envelope), all three auth modes, error decode (\`JsonRpcError\` vs \`JsonRpcTransportError\` on each failure shape).
- \`test/utxo-rpc-config.test.ts\` (10 tests) — env-var precedence, per-chain prefix isolation, whitespace handling.
- \`test/incident-chain-signals.test.ts\` updated — flipped the v1 \`rpcOnlySignals\` test to assert the new \`rpcGatedSignalsUnconfigured\` fallback contract (issue #248 ref required in reasons; chain-specific env-var names surfaced).

End-to-end testing against a live bitcoind/litecoind requires running a daemon; covered by the test plan checklist below.

**Pre-existing flake noted:** \`test/solana-setup-status.test.ts\` has 2 tests timing out against public Solana RPC. Unrelated to this PR — fails on clean main. Not addressed here.

## INSTALL.md update

New \"Optional: bitcoind / litecoind RPC for forensic chain reads\" section in the troubleshooting / advanced-setup chapter, with the three backend options ranked by setup cost and the LTC-vs-BTC self-hosting cost asymmetry called out (LTC ~5GB + ~6h IBD vs BTC ~10GB + ~2 days).

## Test plan

- [x] \`npm run build\` (tsc) — clean
- [x] \`npx vitest run test/jsonrpc.test.ts test/utxo-rpc-config.test.ts test/incident-chain-signals.test.ts\` — 39/39 pass
- [x] \`npm test\` (full suite) — 1273/1274 pass (1 pre-existing Solana RPC flake)
- [ ] Live: with no \`BITCOIN_RPC_URL\` / \`LITECOIN_RPC_URL\` set, call \`get_btc_chain_tips\` / \`get_ltc_chain_tips\` — confirm \`available: false\` with the setup hint and chain-specific env var named.
- [ ] Live: configure \`BITCOIN_RPC_URL\` against a real bitcoind (cookie auth) — confirm \`get_btc_chain_tips\` returns the active tip + any valid-fork tips; \`get_btc_mempool_summary\` returns sensible \`size\` / \`bytes\` / \`mempoolminfee\`; \`get_btc_block_stats({ hashOrHeight })\` returns the fee percentiles.
- [ ] Live: same with hosted-provider header auth — confirm \`BITCOIN_RPC_AUTH_HEADER_NAME\` + \`*_VALUE\` reaches the provider correctly.
- [ ] Live: \`get_market_incident_status({ protocol: \"bitcoin\" })\` with RPC configured — confirm \`deep_reorg\` / \`indexer_divergence\` / \`mempool_anomaly\` flip from \`available: false\` to \`available: true\` with sensible details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)