### PR TITLE
test(send-hash-pin): fix LEDGER BLIND-SIGN HASH gating flake (5s timeout)

### DIFF
--- a/test/send-hash-pin.test.ts
+++ b/test/send-hash-pin.test.ts
@@ -5,7 +5,7 @@
  * calldata-integrity gap in blind-sign mode; before this change Ledger Live
  * picked nonce + fees at send time so the RLP hash was unpredictable.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { keccak256, serializeTransaction } from "viem";
 
 describe("eip1559PreSignHash", () => {
@@ -482,6 +482,17 @@ describe("previewSendHandler — LEDGER BLIND-SIGN HASH gating", () => {
   // `previewSendHandler` returned function is pure (no module-level
   // state read/written), so cross-test contamination from upstream
   // tests in other files is impossible here.
+  //
+  // Pre-warm the import once per file via beforeAll so neither test
+  // pays the cold-load cost on first run. Earlier the FIRST test in
+  // this block paid that cost (no other test in the file imports
+  // src/index.js), which on contended CI workers occasionally spilled
+  // past the 5s default. beforeAll timeout bumped to 30s for the same
+  // contended-worker reason.
+  let previewSendHandler!: typeof import("../src/index.js")["previewSendHandler"];
+  beforeAll(async () => {
+    ({ previewSendHandler } = await import("../src/index.js"));
+  }, 30_000);
 
   // Live-test regression: on a 0.1 ETH self-send the user saw a
   // `LEDGER BLIND-SIGN HASH — RELAY VERBATIM TO USER` block even though
@@ -492,7 +503,6 @@ describe("previewSendHandler — LEDGER BLIND-SIGN HASH gating", () => {
   // previewSendHandler must suppress the block when result.clearSignOnly
   // is true.
   it("does NOT emit the LEDGER BLIND-SIGN HASH block when result.clearSignOnly is true", async () => {
-    const { previewSendHandler } = await import("../src/index.js");
     const fakePreview = async () => ({
       handle: "h",
       chain: "ethereum" as const,
@@ -521,7 +531,6 @@ describe("previewSendHandler — LEDGER BLIND-SIGN HASH gating", () => {
   });
 
   it("DOES emit the LEDGER BLIND-SIGN HASH block when clearSignOnly is absent (regression: swaps / DeFi path unchanged)", async () => {
-    const { previewSendHandler } = await import("../src/index.js");
     const fakePreview = async () => ({
       handle: "h",
       chain: "ethereum" as const,


### PR DESCRIPTION
The `previewSendHandler — LEDGER BLIND-SIGN HASH gating` describe block contains the only two tests in `test/send-hash-pin.test.ts` that `await import("../src/index.js")`. The first one paid the cold-load cost on every run, and the cold load walks the full server module graph (BTC + Solana + TRON + LiFi + Kamino + …) which occasionally spills past vitest's 5s default test timeout on a contended worker.

**Symptom:** spotted on the [PR #261 rebase](https://github.com/szhygulin/vaultpilot-mcp/pull/261):

```
× does NOT emit the LEDGER BLIND-SIGN HASH block when result.clearSignOnly is true 5021ms
Error: Test timed out in 5000ms.
```

Re-running in isolation always passes (~3.9s). Classic "test runs near the timeout limit" flake under CPU contention.

## Root cause

The author's existing comment already explained why `vi.resetModules()` was deliberately removed (would re-pay the import cost on every test). But no test in the file outside this describe block pre-warms `src/index.js`, so the FIRST of the two tests in the describe still paid full cold-load.

## Fix

Lift the import into `beforeAll` so the cost amortizes across both tests, with a 30s timeout to absorb cold-load under contention. Both tests now use the captured `previewSendHandler` from the closure.

```diff
+ let previewSendHandler!: typeof import("../src/index.js")["previewSendHandler"];
+ beforeAll(async () => {
+   ({ previewSendHandler } = await import("../src/index.js"));
+ }, 30_000);

  it("does NOT emit ...", async () => {
-   const { previewSendHandler } = await import("../src/index.js");
    ...
  });

  it("DOES emit ...", async () => {
-   const { previewSendHandler } = await import("../src/index.js");
    ...
  });
```

## Test plan

- [x] `npm run build` — clean.
- [x] `npx vitest run test/send-hash-pin.test.ts` — 19/19 pass in 2.69s (was 3.94s — faster because the import only happens once instead of twice).
- [x] **Stress test**: ran the file three times back-to-back. All passed (8.88s / 10.00s / 6.34s under the higher load that triggered the original flake). Old structure would have flaked the first test at these durations.
- [x] `npm test` — full suite green: **1283 / 104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)