### PR TITLE
feat(safe): prepare_safe_tx_execute — final stage of Safe support (v3 of 3)

### DIFF
--- a/src/abis/safe-multisig.ts
+++ b/src/abis/safe-multisig.ts
@@ -50,4 +50,22 @@ export const safeMultisigAbi = [
     inputs: [],
     outputs: [{ type: "string" }],
   },
+  {
+    type: "function",
+    name: "execTransaction",
+    stateMutability: "payable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+      { name: "operation", type: "uint8" },
+      { name: "safeTxGas", type: "uint256" },
+      { name: "baseGas", type: "uint256" },
+      { name: "gasPrice", type: "uint256" },
+      { name: "gasToken", type: "address" },
+      { name: "refundReceiver", type: "address" },
+      { name: "signatures", type: "bytes" },
+    ],
+    outputs: [{ type: "bool" }],
+  },
 ] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,11 @@ import {
   prepareSafeTxPropose,
   submitSafeTxSignature,
 } from "./modules/safe/actions.js";
+import { prepareSafeTxExecute } from "./modules/safe/execute.js";
 import {
   getSafePositionsInput,
   prepareSafeTxApproveInput,
+  prepareSafeTxExecuteInput,
   prepareSafeTxProposeInput,
   submitSafeTxSignatureInput,
 } from "./modules/safe/schemas.js";
@@ -1384,6 +1386,16 @@ async function main() {
       inputSchema: submitSafeTxSignatureInput.shape,
     },
     handler(submitSafeTxSignature)
+  );
+
+  registerTool(server,
+    "prepare_safe_tx_execute",
+    {
+      description:
+        "Build the final on-chain `execTransaction` UnsignedTx that lands a Safe (Gnosis Safe) multisig payload. The executor doesn't need to have pre-approved on-chain — when `msg.sender` is an owner, the Safe contract treats their inline `(r=msg.sender, s=0, v=1)` signature as implicit consent. So one of the threshold \"signatures\" can be the executor themselves; the rest come from the on-chain `approvedHashes` registry filled by previous `prepare_safe_tx_propose` / `prepare_safe_tx_approve` calls. Refuses to build the tx when the threshold isn't met (which would just revert at execute time). Resolves the SafeTx body from the local store first, falling back to Safe Transaction Service. Returns an UnsignedTx the executor broadcasts via `send_transaction` — the OUTER tx sends 0 ETH (the inner value, if any, is paid by the Safe from its own balance during the inner CALL).",
+      inputSchema: prepareSafeTxExecuteInput.shape,
+    },
+    txHandler("prepare_safe_tx_execute", prepareSafeTxExecute)
   );
 
   // ---- Module 2: Security ----

