### PR TITLE
feat(btc, ltc): multi-input PSBT consolidation in prepare_*_send

### DIFF
--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -19,15 +19,28 @@ import { BTC_DECIMALS, SATS_PER_BTC } from "../../config/btc.js";
  * registered with the in-memory tx-store. The Ledger BTC app consumes
  * the PSBT bytes at signing time via `signPsbtBuffer`.
  *
+ * Multi-source consolidation (issue #264). `wallet` accepts either a
+ * single address or an array of paired source addresses; UTXOs from
+ * every listed source are fetched in parallel, merged into one
+ * coin-selection pool, and assembled into a single multi-input PSBT
+ * with one output (plus change). Phase 1 scope keeps all sources within
+ * the SAME Ledger account (same accountIndex + addressType) — mixed-
+ * type sends (segwit + taproot in one tx) are protocol-supported but
+ * out of scope here. The wallet-policy descriptor `wpkh(@0/**)` /
+ * `tr(@0/**)` Ledger registers at pairing time covers every chain=0/1
+ * descendant under the account, so multi-derivation PSBTs sign
+ * natively without any per-tx policy ceremony.
+ *
  * Change derivation (issue #254). Change goes to the BIP-44 internal
- * chain (`<purpose>'/0'/<account>'/1/<idx>`), looked up from the
- * pairings cache (`pair_ledger_btc` derives the first 20 chain=1
- * addresses per account during the gap-limit scan). The change leaf's
- * `path` and compressed `publicKey` are threaded onto the unsigned tx
- * envelope so the signer can register the change output in
- * `signPsbtBuffer.knownAddressDerivations` — the Ledger BTC app then
- * recognizes it as a same-account change output, labels it "Change"
- * on-screen, and skips the previous "unusual change path" warning.
+ * chain (`<purpose>'/0'/<account>'/1/<idx>`) of the source account,
+ * looked up from the pairings cache (`pair_ledger_btc` derives the
+ * first 20 chain=1 addresses per account during the gap-limit scan).
+ * The change leaf's `path` and compressed `publicKey` are threaded
+ * onto the unsigned tx envelope so the signer can register the change
+ * output in `signPsbtBuffer.knownAddressDerivations` — the Ledger BTC
+ * app then recognizes it as a same-account change output, labels it
+ * "Change" on-screen, and skips the previous "unusual change path"
+ * warning.
  *
  * For now the lowest available `addressIndex` (= 0) is used. Address
  * rotation across multiple sends in one session is out of scope for
@@ -99,7 +112,6 @@ function accountPathFromLeaf(leafPath: string): string {
         `(<purpose>'/0'/<account>'/<change>/<index>).`,
     );
   }
-  // Drop last 2 segments (change + index) → keep purpose'/coin'/account'.
   return parts.slice(0, -2).join("/");
 }
 
