### PR TITLE
feat(pnl): get_pnl_summary — wallet net PnL across EVM/TRON/Solana

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ import { getPortfolioDiff } from "./modules/diff/index.js";
 import { getPortfolioDiffInput } from "./modules/diff/schemas.js";
 import { getDailyBriefing } from "./modules/digest/index.js";
 import { getDailyBriefingInput } from "./modules/digest/schemas.js";
+import { getPnlSummary } from "./modules/pnl/index.js";
+import { getPnlSummaryInput } from "./modules/pnl/schemas.js";
 import { getPortfolioSummaryInput } from "./modules/portfolio/schemas.js";
 
 import { getVaultPilotConfigStatus } from "./modules/diagnostics/index.js";
@@ -1473,11 +1475,11 @@ async function main() {
     handler(getPortfolioSummary)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "get_portfolio_diff",
     {
       description:
-        "Decompose what changed in the user's portfolio over a time window — the AI version of an account statement. Returns the top-level USD change, broken down by chain and per-asset into: price moves (USD impact of price change on what was held the entire window), net deposits / withdrawals (sum of priced external transfers), and 'other' (the residual — interest accrual, swap legs, MEV, anything not cleanly attributable to price or external flow). Supports `wallet` (EVM), `tronAddress`, `solanaAddress`, `bitcoinAddress` — at least one required. Window: 24h / 7d / 30d / ytd. Returns BOTH a structured envelope AND a pre-rendered narrative string suitable for verbatim relay (control via `format`). Distinct from `get_portfolio_summary` (which gives current state) and the planned `get_pnl_summary` (which gives a single number) — this tool gives narrative decomposition. v1 caveats: history fetcher caps at ~50 items per chain, so very active wallets may under-count flows (response surfaces `truncated: true`); DeFi-position interest accrual collapses into the `otherEffectUsd` residual rather than its own bucket; Solana program-interaction txs (Jupiter swaps, MarginFi actions, etc.) are skipped from net-flow accounting (their balance deltas mix swap legs); Bitcoin shows current balance only (no in-window flow accounting yet).",
+        "Decompose what changed in the user's portfolio over a time window — the AI version of an account statement. Returns the top-level USD change, broken down by chain and per-asset into: price moves (USD impact of price change on what was held the entire window), net deposits / withdrawals (sum of priced external transfers), and 'other' (the residual — interest accrual, swap legs, MEV, anything not cleanly attributable to price or external flow). Supports `wallet` (EVM), `tronAddress`, `solanaAddress`, `bitcoinAddress` — at least one required. Window: 24h / 7d / 30d / ytd. Returns BOTH a structured envelope AND a pre-rendered narrative string suitable for verbatim relay (control via `format`). Distinct from `get_portfolio_summary` (which gives current state) and `get_pnl_summary` (which gives the single net-PnL number) — this tool gives narrative decomposition. v1 caveats: history fetcher caps at ~50 items per chain, so very active wallets may under-count flows (response surfaces `truncated: true`); DeFi-position interest accrual collapses into the `otherEffectUsd` residual rather than its own bucket; Solana program-interaction txs (Jupiter swaps, MarginFi actions, etc.) are skipped from net-flow accounting (their balance deltas mix swap legs); Bitcoin shows current balance only (no in-window flow accounting yet).",
       inputSchema: getPortfolioDiffInput.shape,
     },
     handler(getPortfolioDiff)
@@ -1495,6 +1497,16 @@ async function main() {
       inputSchema: getDailyBriefingInput.shape,
     },
     handler(getDailyBriefing)
+  );
+
+  registerTool(server,
+    "get_pnl_summary",
+    {
+      description:
+        "Wallet-level net PnL over a preset time window across EVM (Ethereum/Arbitrum/Polygon/Base/Optimism), TRON, and Solana. Returns the headline `pnlUsd` (= ending value − starting value − net user contribution), with per-chain and per-asset breakdown. Math: starting quantity per asset is reconstructed as `currentQty − netFlowQty` (clamped at zero when negative — user received the asset entirely within the window), priced at the period's start via DefiLlama historical, then `pnlUsd = walletValueChange − (inflowsUsd − outflowsUsd)`. Use this for the simple 'how much did I make?' question; pair with `get_portfolio_diff` for the same window when the user wants the price-vs-quantity decomposition narrative. Periods: 24h / 7d / 30d / ytd / inception (capped at 365d in v1 — \"since wallet creation\" is not literal because the underlying history fetcher caps at ~50 items per chain). At least one of `wallet` / `tronAddress` / `solanaAddress` is required. v1 caveats: wallet token balances only (DeFi position interest accrual collapses into the residual); gas costs not subtracted; Solana program-interaction txs (Jupiter swaps, MarginFi actions, native staking actions) are skipped from net-flow accounting because their balance deltas mix intra-tx swap legs; truncation flagged when history caps. Bitcoin is intentionally NOT supported in v1 — the BTC path lacks in-window flow accounting and a price-effect-only number would be misleading.",
+      inputSchema: getPnlSummaryInput.shape,
+    },
+    handler(getPnlSummary)
   );
 
   registerTool(server,

--- a/src/modules/diff/index.ts
+++ b/src/modules/diff/index.ts
@@ -156,17 +156,27 @@ async function snapshotBitcoin(address: string): Promise<AssetSnapshot[]> {
 }
 
 /**
- * Top-level entry. Reads inputs, fans out per-chain analysis, sums
- * everything, optionally renders the narrative.
+ * Compose per-chain diff slices for an arbitrary timestamp window. Shared
+ * core for `getPortfolioDiff` (this file's public entry point, fixed
+ * 24h/7d/30d/ytd windows) and `getPnlSummary` (`src/modules/pnl/index.ts`,
+ * adds `inception` capped at 365d). Both tools agree on the per-chain
+ * math by construction since they call this same composer — no risk of
+ * drift between the two surfaces' numbers.
  */
-export async function getPortfolioDiff(
-  args: GetPortfolioDiffArgs,
-): Promise<PortfolioDiffSummary> {
-  assertAtLeastOneAddress(args);
-  const { startSec, endSec } = resolveWindow(args.window);
-  const windowStartIso = new Date(startSec * 1000).toISOString();
-  const windowEndIso = new Date(endSec * 1000).toISOString();
-
+export async function composePerChainDiff(args: {
+  wallet?: string;
+  tronAddress?: string;
+  solanaAddress?: string;
+  bitcoinAddress?: string;
+  startSec: number;
+  endSec: number;
+}): Promise<{
+  slices: ChainDiffSlice[];
+  notes: string[];
+  anyMissedPrice: boolean;
+  anyTruncated: boolean;
+}> {
+  const { startSec, endSec } = args;
   const slices: ChainDiffSlice[] = [];
   const notes: string[] = [];
   let anyMissedPrice = false;
@@ -322,6 +332,33 @@ export async function getPortfolioDiff(
       notes.push(`Skipped BTC: ${(e as Error).message ?? "unknown error"}.`);
     }
   }
+
+  return { slices, notes, anyMissedPrice, anyTruncated };
+}
+
+/**
+ * Top-level entry. Reads inputs, fans out per-chain analysis (via
+ * `composePerChainDiff`), sums everything, optionally renders the
+ * narrative.
+ */
+export async function getPortfolioDiff(
+  args: GetPortfolioDiffArgs,
+): Promise<PortfolioDiffSummary> {
+  assertAtLeastOneAddress(args);
+  const { startSec, endSec } = resolveWindow(args.window);
+  const windowStartIso = new Date(startSec * 1000).toISOString();
+  const windowEndIso = new Date(endSec * 1000).toISOString();
+
+  const composed = await composePerChainDiff({
+    ...(args.wallet ? { wallet: args.wallet } : {}),
+    ...(args.tronAddress ? { tronAddress: args.tronAddress } : {}),
+    ...(args.solanaAddress ? { solanaAddress: args.solanaAddress } : {}),
+    ...(args.bitcoinAddress ? { bitcoinAddress: args.bitcoinAddress } : {}),
+    startSec,
+    endSec,
+  });
+  const { slices, anyMissedPrice, anyTruncated } = composed;
+  const notes = [...composed.notes];
 
   // Aggregate top-level numbers from slices.
   const startingValueUsd = round2(

--- a/src/modules/pnl/index.ts
+++ b/src/modules/pnl/index.ts
@@ -1,0 +1,178 @@
+/**
+ * `get_pnl_summary` — wallet-level net PnL over a preset time window
+ * across EVM (Ethereum/Arbitrum/Polygon/Base/Optimism), TRON, and
+ * Solana. Thin projection of `getPortfolioDiff`'s per-chain
+ * decomposition: the diff tool computes `walletValueChange`, `netFlows`,
+ * `priceEffect`, and `otherEffect`; PnL is just
+ * `walletValueChange - netFlows = priceEffect + otherEffect`.
+ *
+ * Both tools share `composePerChainDiff` (in `../diff/index.ts`) so
+ * their numbers cannot drift — same per-asset bigint accounting, same
+ * historical-price fetch, same flow classification.
+ *
+ * v1 scope mirrors the diff tool's: wallet token balances only; DeFi
+ * positions (Aave / Compound / Morpho supply yield, Lido stETH rebase,
+ * Marinade/Jito/native staking accrual, MarginFi / Kamino lending
+ * yield) collapse into the residual rather than getting their own
+ * line. Bitcoin is intentionally omitted in v1 because the diff path
+ * for BTC is "current balance only, no in-window flow accounting" —
+ * a BTC PnL would be the price effect alone, which is misleading.
+ *
+ * `inception` is a 365-day rolling window in v1, NOT "since wallet
+ * creation". The history fetcher caps at ~50 items per chain so a
+ * literal "since-creation" walk would be unreliable for any
+ * non-trivial wallet. The schema description says so.
+ */
+
+import { composePerChainDiff } from "../diff/index.js";
+import type { ChainDiffSlice, AssetDiffRow } from "../diff/schemas.js";
+import {
+  assertAtLeastOneAddress,
+  type GetPnlSummaryArgs,
+  type PnlAssetRow,
+  type PnlChainSlice,
+  type PnlSummary,
+} from "./schemas.js";
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Resolve a period enum to (startSec, endSec). */
+function resolvePeriod(period: GetPnlSummaryArgs["period"]): {
+  startSec: number;
+  endSec: number;
+} {
+  const endMs = Date.now();
+  let startMs: number;
+  switch (period) {
+    case "24h":
+      startMs = endMs - 24 * 3_600_000;
+      break;
+    case "7d":
+      startMs = endMs - 7 * 86_400_000;
+      break;
+    case "30d":
+      startMs = endMs - 30 * 86_400_000;
+      break;
+    case "ytd":
+      startMs = Date.UTC(new Date(endMs).getUTCFullYear(), 0, 1);
+      break;
+    case "inception":
+      // 365d rolling — see file docstring for why "literal since-creation"
+      // isn't honest with the current history-fetcher cap.
+      startMs = endMs - 365 * 86_400_000;
+      break;
+  }
+  return {
+    startSec: Math.floor(startMs / 1000),
+    endSec: Math.floor(endMs / 1000),
+  };
+}
+
+/**
+ * Project a diff's per-asset row to the simpler PnL row. Per-asset
+ * `pnlUsd = endingValue - startingValue - netFlowUsd`.
+ */
+function projectAssetRow(row: AssetDiffRow): PnlAssetRow {
+  const pnlUsd = round2(
+    row.endingValueUsd - row.startingValueUsd - row.netFlowUsd,
+  );
+  return {
+    symbol: row.symbol,
+    token: row.token,
+    startingQty: row.startingQty,
+    endingQty: row.endingQty,
+    ...(row.startingPriceUsd !== undefined
+      ? { startingPriceUsd: row.startingPriceUsd }
+      : {}),
+    ...(row.endingPriceUsd !== undefined
+      ? { endingPriceUsd: row.endingPriceUsd }
+      : {}),
+    pnlUsd,
+  };
+}
+
+/**
+ * Project a diff's chain slice to the PnL chain slice. The diff
+ * already has `topLevelChangeUsd` and `netFlowsUsd`; per-chain PnL is
+ * just their difference.
+ */
+function projectChainSlice(slice: ChainDiffSlice): PnlChainSlice {
+  const pnlUsd = round2(slice.topLevelChangeUsd - slice.netFlowsUsd);
+  return {
+    chain: slice.chain,
+    startingValueUsd: slice.startingValueUsd,
+    endingValueUsd: slice.endingValueUsd,
+    inflowsUsd: slice.inflowsUsd,
+    outflowsUsd: slice.outflowsUsd,
+    pnlUsd,
+    perAsset: slice.perAsset.map(projectAssetRow),
+    truncated: slice.truncated,
+  };
+}
+
+export async function getPnlSummary(
+  args: GetPnlSummaryArgs,
+): Promise<PnlSummary> {
+  assertAtLeastOneAddress(args);
+  const { startSec, endSec } = resolvePeriod(args.period);
+
+  const composed = await composePerChainDiff({
+    ...(args.wallet ? { wallet: args.wallet } : {}),
+    ...(args.tronAddress ? { tronAddress: args.tronAddress } : {}),
+    ...(args.solanaAddress ? { solanaAddress: args.solanaAddress } : {}),
+    startSec,
+    endSec,
+  });
+
+  const slices = composed.slices.map(projectChainSlice);
+
+  // Aggregate top-level numbers from chain slices. We re-aggregate from
+  // the projection rather than reading the diff's pre-computed
+  // top-level numbers because the projection drops some slices (none
+  // currently, but the projection is the single source of truth for
+  // what's surfaced — matches the Solana program-interaction skip
+  // behavior that already lives in the composer).
+  const startingValueUsd = round2(
+    slices.reduce((s, c) => s + c.startingValueUsd, 0),
+  );
+  const endingValueUsd = round2(
+    slices.reduce((s, c) => s + c.endingValueUsd, 0),
+  );
+  const inflowsUsd = round2(slices.reduce((s, c) => s + c.inflowsUsd, 0));
+  const outflowsUsd = round2(slices.reduce((s, c) => s + c.outflowsUsd, 0));
+  const netUserContributionUsd = round2(inflowsUsd - outflowsUsd);
+  const walletValueChangeUsd = round2(endingValueUsd - startingValueUsd);
+  const pnlUsd = round2(walletValueChangeUsd - netUserContributionUsd);
+
+  const notes = [...composed.notes];
+  notes.push(
+    "DeFi position interest accrual (Aave / Compound / Morpho supply yield, " +
+      "Lido stETH rebases, Marinade/Jito/native stake rewards, MarginFi / Kamino " +
+      "lending) is collapsed into `pnlUsd` rather than separated. Per-protocol " +
+      "attribution is a future enhancement.",
+  );
+  notes.push(
+    "Gas costs are NOT subtracted — the underlying history items don't carry " +
+      "`gasUsedUsd` today. v1 PnL excludes gas; for active wallets on cheap " +
+      "chains this is small, on expensive ones it can be material.",
+  );
+
+  return {
+    period: args.period,
+    periodStartIso: new Date(startSec * 1000).toISOString(),
+    periodEndIso: new Date(endSec * 1000).toISOString(),
+    startingValueUsd,
+    endingValueUsd,
+    walletValueChangeUsd,
+    inflowsUsd,
+    outflowsUsd,
+    netUserContributionUsd,
+    pnlUsd,
+    perChain: slices,
+    truncated: composed.anyTruncated,
+    priceCoverage: composed.anyMissedPrice ? "partial" : "full",
+    notes,
+  };
+}

--- a/src/modules/pnl/schemas.ts
+++ b/src/modules/pnl/schemas.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import {
+  EVM_ADDRESS,
+  SOLANA_ADDRESS,
+  TRON_ADDRESS,
+} from "../../shared/address-patterns.js";
+
+/**
+ * `get_pnl_summary` input shape. Mirrors `get_portfolio_diff` for the
+ * wallet args, swapping `window` for `period` and adding an `inception`
+ * option (capped at 365d in v1 to keep the history fetch bounded).
+ *
+ * Same "at least one address" rule as the diff tool — enforced in the
+ * handler via `assertAtLeastOneAddress` since the MCP server consumes
+ * `.shape` directly and `ZodEffects` doesn't expose it.
+ *
+ * Bitcoin is intentionally NOT supported in v1 — the diff path's BTC
+ * branch is "current balance only, no in-window flow accounting", which
+ * means BTC's `pnlUsd` would always be the price effect on the held
+ * balance with no net-flow component. That's misleading enough to
+ * justify deferring the BTC branch entirely until in-window flow
+ * accounting lands.
+ */
+export const getPnlSummaryInput = z.object({
+  wallet: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .optional()
+    .describe(
+      "EVM wallet (Ethereum / Arbitrum / Polygon / Base / Optimism). " +
+        "Used to fetch current balances and walk EVM tx history for the period.",
+    ),
+  tronAddress: z
+    .string()
+    .regex(TRON_ADDRESS)
+    .optional()
+    .describe(
+      "TRON mainnet base58 address (T-prefix). Folds TRX + TRC-20 balances " +
+        "and TRON history into the PnL.",
+    ),
+  solanaAddress: z
+    .string()
+    .regex(SOLANA_ADDRESS)
+    .optional()
+    .describe(
+      "Solana mainnet base58 pubkey. Folds SOL + SPL balances and Solana " +
+        "history into the PnL.",
+    ),
+  period: z
+    .enum(["24h", "7d", "30d", "ytd", "inception"])
+    .default("30d")
+    .describe(
+      'Time window. "24h" / "7d" / "30d" are rolling; "ytd" is calendar-' +
+        'year-to-date (UTC); "inception" is a 365-day rolling window in v1 — ' +
+        '"since wallet creation" is approximated, not literal, to keep the ' +
+        "history fetch bounded. Periods longer than ~30d may under-count flows " +
+        "because the underlying history fetcher caps at ~50 items per chain; " +
+        "the response surfaces `truncated: true` when this happens.",
+    ),
+});
+
+export function assertAtLeastOneAddress(args: GetPnlSummaryArgs): void {
+  if (!args.wallet && !args.tronAddress && !args.solanaAddress) {
+    throw new Error(
+      "At least one of `wallet` / `tronAddress` / `solanaAddress` is required.",
+    );
+  }
+}
+
+export type GetPnlSummaryArgs = z.infer<typeof getPnlSummaryInput>;
+
+/**
+ * Per-asset row in the PnL breakdown. Thin projection of the diff's
+ * `AssetDiffRow` (which carries the same data plus extra
+ * decomposition columns we don't want to surface in the simpler PnL
+ * view).
+ */
+export interface PnlAssetRow {
+  symbol: string;
+  /** EVM contract address, Solana mint, "native" for the chain's native coin. */
+  token: string;
+  startingQty: string;
+  endingQty: string;
+  startingPriceUsd?: number;
+  endingPriceUsd?: number;
+  /** `endingValueUsd - startingValueUsd - netFlowUsd` — the per-asset PnL. */
+  pnlUsd: number;
+}
+
+/**
+ * Per-chain PnL slice. One per non-empty chain. Values are aggregated
+ * from the diff's per-asset rows for the chain.
+ */
+export interface PnlChainSlice {
+  chain: string;
+  startingValueUsd: number;
+  endingValueUsd: number;
+  inflowsUsd: number;
+  outflowsUsd: number;
+  /** `(endingValueUsd - startingValueUsd) - (inflowsUsd - outflowsUsd)`. */
+  pnlUsd: number;
+  perAsset: PnlAssetRow[];
+  /** True if the per-chain history fetcher hit its row cap during the window. */
+  truncated: boolean;
+}
+
+/**
+ * Top-level PnL summary returned by `get_pnl_summary`.
+ *
+ * The honest math: `pnlUsd = walletValueChangeUsd - netUserContributionUsd`.
+ * Where `walletValueChangeUsd = endingValueUsd - startingValueUsd` and
+ * `netUserContributionUsd = inflowsUsd - outflowsUsd`. The split removes
+ * the user's own deposits/withdrawals from the value delta so what's
+ * left is genuine PnL (price moves + DeFi accrual + swap legs + MEV +
+ * any other intra-wallet effects).
+ */
+export interface PnlSummary {
+  period: "24h" | "7d" | "30d" | "ytd" | "inception";
+  periodStartIso: string;
+  periodEndIso: string;
+
+  startingValueUsd: number;
+  endingValueUsd: number;
+  /** `endingValueUsd - startingValueUsd`. */
+  walletValueChangeUsd: number;
+
+  /** External transfers IN, summed at time-of-receipt. */
+  inflowsUsd: number;
+  /** External transfers OUT, summed at time-of-send. */
+  outflowsUsd: number;
+  /** `inflowsUsd - outflowsUsd`. The user's net contribution to the wallet. */
+  netUserContributionUsd: number;
+
+  /** `walletValueChangeUsd - netUserContributionUsd`. */
+  pnlUsd: number;
+
+  perChain: PnlChainSlice[];
+
+  /** True if any per-chain history fetcher truncated. */
+  truncated: boolean;
+  /** "full" / "partial" / "none" — worst case across all priced lookups. */
+  priceCoverage: "full" | "partial" | "none";
+  /** Free-form caveats — DeFi exclusion, gas exclusion, scope reminders. */
+  notes: string[];
+}

--- a/test/pnl.test.ts
+++ b/test/pnl.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Unit tests for `get_pnl_summary`. Same mocking pattern as
+ * `test/diff.test.ts`: the chain-reader stack and DefiLlama historical
+ * price lookups are mocked at the module boundary so no RPC / no
+ * external HTTP fires. Asserts:
+ *   - Input validation: at least one address required.
+ *   - Empty wallet across all chains → pnlUsd === 0, perChain empty.
+ *   - Single external inflow with priced flow → inflowsUsd reflects
+ *     it AND pnlUsd === 0 (the inflow doesn't count as profit).
+ *   - Buy-and-hold with 2× price move → pnlUsd ≈ qty * (endingPrice -
+ *     startingPrice), netUserContributionUsd === 0.
+ *   - Multi-chain fold: EVM wallet + TRON address + Solana address each
+ *     contribute their own slice to perChain; top-level numbers sum.
+ *   - Truncated history flag propagates to summary.truncated.
+ *   - Partial price coverage when DefiLlama misses → summary.priceCoverage
+ *     is "partial".
+ *   - inception period resolves to a 365d-ish startMs (not "since wallet
+ *     creation").
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fetchNativeBalanceMock = vi.fn();
+const fetchTopErc20BalancesMock = vi.fn();
+const getTronBalancesMock = vi.fn();
+const getSolanaBalancesMock = vi.fn();
+const getBitcoinBalanceMock = vi.fn();
+const fetchBitcoinPriceMock = vi.fn();
+const getTransactionHistoryMock = vi.fn();
+const lookupHistoricalPricesMock = vi.fn();
+
+vi.mock("../src/modules/portfolio/index.ts", () => ({
+  fetchNativeBalance: (...a: unknown[]) => fetchNativeBalanceMock(...a),
+  fetchTopErc20Balances: (...a: unknown[]) => fetchTopErc20BalancesMock(...a),
+}));
+vi.mock("../src/modules/tron/balances.ts", () => ({
+  getTronBalances: (...a: unknown[]) => getTronBalancesMock(...a),
+}));
+vi.mock("../src/modules/solana/balances.ts", () => ({
+  getSolanaBalances: (...a: unknown[]) => getSolanaBalancesMock(...a),
+}));
+vi.mock("../src/modules/btc/balances.ts", () => ({
+  getBitcoinBalance: (...a: unknown[]) => getBitcoinBalanceMock(...a),
+}));
+vi.mock("../src/modules/btc/price.ts", () => ({
+  fetchBitcoinPrice: (...a: unknown[]) => fetchBitcoinPriceMock(...a),
+}));
+vi.mock("../src/modules/history/index.ts", () => ({
+  getTransactionHistory: (...a: unknown[]) => getTransactionHistoryMock(...a),
+}));
+vi.mock("../src/modules/history/prices.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/history/prices.ts")>();
+  return {
+    ...actual,
+    lookupHistoricalPrices: (...a: unknown[]) =>
+      lookupHistoricalPricesMock(...a),
+  };
+});
+
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const TRON_ADDR = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const SOLANA_ADDR = "DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt94Wdcuh1S";
+
+async function emptyNative(_w: string, chain: string): Promise<{
+  token: string;
+  symbol: string;
+  decimals: number;
+  amount: string;
+  formatted: string;
+}> {
+  return {
+    token: "0x0000000000000000000000000000000000000000",
+    symbol: chain === "polygon" ? "MATIC" : "ETH",
+    decimals: 18,
+    amount: "0",
+    formatted: "0",
+  };
+}
+
+beforeEach(() => {
+  fetchNativeBalanceMock.mockReset();
+  fetchTopErc20BalancesMock.mockReset();
+  getTronBalancesMock.mockReset();
+  getSolanaBalancesMock.mockReset();
+  getBitcoinBalanceMock.mockReset();
+  fetchBitcoinPriceMock.mockReset();
+  getTransactionHistoryMock.mockReset();
+  lookupHistoricalPricesMock.mockReset();
+
+  fetchNativeBalanceMock.mockImplementation(emptyNative);
+  fetchTopErc20BalancesMock.mockResolvedValue([]);
+  getTronBalancesMock.mockResolvedValue({
+    address: TRON_ADDR,
+    native: [],
+    trc20: [],
+    walletBalancesUsd: 0,
+  });
+  getSolanaBalancesMock.mockResolvedValue({
+    address: SOLANA_ADDR,
+    native: [],
+    spl: [],
+    walletBalancesUsd: 0,
+  });
+  getBitcoinBalanceMock.mockResolvedValue({
+    address: "bc1q-empty",
+    addressType: "p2wpkh",
+    confirmedSats: 0n,
+    mempoolSats: 0n,
+    totalSats: 0n,
+    confirmedBtc: "0",
+    totalBtc: "0",
+    symbol: "BTC",
+    decimals: 8,
+    txCount: 0,
+  });
+  fetchBitcoinPriceMock.mockResolvedValue(60_000);
+  getTransactionHistoryMock.mockResolvedValue({
+    chain: "ethereum",
+    wallet: WALLET,
+    items: [],
+    truncated: false,
+    priceCoverage: "full",
+  });
+  lookupHistoricalPricesMock.mockResolvedValue({
+    prices: new Map(),
+    missed: false,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getPnlSummary — input validation", () => {
+  it("throws when no address is supplied", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    await expect(getPnlSummary({ period: "30d" })).rejects.toThrow(
+      /At least one of `wallet`/,
+    );
+  });
+});
+
+describe("getPnlSummary — empty wallet", () => {
+  it("returns pnlUsd=0 and an empty perChain when no balances or history", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+    expect(r.pnlUsd).toBe(0);
+    expect(r.startingValueUsd).toBe(0);
+    expect(r.endingValueUsd).toBe(0);
+    expect(r.inflowsUsd).toBe(0);
+    expect(r.outflowsUsd).toBe(0);
+    expect(r.netUserContributionUsd).toBe(0);
+    expect(r.perChain).toHaveLength(0);
+    expect(r.priceCoverage).toBe("full");
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("getPnlSummary — single external inflow during period", () => {
+  it("counts the inflow but leaves pnlUsd at 0", async () => {
+    // 0.5 ETH currently held, came in via one external transfer in the
+    // window. The starting quantity reconstructs to 0 (clamped from -0.5).
+    fetchNativeBalanceMock.mockImplementation(async (_w: string, chain: string) => {
+      if (chain === "ethereum") {
+        return {
+          token: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+          amount: "500000000000000000",
+          formatted: "0.5",
+          priceUsd: 4000,
+          valueUsd: 2000,
+        };
+      }
+      return emptyNative(_w, chain);
+    });
+    getTransactionHistoryMock.mockImplementation(async (a: { chain: string }) => ({
+      chain: a.chain,
+      wallet: WALLET,
+      items:
+        a.chain === "ethereum"
+          ? [
+              {
+                type: "external",
+                hash: "0xabc",
+                timestamp: Math.floor(Date.now() / 1000) - 86_400,
+                from: "0x1111111111111111111111111111111111111111",
+                to: WALLET,
+                status: "success",
+                valueNative: "500000000000000000",
+                valueNativeFormatted: "0.5",
+                valueUsd: 2000,
+              },
+            ]
+          : [],
+      truncated: false,
+      priceCoverage: "full",
+    }));
+
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+
+    expect(r.endingValueUsd).toBe(2000);
+    expect(r.inflowsUsd).toBe(2000);
+    expect(r.outflowsUsd).toBe(0);
+    expect(r.netUserContributionUsd).toBe(2000);
+    // walletValueChange (2000) - netUserContribution (2000) = 0.
+    // Tolerate tiny float drift from the netFlowUsd averaging in the diff.
+    expect(Math.abs(r.pnlUsd)).toBeLessThan(1);
+  });
+});
+
+describe("getPnlSummary — buy-and-hold price appreciation", () => {
+  it("attributes pure price moves to pnlUsd, leaves netUserContribution at 0", async () => {
+    // 1 ETH held; ETH was $4000 at period start, $4400 now → +$400 PnL.
+    fetchNativeBalanceMock.mockImplementation(async (_w: string, chain: string) => {
+      if (chain === "ethereum") {
+        return {
+          token: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+          amount: "1000000000000000000",
+          formatted: "1.0",
+          priceUsd: 4400,
+          valueUsd: 4400,
+        };
+      }
+      return emptyNative(_w, chain);
+    });
+    // Permissive map keyed by exactly what the composer asks for. The
+    // composer calls lookupHistoricalPrices with the chain's nativeCoinKey
+    // ("coingecko:ethereum") + the resolved startSec; we synthesize a
+    // matcher that returns 4000 for any timestamp at that key.
+    lookupHistoricalPricesMock.mockImplementation(
+      async (requests: Array<{ coinKey: string; timestamp: number }>) => {
+        const prices = new Map<string, number>();
+        for (const req of requests) {
+          if (req.coinKey === "coingecko:ethereum") {
+            prices.set(`${req.coinKey}@${req.timestamp}`, 4000);
+          }
+        }
+        return { prices, missed: false };
+      },
+    );
+
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+
+    expect(r.endingValueUsd).toBe(4400);
+    expect(r.startingValueUsd).toBe(4000);
+    expect(r.netUserContributionUsd).toBe(0);
+    expect(r.pnlUsd).toBeCloseTo(400, 1);
+    expect(r.walletValueChangeUsd).toBe(400);
+  });
+});
+
+describe("getPnlSummary — multi-chain fold", () => {
+  it("aggregates EVM + TRON + Solana into top-level numbers", async () => {
+    // EVM: 0.1 ETH @ $4000 = $400
+    fetchNativeBalanceMock.mockImplementation(async (_w: string, chain: string) => {
+      if (chain === "ethereum") {
+        return {
+          token: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+          amount: "100000000000000000",
+          formatted: "0.1",
+          priceUsd: 4000,
+          valueUsd: 400,
+        };
+      }
+      return emptyNative(_w, chain);
+    });
+    // TRON: 100 TRX @ $0.10 = $10
+    getTronBalancesMock.mockResolvedValue({
+      address: TRON_ADDR,
+      native: [
+        {
+          chain: "tron",
+          token: "native",
+          symbol: "TRX",
+          decimals: 6,
+          amount: "100000000",
+          formatted: "100",
+          priceUsd: 0.1,
+          valueUsd: 10,
+        },
+      ],
+      trc20: [],
+      walletBalancesUsd: 10,
+    });
+    // Solana: 1 SOL @ $200 = $200
+    getSolanaBalancesMock.mockResolvedValue({
+      address: SOLANA_ADDR,
+      native: [
+        {
+          chain: "solana",
+          token: "native",
+          symbol: "SOL",
+          decimals: 9,
+          amount: "1000000000",
+          formatted: "1",
+          priceUsd: 200,
+          valueUsd: 200,
+        },
+      ],
+      spl: [],
+      walletBalancesUsd: 200,
+    });
+
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({
+      wallet: WALLET,
+      tronAddress: TRON_ADDR,
+      solanaAddress: SOLANA_ADDR,
+      period: "30d",
+    });
+
+    expect(r.endingValueUsd).toBe(610); // 400 + 10 + 200
+    const chains = r.perChain.map((s) => s.chain).sort();
+    expect(chains).toContain("ethereum");
+    expect(chains).toContain("tron");
+    expect(chains).toContain("solana");
+    // Per-chain endingValues sum to top-level.
+    const sumEnding = r.perChain.reduce((s, c) => s + c.endingValueUsd, 0);
+    expect(sumEnding).toBeCloseTo(r.endingValueUsd, 2);
+  });
+});
+
+describe("getPnlSummary — truncation propagation", () => {
+  it("sets summary.truncated when any chain hit the history cap", async () => {
+    getTransactionHistoryMock.mockImplementation(async (a: { chain: string }) => ({
+      chain: a.chain,
+      wallet: WALLET,
+      items: [],
+      truncated: a.chain === "ethereum",
+      priceCoverage: "full",
+    }));
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+    expect(r.truncated).toBe(true);
+  });
+});
+
+describe("getPnlSummary — partial price coverage", () => {
+  it("downgrades priceCoverage to 'partial' when DefiLlama misses", async () => {
+    fetchNativeBalanceMock.mockImplementation(async (_w: string, chain: string) => {
+      if (chain === "ethereum") {
+        return {
+          token: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+          amount: "1000000000000000000",
+          formatted: "1.0",
+          priceUsd: 4400,
+          valueUsd: 4400,
+        };
+      }
+      return emptyNative(_w, chain);
+    });
+    lookupHistoricalPricesMock.mockResolvedValue({
+      prices: new Map(),
+      missed: true,
+    });
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+    expect(r.priceCoverage).toBe("partial");
+  });
+});
+
+describe("getPnlSummary — inception period", () => {
+  it("resolves inception to a ~365-day rolling window (not 'since creation')", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "inception" });
+    const startMs = new Date(r.periodStartIso).getTime();
+    const endMs = new Date(r.periodEndIso).getTime();
+    const spanDays = (endMs - startMs) / 86_400_000;
+    // Allow ~2-second drift between the test's clock and the function's.
+    expect(spanDays).toBeGreaterThan(364.99);
+    expect(spanDays).toBeLessThan(365.01);
+  });
+});
+
+describe("getPnlSummary — notes carry v1 caveats", () => {
+  it("surfaces DeFi-exclusion and gas-exclusion caveats", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "30d" });
+    const joined = r.notes.join("\n").toLowerCase();
+    expect(joined).toContain("defi");
+    expect(joined).toContain("gas");
+  });
+});


### PR DESCRIPTION
## Summary
New `get_pnl_summary` tool returns the headline `pnlUsd` for a wallet across the three supported chain families. Pair with `get_portfolio_diff` (unchanged public shape) when the user wants the price-vs-quantity decomposition narrative as well.

Honest math:
```
pnlUsd = (endingValueUsd - startingValueUsd) - (inflowsUsd - outflowsUsd)
       = walletValueChangeUsd - netUserContributionUsd
```

Starting quantity per asset is reconstructed as `currentQty - netFlowQty` (clamped at zero when the user received it entirely within the window), then priced at the period's start via DefiLlama historical. Periods: `24h` / `7d` / `30d` / `ytd` / `inception` (capped at 365d in v1).

## Architecture — composer extracted from get_portfolio_diff

`getPortfolioDiff`'s body is refactored to call a new internal helper `composePerChainDiff(args, startSec, endSec)` that does the per-chain fan-out + slice build. Both tools call this same composer, so their numbers cannot drift — same per-asset bigint accounting, same historical-price fetch, same flow classification. PnL projects each diff slice into a thinner shape: `pnlUsd = topLevelChangeUsd - netFlowsUsd`.

The diff tool's public API and output shape are unchanged.

## v1 scope

In: native + ERC-20 + TRC-20 + SOL + SPL token balances held directly in the wallet.

Out (named in `notes`):
- DeFi position interest accrual collapses into `pnlUsd` rather than its own line.
- Gas costs not subtracted; history items don't carry `gasUsedUsd` today.
- Solana `program_interaction` txs (Jupiter swaps, MarginFi actions, native staking) are skipped from net-flow accounting — their balance deltas mix intra-tx swap legs that would miscount as transfers.
- Bitcoin is intentionally **not** supported in v1: the diff path's BTC branch is current-balance-only with no in-window flow accounting, so a BTC PnL would be the price effect alone — misleading enough to defer.
- `inception` is a 365-day rolling window, not literal "since wallet creation" (history fetcher caps at ~50 items per chain).

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/pnl.test.ts` — 9/9 pass: input validation, empty wallet, single inflow priced, buy-and-hold 2× appreciation, multi-chain fold (EVM + TRON + Solana), truncation flag propagation, partial price coverage, inception period shape, v1 caveats present in notes
- [x] `npx vitest run test/diff.test.ts` — 7/7 pass; the diff refactor preserves all existing assertions
- [x] `npx vitest run` (full suite) — **1388/1388 pass**
- [ ] Live sanity: call against a known wallet with recent activity, eyeball the math vs. that wallet's Etherscan / TronScan / Solscan history

## Plan

`claude-work/plan-pnl-summary-tool.md` (gitignored). The plan called for a fresh `src/modules/pnl/` module duplicating the diff math; the implementation diverged toward a thin projection because exploration showed `get_portfolio_diff` already computes everything PnL needs and reuse-via-composer is strictly better than re-implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)