--- a/src/modules/safe/execute.ts
+++ b/src/modules/safe/execute.ts
@@ -1,0 +1,212 @@
+import { encodeFunctionData, getAddress } from "viem";
+import { safeMultisigAbi } from "../../abis/safe-multisig.js";
+import { getClient } from "../../data/rpc.js";
+import { encodeApprovedHashSignature, type SafeTxBody } from "./safe-tx.js";
+import { lookupSafeTx } from "./safe-tx-store.js";
+import { getSafeApiKit } from "./sdk.js";
+import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+import type { PrepareSafeTxExecuteArgs } from "./schemas.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+
+/**
+ * Resolve the SafeTx body for an execute call. Local store first (fast path
+ * — set by prepare_safe_tx_propose this session); falls back to Safe Tx
+ * Service `getTransaction` for txs proposed elsewhere.
+ *
+ * Throws when neither path yields a body, since `execTransaction` cannot be
+ * built without `(to, value, data, operation, nonce)`.
+ */
+async function resolveSafeTxBody(args: {
+  chain: SupportedChain;
+  safeTxHash: `0x${string}`;
+}): Promise<SafeTxBody> {
+  const cached = lookupSafeTx(args.safeTxHash);
+  if (cached) return cached.body;
+
+  const kit = getSafeApiKit(args.chain);
+  const remote = await kit.getTransaction(args.safeTxHash).catch((e: unknown) => {
+    throw new Error(
+      `SafeTx ${args.safeTxHash} not found in local cache or Safe Transaction Service: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+    );
+  });
+  return {
+    to: remote.to as `0x${string}`,
+    value: remote.value,
+    data: (remote.data ?? "0x") as `0x${string}`,
+    operation: (remote.operation === 1 ? 1 : 0) as 0 | 1,
+    safeTxGas: "0",
+    baseGas: "0",
+    gasPrice: "0",
+    gasToken: ZERO_ADDRESS,
+    refundReceiver: ZERO_ADDRESS,
+    nonce: remote.nonce,
+  };
+}
+
+/**
+ * Read the Safe's owner list, threshold, and per-owner approveHash status
+ * for a given safeTxHash in a single multicall. Returns the owners that
+ * have already approved + the threshold so the caller can check whether
+ * execution is feasible.
+ */
+async function readApprovalState(args: {
+  chain: SupportedChain;
+  safeAddress: `0x${string}`;
+  safeTxHash: `0x${string}`;
+}): Promise<{
+  threshold: number;
+  owners: `0x${string}`[];
+  approvedOwners: `0x${string}`[];
+}> {
+  const client = getClient(args.chain);
+  const [threshold, owners] = (await Promise.all([
+    client.readContract({
+      address: args.safeAddress,
+      abi: safeMultisigAbi,
+      functionName: "getThreshold",
+    }) as Promise<bigint>,
+    client.readContract({
+      address: args.safeAddress,
+      abi: safeMultisigAbi,
+      functionName: "getOwners",
+    }) as Promise<readonly `0x${string}`[]>,
+  ])) as [bigint, readonly `0x${string}`[]];
+
+  // Per-owner approvedHashes lookup, parallelised. A single multicall would
+  // be one fewer RPC call but adds the multicall ABI to this module for
+  // negligible benefit at owner counts < 20 (essentially every Safe).
+  const approvalFlags = await Promise.all(
+    owners.map((owner) =>
+      client.readContract({
+        address: args.safeAddress,
+        abi: safeMultisigAbi,
+        functionName: "approvedHashes",
+        args: [owner, args.safeTxHash],
+      }) as Promise<bigint>,
+    ),
+  );
+  const approvedOwners: `0x${string}`[] = [];
+  for (let i = 0; i < owners.length; i++) {
+    if (approvalFlags[i] !== 0n) approvedOwners.push(owners[i]);
+  }
+  return {
+    threshold: Number(threshold),
+    owners: [...owners],
+    approvedOwners,
+  };
+}
+
+/**
+ * Build the `signatures` blob `execTransaction` expects. Safe contract rules:
+ *
+ *  - Each signature is 65 bytes: `r (32) | s (32) | v (1)`.
+ *  - For "approved hashes" we use the pre-validated form: r = signer left-
+ *    padded to 32 bytes, s = 0, v = 1. The contract verifies this against
+ *    `msg.sender == signer || approvedHashes[signer][hash] != 0`.
+ *  - Signatures MUST be ordered by ascending owner address — the contract
+ *    iterates `currentOwner > lastOwner` and reverts otherwise.
+ *
+ * The executor counts as their own signature when they're an owner (the
+ * `msg.sender` clause of the contract check), so they don't need to have
+ * pre-approved on-chain. We include the executor in the picked list FIRST
+ * (highest priority) so a cold-start execute by an owner just works.
+ */
+function buildSignaturesBlob(args: {
+  threshold: number;
+  approvedOwners: `0x${string}`[];
+  executor: `0x${string}`;
+  ownersSet: Set<string>;
+}): `0x${string}` {
+  // Combined eligible-signer set: confirmed approveHashers + the executor
+  // (when they're an owner). Lower-cased keys for set semantics.
+  const eligible = new Set<string>(args.approvedOwners.map((o) => o.toLowerCase()));
+  if (args.ownersSet.has(args.executor.toLowerCase())) {
+    eligible.add(args.executor.toLowerCase());
+  }
+  if (eligible.size < args.threshold) {
+    throw new Error(
+      `Threshold not met: ${eligible.size}/${args.threshold} signers ready ` +
+        `(approveHash count = ${args.approvedOwners.length}; executor counts iff they're an owner).`,
+    );
+  }
+
+  // Sort ascending — what the contract requires. Lower-case comparison is
+  // lexicographic on hex; that matches numeric address ordering.
+  const ordered = [...eligible].sort();
+
+  // Take exactly `threshold` of them — extra signatures are accepted but
+  // waste calldata gas on every chain.
+  const picked = ordered.slice(0, args.threshold) as `0x${string}`[];
+
+  const sigs = picked.map((s) => encodeApprovedHashSignature(getAddress(s) as `0x${string}`));
+  return ("0x" + sigs.map((s) => s.slice(2)).join("")) as `0x${string}`;
+}
+
+/**
+ * Build the executor-side `execTransaction` UnsignedTx. The OUTER tx sends
+ * 0 ETH from the executor — the inner value (if any) is paid by the Safe
+ * contract from its own balance to the inner `to` during the inner CALL.
+ */
+export async function prepareSafeTxExecute(
+  args: PrepareSafeTxExecuteArgs,
+): Promise<UnsignedTx> {
+  const chain = args.chain as SupportedChain;
+  const safeAddress = getAddress(args.safeAddress) as `0x${string}`;
+  const executor = getAddress(args.executor) as `0x${string}`;
+  const safeTxHash = args.safeTxHash as `0x${string}`;
+
+  const [body, approvalState] = await Promise.all([
+    resolveSafeTxBody({ chain, safeTxHash }),
+    readApprovalState({ chain, safeAddress, safeTxHash }),
+  ]);
+
+  const ownersSet = new Set(approvalState.owners.map((o) => o.toLowerCase()));
+  const signatures = buildSignaturesBlob({
+    threshold: approvalState.threshold,
+    approvedOwners: approvalState.approvedOwners,
+    executor,
+    ownersSet,
+  });
+
+  const data = encodeFunctionData({
+    abi: safeMultisigAbi,
+    functionName: "execTransaction",
+    args: [
+      body.to,
+      BigInt(body.value),
+      body.data,
+      body.operation,
+      BigInt(body.safeTxGas),
+      BigInt(body.baseGas),
+      BigInt(body.gasPrice),
+      body.gasToken,
+      body.refundReceiver,
+      signatures,
+    ],
+  });
+
+  const opLabel = body.operation === 1 ? " ⚠ DELEGATECALL" : "";
+  return {
+    chain,
+    to: safeAddress,
+    data,
+    value: "0",
+    from: executor,
+    description:
+      `Execute Safe tx ${safeTxHash.slice(0, 10)}… on ${safeAddress.slice(0, 8)}…` +
+      ` (nonce ${body.nonce}${opLabel}). Inner: ${body.to.slice(0, 8)}… value ${body.value} wei` +
+      `${body.data === "0x" ? " (plain transfer)" : ` data ${body.data.slice(0, 10)}…`}.`,
+    decoded: {
+      functionName: "execTransaction",
+      args: {
+        to: body.to,
+        value: body.value,
+        operation: body.operation === 1 ? "DELEGATECALL" : "CALL",
+        nonce: body.nonce,
+        signaturesLength: String((signatures.length - 2) / 2),
+      },
+    },
+  };
+}

--- a/src/modules/safe/schemas.ts
+++ b/src/modules/safe/schemas.ts
@@ -116,6 +116,28 @@ export const submitSafeTxSignatureInput = z.object({
   safeTxHash: z.string().regex(/^0x[a-fA-F0-9]{64}$/),
 });
 
+/**
+ * `prepare_safe_tx_execute` builds the final `execTransaction` UnsignedTx
+ * that lands the multi-sig payload on chain. The executor doesn't need to
+ * have pre-approved on-chain — when `msg.sender` is an owner, the Safe
+ * contract treats their inline `(r=msg.sender, s=0, v=1)` signature as
+ * implicit consent. So one of the threshold "signatures" can be the
+ * executor themselves; the rest come from the on-chain `approvedHashes`
+ * registry filled in by previous `prepare_safe_tx_propose` /
+ * `prepare_safe_tx_approve` calls.
+ *
+ * The handler refuses to build the tx when fewer than `threshold` owners
+ * (counting the executor) have approved on-chain — which would just
+ * revert at execute time.
+ */
+export const prepareSafeTxExecuteInput = z.object({
+  executor: z.string().regex(EVM_ADDRESS),
+  safeAddress: z.string().regex(EVM_ADDRESS),
+  chain: evmChainEnum.default("ethereum"),
+  safeTxHash: z.string().regex(/^0x[a-fA-F0-9]{64}$/),
+});
+
 export type PrepareSafeTxProposeArgs = z.infer<typeof prepareSafeTxProposeInput>;
 export type PrepareSafeTxApproveArgs = z.infer<typeof prepareSafeTxApproveInput>;
 export type SubmitSafeTxSignatureArgs = z.infer<typeof submitSafeTxSignatureInput>;
+export type PrepareSafeTxExecuteArgs = z.infer<typeof prepareSafeTxExecuteInput>;

--- a/test/safe-execute.test.ts
+++ b/test/safe-execute.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { prepareSafeTxExecute } from "../src/modules/safe/execute.js";
+import {
+  rememberSafeTx,
+  clearSafeTxStoreForTesting,
+} from "../src/modules/safe/safe-tx-store.js";
+import { buildSafeTxBody } from "../src/modules/safe/safe-tx.js";
+
+const mockKit = {
+  getTransaction: vi.fn(),
+};
+vi.mock("../src/modules/safe/sdk.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/modules/safe/sdk.js")>();
+  return {
+    ...actual,
+    getSafeApiKit: () => mockKit,
+  };
+});
+
+const mockClient = {
+  readContract: vi.fn(),
+};
+vi.mock("../src/data/rpc.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/data/rpc.js")>();
+  return {
+    ...actual,
+    getClient: () => mockClient,
+  };
+});
+
+const SAFE = "0x1111111111111111111111111111111111111111";
+const RECIPIENT = "0x0000000000000000000000000000000000000abc";
+// Three owner addresses, deliberately NOT in ascending order so the
+// signatures-blob ordering test can detect mistakes.
+const OWNER_A = "0x9999999999999999999999999999999999999999";
+const OWNER_B = "0x4444444444444444444444444444444444444444";
+const OWNER_C = "0x7777777777777777777777777777777777777777";
+const STRANGER = "0x0000000000000000000000000000000000001234";
+
+function safeTxHash(): `0x${string}` {
+  return `0x${"ab".repeat(32)}` as `0x${string}`;
+}
+
+function setOnChainState(args: {
+  threshold: bigint;
+  owners: readonly `0x${string}`[];
+  approvalsByOwner: Record<string, bigint>;
+}): void {
+  mockClient.readContract.mockImplementation((req: { functionName: string; args?: unknown[] }) => {
+    if (req.functionName === "getThreshold") return Promise.resolve(args.threshold);
+    if (req.functionName === "getOwners") return Promise.resolve(args.owners);
+    if (req.functionName === "approvedHashes") {
+      const owner = (req.args?.[0] as string).toLowerCase();
+      return Promise.resolve(args.approvalsByOwner[owner] ?? 0n);
+    }
+    return Promise.resolve(0n);
+  });
+}
+
+beforeEach(() => {
+  clearSafeTxStoreForTesting();
+  mockClient.readContract.mockReset();
+  mockKit.getTransaction.mockReset();
+  rememberSafeTx({
+    safeTxHash: safeTxHash(),
+    chain: "ethereum",
+    safeAddress: SAFE as `0x${string}`,
+    body: buildSafeTxBody({
+      to: RECIPIENT as `0x${string}`,
+      value: "1000",
+      data: "0x",
+      operation: 0,
+      nonce: "5",
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("prepare_safe_tx_execute — threshold gating", () => {
+  it("refuses when fewer than `threshold` signers are ready", async () => {
+    // Threshold 2, but only OWNER_A approved + executor is OWNER_B (an owner).
+    // Eligible = {A, B} → 2 ≥ 2: actually meets! Use a tighter case.
+    // Threshold 3, OWNER_A approved, executor OWNER_B → eligible = 2.
+    setOnChainState({
+      threshold: 3n,
+      owners: [OWNER_A, OWNER_B, OWNER_C],
+      approvalsByOwner: { [OWNER_A.toLowerCase()]: 1n },
+    });
+    await expect(
+      prepareSafeTxExecute({
+        executor: OWNER_B,
+        safeAddress: SAFE,
+        chain: "ethereum",
+        safeTxHash: safeTxHash(),
+      }),
+    ).rejects.toThrow(/Threshold not met/);
+  });
+
+  it("does not count the executor when they're NOT an owner", async () => {
+    // Threshold 2, OWNER_A approved, executor is a stranger → eligible = 1.
+    setOnChainState({
+      threshold: 2n,
+      owners: [OWNER_A, OWNER_B, OWNER_C],
+      approvalsByOwner: { [OWNER_A.toLowerCase()]: 1n },
+    });
+    await expect(
+      prepareSafeTxExecute({
+        executor: STRANGER,
+        safeAddress: SAFE,
+        chain: "ethereum",
+        safeTxHash: safeTxHash(),
+      }),
+    ).rejects.toThrow(/Threshold not met/);
+  });
+
+  it("counts the executor when they ARE an owner", async () => {
+    // Threshold 2, OWNER_A approved, executor is OWNER_B (an owner) → eligible = 2 OK.
+    setOnChainState({
+      threshold: 2n,
+      owners: [OWNER_A, OWNER_B, OWNER_C],
+      approvalsByOwner: { [OWNER_A.toLowerCase()]: 1n },
+    });
+    const tx = await prepareSafeTxExecute({
+      executor: OWNER_B,
+      safeAddress: SAFE,
+      chain: "ethereum",
+      safeTxHash: safeTxHash(),
+    });
+    expect(tx.to.toLowerCase()).toBe(SAFE.toLowerCase());
+    // execTransaction selector is 0x6a761202.
+    expect(tx.data.slice(0, 10)).toBe("0x6a761202");
+  });
+});
+
+describe("prepare_safe_tx_execute — signature ordering", () => {
+  it("orders signatures by ascending signer address", async () => {
+    // All three owners approved; threshold 3 → blob has 3*65 = 195 bytes.
+    setOnChainState({
+      threshold: 3n,
+      owners: [OWNER_A, OWNER_B, OWNER_C],
+      approvalsByOwner: {
+        [OWNER_A.toLowerCase()]: 1n,
+        [OWNER_B.toLowerCase()]: 1n,
+        [OWNER_C.toLowerCase()]: 1n,
+      },
+    });
+    const tx = await prepareSafeTxExecute({
+      executor: OWNER_A,
+      safeAddress: SAFE,
+      chain: "ethereum",
+      safeTxHash: safeTxHash(),
+    });
+
+    // Find the signatures bytes in the calldata. The blob is at the tail of
+    // execTransaction calldata (bytes is dynamic, so it sits after the offset
+    // table). For our test we just check that the three signer addresses
+    // appear in ascending order anywhere in the calldata.
+    const lower = tx.data.toLowerCase();
+    const idxB = lower.indexOf(OWNER_B.slice(2).toLowerCase());
+    const idxC = lower.indexOf(OWNER_C.slice(2).toLowerCase());
+    const idxA = lower.indexOf(OWNER_A.slice(2).toLowerCase());
+    // OWNER_B (0x44…) < OWNER_C (0x77…) < OWNER_A (0x99…); the signatures
+    // blob must list them in that order. (idxA may also match the executor
+    // field earlier in the calldata; we only check that B and C exist with
+    // B before C, then C before A.)
+    expect(idxB).toBeGreaterThan(0);
+    expect(idxC).toBeGreaterThan(idxB);
+    expect(idxA).toBeGreaterThan(idxC);
+  });
+});
+
+describe("prepare_safe_tx_execute — body resolution", () => {
+  it("falls back to Safe Tx Service when the body isn't in the local cache", async () => {
+    // Wipe the seeded store entry and force the SDK fallback.
+    clearSafeTxStoreForTesting();
+    mockKit.getTransaction.mockResolvedValueOnce({
+      safeTxHash: safeTxHash(),
+      to: RECIPIENT,
+      value: "777",
+      data: "0xabcdef",
+      operation: 0,
+      nonce: "9",
+      confirmationsRequired: 1,
+      confirmations: [{ owner: OWNER_A }],
+      proposer: OWNER_A,
+      submissionDate: "",
+      transactionHash: null,
+      executionDate: null,
+      isExecuted: false,
+    });
+    setOnChainState({
+      threshold: 1n,
+      owners: [OWNER_A],
+      approvalsByOwner: { [OWNER_A.toLowerCase()]: 1n },
+    });
+    const tx = await prepareSafeTxExecute({
+      executor: OWNER_A,
+      safeAddress: SAFE,
+      chain: "ethereum",
+      safeTxHash: safeTxHash(),
+    });
+    expect(mockKit.getTransaction).toHaveBeenCalledOnce();
+    // The recipient + the inner value should appear inside the encoded
+    // execTransaction calldata.
+    expect(tx.data.toLowerCase()).toContain(RECIPIENT.slice(2).toLowerCase());
+  });
+});


### PR DESCRIPTION
## Summary

Closes the Safe support arc. Adds the executor-side tool that lands a multi-sig payload on chain after threshold is met. Stacked on #265 (`feat/safe-v2-propose`); merge order: #261 → #265 → this PR.

## Tool

**`prepare_safe_tx_execute(executor, safeAddress, chain, safeTxHash)`**

Looks up the SafeTx body (local store first → Safe Tx Service fallback), reads on-chain `approvedHashes` per owner, builds the `signatures` blob in ascending-address order, encodes `execTransaction`, returns UnsignedTx. Executor broadcasts via existing `send_transaction` — same WC scope, no new capabilities.

## Threshold gate (where this PR earns its keep)

The Safe contract treats `msg.sender` as an implicit signer when their inline signature is `(r=msg.sender, s=0, v=1)`. So the executor doesn't need to pre-approve on-chain when they're an owner. The handler:

- builds eligible = approveHash-confirmed owners ∪ {executor if owner}
- refuses when `|eligible| < threshold` (saves a guaranteed revert)
- picks `threshold` signatures sorted ascending — Safe contract requires `currentOwner > lastOwner`

## `signatures` blob shape

65 bytes per entry, identical to v2's "approved hashes" form: `r = bytes32(uint256(uint160(signer)))`, `s = 0`, `v = 1`. Concatenated in ascending-signer order. Same encoder used by submit (so propose / approve / execute all share the bit-shape).

## Test plan

- [x] `npm run build` passes.
- [x] `test/safe-execute.test.ts` — 5/5 (executor-is-owner counts toward threshold; executor-isn't-owner doesn't; refuses below threshold; ascending-address ordering; Safe Tx Service body fallback).
- [x] All Safe tests together: 17/17 (`safe-tx`, `safe-propose`, `safe-execute`).
- [ ] Live: 2/N Safe with one other owner pre-approved → execute as a second owner; inner call lands.
- [ ] Live: try threshold-not-met → "Threshold not met" error before any tx is built.
- [ ] Live: execute as a non-owner with threshold met by approveHash → tx builds (executor only pays gas; not in sig blob).

## End of staged Safe rollout

| PR | Stage | Tool |
|---|---|---|
| #261 | v1 read-only | `get_safe_positions` |
| #265 | v2 propose | `prepare_safe_tx_propose` / `prepare_safe_tx_approve` / `submit_safe_tx_signature` |
| this | v3 execute | `prepare_safe_tx_execute` |

Out of scope (separate plans if/when wanted): MultiSend batching, Safe Modules, Safe Apps integration, Safe deployment via VaultPilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)