@@ -111,12 +123,7 @@ function roughVbytes(inputCount: number, outputCount: number): number {
 /**
  * Pick the chain=1 (BIP-32 internal/change) entry from the pairings
  * cache that matches the source's (accountIndex, addressType). Lowest
- * `addressIndex` wins. Returns null when none is cached — caller
- * surfaces a re-pair instruction (the gap-limit scan in
- * `pair_ledger_btc` skips chain=1 when chain=0 has zero history, so
- * fresh wallets need a re-pair after their first received tx).
- *
- * Issue #254.
+ * `addressIndex` wins. Returns null when none is cached. Issue #254.
  */
 function pickChangeEntry(
   paired: ReturnType<typeof getPairedBtcByAddress>,
@@ -137,7 +144,6 @@ function pickChangeEntry(
   return { address: c.address, path: c.path, publicKey: c.publicKey };
 }
 
-/** Format sats as a BTC decimal string (8-decimal padding, trailing-zero strip). */
 function satsToBtcString(sats: bigint): string {
   const negative = sats < 0n;
   const abs = negative ? -sats : sats;
@@ -148,11 +154,6 @@ function satsToBtcString(sats: bigint): string {
   return negative ? `-${body}` : body;
 }
 
-/**
- * Parse a human BTC amount ("0.001") or "max" to sats.
- *   - "max" returns null; the caller resolves it after coin-selection
- *     (because "max" depends on the fee, which depends on input count).
- */
 function parseBtcAmountToSats(amount: string): bigint | null {
   if (amount === "max") return null;
   if (!/^\d+(\.\d{1,8})?$/.test(amount)) {
@@ -167,84 +168,118 @@ function parseBtcAmountToSats(amount: string): bigint | null {
 }
 
 export interface BuildBitcoinNativeSendArgs {
-  /** Paired BTC source address. Must be in `UserConfig.pairings.bitcoin`. */
-  wallet: string;
+  /**
+   * Paired BTC source address(es). String for single-source;
+   * `string[]` (1-20 entries) for multi-input consolidation. All
+   * addresses must be in `UserConfig.pairings.bitcoin` and share the
+   * same accountIndex + addressType. Issue #264.
+   */
+  wallet: string | string[];
   /** Recipient. Any of the four mainnet address types. */
   to: string;
   /** Decimal BTC string ("0.001"), or "max" for full-balance-minus-fee. */
   amount: string;
   /**
    * Fee rate in sat/vB. Optional — when omitted, uses the indexer's
-   * `halfHourFee` recommendation (~3-block target). Override for
-   * congestion-priority sends or low-fee draining.
+   * `halfHourFee` recommendation (~3-block target).
    */
   feeRateSatPerVb?: number;
   /**
    * BIP-125 RBF. Default true → sequence `0xFFFFFFFD` (replaceable).
-   * Pass false → `0xFFFFFFFE` (final, not replaceable). RBF lets the
-   * user fee-bump a stuck tx via a follow-up `prepare_btc_rbf_bump`
-   * (PR4+).
    */
   rbf?: boolean;
-  /**
-   * Override the fee-cap guard. The cap is `max(10 × feeRate × vbytes,
-   * 2% of total output value)`; legitimate priority sends through
-   * heavy congestion can exceed it. Default false.
-   */
+  /** Override the fee-cap guard. Default false. */
   allowHighFee?: boolean;
+}
+
+/**
+ * Normalize the `wallet` arg to an ordered, deduplicated list of source
+ * addresses. The first entry becomes the "primary" source surfaced as
+ * `tx.from` for backwards compat.
+ */
+function normalizeWallets(arg: string | string[]): string[] {
+  const list = Array.isArray(arg) ? arg : [arg];
+  if (list.length === 0) {
+    throw new Error(
+      "`wallet` must be a paired Bitcoin address or a non-empty array of paired addresses.",
+    );
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const w of list) {
+    if (!seen.has(w)) {
+      seen.add(w);
+      out.push(w);
+    }
+  }
+  return out;
 }
 
 export async function buildBitcoinNativeSend(
   args: BuildBitcoinNativeSendArgs,
 ): Promise<UnsignedBitcoinTx> {
-  // 1. Validate source + destination format.
-  assertBitcoinAddress(args.wallet);
-  assertBitcoinAddress(args.to);
+  const wallets = normalizeWallets(args.wallet);
 
-  // 2. Resolve the paired entry for the source. Without it we don't know
-  //    the BIP-44 purpose / address type / leaf path, so we can't tell
-  //    Ledger which account is signing.
-  const paired = getPairedBtcByAddress(args.wallet);
-  if (!paired) {
-    throw new Error(
-      `Bitcoin address ${args.wallet} is not paired. Run \`pair_ledger_btc\` ` +
-        `to register the four standard address types (legacy/p2sh-segwit/segwit/taproot) ` +
-        `for an account, then pass any of those addresses as \`wallet\`.`,
-    );
+  // 1. Validate every source address format + resolve every paired
+  //    entry. Reject mixed accountIndex / addressType up-front.
+  assertBitcoinAddress(args.to);
+  const pairedList = wallets.map((w) => {
+    assertBitcoinAddress(w);
+    const paired = getPairedBtcByAddress(w);
+    if (!paired) {
+      throw new Error(
+        `Bitcoin address ${w} is not paired. Run \`pair_ledger_btc\` to register ` +
+          `the four standard address types (legacy/p2sh-segwit/segwit/taproot) for ` +
+          `an account, then pass any of those addresses as \`wallet\`.`,
+      );
+    }
+    return paired;
+  });
+
+  const primary = pairedList[0];
+  for (let i = 1; i < pairedList.length; i++) {
+    const p = pairedList[i];
+    if (p.addressType !== primary.addressType) {
+      throw new Error(
+        `Mixed source-address types in one send are not supported in Phase 1 ` +
+          `(${pairedList[0].address} is ${primary.addressType}, ${p.address} is ` +
+          `${p.addressType}). Group sources by type — segwit-only or taproot-only ` +
+          `— and run separate sends.`,
+      );
+    }
+    if (p.accountIndex !== primary.accountIndex) {
+      throw new Error(
+        `Cross-account multi-source sends are not supported (${pairedList[0].address} ` +
+          `is accountIndex=${primary.accountIndex}, ${p.address} is ` +
+          `accountIndex=${p.accountIndex}). Each Ledger account signs under its own ` +
+          `wallet policy — pull from one account at a time.`,
+      );
+    }
   }
-  // Phase 1 send-side scope: native segwit + taproot only. Legacy /
-  // P2SH-wrapped sends require `nonWitnessUtxo` (full prev-tx hex) on
-  // every input, which is a separate code path. Reads work for all
-  // four types — only sends are restricted.
-  if (paired.addressType !== "segwit" && paired.addressType !== "taproot") {
+
+  // Phase 1 send-side scope: native segwit + taproot only.
+  if (primary.addressType !== "segwit" && primary.addressType !== "taproot") {
     throw new Error(
-      `Bitcoin sends from ${paired.addressType} (${paired.path}) addresses are not ` +
+      `Bitcoin sends from ${primary.addressType} (${primary.path}) addresses are not ` +
         `supported in Phase 1 — only native segwit (bc1q...) and taproot (bc1p...). ` +
         `Move funds to your paired segwit or taproot address first.`,
     );
   }
 
-  // Resolve the change address (BIP-32 chain=1) from the pairings
-  // cache. Same accountIndex + addressType as the source; lowest
-  // available addressIndex. `pair_ledger_btc` walks both chains and
-  // caches them — if the user paired before any chain=0 history, the
-  // change-chain walk was skipped (no UTXOs → no spends → no change
-  // can exist anyway). Once they have UTXOs to send, re-pairing
-  // populates chain=1 entries. Issue #254.
-  const changeEntry = pickChangeEntry(paired);
+  const changeEntry = pickChangeEntry(primary);
   if (!changeEntry) {
     throw new Error(
-      `No paired chain=1 (change) address found for ${args.wallet}'s account ` +
-        `(${paired.addressType}, accountIndex=${paired.accountIndex}). The pairings cache ` +
+      `No paired chain=1 (change) address found for ${primary.address}'s account ` +
+        `(${primary.addressType}, accountIndex=${primary.accountIndex}). The pairings cache ` +
         `was likely populated when the wallet had no on-chain history (the gap-limit scan ` +
         `skips the change-chain walk in that case). Re-run \`pair_ledger_btc({ accountIndex: ` +
-        `${paired.accountIndex} })\` now that this address has UTXOs and retry.`,
+        `${primary.accountIndex} })\` now that this address has UTXOs and retry.`,
     );
   }
 
   const indexer = getBitcoinIndexer();
 
-  // 3. Resolve fee rate.
+  // 2. Resolve fee rate.
   let feeRate: number;
   if (args.feeRateSatPerVb !== undefined) {
     feeRate = args.feeRateSatPerVb;
@@ -259,32 +294,38 @@ export async function buildBitcoinNativeSend(
     );
   }
 
-  // 4. Fetch UTXOs.
-  const utxos = await indexer.getUtxos(args.wallet);
-  if (utxos.length === 0) {
+  // 3. Fan out UTXO fetches across all sources in parallel; tag each
+  //    UTXO with its source so coin-selection's output preserves the
+  //    per-input mapping for PSBT building + the LTC legacy fallback.
+  const utxosBySource = await Promise.all(
+    wallets.map(async (w) => ({
+      address: w,
+      utxos: await indexer.getUtxos(w),
+    })),
+  );
+  const totalUtxoCount = utxosBySource.reduce((n, e) => n + e.utxos.length, 0);
+  if (totalUtxoCount === 0) {
     throw new Error(
-      `No UTXOs at ${args.wallet} — the wallet has zero spendable balance. ` +
-        `Verify with \`get_btc_balance\` and confirm at least one tx has confirmed ` +
-        `(unconfirmed mempool UTXOs are eligible for selection but very-young ones ` +
-        `may be rejected by the relay).`,
+      `No UTXOs across the ${wallets.length === 1 ? "source" : `${wallets.length} sources`} ` +
+        `(${wallets.join(", ")}). Verify with \`get_btc_balance\` and confirm at least one ` +
+        `tx has confirmed (unconfirmed mempool UTXOs are eligible for selection but very-young ` +
+        `ones may be rejected by the relay).`,
     );
   }
 
-  // 5. Resolve "max" → fee-aware amount, or convert decimal-BTC → sats.
-  const csUtxos: CoinSelectInput[] = utxos.map((u) => ({
-    txid: u.txid,
-    vout: u.vout,
-    value: u.value,
-  }));
+  type TaggedUtxo = CoinSelectInput & { sourceAddress: string };
+  const csUtxos: TaggedUtxo[] = utxosBySource.flatMap((src) =>
+    src.utxos.map<TaggedUtxo>((u) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      sourceAddress: src.address,
+    })),
+  );
+
+  // 4. Resolve "max" → fee-aware amount, or convert decimal-BTC → sats.
   let amountSats: bigint;
   if (args.amount === "max") {
-    // For max: assume all UTXOs are inputs, single output, no change.
-    // coinselect's internal vbyte estimate can differ from ours by 1-2
-    // bytes (taproot signatures land slightly under our P2WPKH estimate;
-    // segwit signatures match closely). Add a small headroom so the
-    // exact-fit branch coinselect picks still leaves room — without it,
-    // a 1-byte estimator drift turns a feasible "max" into an
-    // INSUFFICIENT-FUNDS error.
     const totalSats = csUtxos.reduce((sum, u) => sum + u.value, 0);
     const vbytes = roughVbytes(csUtxos.length, 1);
     const feeMax = Math.ceil(feeRate * vbytes) + Math.ceil(feeRate * 5);
@@ -309,8 +350,7 @@ export async function buildBitcoinNativeSend(
     );
   }
 
-  // 6. Coin-selection. Change goes to the BIP-44 internal-chain address
-  //    we resolved above (issue #254).
+  // 5. Coin-selection over the merged pool.
   const selection = selectInputs({
     utxos: csUtxos,
     outputs: [{ address: args.to, value: Number(amountSats) }],
@@ -319,22 +359,46 @@ export async function buildBitcoinNativeSend(
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 
-  // 7. Fetch full prev-tx hex for every UNIQUE input txid. Required by
-  //    Ledger BTC app 2.x's segwit-fee-inflation defense — see file
-  //    docstring + issue #213. Dedup by txid so a multi-vout-from-the-
-  //    same-prev-tx selection only fans out once. Parallel fan-out so
-  //    the wall-time stays bounded even with many distinct prev txs.
+  // Map selected inputs back to their source via (txid, vout) — that
+  // pair uniquely identifies a pool entry within a single send.
+  const utxoSourceByKey = new Map<string, string>();
+  for (const u of csUtxos) {
+    utxoSourceByKey.set(`${u.txid}:${u.vout}`, u.sourceAddress);
+  }
+  const inputSources: string[] = selection.inputs.map((i) => {
+    const src = utxoSourceByKey.get(`${i.txid}:${i.vout}`);
+    if (!src) {
+      throw new Error(
+        `Internal error: selected input ${i.txid}:${i.vout} not found in source-tagged pool.`,
+      );
+    }
+    return src;
+  });
+
+  // 6. Fetch full prev-tx hex for every UNIQUE input txid (issue #213).
   const uniqueTxids = [...new Set(selection.inputs.map((i) => i.txid))];
   const prevTxHexEntries = await Promise.all(
     uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
   );
   const prevTxHexByTxid = new Map(prevTxHexEntries);
 
-  // 8. Build PSBT.
+  // 7. Build PSBT. Each input gets ITS source's scriptPubKey.
+  const sourceScriptByAddr = new Map<string, Buffer>();
+  for (const w of wallets) {
+    sourceScriptByAddr.set(w, bitcoinjs.address.toOutputScript(w, NETWORK));
+  }
+
   const psbt = new bitcoinjs.Psbt({ network: NETWORK });
   const sequence = args.rbf === false ? 0xfffffffe : 0xfffffffd;
-  const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
-  for (const input of selection.inputs) {
+  for (let i = 0; i < selection.inputs.length; i++) {
+    const input = selection.inputs[i];
+    const srcAddr = inputSources[i];
+    const sourceScript = sourceScriptByAddr.get(srcAddr);
+    if (!sourceScript) {
+      throw new Error(
+        `Internal error: missing source script for ${srcAddr} (input ${input.txid}:${input.vout}).`,
+      );
+    }
     const prevTxHex = prevTxHexByTxid.get(input.txid);
     if (!prevTxHex) {
       throw new Error(
@@ -346,10 +410,6 @@ export async function buildBitcoinNativeSend(
       hash: input.txid,
       index: input.vout,
       sequence,
-      // `witnessUtxo` (script + value) feeds the segwit sighash;
-      // `nonWitnessUtxo` (full prev-tx) is what Ledger BTC app 2.x
-      // uses to cryptographically verify the input amount. Both are
-      // required — see file docstring.
       witnessUtxo: { script: sourceScript, value: input.value },
       nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
     });
@@ -363,13 +423,7 @@ export async function buildBitcoinNativeSend(
   }
   const psbtBase64 = psbt.toBase64();
 
-  // 9. Decoded-output projection for the verification block. Each
-  //    output gets a sats + BTC-decimal string + isChange flag. The
-  //    Ledger walks every entry on-screen — this projection is what
-  //    `render-verification.ts` mirrors for the user to cross-check.
-  //    For the change output (BIP-32 chain=1) we surface its full leaf
-  //    path so the user — and the second-LLM verifier — can see the
-  //    derivation that backs the on-screen "Change" label.
+  // 8. Decoded-output projection for the verification block.
   const decodedOutputs = selection.outputs.map((o) => {
     const isChange = o.isChange;
     const address = o.address ?? changeEntry.address;
@@ -382,17 +436,53 @@ export async function buildBitcoinNativeSend(
     };
   });
 
-  const accountPath = accountPathFromLeaf(paired.path);
+  // 9. Per-source breakdown — sats pulled from each source + how many
+  //    inputs that source contributed. Sources whose UTXOs coinselect
+  //    didn't pick are dropped (no zero-line rows in the verification).
+  const sourceTotals = new Map<string, { sats: bigint; count: number }>();
+  for (const w of wallets) {
+    sourceTotals.set(w, { sats: 0n, count: 0 });
+  }
+  for (let i = 0; i < selection.inputs.length; i++) {
+    const acc = sourceTotals.get(inputSources[i]);
+    if (!acc) continue;
+    acc.sats += BigInt(selection.inputs[i].value);
+    acc.count += 1;
+  }
+  const decodedSources = wallets
+    .map((w) => {
+      const t = sourceTotals.get(w) ?? { sats: 0n, count: 0 };
+      return {
+        address: w,
+        pulledSats: t.sats.toString(),
+        pulledBtc: satsToBtcString(t.sats),
+        inputCount: t.count,
+      };
+    })
+    .filter((s) => s.inputCount > 0);
+
+  const sources = wallets.map((addr, idx) => ({
+    address: addr,
+    path: pairedList[idx].path,
+    publicKey: pairedList[idx].publicKey,
+  }));
+
+  const accountPath = accountPathFromLeaf(primary.path);
   const vsize = roughVbytes(selection.inputs.length, selection.outputs.length);
-  const description = `Send ${satsToBtcString(amountSats)} BTC to ${args.to}`;
+  const description =
+    wallets.length === 1
+      ? `Send ${satsToBtcString(amountSats)} BTC to ${args.to}`
+      : `Consolidate ${satsToBtcString(amountSats)} BTC from ${wallets.length} addresses to ${args.to}`;
 
   const tx: Omit<UnsignedBitcoinTx, "handle" | "fingerprint"> = {
     chain: "bitcoin",
     action: "native_send",
-    from: args.wallet,
+    from: wallets[0],
+    sources,
+    inputSources,
     psbtBase64,
     accountPath,
-    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[primary.addressType],
     change: {
       address: changeEntry.address,
       path: changeEntry.path,
@@ -402,12 +492,13 @@ export async function buildBitcoinNativeSend(
     decoded: {
       functionName: "bitcoin.native_send",
       args: {
-        from: args.wallet,
+        from: wallets.join(","),
         to: args.to,
         amount: satsToBtcString(amountSats),
         feeRate: `${feeRate} sat/vB`,
       },
       outputs: decodedOutputs,
+      sources: decodedSources,
       feeSats: selection.fee.toString(),
       feeBtc: satsToBtcString(BigInt(selection.fee)),
       feeRateSatPerVb: feeRate,
@@ -425,21 +516,6 @@ export function _isSendableAddressType(
   return type === "p2wpkh" || type === "p2tr";
 }
 
-/**
- * Sign a UTF-8 message with the paired Bitcoin address using the
- * Bitcoin Signed Message format (BIP-137). The Ledger BTC app prompts
- * the user to confirm the message text on-device before producing the
- * signature — same clear-sign UX as send-side flows.
- *
- * Taproot is refused (BIP-322 not yet exposed by Ledger). Legacy /
- * P2SH-wrapped / native segwit all return base64-encoded compact
- * signatures with header bytes that match the address-type convention
- * Sparrow / Electrum / Bitcoin Core's `verifymessage` accept.
- *
- * The returned `format: "BIP-137"` field tells the verifier which scheme
- * to use; useful for cross-wallet verification flows where the verifier
- * needs to know whether to expect BIP-137 or BIP-322.
- */
 export interface SignBitcoinMessageArgs {
   wallet: string;
   message: string;
@@ -453,6 +529,12 @@ export interface SignedBitcoinMessage {
   addressType: PairedBtcAddressType;
 }
 
+/**
+ * Sign a UTF-8 message with the paired Bitcoin address using the
+ * Bitcoin Signed Message format (BIP-137). The Ledger BTC app prompts
+ * the user to confirm the message text on-device before producing the
+ * signature.
+ */
 export async function signBitcoinMessage(
   args: SignBitcoinMessageArgs,
 ): Promise<SignedBitcoinMessage> {

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1867,18 +1867,23 @@ async function sendBitcoinTransaction(args: SendTransactionArgs): Promise<{
   chain: "bitcoin";
 }> {
   const tx = consumeBitcoinHandle(args.handle);
-  const paired = getPairedBtcByAddress(tx.from);
-  if (!paired) {
-    throw new Error(
-      `Bitcoin source ${tx.from} is no longer in the pairing cache. The cache may have ` +
-        `been cleared since prepare_btc_send. Re-pair via \`pair_ledger_btc\` and re-run ` +
-        `prepare_btc_send to get a fresh handle.`,
-    );
+  // Validate every source in the envelope is still paired. The signer
+  // re-derives each source against the device for the proof-of-identity
+  // guard, but we want the clear "cache cleared since prepare" error
+  // surfaced before the USB transport opens.
+  for (const src of tx.sources) {
+    const paired = getPairedBtcByAddress(src.address);
+    if (!paired) {
+      throw new Error(
+        `Bitcoin source ${src.address} is no longer in the pairing cache. The cache ` +
+          `may have been cleared since prepare_btc_send. Re-pair via \`pair_ledger_btc\` ` +
+          `and re-run prepare_btc_send to get a fresh handle.`,
+      );
+    }
   }
   const { rawTxHex } = await signBtcPsbtOnLedger({
     psbtBase64: tx.psbtBase64,
-    expectedFrom: tx.from,
-    path: paired.path,
+    sources: tx.sources.map((s) => ({ address: s.address, path: s.path })),
     accountPath: tx.accountPath,
     addressFormat: tx.addressFormat,
     ...(tx.change ? { change: tx.change } : {}),
@@ -1901,17 +1906,19 @@ async function sendLitecoinTransaction(args: SendTransactionArgs): Promise<{
   chain: "litecoin";
 }> {
   const tx = consumeLitecoinHandle(args.handle);
-  const paired = getPairedLtcByAddress(tx.from);
-  if (!paired) {
-    throw new Error(
-      `Litecoin source ${tx.from} is no longer in the pairing cache. Re-pair via ` +
-        `\`pair_ledger_ltc\` and re-run prepare_litecoin_native_send for a fresh handle.`,
-    );
+  for (const src of tx.sources) {
+    const paired = getPairedLtcByAddress(src.address);
+    if (!paired) {
+      throw new Error(
+        `Litecoin source ${src.address} is no longer in the pairing cache. Re-pair via ` +
+          `\`pair_ledger_ltc\` and re-run prepare_litecoin_native_send for a fresh handle.`,
+      );
+    }
   }
   const { rawTxHex } = await signLtcPsbtOnLedger({
     psbtBase64: tx.psbtBase64,
-    expectedFrom: tx.from,
-    path: paired.path,
+    sources: tx.sources.map((s) => ({ address: s.address, path: s.path })),
+    inputSources: tx.inputSources,
     accountPath: tx.accountPath,
     addressFormat: tx.addressFormat,
     ...(tx.change ? { change: tx.change } : {}),

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1139,12 +1139,19 @@ export const rescanBitcoinAccountInput = z.object({
 });
 
 export const prepareBitcoinNativeSendInput = z.object({
-  wallet: bitcoinAddressSchema.describe(
-    "Paired Bitcoin source address. Must already be in `pairings.bitcoin` " +
-      "(call `pair_ledger_btc` first). Phase 1 sends only support native " +
-      "segwit (`bc1q...`) and taproot (`bc1p...`) source addresses; legacy " +
-      "(`1...`) and P2SH-wrapped (`3...`) sends are deferred."
-  ),
+  wallet: z
+    .union([bitcoinAddressSchema, z.array(bitcoinAddressSchema).min(1).max(20)])
+    .describe(
+      "One paired Bitcoin source address (string), OR an array of 1-20 paired " +
+        "source addresses for multi-input consolidation (issue #264). All " +
+        "addresses must belong to the SAME Ledger account (same accountIndex + " +
+        "addressType) — Phase 1 mixed-type sends (segwit + taproot in one tx) " +
+        "are out of scope. UTXOs are fetched in parallel for every listed " +
+        "source and merged into one coin-selection pool. \"max\" sweeps every " +
+        "UTXO from every listed wallet into a single output. Phase 1 sends only " +
+        "support native segwit (`bc1q...`) and taproot (`bc1p...`) sources; " +
+        "legacy (`1...`) and P2SH-wrapped (`3...`) sends are deferred."
+    ),
   to: bitcoinAddressSchema.describe(
     "Bitcoin recipient address. Any of the four mainnet types is accepted as " +
       "a destination — the restriction is only on the source side."
@@ -1289,12 +1296,17 @@ export const getLitecoinBalanceInput = z.object({
 });
 
 export const prepareLitecoinNativeSendInput = z.object({
-  wallet: litecoinAddressSchema.describe(
-    "Paired Litecoin source address. Must already be in `pairings.litecoin` " +
-      "(call `pair_ledger_ltc` first). Initial release sends only support " +
-      "native segwit (`ltc1q...`) and taproot (`ltc1p...`) source addresses; " +
-      "legacy (`L...`) and P2SH-wrapped (`M.../3...`) sends are deferred."
-  ),
+  wallet: z
+    .union([litecoinAddressSchema, z.array(litecoinAddressSchema).min(1).max(20)])
+    .describe(
+      "One paired Litecoin source address (string), OR an array of 1-20 paired " +
+        "source addresses for multi-input consolidation (issue #264). All " +
+        "addresses must belong to the SAME Ledger account (same accountIndex + " +
+        "addressType). UTXOs are fetched in parallel and merged into one " +
+        "coin-selection pool. Initial release sends only support native segwit " +
+        "(`ltc1q...`) and taproot (`ltc1p...`) source addresses; legacy " +
+        "(`L...`) and P2SH-wrapped (`M.../3...`) sends are deferred."
+    ),
   to: litecoinAddressSchema.describe(
     "Litecoin recipient address. L/M/ltc1q/ltc1p accepted. Legacy 3-prefix " +
       "P2SH is rejected on send (it's read-supported only) — ask the recipient " +

--- a/src/modules/litecoin/actions.ts
+++ b/src/modules/litecoin/actions.ts
@@ -16,31 +16,20 @@ import { LTC_DECIMALS, LITOSHIS_PER_LTC } from "../../config/litecoin.js";
  * Same PSBT v0 / coin-selection / fee-cap pattern; only network params
  * and chain identifiers differ.
  *
+ * Multi-source consolidation (issue #264). `wallet` accepts either a
+ * single address or an array of paired source addresses; mirrors BTC's
+ * fan-out + merged coin-selection. Phase 1 scope keeps all sources
+ * within the SAME Ledger account (same accountIndex + addressType).
+ *
  * bitcoinjs-lib does not ship a Litecoin network preset, so we
  * construct one inline (mainnet only). pubKeyHash 0x30 (L-prefix),
  * scriptHash 0x32 (M-prefix; modern Litecoin P2SH version), bech32
- * HRP `ltc`. The xpub/xprv version bytes match BTC's `0x0488B21E` /
- * `0x0488ADE4` — Litecoin Core uses the standard BIP-32 versions
- * (Ltub/Ltpv exist in some third-party wallets but Core does not
- * emit them).
+ * HRP `ltc`.
  *
- * Legacy 3-prefix (0x05) Litecoin P2SH addresses are READ-side only:
- * `assertLitecoinAddress` accepts them, but the SEND path rejects
- * them because bitcoinjs-lib's `address.toOutputScript` validates the
- * version byte against the configured `scriptHash` and we only carry
- * one `scriptHash` per network object. Recipients on 3-prefix P2SH
- * are vanishingly rare on Litecoin (the M-prefix migration completed
- * years ago); when one shows up, we surface a clear error pointing
- * the user to ask the recipient for an M-prefix address.
- *
- * Change derivation mirrors BTC's (issue #254): the change output goes
- * to a BIP-44 internal-chain (`/1/<idx>`) address looked up from the
- * pairings cache, and the change leaf's `path` + `publicKey` are
- * threaded onto the unsigned tx so the signer can register the change
- * in `signPsbtBuffer.knownAddressDerivations` (and, on the legacy
- * `createPaymentTransaction` fallback path, populate `changePath`).
- * Same RBF default (`0xFFFFFFFD`). Same nonWitnessUtxo requirement on
- * every input (Ledger BTC/LTC app 2.x — issue #213).
+ * Legacy 3-prefix (0x05) Litecoin P2SH addresses are READ-side only.
+ * Change derivation mirrors BTC's (issue #254). Same RBF default
+ * (`0xFFFFFFFD`). Same nonWitnessUtxo requirement on every input
+ * (Ledger BTC/LTC app 2.x — issue #213).
  */
 
 const requireCjs = createRequire(import.meta.url);
@@ -61,28 +50,20 @@ const bitcoinjs = requireCjs("bitcoinjs-lib") as {
   };
 };
 
-/**
- * Litecoin mainnet network params, in the bitcoinjs-lib `Network`
- * shape. Since bitcoinjs-lib doesn't ship a Litecoin preset we define
- * it here.
- */
 const LITECOIN_NETWORK = {
   messagePrefix: "\x19Litecoin Signed Message:\n",
   bech32: "ltc",
   bip32: {
-    public: 0x0488b21e, // xpub — Litecoin Core convention
-    private: 0x0488ade4, // xprv
+    public: 0x0488b21e,
+    private: 0x0488ade4,
   },
-  pubKeyHash: 0x30, // L-prefix
-  scriptHash: 0x32, // M-prefix (modern); legacy 3-prefix not supported on send
+  pubKeyHash: 0x30,
+  scriptHash: 0x32,
   wif: 0xb0,
 };
 
 const NETWORK = LITECOIN_NETWORK;
 
-/**
- * Map BIP-32-purpose-to-our-paired-type.
- */
 const ADDRESS_FORMAT_BY_TYPE: Record<
   PairedLtcAddressType,
   UnsignedLitecoinTx["addressFormat"]
@@ -93,9 +74,6 @@ const ADDRESS_FORMAT_BY_TYPE: Record<
   taproot: "bech32m",
 };
 
-/**
- * Account-level path derivation from leaf path.
- */
 function accountPathFromLeaf(leafPath: string): string {
   const parts = leafPath.split("/");
   if (parts.length < 5) {
@@ -111,12 +89,6 @@ function roughVbytes(inputCount: number, outputCount: number): number {
   return 10 + inputCount * 68 + outputCount * 31;
 }
 
-/**
- * Pick the chain=1 (BIP-32 internal/change) entry from the LTC pairings
- * cache that matches the source's (accountIndex, addressType). Mirror
- * of `pickChangeEntry` in btc/actions.ts. Returns null when none is
- * cached. Issue #254.
- */
 function pickChangeEntry(
   paired: ReturnType<typeof getPairedLtcByAddress>,
 ): { address: string; path: string; publicKey: string } | null {
@@ -160,27 +132,44 @@ function parseLtcAmountToLitoshis(amount: string): bigint | null {
 }
 
 export interface BuildLitecoinNativeSendArgs {
-  /** Paired LTC source address. Must be in `UserConfig.pairings.litecoin`. */
-  wallet: string;
-  /** Recipient. L/M/ltc1q/ltc1p — 3-prefix legacy P2SH not supported on send. */
+  /**
+   * Paired LTC source address(es). String for single-source; `string[]`
+   * (1-20 entries) for multi-input consolidation. All addresses must
+   * be in `UserConfig.pairings.litecoin` and share the same accountIndex
+   * + addressType. Issue #264.
+   */
+  wallet: string | string[];
   to: string;
-  /** Decimal LTC string ("0.001"), or "max" for full-balance-minus-fee. */
   amount: string;
-  /** Fee rate in litoshi/vB. Default: indexer's halfHourFee recommendation. */
   feeRateSatPerVb?: number;
-  /** BIP-125 RBF. Default true. */
   rbf?: boolean;
-  /** Override the fee-cap guard. Default false. */
   allowHighFee?: boolean;
+}
+
+function normalizeWallets(arg: string | string[]): string[] {
+  const list = Array.isArray(arg) ? arg : [arg];
+  if (list.length === 0) {
+    throw new Error(
+      "`wallet` must be a paired Litecoin address or a non-empty array of paired addresses.",
+    );
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const w of list) {
+    if (!seen.has(w)) {
+      seen.add(w);
+      out.push(w);
+    }
+  }
+  return out;
 }
 
 export async function buildLitecoinNativeSend(
   args: BuildLitecoinNativeSendArgs,
 ): Promise<UnsignedLitecoinTx> {
-  // 1. Validate source + destination format.
-  assertLitecoinAddress(args.wallet);
+  const wallets = normalizeWallets(args.wallet);
+
   const toType = assertLitecoinAddress(args.to);
-  // Reject 3-prefix legacy P2SH on send-side — see file docstring.
   if (toType === "p2sh" && args.to.startsWith("3")) {
     throw new Error(
       `Sending to legacy 3-prefix Litecoin P2SH addresses (${args.to}) is not supported. ` +
@@ -188,45 +177,56 @@ export async function buildLitecoinNativeSend(
         `recipient for their modern M-prefix address, or send via Litecoin Core directly.`,
     );
   }
+  const pairedList = wallets.map((w) => {
+    assertLitecoinAddress(w);
+    const paired = getPairedLtcByAddress(w);
+    if (!paired) {
+      throw new Error(
+        `Litecoin address ${w} is not paired. Run \`pair_ledger_ltc\` to register ` +
+          `the four standard address types and retry with one of the resulting addresses.`,
+      );
+    }
+    return paired;
+  });
 
-  // 2. Resolve the paired entry for the source.
-  const paired = getPairedLtcByAddress(args.wallet);
-  if (!paired) {
-    throw new Error(
-      `Litecoin address ${args.wallet} is not paired. Run \`pair_ledger_ltc\` ` +
-        `to register the four standard address types (legacy/p2sh-segwit/segwit/taproot) ` +
-        `for an account, then pass any of those addresses as \`wallet\`.`,
-    );
+  const primary = pairedList[0];
+  for (let i = 1; i < pairedList.length; i++) {
+    const p = pairedList[i];
+    if (p.addressType !== primary.addressType) {
+      throw new Error(
+        `Mixed source-address types in one Litecoin send are not supported in Phase 1 ` +
+          `(${pairedList[0].address} is ${primary.addressType}, ${p.address} is ` +
+          `${p.addressType}). Group sources by type and run separate sends.`,
+      );
+    }
+    if (p.accountIndex !== primary.accountIndex) {
+      throw new Error(
+        `Cross-account multi-source Litecoin sends are not supported (${pairedList[0].address} ` +
+          `is accountIndex=${primary.accountIndex}, ${p.address} is ` +
+          `accountIndex=${p.accountIndex}). Pull from one account at a time.`,
+      );
+    }
   }
-  // Phase 1 send-side scope: native segwit + taproot only — same scope
-  // discipline as BTC. (Note: Litecoin Core has not activated Taproot
-  // on mainnet, so taproot sends will derive correctly but recipients
-  // can't spend until activation. Native segwit is the recommended
-  // path.)
-  if (paired.addressType !== "segwit" && paired.addressType !== "taproot") {
+
+  if (primary.addressType !== "segwit" && primary.addressType !== "taproot") {
     throw new Error(
-      `Litecoin sends from ${paired.addressType} (${paired.path}) addresses are not ` +
+      `Litecoin sends from ${primary.addressType} (${primary.path}) addresses are not ` +
         `supported in Phase 1 — only native segwit (ltc1q...) and taproot (ltc1p...). ` +
         `Move funds to your paired segwit address first.`,
     );
   }
 
-  // Resolve the BIP-32 chain=1 change address from the pairings cache.
-  // Symmetric with the BTC builder. Issue #254.
-  const changeEntry = pickChangeEntry(paired);
+  const changeEntry = pickChangeEntry(primary);
   if (!changeEntry) {
     throw new Error(
-      `No paired chain=1 (change) address found for ${args.wallet}'s account ` +
-        `(${paired.addressType}, accountIndex=${paired.accountIndex}). The pairings cache ` +
-        `was likely populated when the wallet had no on-chain history (the gap-limit scan ` +
-        `skips the change-chain walk in that case). Re-run \`pair_ledger_ltc({ accountIndex: ` +
-        `${paired.accountIndex} })\` now that this address has UTXOs and retry.`,
+      `No paired chain=1 (change) address found for ${primary.address}'s account ` +
+        `(${primary.addressType}, accountIndex=${primary.accountIndex}). Re-run ` +
+        `\`pair_ledger_ltc({ accountIndex: ${primary.accountIndex} })\` and retry.`,
     );
   }
 
   const indexer = getLitecoinIndexer();
 
-  // 3. Resolve fee rate.
   let feeRate: number;
   if (args.feeRateSatPerVb !== undefined) {
     feeRate = args.feeRateSatPerVb;
@@ -241,22 +241,31 @@ export async function buildLitecoinNativeSend(
     );
   }
 
-  // 4. Fetch UTXOs.
-  const utxos = await indexer.getUtxos(args.wallet);
-  if (utxos.length === 0) {
+  const utxosBySource = await Promise.all(
+    wallets.map(async (w) => ({
+      address: w,
+      utxos: await indexer.getUtxos(w),
+    })),
+  );
+  const totalUtxoCount = utxosBySource.reduce((n, e) => n + e.utxos.length, 0);
+  if (totalUtxoCount === 0) {
     throw new Error(
-      `No UTXOs at ${args.wallet} — the wallet has zero spendable balance. ` +
-        `Verify with \`get_token_balance\` (chain:"litecoin") and confirm at least one ` +
-        `tx has confirmed.`,
+      `No UTXOs across the ${wallets.length === 1 ? "source" : `${wallets.length} sources`} ` +
+        `(${wallets.join(", ")}). Verify with \`get_token_balance\` (chain:"litecoin") and ` +
+        `confirm at least one tx has confirmed.`,
     );
   }
 
-  // 5. Resolve "max" → fee-aware amount, or convert decimal-LTC → litoshis.
-  const csUtxos: CoinSelectInput[] = utxos.map((u) => ({
-    txid: u.txid,
-    vout: u.vout,
-    value: u.value,
-  }));
+  type TaggedUtxo = CoinSelectInput & { sourceAddress: string };
+  const csUtxos: TaggedUtxo[] = utxosBySource.flatMap((src) =>
+    src.utxos.map<TaggedUtxo>((u) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      sourceAddress: src.address,
+    })),
+  );
+
   let amountSats: bigint;
   if (args.amount === "max") {
     const totalSats = csUtxos.reduce((sum, u) => sum + u.value, 0);
@@ -283,8 +292,6 @@ export async function buildLitecoinNativeSend(
     );
   }
 
-  // 6. Coin-selection. Change goes to the BIP-44 chain=1 address from
-  //    the pairings cache (issue #254).
   const selection = selectInputs({
     utxos: csUtxos,
     outputs: [{ address: args.to, value: Number(amountSats) }],
@@ -293,18 +300,42 @@ export async function buildLitecoinNativeSend(
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 
-  // 7. Fetch full prev-tx hex for every UNIQUE input txid (issue #213).
+  const utxoSourceByKey = new Map<string, string>();
+  for (const u of csUtxos) {
+    utxoSourceByKey.set(`${u.txid}:${u.vout}`, u.sourceAddress);
+  }
+  const inputSources: string[] = selection.inputs.map((i) => {
+    const src = utxoSourceByKey.get(`${i.txid}:${i.vout}`);
+    if (!src) {
+      throw new Error(
+        `Internal error: selected input ${i.txid}:${i.vout} not found in source-tagged pool.`,
+      );
+    }
+    return src;
+  });
+
   const uniqueTxids = [...new Set(selection.inputs.map((i) => i.txid))];
   const prevTxHexEntries = await Promise.all(
     uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
   );
   const prevTxHexByTxid = new Map(prevTxHexEntries);
 
-  // 8. Build PSBT.
+  const sourceScriptByAddr = new Map<string, Buffer>();
+  for (const w of wallets) {
+    sourceScriptByAddr.set(w, bitcoinjs.address.toOutputScript(w, NETWORK));
+  }
+
   const psbt = new bitcoinjs.Psbt({ network: NETWORK });
   const sequence = args.rbf === false ? 0xfffffffe : 0xfffffffd;
-  const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
-  for (const input of selection.inputs) {
+  for (let i = 0; i < selection.inputs.length; i++) {
+    const input = selection.inputs[i];
+    const srcAddr = inputSources[i];
+    const sourceScript = sourceScriptByAddr.get(srcAddr);
+    if (!sourceScript) {
+      throw new Error(
+        `Internal error: missing source script for ${srcAddr} (input ${input.txid}:${input.vout}).`,
+      );
+    }
     const prevTxHex = prevTxHexByTxid.get(input.txid);
     if (!prevTxHex) {
       throw new Error(
@@ -341,17 +372,50 @@ export async function buildLitecoinNativeSend(
     };
   });
 
-  const accountPath = accountPathFromLeaf(paired.path);
+  const sourceTotals = new Map<string, { sats: bigint; count: number }>();
+  for (const w of wallets) {
+    sourceTotals.set(w, { sats: 0n, count: 0 });
+  }
+  for (let i = 0; i < selection.inputs.length; i++) {
+    const acc = sourceTotals.get(inputSources[i]);
+    if (!acc) continue;
+    acc.sats += BigInt(selection.inputs[i].value);
+    acc.count += 1;
+  }
+  const decodedSources = wallets
+    .map((w) => {
+      const t = sourceTotals.get(w) ?? { sats: 0n, count: 0 };
+      return {
+        address: w,
+        pulledSats: t.sats.toString(),
+        pulledLtc: litoshisToLtcString(t.sats),
+        inputCount: t.count,
+      };
+    })
+    .filter((s) => s.inputCount > 0);
+
+  const sources = wallets.map((addr, idx) => ({
+    address: addr,
+    path: pairedList[idx].path,
+    publicKey: pairedList[idx].publicKey,
+  }));
+
+  const accountPath = accountPathFromLeaf(primary.path);
   const vsize = roughVbytes(selection.inputs.length, selection.outputs.length);
-  const description = `Send ${litoshisToLtcString(amountSats)} LTC to ${args.to}`;
+  const description =
+    wallets.length === 1
+      ? `Send ${litoshisToLtcString(amountSats)} LTC to ${args.to}`
+      : `Consolidate ${litoshisToLtcString(amountSats)} LTC from ${wallets.length} addresses to ${args.to}`;
 
   const tx: Omit<UnsignedLitecoinTx, "handle" | "fingerprint"> = {
     chain: "litecoin",
     action: "native_send",
-    from: args.wallet,
+    from: wallets[0],
+    sources,
+    inputSources,
     psbtBase64,
     accountPath,
-    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[primary.addressType],
     change: {
       address: changeEntry.address,
       path: changeEntry.path,
@@ -361,12 +425,13 @@ export async function buildLitecoinNativeSend(
     decoded: {
       functionName: "litecoin.native_send",
       args: {
-        from: args.wallet,
+        from: wallets.join(","),
         to: args.to,
         amount: litoshisToLtcString(amountSats),
         feeRate: `${feeRate} litoshi/vB`,
       },
       outputs: decodedOutputs,
+      sources: decodedSources,
       feeSats: selection.fee.toString(),
       feeLtc: litoshisToLtcString(BigInt(selection.fee)),
       feeRateSatPerVb: feeRate,
@@ -384,11 +449,6 @@ export function _isSendableAddressType(
   return type === "p2wpkh" || type === "p2tr";
 }
 
-/**
- * Sign a UTF-8 message with the paired Litecoin address using the
- * Litecoin Signed Message format (BIP-137 with Litecoin's message
- * prefix). Mirrors BTC's signBitcoinMessage.
- */
 export interface SignLitecoinMessageArgs {
   wallet: string;
   message: string;
@@ -402,6 +462,11 @@ export interface SignedLitecoinMessage {
   addressType: PairedLtcAddressType;
 }
 
+/**
+ * Sign a UTF-8 message with the paired Litecoin address using the
+ * Litecoin Signed Message format (BIP-137 with Litecoin's message
+ * prefix).
+ */
 export async function signLitecoinMessage(
   args: SignLitecoinMessageArgs,
 ): Promise<SignedLitecoinMessage> {

--- a/src/signing/btc-usb-signer.ts
+++ b/src/signing/btc-usb-signer.ts
@@ -630,20 +630,32 @@ export function compressPubkey(pubkey: Buffer): Buffer {
  */
 export async function signBtcPsbtOnLedger(args: {
   psbtBase64: string;
-  expectedFrom: string;
-  path: string;
+  /**
+   * One descriptor per UNIQUE source address contributing inputs to
+   * the PSBT. Single-source sends pass a one-element array; multi-
+   * source consolidation (issue #264) passes one entry per source. The
+   * signer registers one `knownAddressDerivations` entry per source so
+   * the SDK can populate `bip32Derivation` on every input. Each
+   * source's address is re-derived against the live device for the
+   * proof-of-identity guard — N sources → N device round-trips before
+   * the sign prompt.
+   */
+  sources: Array<{
+    address: string;
+    path: string;
+  }>;
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
   /**
    * BIP-32 chain=1 change-output derivation (issue #254). When set, the
-   * signer adds a second `knownAddressDerivations` entry so the SDK
-   * populates the change output's bip32Derivation, which the Ledger BTC
-   * app uses to recognize the address as same-account change and skip
-   * the "unusual change path" warning. The pairings cache is the source
-   * of truth — we trust it to point at a real device-derivable address;
-   * if the cache is stale the device's own derivation check (run inside
-   * the BTC app at sign time) will refuse before the user sees a wrong
-   * address.
+   * signer adds an additional `knownAddressDerivations` entry so the
+   * SDK populates the change output's bip32Derivation, which the
+   * Ledger BTC app uses to recognize the address as same-account
+   * change and skip the "unusual change path" warning. The pairings
+   * cache is the source of truth — we trust it to point at a real
+   * device-derivable address; if the cache is stale the device's own
+   * derivation check (run inside the BTC app at sign time) will refuse
+   * before the user sees a wrong address.
    */
   change?: {
     address: string;
@@ -651,6 +663,11 @@ export async function signBtcPsbtOnLedger(args: {
     publicKey: string;
   };
 }): Promise<{ rawTxHex: string }> {
+  if (args.sources.length === 0) {
+    throw new Error(
+      "signBtcPsbtOnLedger: `sources` must list at least one source descriptor.",
+    );
+  }
   return withBtcUsbLock(async () => {
     const { app, transport, rawTransport } = await openLedger();
     try {
@@ -665,43 +682,44 @@ export async function signBtcPsbtOnLedger(args: {
             `Open the Bitcoin app on your device and retry.`,
         );
       }
-      // Re-derive + validate the source address. If the device produces
-      // a different address for the same path the pairing cache
-      // registered, refuse to sign — something is wrong (different seed,
-      // different app, planted pairing). Don't blind-sign through it.
-      const derived = await app.getWalletPublicKey(args.path, {
-        format: args.addressFormat,
-      });
-      if (derived.bitcoinAddress !== args.expectedFrom) {
-        throw new Error(
-          `Ledger derived ${derived.bitcoinAddress} at ${args.path}, but the prepared tx ` +
-            `lists ${args.expectedFrom} as the source. The device may have a different seed ` +
-            `loaded, the Bitcoin app version may have changed the derivation, or the cached ` +
-            `pairing is stale. Re-pair via \`pair_ledger_btc\` and retry.`,
+
+      // Build knownAddressDerivations. The SDK keys the map by the
+      // witness-program payload extracted from each scriptPubKey —
+      // bytes 2..22 (hash160 of pubkey) for P2WPKH, bytes 2..34
+      // (tweaked x-only key) for P2TR. Mirrors @ledgerhq/psbtv2
+      // `extractHashFromScriptPubKey`, which is what
+      // `populateMissingBip32Derivations` looks up against. Issue #206.
+      //
+      // One entry per unique source (issue #264 multi-source) plus an
+      // optional change entry (issue #254).
+      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
+
+      // Per-source: re-derive against device + register. Refuse to
+      // sign if the device produces a different address for any
+      // source's path — proof-of-identity guard mirroring the prior
+      // single-source behavior, just iterated.
+      for (const src of args.sources) {
+        const derived = await app.getWalletPublicKey(src.path, {
+          format: args.addressFormat,
+        });
+        if (derived.bitcoinAddress !== src.address) {
+          throw new Error(
+            `Ledger derived ${derived.bitcoinAddress} at ${src.path}, but the prepared tx ` +
+              `lists ${src.address} as a source. The device may have a different seed loaded, ` +
+              `the Bitcoin app version may have changed the derivation, or the cached pairing ` +
+              `is stale. Re-pair via \`pair_ledger_btc\` and retry.`,
+          );
+        }
+        const sourceScript = bitcoinjs.address.toOutputScript(
+          src.address,
+          bitcoinjs.networks.bitcoin,
         );
+        known.set(extractWitnessProgramHex(sourceScript), {
+          pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
+          path: pathStringToNumbers(src.path),
+        });
       }
 
-      // Build the knownAddressDerivations map. The SDK keys the map by
-      // the witness-program payload extracted from each scriptPubKey —
-      // bytes 2..22 (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked
-      // x-only key) for P2TR. Mirrors @ledgerhq/psbtv2
-      // `extractHashFromScriptPubKey`, which is what
-      // `populateMissingBip32Derivations` looks up against. Issue #206:
-      // an earlier sha256(scriptPubKey) key never matched, so the
-      // library left the PSBT without bip32Derivation and the Ledger
-      // BTC app v2.x rejected with 0x6a80 before any UI.
-      //
-      // Two entries today: the source (input + same-address-as-recipient
-      // edge case) and the BIP-32 chain=1 change output (issue #254).
-      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
-      const sourceScript = bitcoinjs.address.toOutputScript(
-        args.expectedFrom,
-        bitcoinjs.networks.bitcoin,
-      );
-      known.set(extractWitnessProgramHex(sourceScript), {
-        pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
-        path: pathStringToNumbers(args.path),
-      });
       if (args.change) {
         const changeScript = bitcoinjs.address.toOutputScript(
           args.change.address,

--- a/src/signing/ltc-usb-signer.ts
+++ b/src/signing/ltc-usb-signer.ts
@@ -674,8 +674,24 @@ export function compressPubkey(pubkey: Buffer): Buffer {
  */
 export async function signLtcPsbtOnLedger(args: {
   psbtBase64: string;
-  expectedFrom: string;
-  path: string;
+  /**
+   * One descriptor per UNIQUE source address contributing inputs to the
+   * PSBT. Single-source sends pass a one-element array; multi-source
+   * consolidation (issue #264) passes one entry per source.
+   */
+  sources: Array<{
+    address: string;
+    path: string;
+  }>;
+  /**
+   * Per-PSBT-input source address (issue #264) — `inputSources[i]`
+   * names which entry in `sources` provided the i-th PSBT input. The
+   * legacy `createPaymentTransaction` fallback uses this to populate
+   * `associatedKeysets` with the per-input path; the modern
+   * `signPsbtBuffer` path keys off witness-program lookup and ignores
+   * it.
+   */
+  inputSources: string[];
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
   /**
@@ -688,6 +704,11 @@ export async function signLtcPsbtOnLedger(args: {
     publicKey: string;
   };
 }): Promise<{ rawTxHex: string }> {
+  if (args.sources.length === 0) {
+    throw new Error(
+      "signLtcPsbtOnLedger: `sources` must list at least one source descriptor.",
+    );
+  }
   return withLtcUsbLock(async () => {
     const { app, transport, rawTransport } = await openLedger();
     try {
@@ -702,43 +723,36 @@ export async function signLtcPsbtOnLedger(args: {
             `Open the Litecoin app on your device and retry.`,
         );
       }
-      // Re-derive + validate the source address. If the device produces
-      // a different address for the same path the pairing cache
-      // registered, refuse to sign — something is wrong (different seed,
-      // different app, planted pairing). Don't blind-sign through it.
-      const derived = await app.getWalletPublicKey(args.path, {
-        format: args.addressFormat,
-      });
-      if (derived.bitcoinAddress !== args.expectedFrom) {
-        throw new Error(
-          `Ledger derived ${derived.bitcoinAddress} at ${args.path}, but the prepared tx ` +
-            `lists ${args.expectedFrom} as the source. The device may have a different seed ` +
-            `loaded, the Litecoin app version may have changed the derivation, or the cached ` +
-            `pairing is stale. Re-pair via \`pair_ledger_ltc\` and retry.`,
+
+      // Build knownAddressDerivations — one entry per unique source
+      // (issue #264 multi-source) plus an optional change entry
+      // (issue #254). Each source's address is re-derived against the
+      // live device for the proof-of-identity guard; if any source's
+      // path produces a different address, refuse to sign.
+      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
+
+      for (const src of args.sources) {
+        const derived = await app.getWalletPublicKey(src.path, {
+          format: args.addressFormat,
+        });
+        if (derived.bitcoinAddress !== src.address) {
+          throw new Error(
+            `Ledger derived ${derived.bitcoinAddress} at ${src.path}, but the prepared tx ` +
+              `lists ${src.address} as a source. The device may have a different seed loaded, ` +
+              `the Litecoin app version may have changed the derivation, or the cached pairing ` +
+              `is stale. Re-pair via \`pair_ledger_ltc\` and retry.`,
+          );
+        }
+        const sourceScript = bitcoinjs.address.toOutputScript(
+          src.address,
+          LITECOIN_NETWORK,
         );
+        known.set(extractWitnessProgramHex(sourceScript), {
+          pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
+          path: pathStringToNumbers(src.path),
+        });
       }
 
-      // Build the knownAddressDerivations map. The SDK keys the map by
-      // the witness-program payload extracted from each scriptPubKey —
-      // bytes 2..22 (hash160 of pubkey) for P2WPKH, bytes 2..34 (tweaked
-      // x-only key) for P2TR. Mirrors @ledgerhq/psbtv2
-      // `extractHashFromScriptPubKey`, which is what
-      // `populateMissingBip32Derivations` looks up against. Issue #206:
-      // an earlier sha256(scriptPubKey) key never matched, so the
-      // library left the PSBT without bip32Derivation and the Ledger
-      // Litecoin app v2.x rejected with 0x6a80 before any UI.
-      //
-      // Two entries today: the source (input + same-address-as-recipient
-      // edge case) and the BIP-32 chain=1 change output (issue #254).
-      const known = new Map<string, { pubkey: Buffer; path: number[] }>();
-      const sourceScript = bitcoinjs.address.toOutputScript(
-        args.expectedFrom,
-        LITECOIN_NETWORK,
-      );
-      known.set(extractWitnessProgramHex(sourceScript), {
-        pubkey: compressPubkey(Buffer.from(derived.publicKey, "hex")),
-        path: pathStringToNumbers(args.path),
-      });
       if (args.change) {
         const changeScript = bitcoinjs.address.toOutputScript(
           args.change.address,
@@ -767,14 +781,11 @@ export async function signLtcPsbtOnLedger(args: {
         }
         return { rawTxHex: result.tx };
       } catch (err) {
-        // Issue #240: the Ledger Litecoin app at v2.4.11 still exposes the
-        // LEGACY signing API (`createPaymentTransaction`); the modern
-        // `signPsbtBuffer` path the BTC app uses isn't implemented and
-        // hw-app-btc raises this exact string when it detects the legacy
-        // surface. Fall back to the legacy API rebuilt from the PSBT.
-        // The error message is stable across hw-app-btc 10.x versions
-        // and is the cleanest signal we have without a separate getApp
-        // capability probe.
+        // Issue #240: the Ledger Litecoin app at v2.4.11 still exposes
+        // the LEGACY signing API (`createPaymentTransaction`); the
+        // modern `signPsbtBuffer` path the BTC app uses isn't
+        // implemented and hw-app-btc raises this exact string when it
+        // detects the legacy surface.
         const msg = err instanceof Error ? err.message : String(err);
         if (
           msg.includes("signPsbtBuffer is not supported with the legacy Bitcoin app")
@@ -836,30 +847,29 @@ function additionalsForAddressFormat(
  *   - Each PSBT input has `nonWitnessUtxo` populated (issue #213's fix
  *     made that mandatory) — we feed that hex into `app.splitTransaction`
  *     to get the legacy-API `Transaction` object.
- *   - The `associatedKeysets` array carries one path per input. Phase 1
- *     LTC sends are single-source-address, so every input shares
- *     `args.path`.
+ *   - The `associatedKeysets` array carries one path per input. For
+ *     multi-source consolidation (issue #264) different inputs can come
+ *     from different source paths; we map each PSBT input → its source
+ *     via `inputSources[i]` and look up the corresponding entry in
+ *     `sources[]` for the path.
  *   - `outputScriptHex` is constructed manually as varint(N) ||
  *     foreach( uint64LE(value) || varint(scriptLen) || script ) — the
  *     exact serialization the BTC tx format expects in the outputs
  *     section.
- *   - `changePath` is set when an output's address matches the source
- *     (Phase 1 LTC keeps change on the source address); the legacy API
- *     uses this to render the change output as "yours" on the device
- *     screen instead of as a second external recipient.
+ *   - `changePath` is set when an output's address matches the registered
+ *     change address (or, for legacy on-disk envelopes without `change`,
+ *     when an output script matches the primary source's script — same
+ *     same-address-as-source fallback we used pre-#254).
  *
  * Restricted to native segwit / taproot for now (matches the build-side
- * Phase 1 scope in `actions.ts`). Legacy / P2SH-wrapped sends are
- * rejected upstream, so we never reach here with `addressFormat` outside
- * the `bech32`/`bech32m` set in practice — but the `additionals` map
- * handles the four formats anyway in case future scope expands.
+ * Phase 1 scope in `actions.ts`).
  */
 async function signLtcPsbtViaLegacyApi(
   app: LtcLedgerApp,
   args: {
     psbtBase64: string;
-    expectedFrom: string;
-    path: string;
+    sources: Array<{ address: string; path: string }>;
+    inputSources: string[];
     accountPath: string;
     addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
     change?: { address: string; path: string; publicKey: string };
@@ -869,9 +879,18 @@ async function signLtcPsbtViaLegacyApi(
   if (psbt.data.inputs.length === 0) {
     throw new Error("Litecoin legacy-API fallback: PSBT has zero inputs.");
   }
+  if (args.inputSources.length !== psbt.data.inputs.length) {
+    throw new Error(
+      `Litecoin legacy-API fallback: inputSources length ${args.inputSources.length} ` +
+        `does not match PSBT input count ${psbt.data.inputs.length}.`,
+    );
+  }
   const additionals = additionalsForAddressFormat(args.addressFormat);
   const segwit =
     args.addressFormat === "bech32" || args.addressFormat === "bech32m";
+
+  const sourcePathByAddr = new Map<string, string>();
+  for (const s of args.sources) sourcePathByAddr.set(s.address, s.path);
 
   // Build the legacy-API input tuples from the PSBT.
   const inputs: Array<
@@ -882,6 +901,7 @@ async function signLtcPsbtViaLegacyApi(
       number | null,
     ]
   > = [];
+  const associatedKeysets: string[] = [];
   for (let i = 0; i < psbt.data.inputs.length; i++) {
     const inputData = psbt.data.inputs[i];
     if (!inputData.nonWitnessUtxo) {
@@ -895,27 +915,33 @@ async function signLtcPsbtViaLegacyApi(
     const prevTx = app.splitTransaction(prevHex, true, false, additionals);
     const txInput = psbt.txInputs[i];
     inputs.push([prevTx, txInput.index, null, txInput.sequence]);
+
+    const srcAddr = args.inputSources[i];
+    const srcPath = sourcePathByAddr.get(srcAddr);
+    if (!srcPath) {
+      throw new Error(
+        `Litecoin legacy-API fallback: input ${i} sources to ${srcAddr}, but no matching ` +
+          `entry exists in sources[]. The unsigned-tx envelope is malformed.`,
+      );
+    }
+    associatedKeysets.push(srcPath);
   }
 
   // Build outputScriptHex manually: varint(N) || (uint64LE(value) ||
-  // varint(scriptLen) || script) per output. The legacy API parses this
-  // verbatim into the tx's outputs section before signing.
+  // varint(scriptLen) || script) per output.
   const outChunks: Buffer[] = [encodeVarInt(psbt.txOutputs.length)];
   let changePath: string | undefined;
-  // Issue #254: detect change by matching the script either against the
-  // BIP-32 chain=1 change address (when supplied — modern path) or
-  // against the source script as a same-address-as-source fallback (so
-  // a legacy on-disk envelope without `change` still labels its change
-  // output to the device). Compare scripts byte-equal rather than
-  // addresses to handle the bech32/bech32m case where the same address
-  // renders identically on both sides.
-  const sourceScript = bitcoinjs.address.toOutputScript(
-    args.expectedFrom,
-    LITECOIN_NETWORK,
-  );
   const changeScript = args.change
     ? bitcoinjs.address.toOutputScript(args.change.address, LITECOIN_NETWORK)
     : null;
+  // Same-address-as-source fallback for envelopes without `change` set.
+  // Multi-source: we treat ANY of the listed source scripts as a
+  // potential change marker (the source scripts are equivalent for the
+  // legacy-API "your wallet" labeling). Single-source sends behave
+  // exactly as before.
+  const sourceScripts = args.sources.map((s) =>
+    bitcoinjs.address.toOutputScript(s.address, LITECOIN_NETWORK),
+  );
   for (const o of psbt.txOutputs) {
     const value = Buffer.alloc(8);
     value.writeBigUInt64LE(BigInt(o.value), 0);
@@ -924,15 +950,18 @@ async function signLtcPsbtViaLegacyApi(
     outChunks.push(o.script);
     if (changeScript && o.script.equals(changeScript)) {
       changePath = args.change!.path;
-    } else if (!changeScript && o.script.equals(sourceScript)) {
-      changePath = args.path;
+    } else if (!changeScript) {
+      const matchIdx = sourceScripts.findIndex((s) => o.script.equals(s));
+      if (matchIdx >= 0) {
+        changePath = args.sources[matchIdx].path;
+      }
     }
   }
   const outputScriptHex = Buffer.concat(outChunks).toString("hex");
 
   return app.createPaymentTransaction({
     inputs,
-    associatedKeysets: psbt.txInputs.map(() => args.path),
+    associatedKeysets,
     ...(changePath !== undefined ? { changePath } : {}),
     outputScriptHex,
     lockTime: psbt.locktime,

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -948,7 +948,10 @@ export function renderTronVerificationBlock(tx: UnsignedTronTx & { verification:
  */
 export function renderBitcoinVerificationBlock(tx: UnsignedBitcoinTx): string {
   const lines: string[] = [];
-  lines.push("VERIFY BEFORE SIGNING (Bitcoin — native send)");
+  const isMultiSource = tx.decoded.sources.length > 1;
+  lines.push(
+    `VERIFY BEFORE SIGNING (Bitcoin — ${isMultiSource ? "multi-source consolidation" : "native send"})`,
+  );
   lines.push(
     "The Ledger Bitcoin app clear-signs every output. Confirm on-device:",
   );
@@ -964,9 +967,22 @@ export function renderBitcoinVerificationBlock(tx: UnsignedBitcoinTx): string {
   lines.push(
     `  • RBF:      ${tx.decoded.rbfEligible ? "enabled — replaceable" : "disabled — final"}`,
   );
-  lines.push(
-    `  • From:     ${tx.from}  (BIP-32 account ${tx.accountPath})`,
-  );
+  // Per-source breakdown (issue #264). Single-source: one line that
+  // reproduces the prior "From:" output. Multi-source: one line per
+  // source plus the input count, so the user sees exactly which
+  // derivations are being drained and how much from each.
+  if (isMultiSource) {
+    lines.push(`  • From:     ${tx.decoded.sources.length} source addresses`);
+    for (const s of tx.decoded.sources) {
+      const inputsLabel = s.inputCount === 1 ? "1 input" : `${s.inputCount} inputs`;
+      lines.push(`      - ${s.address}: ${s.pulledBtc} BTC (${inputsLabel})`);
+    }
+    lines.push(`              (BIP-32 account ${tx.accountPath})`);
+  } else {
+    lines.push(
+      `  • From:     ${tx.from}  (BIP-32 account ${tx.accountPath})`,
+    );
+  }
   lines.push("");
   lines.push(
     "If ANY output address or amount on-device differs from the above → " +
@@ -1013,7 +1029,10 @@ export function renderBitcoinVerificationBlock(tx: UnsignedBitcoinTx): string {
  */
 export function renderLitecoinVerificationBlock(tx: UnsignedLitecoinTx): string {
   const lines: string[] = [];
-  lines.push("VERIFY BEFORE SIGNING (Litecoin — native send)");
+  const isMultiSource = tx.decoded.sources.length > 1;
+  lines.push(
+    `VERIFY BEFORE SIGNING (Litecoin — ${isMultiSource ? "multi-source consolidation" : "native send"})`,
+  );
   lines.push(
     "The Ledger Litecoin app clear-signs every output. Confirm on-device:",
   );
@@ -1029,9 +1048,18 @@ export function renderLitecoinVerificationBlock(tx: UnsignedLitecoinTx): string 
   lines.push(
     `  • RBF:      ${tx.decoded.rbfEligible ? "enabled — replaceable" : "disabled — final"}`,
   );
-  lines.push(
-    `  • From:     ${tx.from}  (BIP-32 account ${tx.accountPath})`,
-  );
+  if (isMultiSource) {
+    lines.push(`  • From:     ${tx.decoded.sources.length} source addresses`);
+    for (const s of tx.decoded.sources) {
+      const inputsLabel = s.inputCount === 1 ? "1 input" : `${s.inputCount} inputs`;
+      lines.push(`      - ${s.address}: ${s.pulledLtc} LTC (${inputsLabel})`);
+    }
+    lines.push(`              (BIP-32 account ${tx.accountPath})`);
+  } else {
+    lines.push(
+      `  • From:     ${tx.from}  (BIP-32 account ${tx.accountPath})`,
+    );
+  }
   lines.push("");
   lines.push(
     "If ANY output address or amount on-device differs from the above → " +

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1205,8 +1205,37 @@ export interface UnsignedBitcoinTx {
   chain: "bitcoin";
   /** Discriminator for the action — only native_send in Phase 1. */
   action: "native_send";
-  /** Base58/bech32 source address — must already be paired. */
+  /**
+   * Primary source address (the first entry in `sources` for multi-source
+   * sends, or the only source for single-source sends). Kept for
+   * backwards compat — handlers and the verification block treat this as
+   * the "from" label. Multi-source consumers should read `sources`.
+   */
   from: string;
+  /**
+   * All source addresses contributing UTXOs to this tx. One entry per
+   * unique source. Issue #264 — multi-input consolidation. For
+   * single-source sends this is a one-element array; the signer treats
+   * both shapes uniformly. All sources share `accountPath` +
+   * `addressFormat` (Phase 1 intra-account / uniform-type constraint).
+   */
+  sources: Array<{
+    address: string;
+    /** Full leaf path of the source address, e.g. `84'/0'/0'/0/N`. */
+    path: string;
+    /** Compressed (or uncompressed; signer compresses) public key hex. */
+    publicKey: string;
+  }>;
+  /**
+   * Per-PSBT-input source address — `inputSources[i]` names which entry
+   * in `sources` provided the i-th PSBT input. Used by the LTC legacy
+   * `createPaymentTransaction` fallback to populate `associatedKeysets`
+   * with the per-input path; the modern `signPsbtBuffer` path keys off
+   * the witness program in each input's `witnessUtxo` script and looks
+   * up the source via `knownAddressDerivations`. Length equals the PSBT
+   * input count, in PSBT input order.
+   */
+  inputSources: string[];
   /** Base64-encoded PSBT v0 bytes. The device's `signPsbtBuffer` consumes this. */
   psbtBase64: string;
   /**
@@ -1253,6 +1282,21 @@ export interface UnsignedBitcoinTx {
       /** Path of the change output (when isChange=true), e.g. `m/84'/0'/0'/1/0`. */
       changePath?: string;
     }>;
+    /**
+     * Per-source breakdown — one entry per unique source contributing a
+     * UTXO to this tx. Mirrors the verification-block "From: each source
+     * address with sats pulled" line (issue #264). Always populated;
+     * single-source sends produce a one-element array.
+     */
+    sources: Array<{
+      address: string;
+      /** Total sats pulled from this source across all selected inputs. */
+      pulledSats: string;
+      /** Same value as `pulledSats`, formatted as a BTC decimal string. */
+      pulledBtc: string;
+      /** How many of the PSBT's inputs come from this source. */
+      inputCount: number;
+    }>;
     feeSats: string;
     feeBtc: string;
     feeRateSatPerVb: number;
@@ -1283,6 +1327,14 @@ export interface UnsignedLitecoinTx {
   chain: "litecoin";
   action: "native_send";
   from: string;
+  /** See `UnsignedBitcoinTx.sources`. Issue #264. */
+  sources: Array<{
+    address: string;
+    path: string;
+    publicKey: string;
+  }>;
+  /** See `UnsignedBitcoinTx.inputSources`. Issue #264. */
+  inputSources: string[];
   psbtBase64: string;
   accountPath: string;
   addressFormat: "legacy" | "p2sh" | "bech32" | "bech32m";
@@ -1302,6 +1354,13 @@ export interface UnsignedLitecoinTx {
       amountLtc: string;
       isChange: boolean;
       changePath?: string;
+    }>;
+    /** See `UnsignedBitcoinTx.decoded.sources`. Issue #264. */
+    sources: Array<{
+      address: string;
+      pulledSats: string;
+      pulledLtc: string;
+      inputCount: number;
     }>;
     feeSats: string;
     feeLtc: string;

--- a/test/btc-multi-source-send.test.ts
+++ b/test/btc-multi-source-send.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjsForFixtures = requireCjs("bitcoinjs-lib") as {
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          witnessUtxo?: { script: Buffer; value: number };
+          nonWitnessUtxo?: Buffer;
+        }>;
+      };
+    };
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+  networks: { bitcoin: unknown };
+};
+
+/**
+ * Issue #264 — multi-source consolidation regression suite.
+ *
+ * Builds two paired chain=0 source addresses under the same Ledger
+ * account (segwit, accountIndex=0) and exercises:
+ *   - merged UTXO pool fed into one PSBT with one output (+ change)
+ *   - per-PSBT-input source mapping (`tx.inputSources`)
+ *   - per-source breakdown in `tx.decoded.sources`
+ *   - signer's `knownAddressDerivations` carries one entry per source
+ *   - rejection of mixed addressType
+ *   - rejection of mixed accountIndex
+ *   - "max" sweep across the merged pool
+ *   - single-source backwards-compat (string `wallet` works exactly
+ *     as before — same accountPath, same single sources entry)
+ */
+
+function buildPrevTxHex(value: number, address: string, vout = 0): string {
+  const tx = new bitcoinjsForFixtures.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  for (let i = 0; i <= vout; i++) {
+    const script = bitcoinjsForFixtures.address.toOutputScript(
+      address,
+      bitcoinjsForFixtures.networks.bitcoin,
+    );
+    tx.addOutput(script, i === vout ? value : 0);
+  }
+  return tx.toHex();
+}
+
+// Two real-looking native segwit addresses with deterministic pubkey
+// fixtures. They don't need to be on-curve consistent with any known
+// seed — the mocked Ledger SDK echoes back the address we hand it for
+// the proof-of-identity guard.
+const SEGWIT_ADDR_A = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SEGWIT_ADDR_B = "bc1q7xkc9sr96a773zpagat8cg7y3vwx0v5gjpw60j";
+const TAPROOT_ADDR_C = "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4z63cgcfr0xj0qg";
+const SEGWIT_PUBKEY = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+const SEGWIT_PUBKEY_UNCOMPRESSED =
+  "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd" +
+  "5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235";
+const CHANGE_ADDR = "bc1qr0p2usnskwqhupc2590l2skll0vzd84cdp3gly";
+const CHANGE_PATH = "84'/0'/0'/1/0";
+const RECIPIENT = "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu";
+
+const TXID_A =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+const TXID_B =
+  "2222222222222222222222222222222222222222222222222222222222222222";
+const FAKE_RAW_TX_HEX = "020000000001abcd";
+const FAKE_BROADCAST_TXID =
+  "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+const getWalletPublicKeyMock = vi.fn();
+const signPsbtBufferMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+const getAppAndVersionMock = vi.fn();
+
+vi.mock("../src/signing/btc-usb-loader.js", () => ({
+  openLedger: async () => ({
+    app: {
+      getWalletPublicKey: getWalletPublicKeyMock,
+      signPsbtBuffer: signPsbtBufferMock,
+    },
+    transport: { close: transportCloseMock },
+    rawTransport: {},
+  }),
+  getAppAndVersion: (rt: unknown) => getAppAndVersionMock(rt),
+}));
+
+const getUtxosMock = vi.fn();
+const getFeeEstimatesMock = vi.fn();
+const broadcastTxMock = vi.fn();
+const getTxStatusMock = vi.fn();
+const getTxHexMock = vi.fn();
+
+// Map (address, txid) → registered value for the prev-tx fixture.
+// The mock's getUtxos calls capture which UTXO came from which source;
+// getTxHex pulls the value from that registry to build a parseable
+// prev-tx hex paying the right address.
+const utxoFixtureRegistry = new Map<
+  string,
+  { value: number; vout: number; sourceAddress: string }
+>();
+
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getUtxos: getUtxosMock,
+    getFeeEstimates: getFeeEstimatesMock,
+    broadcastTx: broadcastTxMock,
+    getTxStatus: getTxStatusMock,
+    getTxHex: getTxHexMock,
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-btc-multi-"));
+  setConfigDirForTesting(tmpHome);
+  getWalletPublicKeyMock.mockReset();
+  signPsbtBufferMock.mockReset();
+  transportCloseMock.mockClear();
+  getAppAndVersionMock.mockReset();
+  getUtxosMock.mockReset();
+  getFeeEstimatesMock.mockReset();
+  broadcastTxMock.mockReset();
+  getTxStatusMock.mockReset();
+  getTxHexMock.mockReset();
+  utxoFixtureRegistry.clear();
+  // getTxHex looks up the registry to find which source funded the txid
+  // (so the prev-tx fixture pays the right address back).
+  getTxHexMock.mockImplementation(async (txid: string) => {
+    const fix = utxoFixtureRegistry.get(txid);
+    if (!fix) {
+      throw new Error(`Test setup error: no fixture registered for txid ${txid}`);
+    }
+    return buildPrevTxHex(fix.value, fix.sourceAddress, fix.vout);
+  });
+
+  const { clearPairedBtcAddresses, setPairedBtcAddress } = await import(
+    "../src/signing/btc-usb-signer.js"
+  );
+  const { __clearBitcoinTxStore } = await import(
+    "../src/signing/btc-tx-store.js"
+  );
+  clearPairedBtcAddresses();
+  __clearBitcoinTxStore();
+  // Pair two segwit sources under accountIndex=0.
+  setPairedBtcAddress({
+    address: SEGWIT_ADDR_A,
+    publicKey: SEGWIT_PUBKEY,
+    path: "84'/0'/0'/0/0",
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 0,
+    addressIndex: 0,
+  });
+  setPairedBtcAddress({
+    address: SEGWIT_ADDR_B,
+    publicKey: SEGWIT_PUBKEY,
+    path: "84'/0'/0'/0/1",
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 0,
+    addressIndex: 1,
+  });
+  // Change address (chain=1) for the same account.
+  setPairedBtcAddress({
+    address: CHANGE_ADDR,
+    publicKey: SEGWIT_PUBKEY,
+    path: CHANGE_PATH,
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 1,
+    addressIndex: 0,
+  });
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+/**
+ * Stage `getUtxos` so each address returns its own UTXO list, in the
+ * order the builder calls per `wallets`. Records each (txid, value,
+ * source) tuple in `utxoFixtureRegistry` so getTxHex can synthesize
+ * matching prev-tx hex.
+ */
+function stageUtxos(perSource: Array<{
+  address: string;
+  utxos: Array<{ txid: string; vout: number; value: number }>;
+}>): void {
+  for (const src of perSource) {
+    for (const u of src.utxos) {
+      utxoFixtureRegistry.set(u.txid, {
+        value: u.value,
+        vout: u.vout,
+        sourceAddress: src.address,
+      });
+    }
+    getUtxosMock.mockResolvedValueOnce(
+      src.utxos.map((u) => ({ ...u, unconfirmed: false })),
+    );
+  }
+}
+
+describe("buildBitcoinNativeSend — multi-source (issue #264)", () => {
+  it("merges UTXOs from multiple sources into one PSBT with per-input source mapping", async () => {
+    stageUtxos([
+      {
+        address: SEGWIT_ADDR_A,
+        utxos: [{ txid: TXID_A, vout: 0, value: 60_000 }],
+      },
+      {
+        address: SEGWIT_ADDR_B,
+        utxos: [{ txid: TXID_B, vout: 0, value: 80_000 }],
+      },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: [SEGWIT_ADDR_A, SEGWIT_ADDR_B],
+      to: RECIPIENT,
+      amount: "0.0009",
+      feeRateSatPerVb: 1,
+    });
+
+    // Both sources show up in the envelope.
+    expect(tx.sources).toHaveLength(2);
+    expect(tx.sources[0]).toMatchObject({ address: SEGWIT_ADDR_A });
+    expect(tx.sources[1]).toMatchObject({ address: SEGWIT_ADDR_B });
+
+    // Multi-input PSBT: both 60k + 80k UTXOs are pulled to cover 90k +
+    // fee. Per-input source mapping is recorded on the envelope and
+    // ordered by PSBT input order.
+    expect(tx.inputSources.length).toBe(2);
+    const inputSourceSet = new Set(tx.inputSources);
+    expect(inputSourceSet.has(SEGWIT_ADDR_A)).toBe(true);
+    expect(inputSourceSet.has(SEGWIT_ADDR_B)).toBe(true);
+
+    // PSBT carries 2 inputs with witnessUtxo + nonWitnessUtxo.
+    const psbt = bitcoinjsForFixtures.Psbt.fromBase64(tx.psbtBase64);
+    expect(psbt.data.inputs.length).toBe(2);
+    for (const inp of psbt.data.inputs) {
+      expect(inp.witnessUtxo).toBeDefined();
+      expect(inp.nonWitnessUtxo).toBeDefined();
+    }
+
+    // Per-source breakdown surfaces both addresses with the right sat
+    // totals and input counts.
+    expect(tx.decoded.sources).toHaveLength(2);
+    const a = tx.decoded.sources.find((s) => s.address === SEGWIT_ADDR_A)!;
+    const b = tx.decoded.sources.find((s) => s.address === SEGWIT_ADDR_B)!;
+    expect(a.pulledSats).toBe("60000");
+    expect(b.pulledSats).toBe("80000");
+    expect(a.inputCount).toBe(1);
+    expect(b.inputCount).toBe(1);
+
+    // `from` defaults to the first wallet in the input list (backwards
+    // compat label).
+    expect(tx.from).toBe(SEGWIT_ADDR_A);
+    expect(tx.description).toMatch(/Consolidate.*from 2 addresses/);
+  });
+
+  it("rejects mixed addressType across sources (Phase 1 scope)", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    setPairedBtcAddress({
+      address: TAPROOT_ADDR_C,
+      publicKey: SEGWIT_PUBKEY,
+      path: "86'/0'/0'/0/0",
+      appVersion: "2.2.0",
+      addressType: "taproot",
+      accountIndex: 0,
+      chain: 0,
+      addressIndex: 0,
+    });
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinNativeSend({
+        wallet: [SEGWIT_ADDR_A, TAPROOT_ADDR_C],
+        to: RECIPIENT,
+        amount: "0.0001",
+        feeRateSatPerVb: 1,
+      }),
+    ).rejects.toThrow(/Mixed source-address types/);
+  });
+
+  it("rejects mixed accountIndex across sources", async () => {
+    const { setPairedBtcAddress } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    const otherAccountAddr = "bc1qksrfmukh8582qhdpy74f7z0y4qluyx489m3jaz";
+    setPairedBtcAddress({
+      address: otherAccountAddr,
+      publicKey: SEGWIT_PUBKEY,
+      path: "84'/0'/1'/0/0",
+      appVersion: "2.2.0",
+      addressType: "segwit",
+      accountIndex: 1,
+      chain: 0,
+      addressIndex: 0,
+    });
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinNativeSend({
+        wallet: [SEGWIT_ADDR_A, otherAccountAddr],
+        to: RECIPIENT,
+        amount: "0.0001",
+        feeRateSatPerVb: 1,
+      }),
+    ).rejects.toThrow(/Cross-account multi-source/);
+  });
+
+  it("'max' sweeps the merged pool across all sources", async () => {
+    stageUtxos([
+      {
+        address: SEGWIT_ADDR_A,
+        utxos: [{ txid: TXID_A, vout: 0, value: 100_000 }],
+      },
+      {
+        address: SEGWIT_ADDR_B,
+        utxos: [{ txid: TXID_B, vout: 0, value: 200_000 }],
+      },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: [SEGWIT_ADDR_A, SEGWIT_ADDR_B],
+      to: RECIPIENT,
+      amount: "max",
+      feeRateSatPerVb: 1,
+    });
+    // Total balance 300k, max produces a single recipient output with
+    // the full balance minus fee. No change output (exact-fit branch).
+    const recipientOutput = tx.decoded.outputs.find(
+      (o) => o.address === RECIPIENT,
+    );
+    expect(recipientOutput).toBeDefined();
+    const sats = Number(recipientOutput!.amountSats);
+    expect(sats).toBeGreaterThan(298_000);
+    expect(sats).toBeLessThan(300_000);
+    // Both sources contributed.
+    expect(tx.decoded.sources).toHaveLength(2);
+    expect(tx.inputSources.length).toBe(2);
+  });
+
+  it("backwards-compat: string `wallet` builds a single-source tx unchanged", async () => {
+    stageUtxos([
+      {
+        address: SEGWIT_ADDR_A,
+        utxos: [{ txid: TXID_A, vout: 0, value: 100_000 }],
+      },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: SEGWIT_ADDR_A,
+      to: RECIPIENT,
+      amount: "0.0005",
+      feeRateSatPerVb: 1,
+    });
+    expect(tx.from).toBe(SEGWIT_ADDR_A);
+    expect(tx.sources).toHaveLength(1);
+    expect(tx.sources[0].address).toBe(SEGWIT_ADDR_A);
+    expect(tx.decoded.sources).toHaveLength(1);
+    expect(tx.decoded.sources[0].inputCount).toBe(1);
+    expect(tx.description).toMatch(/^Send /);
+  });
+
+  it("signer registers one knownAddressDerivations entry per unique source + change", async () => {
+    stageUtxos([
+      {
+        address: SEGWIT_ADDR_A,
+        utxos: [{ txid: TXID_A, vout: 0, value: 60_000 }],
+      },
+      {
+        address: SEGWIT_ADDR_B,
+        utxos: [{ txid: TXID_B, vout: 0, value: 80_000 }],
+      },
+    ]);
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.2.0",
+    });
+    // The signer re-derives every source against the device — return
+    // the matching address each call.
+    getWalletPublicKeyMock.mockImplementation(async (path: string) => {
+      if (path === "84'/0'/0'/0/0") {
+        return {
+          bitcoinAddress: SEGWIT_ADDR_A,
+          publicKey: SEGWIT_PUBKEY_UNCOMPRESSED,
+          chainCode: "0".repeat(64),
+        };
+      }
+      if (path === "84'/0'/0'/0/1") {
+        return {
+          bitcoinAddress: SEGWIT_ADDR_B,
+          publicKey: SEGWIT_PUBKEY_UNCOMPRESSED,
+          chainCode: "0".repeat(64),
+        };
+      }
+      throw new Error(`Unexpected path ${path}`);
+    });
+    signPsbtBufferMock.mockResolvedValueOnce({
+      psbt: Buffer.alloc(0),
+      tx: FAKE_RAW_TX_HEX,
+    });
+    broadcastTxMock.mockResolvedValueOnce(FAKE_BROADCAST_TXID);
+
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: [SEGWIT_ADDR_A, SEGWIT_ADDR_B],
+      to: RECIPIENT,
+      amount: "0.0009",
+      feeRateSatPerVb: 1,
+    });
+
+    const { sendTransaction } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await sendTransaction({
+      handle: tx.handle!,
+      confirmed: true,
+    });
+    const [, options] = signPsbtBufferMock.mock.calls[0];
+    const known = options.knownAddressDerivations as Map<
+      string,
+      { pubkey: Buffer; path: number[] }
+    >;
+    // 2 sources + 1 change = 3 entries.
+    expect(known.size).toBe(3);
+    // Both source paths show up under chain=0; change path under chain=1.
+    const entries = [...known.values()];
+    const sourceA = entries.find((e) => e.path[3] === 0 && e.path[4] === 0);
+    const sourceB = entries.find((e) => e.path[3] === 0 && e.path[4] === 1);
+    const changeEntry = entries.find((e) => e.path[3] === 1);
+    expect(sourceA).toBeDefined();
+    expect(sourceB).toBeDefined();
+    expect(changeEntry).toBeDefined();
+  });
+
+  it("verification block lists every source with its sat pull", async () => {
+    stageUtxos([
+      {
+        address: SEGWIT_ADDR_A,
+        utxos: [{ txid: TXID_A, vout: 0, value: 60_000 }],
+      },
+      {
+        address: SEGWIT_ADDR_B,
+        utxos: [{ txid: TXID_B, vout: 0, value: 80_000 }],
+      },
+    ]);
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: [SEGWIT_ADDR_A, SEGWIT_ADDR_B],
+      to: RECIPIENT,
+      amount: "0.0009",
+      feeRateSatPerVb: 1,
+    });
+    const { renderBitcoinVerificationBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderBitcoinVerificationBlock(tx);
+    expect(block).toMatch(/multi-source consolidation/);
+    expect(block).toContain("2 source addresses");
+    expect(block).toContain(SEGWIT_ADDR_A);
+    expect(block).toContain(SEGWIT_ADDR_B);
+    // Sat totals from each source surface in the block.
+    expect(block).toMatch(/0\.0006 BTC/);
+    expect(block).toMatch(/0\.0008 BTC/);
+  });
+});

--- a/test/ltc-message-prefix-and-legacy-app.test.ts
+++ b/test/ltc-message-prefix-and-legacy-app.test.ts
@@ -298,8 +298,8 @@ describe("issue #240 — legacy createPaymentTransaction fallback", () => {
     );
     const result = await signLtcPsbtOnLedger({
       psbtBase64: buildPsbtB64(),
-      expectedFrom: LTC_SEGWIT_ADDR,
-      path: "84'/2'/0'/0/0",
+      sources: [{ address: LTC_SEGWIT_ADDR, path: "84'/2'/0'/0/0" }],
+      inputSources: [LTC_SEGWIT_ADDR],
       accountPath: "84'/2'/0'",
       addressFormat: "bech32",
     });
@@ -332,8 +332,8 @@ describe("issue #240 — legacy createPaymentTransaction fallback", () => {
     await expect(
       signLtcPsbtOnLedger({
         psbtBase64: buildPsbtB64(),
-        expectedFrom: LTC_SEGWIT_ADDR,
-        path: "84'/2'/0'/0/0",
+        sources: [{ address: LTC_SEGWIT_ADDR, path: "84'/2'/0'/0/0" }],
+        inputSources: [LTC_SEGWIT_ADDR],
         accountPath: "84'/2'/0'",
         addressFormat: "bech32",
       }),
@@ -351,8 +351,8 @@ describe("issue #240 — legacy createPaymentTransaction fallback", () => {
     );
     const result = await signLtcPsbtOnLedger({
       psbtBase64: buildPsbtB64(),
-      expectedFrom: LTC_SEGWIT_ADDR,
-      path: "84'/2'/0'/0/0",
+      sources: [{ address: LTC_SEGWIT_ADDR, path: "84'/2'/0'/0/0" }],
+      inputSources: [LTC_SEGWIT_ADDR],
       accountPath: "84'/2'/0'",
       addressFormat: "bech32",
     });


### PR DESCRIPTION
## Summary
- `prepare_btc_send` / `prepare_litecoin_native_send` now accept `wallet: string | string[]` — one paired source address (unchanged) or an array of 1-20 paired sources for one-shot consolidation. UTXOs from every listed source are fetched in parallel, merged into one coin-selection pool, and assembled into a single multi-input PSBT with one output (plus change). Closes #264.
- Same Ledger account / same address-type per send (Phase 1 scope). The wallet-policy descriptor Ledger registers at pairing time covers every chain=0/1 descendant under the account, so multi-derivation PSBTs sign natively without any per-tx ceremony.
- Verification block now lists each source separately with its sat pull and input count, so the user sees exactly which derivations are being drained.

## How it threads through the stack
- `UnsignedBitcoinTx` / `UnsignedLitecoinTx` carry two new fields: `sources[]` (one descriptor per unique source) and `inputSources[]` (per-PSBT-input source mapping). `from` stays as the primary source for backwards compat.
- `signBtcPsbtOnLedger` / `signLtcPsbtOnLedger` accept `sources: Array<{address, path}>` and register one `knownAddressDerivations` entry per source, re-deriving each address against the live device for the proof-of-identity guard.
- LTC legacy-API fallback (`createPaymentTransaction`) maps each PSBT input → its source's path via `inputSources`, so the per-input `associatedKeysets` can carry different paths.
- Per-input `witnessUtxo.script` is derived from each input's own source address; `nonWitnessUtxo` (#213) populates as before.

## Out of scope (per #264)
- Mixed-type sources in one tx (segwit + taproot together) — rejected with a clear error.
- Cross-account multi-source — rejected with a clear error.
- Multi-output sends (N → M payments) — scope is consolidation (N → 1).

## Related
- #213 (nonWitnessUtxo on every input) — already wired; multi-input just iterates per source script.
- #254 / #259 (BIP-44 chain=1 change derivation + bip32Derivation on change) — input-side mirror.

## Test plan
- [x] New `test/btc-multi-source-send.test.ts` exercises: 2-source merge → multi-input PSBT, mixed-type rejection, cross-account rejection, `"max"` sweep across merged pool, single-string backwards-compat, per-source `knownAddressDerivations` map (2 sources + 1 change = 3 entries), verification-block per-source breakdown.
- [x] All 25 existing `btc-pr3-send.test.ts` cases still pass (single-source backwards compat).
- [x] LTC legacy-API fallback test (`ltc-message-prefix-and-legacy-app.test.ts`) updated for the new `sources` / `inputSources` shape and passes.
- [x] Full suite: 1289 / 1290 passing (the one fail is the pre-existing flake `test/send-hash-pin.test.ts` which passes in isolation; not touched by this PR).
- [ ] Live retest on the consolidation case from the issue (3 segwit chain=0/1 entries → one M-prefix recipient) once a tester has the funds available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)