### PR TITLE
feat(pricing): get_coin_price tool + LTC portfolio integration (closes #274)

### DIFF
--- a/src/data/coin-allowlist.ts
+++ b/src/data/coin-allowlist.ts
@@ -1,0 +1,187 @@
+/**
+ * Symbol → CoinGecko ID allowlist for the `get_coin_price` tool (issue #274).
+ *
+ * Why an allowlist (vs free-form ticker resolution): CoinGecko has dozens
+ * of coins per ticker for popular ones (search "USDC" on
+ * https://www.coingecko.com/en/coins and you'll find 30+ entries — most
+ * are scams or wrapped variants on weird chains). Free-form `symbol →
+ * top-result` resolution would silently price scam tickers when the user
+ * meant the canonical asset. The allowlist hardcodes the canonical mapping
+ * for the assets that actually matter to the kind of user this server has
+ * (DeFi-aware self-custodial wallet holders).
+ *
+ * Coverage: top ~100 by market cap as of 2026-04, plus the major LSTs and
+ * the assets natively supported by VaultPilot's signing flows
+ * (BTC/LTC/SOL/TRX/EVM-natives are essential — others are convenience).
+ *
+ * Escape hatch: callers can bypass the allowlist by passing
+ * `coingeckoId` directly to `get_coin_price`. The allowlist is the
+ * default-safe path; the escape hatch is for the rare legitimate need
+ * (e.g. a non-allowlisted long-tail asset the user cares about).
+ *
+ * IDs sourced from CoinGecko's coin pages — the URL path segment IS
+ * the API ID (e.g. https://www.coingecko.com/en/coins/litecoin →
+ * "litecoin"). DefiLlama uses these IDs verbatim under the
+ * `coingecko:` key prefix.
+ *
+ * Refresh policy: hardcoded so the tool works without an extra HTTP
+ * roundtrip per call. Refresh quarterly OR when a user asks about an
+ * asset not in the list. Adding entries is a one-line PR.
+ */
+
+/**
+ * Lowercase symbol → CoinGecko ID. Lookup is case-insensitive on the
+ * symbol side; the tool normalizes the input before querying.
+ */
+export const COIN_SYMBOL_ALLOWLIST: Readonly<Record<string, string>> = {
+  // ===== Native EVM / L1 currencies (essential — VaultPilot holds these) =====
+  btc: "bitcoin",
+  eth: "ethereum",
+  sol: "solana",
+  ltc: "litecoin",
+  trx: "tron",
+  bnb: "binancecoin",
+  pol: "polygon-ecosystem-token", // formerly "matic-network" pre-2024 rebrand
+  matic: "polygon-ecosystem-token", // alias for legacy users
+  avax: "avalanche-2",
+  xrp: "ripple",
+  ada: "cardano",
+  dot: "polkadot",
+  atom: "cosmos",
+  near: "near",
+  apt: "aptos",
+  sui: "sui",
+  hbar: "hedera-hashgraph",
+  algo: "algorand",
+  ftm: "fantom",
+  s: "sonic-3", // Sonic (Fantom successor)
+  one: "harmony",
+  cro: "crypto-com-chain",
+  egld: "elrond-erd-2",
+  flow: "flow",
+  icp: "internet-computer",
+  xlm: "stellar",
+  xmr: "monero",
+  xtz: "tezos",
+  zec: "zcash",
+  dash: "dash",
+  etc: "ethereum-classic",
+  bch: "bitcoin-cash",
+  bsv: "bitcoin-cash-sv",
+  fil: "filecoin",
+  arb: "arbitrum",
+  op: "optimism",
+  base: "base", // wraps "no separate token" — placeholder, returns ETH
+  kas: "kaspa",
+  mina: "mina-protocol",
+  inj: "injective-protocol",
+  tia: "celestia",
+  sei: "sei-network",
+  jto: "jito-governance-token",
+  pyth: "pyth-network",
+  wld: "worldcoin-wld",
+  ondo: "ondo-finance",
+  tao: "bittensor",
+  rndr: "render-token",
+  fet: "fetch-ai",
+
+  // ===== Stablecoins (every chain — these resolve to the canonical CoinGecko entry) =====
+  usdc: "usd-coin",
+  usdt: "tether",
+  dai: "dai",
+  busd: "binance-usd",
+  tusd: "true-usd",
+  usdd: "usdd",
+  pyusd: "paypal-usd",
+  fdusd: "first-digital-usd",
+  usde: "ethena-usde",
+  usds: "usds",
+  frax: "frax",
+  lusd: "liquity-usd",
+  gho: "gho",
+  crvusd: "crvusd",
+
+  // ===== Liquid-staking tokens (VaultPilot has read/write integration) =====
+  steth: "staked-ether", // Lido
+  wsteth: "wrapped-steth", // Lido wrapped
+  reth: "rocket-pool-eth",
+  cbeth: "coinbase-wrapped-staked-eth",
+  msol: "marinade-staked-sol", // Marinade
+  jitosol: "jito-staked-sol", // Jito
+  bsol: "blazestake-staked-sol",
+  ezeth: "renzo-restaked-eth",
+  weeth: "wrapped-eeth",
+
+  // ===== Wrapped versions =====
+  wbtc: "wrapped-bitcoin",
+  weth: "weth",
+  wsol: "wrapped-solana", // wraps native SOL — same price
+  wbnb: "wbnb",
+
+  // ===== Top DeFi governance tokens =====
+  aave: "aave",
+  comp: "compound-governance-token",
+  mkr: "maker",
+  uni: "uniswap",
+  sushi: "sushi",
+  crv: "curve-dao-token",
+  cvx: "convex-finance",
+  bal: "balancer",
+  pendle: "pendle",
+  gmx: "gmx",
+  ldo: "lido-dao",
+  rpl: "rocket-pool",
+  ena: "ethena",
+  morpho: "morpho",
+  bgt: "berachain-bera", // Berachain governance
+
+  // ===== Memecoins (high user-question volume despite being silly) =====
+  doge: "dogecoin",
+  shib: "shiba-inu",
+  pepe: "pepe",
+  bonk: "bonk",
+  wif: "dogwifcoin",
+  floki: "floki",
+  mog: "mog-coin",
+  trump: "official-trump",
+  popcat: "popcat",
+
+  // ===== Solana ecosystem =====
+  jup: "jupiter-exchange-solana",
+  ray: "raydium",
+  orca: "orca",
+  pyth_network: "pyth-network", // disambiguator — avoids collision with stripped "pyth" symbol
+
+  // ===== TRON ecosystem =====
+  win: "wink",
+  jst: "just",
+  sun: "sun-token",
+
+  // ===== Privacy / niche but actively traded =====
+  link: "chainlink",
+  ar: "arweave",
+  grt: "the-graph",
+  imx: "immutable-x",
+  manta: "manta-network",
+  strk: "starknet",
+  ens: "ethereum-name-service",
+  rune: "thorchain",
+} as const;
+
+/**
+ * Resolve a user-supplied symbol to its CoinGecko ID. Case-insensitive
+ * on input. Returns undefined when the symbol isn't on the allowlist —
+ * caller surfaces a "use coingeckoId instead" hint.
+ */
+export function resolveSymbolToCoingeckoId(symbol: string): string | undefined {
+  const normalized = symbol.trim().toLowerCase();
+  return COIN_SYMBOL_ALLOWLIST[normalized];
+}
+
+/**
+ * Diagnostic: how many entries are on the allowlist. Used by the tool
+ * description so the agent can tell the user "supports ~N tickers."
+ */
+export function allowlistSize(): number {
+  return Object.keys(COIN_SYMBOL_ALLOWLIST).length;
+}

--- a/src/data/prices.ts
+++ b/src/data/prices.ts
@@ -109,3 +109,57 @@ export async function getTokenPrice(chain: SupportedChain, address: `0x${string}
   const map = await getTokenPrices([{ chain, address }]);
   return map.get(queryToLlamaKey({ chain, address }));
 }
+
+/**
+ * DefiLlama price for an arbitrary CoinGecko ID via the `coingecko:`
+ * key prefix (issue #274). Same endpoint, same cache, different key
+ * shape. Used by the public `get_coin_price` tool — the EVM-only
+ * `getTokenPrices` above is wrong-shaped for assets without a contract
+ * address (LTC, BTC, SOL, XMR, etc.).
+ *
+ * Returns the raw CoinGecko entry: price + symbol + decimals + timestamp +
+ * (optional) confidence. Caller decides how to project it; the public
+ * tool surfaces the full envelope. Returns undefined when DefiLlama
+ * has no entry for the ID (typo, illiquid, brand-new listing).
+ */
+export interface DefillamaCoinEntry {
+  price: number;
+  symbol?: string;
+  decimals?: number;
+  /** Unix seconds of the last upstream price tick. */
+  timestamp?: number;
+  /** DefiLlama's 0–1 confidence score; absent for very-low-liquidity coins. */
+  confidence?: number;
+}
+
+interface LlamaResponseExt {
+  coins: Record<string, DefillamaCoinEntry>;
+}
+
+export async function getDefillamaCoinPrice(
+  coingeckoId: string,
+): Promise<DefillamaCoinEntry | undefined> {
+  const trimmed = coingeckoId.trim().toLowerCase();
+  if (trimmed.length === 0) return undefined;
+  const key = `coingecko:${trimmed}`;
+  const cacheK = `price:${key}`;
+  // Reuse the same cache the EVM-side prices.ts already uses, so a
+  // portfolio call that hits both EVM tokens AND a coin-price lookup
+  // doesn't double-pay.
+  const hit = cache.get<DefillamaCoinEntry>(cacheK);
+  if (hit) return hit;
+  const url = `${DEFILLAMA_BASE}/prices/current/${encodeURIComponent(key)}`;
+  try {
+    const res = await fetchWithTimeout(url);
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as LlamaResponseExt;
+    const entry = body.coins[key];
+    if (!entry || typeof entry.price !== "number") return undefined;
+    cache.set(cacheK, entry, CACHE_TTL.PRICE);
+    return entry;
+  } catch {
+    // Same swallow-and-degrade posture as getTokenPrices — callers
+    // surface "price missing" rather than crashing the parent flow.
+    return undefined;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,7 +308,12 @@ import {
   prepareMorphoWithdrawCollateralInput,
 } from "./modules/morpho/schemas.js";
 
-import { getTokenPriceInput, getTokenPriceTool } from "./modules/prices/index.js";
+import {
+  getTokenPriceInput,
+  getTokenPriceTool,
+  getCoinPriceInput,
+  getCoinPriceTool,
+} from "./modules/prices/index.js";
 
 import { simulateTransaction } from "./modules/simulation/index.js";
 import { simulateTransactionInput } from "./modules/simulation/schemas.js";
@@ -2751,14 +2756,28 @@ async function main() {
     handler(getTokenBalance)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "get_token_price",
     {
       description:
-        "Fetch the USD price of a token via DefiLlama. Pass `token: \"native\"` for the chain's native asset (ETH on ethereum/arbitrum, MATIC on polygon) or an ERC-20 contract address. Prefer this over get_swap_quote for pure price lookups — no wallet or liquidity simulation needed.",
+        "Fetch the USD price of a token via DefiLlama. Pass `token: \"native\"` for the chain's native asset (ETH on ethereum/arbitrum, MATIC on polygon) or an ERC-20 contract address. Prefer this over get_swap_quote for pure price lookups — no wallet or liquidity simulation needed. EVM-only — for non-EVM natives (BTC, LTC, SOL, XMR, etc.) or any well-known coin without an EVM contract address, use `get_coin_price` instead.",
       inputSchema: getTokenPriceInput.shape,
     },
     handler(getTokenPriceTool)
+  );
+
+  registerTool(server,
+    "get_coin_price",
+    {
+      description:
+        "Fetch the USD price of any well-known cryptocurrency by ticker symbol or CoinGecko ID — no contract address required. Sister tool to `get_token_price`; use this for non-EVM natives (BTC, LTC, SOL, TRX, XMR, DOGE, etc.) and any asset that doesn't have an EVM ERC-20 representation. Two input modes: " +
+        "(a) `symbol` — case-insensitive ticker from a curated allowlist (~120 entries covering top market-cap coins, all native chain currencies VaultPilot supports, major LSTs, top stablecoins, top DeFi governance tokens, and high-question-volume memecoins). The allowlist hardcodes the canonical CoinGecko ID per ticker so scam-token collisions can't poison the result. " +
+        "(b) `coingeckoId` — escape hatch for long-tail assets. Pass the URL slug from coingecko.com/en/coins/<id>. " +
+        "Returns: { symbol, priceUsd, source: \"defillama-coingecko\", resolvedKey, asOf, confidence }. The `confidence` field is DefiLlama's 0–1 thin-liquidity score; surface it to the user when it's below 0.9. " +
+        "When the agent sees a portfolio response with `priceMissing: true` for a non-EVM asset, this is the tool to call.",
+      inputSchema: getCoinPriceInput.shape,
+    },
+    handler(getCoinPriceTool)
   );
 
   registerTool(server, 

--- a/src/modules/btc/balances.ts
+++ b/src/modules/btc/balances.ts
@@ -4,6 +4,7 @@ import {
   type BitcoinAddressBalance,
 } from "./indexer.js";
 import { BTC_DECIMALS, BTC_SYMBOL, SATS_PER_BTC } from "../../config/btc.js";
+import { fetchBitcoinPrice } from "./price.js";
 
 /**
  * Bitcoin balance reader. Single + multi-address surface; multi fans out
@@ -41,6 +42,20 @@ export interface BitcoinBalance {
   decimals: typeof BTC_DECIMALS;
   /** Number of total tx (confirmed + mempool) the address has been involved in. */
   txCount: number;
+  /**
+   * USD price per 1 BTC at lookup time (DefiLlama). Issue #274 — folds
+   * pricing into the read so callers don't need to compose `get_btc_balance`
+   * + `get_coin_price` themselves. Absent when DefiLlama was unreachable.
+   */
+  priceUsd?: number;
+  /**
+   * Confirmed balance × `priceUsd`. Absent when `priceUsd` is absent.
+   * Computed from the confirmed amount only — mempool deltas can flip
+   * sign and aren't load-bearing for "what's this wallet worth".
+   */
+  valueUsd?: number;
+  /** True iff DefiLlama returned no price; set so callers can flag it without checking undefined. */
+  priceMissing?: boolean;
 }
 
 /**
@@ -61,8 +76,9 @@ function satsToBtcString(sats: bigint): string {
 function projectBalance(
   raw: BitcoinAddressBalance,
   addressType: BitcoinAddressType,
+  priceUsd: number | undefined,
 ): BitcoinBalance {
-  return {
+  const base: BitcoinBalance = {
     address: raw.address,
     addressType,
     confirmedSats: raw.confirmedSats,
@@ -74,12 +90,26 @@ function projectBalance(
     decimals: BTC_DECIMALS,
     txCount: raw.txCount,
   };
+  if (priceUsd === undefined) {
+    base.priceMissing = true;
+    return base;
+  }
+  base.priceUsd = priceUsd;
+  // Confirmed-only valuation (mempool can be negative). 8 decimals.
+  const confirmedBtcNum = Number(satsToBtcString(raw.confirmedSats));
+  if (Number.isFinite(confirmedBtcNum)) {
+    base.valueUsd = Math.round(confirmedBtcNum * priceUsd * 100) / 100;
+  }
+  return base;
 }
 
 export async function getBitcoinBalance(address: string): Promise<BitcoinBalance> {
   const addressType = assertBitcoinAddress(address);
-  const raw = await getBitcoinIndexer().getBalance(address);
-  return projectBalance(raw, addressType);
+  const [raw, priceUsd] = await Promise.all([
+    getBitcoinIndexer().getBalance(address),
+    fetchBitcoinPrice(),
+  ]);
+  return projectBalance(raw, addressType, priceUsd);
 }
 
 /**

--- a/src/modules/litecoin/balances.ts
+++ b/src/modules/litecoin/balances.ts
@@ -4,6 +4,7 @@ import {
   type LitecoinAddressBalance,
 } from "./indexer.js";
 import { LTC_DECIMALS, LTC_SYMBOL, LITOSHIS_PER_LTC } from "../../config/litecoin.js";
+import { fetchLitecoinPrice } from "./price.js";
 
 /**
  * Litecoin balance reader. Mirror of `src/modules/btc/balances.ts` —
@@ -29,6 +30,17 @@ export interface LitecoinBalance {
   decimals: typeof LTC_DECIMALS;
   /** Number of total tx (confirmed + mempool) the address has been involved in. */
   txCount: number;
+  /**
+   * USD price per 1 LTC at lookup time (DefiLlama). Issue #274 — folds
+   * pricing into the read so the agent doesn't need to compose
+   * `get_ltc_balance` + `get_coin_price`. Absent when DefiLlama was
+   * unreachable.
+   */
+  priceUsd?: number;
+  /** Confirmed-balance LTC × `priceUsd`. Absent when `priceUsd` is absent. */
+  valueUsd?: number;
+  /** True iff DefiLlama returned no price; set so callers can flag it without checking undefined. */
+  priceMissing?: boolean;
 }
 
 /**
@@ -47,8 +59,9 @@ function litoshisToLtcString(litoshis: bigint): string {
 function projectBalance(
   raw: LitecoinAddressBalance,
   addressType: LitecoinAddressType,
+  priceUsd: number | undefined,
 ): LitecoinBalance {
-  return {
+  const base: LitecoinBalance = {
     address: raw.address,
     addressType,
     confirmedSats: raw.confirmedSats,
@@ -60,12 +73,25 @@ function projectBalance(
     decimals: LTC_DECIMALS,
     txCount: raw.txCount,
   };
+  if (priceUsd === undefined) {
+    base.priceMissing = true;
+    return base;
+  }
+  base.priceUsd = priceUsd;
+  const confirmedLtcNum = Number(litoshisToLtcString(raw.confirmedSats));
+  if (Number.isFinite(confirmedLtcNum)) {
+    base.valueUsd = Math.round(confirmedLtcNum * priceUsd * 100) / 100;
+  }
+  return base;
 }
 
 export async function getLitecoinBalance(address: string): Promise<LitecoinBalance> {
   const addressType = assertLitecoinAddress(address);
-  const raw = await getLitecoinIndexer().getBalance(address);
-  return projectBalance(raw, addressType);
+  const [raw, priceUsd] = await Promise.all([
+    getLitecoinIndexer().getBalance(address),
+    fetchLitecoinPrice(),
+  ]);
+  return projectBalance(raw, addressType, priceUsd);
 }
 
 export type MultiLitecoinBalance =

--- a/src/modules/portfolio/index.ts
+++ b/src/modules/portfolio/index.ts
@@ -20,6 +20,7 @@ import type { GetPortfolioSummaryArgs } from "./schemas.js";
 import type {
   BitcoinPortfolioSlice,
   LendingPositionUnion,
+  LitecoinPortfolioSlice,
   MultiWalletPortfolioSummary,
   PortfolioCoverage,
   PortfolioSummary,
@@ -34,7 +35,7 @@ import type {
   UnpricedAsset,
 } from "../../types/index.js";
 import { getBitcoinBalances } from "../btc/balances.js";
-import { fetchBitcoinPrice } from "../btc/price.js";
+import { getLitecoinBalances } from "../litecoin/balances.js";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 
 function zeroNative(wallet: `0x${string}`, chain: SupportedChain): TokenAmount {
@@ -149,6 +150,17 @@ export async function getPortfolioSummary(
     ? [args.bitcoinAddress]
     : [];
 
+  if (args.litecoinAddress && args.litecoinAddresses && args.litecoinAddresses.length > 0) {
+    throw new Error(
+      "Pass `litecoinAddress` (single) OR `litecoinAddresses` (array), not both.",
+    );
+  }
+  const litecoinAddresses = args.litecoinAddresses?.length
+    ? args.litecoinAddresses
+    : args.litecoinAddress
+    ? [args.litecoinAddress]
+    : [];
+
   // Single-wallet branch: keep the existing fold-non-EVM-into-totals
   // shape (backwards compat). Multi-address TRON/Solana don't have a
   // single-slice projection in this shape; reject explicitly so the
@@ -178,6 +190,7 @@ export async function getPortfolioSummary(
       tronAddresses[0],
       solanaAddresses[0],
       bitcoinAddresses,
+      litecoinAddresses,
     );
   }
 
@@ -210,6 +223,7 @@ export async function getPortfolioSummary(
       tronAddresses,
       solanaAddresses,
       bitcoinAddresses,
+      litecoinAddresses,
     }),
   ]);
   void evmPrefetchDone;
@@ -231,7 +245,8 @@ export async function getPortfolioSummary(
       (nonEvm.solanaUsd ?? 0) +
       (nonEvm.solanaLendingUsd ?? 0) +
       (nonEvm.solanaStakingUsd ?? 0) +
-      (nonEvm.bitcoinUsd ?? 0),
+      (nonEvm.bitcoinUsd ?? 0) +
+      (nonEvm.litecoinUsd ?? 0),
     2,
   );
   const totalUsd = round(evmTotal + nonEvmContribution, 2);
@@ -304,6 +319,7 @@ export async function getPortfolioSummary(
       ? { solanaStakingUsd: nonEvm.solanaStakingUsd }
       : {}),
     ...(nonEvm.bitcoinUsd !== undefined ? { bitcoinUsd: nonEvm.bitcoinUsd } : {}),
+    ...(nonEvm.litecoinUsd !== undefined ? { litecoinUsd: nonEvm.litecoinUsd } : {}),
     coverage: mergedCoverage,
   };
 }
@@ -413,7 +429,10 @@ async function fetchBitcoinSlice(
   addresses: string[],
 ): Promise<{ slice: BitcoinPortfolioSlice; unpriced: UnpricedAsset[] } | null> {
   // getBitcoinBalances returns per-address ok/err entries; `null` is reserved
-  // for catastrophic failure (every address errored).
+  // for catastrophic failure (every address errored). Each balance now
+  // carries its own priceUsd / valueUsd from the reader (issue #274 —
+  // the reader handles the DefiLlama lookup centrally), so we don't
+  // double-fetch the price here.
   let results: Awaited<ReturnType<typeof getBitcoinBalances>>;
   try {
     results = await getBitcoinBalances(addresses);
@@ -422,7 +441,6 @@ async function fetchBitcoinSlice(
   }
   const okBalances = results.filter((r) => r.ok);
   if (okBalances.length === 0) return null;
-  const price = await fetchBitcoinPrice();
   const unpriced: UnpricedAsset[] = [];
   let walletBalancesUsd = 0;
   const balances = results.map((r) => {
@@ -445,14 +463,9 @@ async function fetchBitcoinSlice(
       };
     }
     const b = r.balance;
-    let valueUsd: number | undefined;
-    let priceMissing: boolean | undefined;
-    if (price !== undefined && b.confirmedSats > 0n) {
-      valueUsd = Number(b.confirmedBtc) * price;
-      walletBalancesUsd += valueUsd;
-    } else if (b.confirmedSats > 0n) {
-      // Non-zero balance but no price → flag for the unpriced-assets list.
-      priceMissing = true;
+    if (b.valueUsd !== undefined && b.confirmedSats > 0n) {
+      walletBalancesUsd += b.valueUsd;
+    } else if (b.priceMissing && b.confirmedSats > 0n) {
       unpriced.push({
         chain: "bitcoin",
         symbol: "BTC",
@@ -470,8 +483,79 @@ async function fetchBitcoinSlice(
       symbol: b.symbol,
       decimals: b.decimals,
       txCount: b.txCount,
-      ...(valueUsd !== undefined ? { valueUsd: round(valueUsd, 2) } : {}),
-      ...(priceMissing ? { priceMissing: true } : {}),
+      ...(b.valueUsd !== undefined ? { valueUsd: round(b.valueUsd, 2) } : {}),
+      ...(b.priceMissing ? { priceMissing: true } : {}),
+    };
+  });
+  return {
+    slice: {
+      addresses,
+      balances,
+      walletBalancesUsd: round(walletBalancesUsd, 2),
+    },
+    unpriced,
+  };
+}
+
+/**
+ * Mirror of fetchBitcoinSlice for Litecoin (issue #274). Same fan-out
+ * + per-address fail-soft + price-via-fetchLitecoinPrice posture; only
+ * the symbol/precision/slice-type differ.
+ */
+async function fetchLitecoinSlice(
+  addresses: string[],
+): Promise<{ slice: LitecoinPortfolioSlice; unpriced: UnpricedAsset[] } | null> {
+  // Same DRY pattern as fetchBitcoinSlice — the reader supplies
+  // priceUsd / valueUsd per balance (issue #274), no double-fetch.
+  let results: Awaited<ReturnType<typeof getLitecoinBalances>>;
+  try {
+    results = await getLitecoinBalances(addresses);
+  } catch {
+    return null;
+  }
+  const okBalances = results.filter((r) => r.ok);
+  if (okBalances.length === 0) return null;
+  const unpriced: UnpricedAsset[] = [];
+  let walletBalancesUsd = 0;
+  const balances = results.map((r) => {
+    if (!r.ok) {
+      return {
+        address: r.address,
+        addressType: "p2wpkh" as const,
+        confirmedSats: "0",
+        mempoolSats: "0",
+        totalSats: "0",
+        confirmedLtc: "0",
+        totalLtc: "0",
+        symbol: "LTC" as const,
+        decimals: 8 as const,
+        txCount: 0,
+        priceMissing: true,
+      };
+    }
+    const b = r.balance;
+    if (b.valueUsd !== undefined && b.confirmedSats > 0n) {
+      walletBalancesUsd += b.valueUsd;
+    } else if (b.priceMissing && b.confirmedSats > 0n) {
+      unpriced.push({
+        chain: "litecoin",
+        symbol: "LTC",
+        amount: b.confirmedLtc,
+      });
+    }
+    return {
+      address: b.address,
+      addressType: b.addressType,
+      confirmedSats: b.confirmedSats.toString(),
+      mempoolSats: b.mempoolSats.toString(),
+      totalSats: b.totalSats.toString(),
+      confirmedLtc: b.confirmedLtc,
+      totalLtc: b.totalLtc,
+      symbol: b.symbol,
+      decimals: b.decimals,
+      txCount: b.txCount,
+      ...(b.valueUsd !== undefined ? { valueUsd: round(b.valueUsd, 2) } : {}),
+      ...(b.priceMissing ? { priceMissing: true } : {}),
     };
   });
   return {
@@ -509,30 +593,36 @@ async function aggregateNonEvm(args: {
   tronAddresses: string[];
   solanaAddresses: string[];
   bitcoinAddresses: string[];
+  litecoinAddresses: string[];
 }): Promise<{
   tron?: TronPortfolioSlice[];
   solana?: SolanaPortfolioSlice[];
   bitcoin?: BitcoinPortfolioSlice;
+  litecoin?: LitecoinPortfolioSlice;
   tronUsd?: number;
   tronStakingUsd?: number;
   solanaUsd?: number;
   solanaLendingUsd?: number;
   solanaStakingUsd?: number;
   bitcoinUsd?: number;
+  litecoinUsd?: number;
   coverage?: Pick<
     PortfolioCoverage,
-    "tron" | "tronStaking" | "solana" | "marginfi" | "kamino" | "solanaStaking" | "bitcoin"
+    "tron" | "tronStaking" | "solana" | "marginfi" | "kamino" | "solanaStaking" | "bitcoin" | "litecoin"
   >;
   unpricedAssetsDetail?: UnpricedAsset[];
 }> {
-  // Fan out all three chain groups in parallel — they don't share
-  // network paths so latency stacks pessimistically only inside a
-  // single chain group.
-  const [tronResult, solanaResult, bitcoinResult] = await Promise.all([
+  // Fan out all chain groups in parallel — they don't share network
+  // paths so latency stacks pessimistically only inside a single chain
+  // group.
+  const [tronResult, solanaResult, bitcoinResult, litecoinResult] = await Promise.all([
     aggregateTron(args.tronAddresses),
     aggregateSolana(args.solanaAddresses),
     args.bitcoinAddresses.length > 0
       ? fetchBitcoinSlice(args.bitcoinAddresses)
+      : Promise.resolve(null),
+    args.litecoinAddresses.length > 0
+      ? fetchLitecoinSlice(args.litecoinAddresses)
       : Promise.resolve(null),
   ]);
 
@@ -632,6 +722,23 @@ async function aggregateNonEvm(args: {
         note:
           "Bitcoin indexer fetch failed — BTC balances not included in totals. " +
           "Check `BITCOIN_INDEXER_URL` env var or `bitcoinIndexerUrl` user config.",
+      };
+    }
+  }
+
+  if (args.litecoinAddresses.length > 0) {
+    if (litecoinResult) {
+      out.litecoin = litecoinResult.slice;
+      out.litecoinUsd = litecoinResult.slice.walletBalancesUsd;
+      unpricedAssetsDetail.push(...litecoinResult.unpriced);
+      coverage.litecoin = { covered: true };
+    } else {
+      coverage.litecoin = {
+        covered: false,
+        errored: true,
+        note:
+          "Litecoin indexer fetch failed — LTC balances not included in totals. " +
+          "Check `LITECOIN_INDEXER_URL` env var or `litecoinIndexerUrl` user config.",
       };
     }
   }
@@ -920,6 +1027,7 @@ async function buildWalletSummary(
   tronAddress?: string,
   solanaAddress?: string,
   bitcoinAddresses: string[] = [],
+  litecoinAddresses: string[] = [],
 ): Promise<PortfolioSummary> {
   // Each subquery is independent — one failing shouldn't kill the summary. We swap
   // Promise.all for per-task catchers that return empty payloads on error, so a flaky
@@ -944,6 +1052,7 @@ async function buildWalletSummary(
     kamino: false,
     solanaStaking: false,
     bitcoin: false,
+    litecoin: false,
   };
   // Per-market Compound V3 failure detail, populated when at least one market
   // read errored. Surfaced in coverage.compound.note so the agent can tell
@@ -985,6 +1094,7 @@ async function buildWalletSummary(
     kaminoPositionsRaw,
     solanaStakingRaw,
     bitcoinFetch,
+    litecoinFetch,
   ] = await Promise.all([
       Promise.all(
         chains.map((c) =>
@@ -1162,12 +1272,24 @@ async function buildWalletSummary(
         : (Promise.resolve(null) as Promise<Awaited<
             ReturnType<typeof fetchBitcoinSlice>
           > | null>),
+      // Litecoin reads — same shape + degradation as Bitcoin (issue #274).
+      litecoinAddresses.length > 0
+        ? fetchLitecoinSlice(litecoinAddresses).catch(() => {
+            errors.litecoin = true;
+            return null as Awaited<ReturnType<typeof fetchLitecoinSlice>>;
+          })
+        : (Promise.resolve(null) as Promise<Awaited<
+            ReturnType<typeof fetchLitecoinSlice>
+          > | null>),
     ]);
   if (bitcoinAddresses.length > 0 && bitcoinFetch === null) {
     // fetchBitcoinSlice returns null when every per-address read errored
     // (or the indexer call itself threw). Distinct from "not attempted":
     // surface as coverage.bitcoin.errored.
     errors.bitcoin = true;
+  }
+  if (litecoinAddresses.length > 0 && litecoinFetch === null) {
+    errors.litecoin = true;
   }
   const morphoPositions = morphoByChain.flatMap((r) => r.positions);
 
@@ -1189,6 +1311,9 @@ async function buildWalletSummary(
   const bitcoinSlice = bitcoinFetch?.slice;
   const bitcoinBalancesUsd = bitcoinSlice?.walletBalancesUsd ?? 0;
   const bitcoinUnpriced = bitcoinFetch?.unpriced ?? [];
+  const litecoinSlice = litecoinFetch?.slice;
+  const litecoinBalancesUsd = litecoinSlice?.walletBalancesUsd ?? 0;
+  const litecoinUnpriced = litecoinFetch?.unpriced ?? [];
   // Project the reader's full MarginfiPosition into the thin slice the
   // types module exposes. Dropping bank/mint keeps the portfolio JSON
   // compact — callers who want the full per-bank detail call
@@ -1295,7 +1420,8 @@ async function buildWalletSummary(
     [...native, ...erc20].reduce((sum, t) => sum + (t.valueUsd ?? 0), 0) +
       tronBalancesUsd +
       solanaBalancesUsd +
-      bitcoinBalancesUsd,
+      bitcoinBalancesUsd +
+      litecoinBalancesUsd,
     2
   );
   const lendingNetUsd = round(
@@ -1373,6 +1499,7 @@ async function buildWalletSummary(
     ...tronUnpricedDetail,
     ...solanaUnpricedDetail,
     ...bitcoinUnpriced,
+    ...litecoinUnpriced,
   ];
   const unpricedAssets = unpricedAssetsDetail.length;
   const coverage: PortfolioCoverage = {
@@ -1433,6 +1560,20 @@ async function buildWalletSummary(
                   "Bitcoin indexer fetch failed — BTC balances not included in totals. " +
                   "Check `bitcoinIndexerUrl` config or BITCOIN_INDEXER_URL env var; " +
                   "mempool.space's free public API is the default.",
+              }
+            : { covered: true },
+        }
+      : {}),
+    ...(litecoinAddresses.length > 0
+      ? {
+          litecoin: errors.litecoin
+            ? {
+                covered: false,
+                errored: true,
+                note:
+                  "Litecoin indexer fetch failed — LTC balances not included in totals. " +
+                  "Check `litecoinIndexerUrl` config or LITECOIN_INDEXER_URL env var; " +
+                  "litecoinspace.org's free public API is the default.",
               }
             : { covered: true },
         }
@@ -1508,6 +1649,7 @@ async function buildWalletSummary(
       ? { solanaStakingUsd: round(solanaStakingUsd, 2) }
       : {}),
     ...(bitcoinSlice ? { bitcoinUsd: round(bitcoinBalancesUsd, 2) } : {}),
+    ...(litecoinSlice ? { litecoinUsd: round(litecoinBalancesUsd, 2) } : {}),
     breakdown: {
       native,
       erc20,
@@ -1516,6 +1658,7 @@ async function buildWalletSummary(
       staking: staking.positions,
       ...(tronBreakdown ? { tron: tronBreakdown } : {}),
       ...(bitcoinSlice ? { bitcoin: bitcoinSlice } : {}),
+      ...(litecoinSlice ? { litecoin: litecoinSlice } : {}),
       ...(solanaSlice
         ? {
             solana: {

--- a/src/modules/portfolio/schemas.ts
+++ b/src/modules/portfolio/schemas.ts
@@ -28,6 +28,15 @@ const bitcoinAddressSchema = z
       "segwit (bc1q...), and taproot (bc1p...). Testnet/signet not supported."
   );
 
+const litecoinAddressSchema = z
+  .string()
+  .min(26)
+  .max(64)
+  .describe(
+    "Litecoin mainnet address. Accepts legacy (L...), P2SH (M.../3...), " +
+      "native segwit (ltc1q...), and taproot (ltc1p...). Testnet/MWEB not supported."
+  );
+
 /**
  * Raw shape — MCP requires a bare ZodObject (no .refine) so it can expose `.shape`
  * to build the JSON schema. Cross-field validation is enforced in the handler.
@@ -111,6 +120,27 @@ export const getPortfolioSummaryInput = z.object({
         "per-address fetch errors degrade via `coverage.bitcoin`. Multi-wallet " +
         "mode aggregates ALL passed addresses into a single `nonEvm.bitcoin` " +
         "slice. Mutually exclusive with `bitcoinAddress`."
+    ),
+  litecoinAddress: litecoinAddressSchema
+    .optional()
+    .describe(
+      "Single Litecoin mainnet address. Mirrors `bitcoinAddress`: with a " +
+        "single `wallet`, LTC balance × USD price folds into per-wallet totals " +
+        "(`breakdown.litecoin`, `litecoinUsd`); with `wallets[]`, surfaced in " +
+        "`nonEvm.litecoin`. Mutually exclusive with `litecoinAddresses`. " +
+        "Issue #274."
+    ),
+  litecoinAddresses: z
+    .array(litecoinAddressSchema)
+    .min(1)
+    .max(20)
+    .optional()
+    .describe(
+      "Multiple Litecoin addresses (e.g. legacy + segwit + taproot for the " +
+        "same Ledger account). 1-20 entries; per-address fetch errors degrade " +
+        "via `coverage.litecoin`. Multi-wallet mode aggregates ALL passed " +
+        "addresses into a single `nonEvm.litecoin` slice. Mutually exclusive " +
+        "with `litecoinAddress`."
     ),
 });
 

--- a/src/modules/prices/index.ts
+++ b/src/modules/prices/index.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
-import { getTokenPrice } from "../../data/prices.js";
+import { getTokenPrice, getDefillamaCoinPrice } from "../../data/prices.js";
 import { SUPPORTED_CHAINS, type SupportedChain } from "../../types/index.js";
 import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+import {
+  resolveSymbolToCoingeckoId,
+  allowlistSize,
+} from "../../data/coin-allowlist.js";
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 const tokenSchema = z.union([
@@ -26,4 +30,111 @@ export async function getTokenPriceTool(args: GetTokenPriceArgs) {
     );
   }
   return { chain, token, priceUsd, source: "defillama" as const };
+}
+
+// ===========================================================================
+// get_coin_price — issue #274. EVM-agnostic price lookup by ticker symbol
+// (allowlist) or CoinGecko ID (escape hatch). Closes the gap where LTC
+// (and any future non-EVM native without an EVM contract) can't be
+// priced via the EVM-only `get_token_price` tool.
+// ===========================================================================
+
+/**
+ * Input shape — exactly one of `symbol` / `coingeckoId` must be set.
+ * The XOR check lives in the handler (not as `.refine()`) because
+ * the MCP SDK requires a plain `ZodObject` to extract `.shape` for the
+ * tool registration; `.refine()` would wrap it in ZodEffects and
+ * break that.
+ */
+export const getCoinPriceInput = z.object({
+  symbol: z
+    .string()
+    .min(1)
+    .max(20)
+    .optional()
+    .describe(
+      `Ticker symbol from the curated allowlist (~${allowlistSize()} entries; case-insensitive). ` +
+        `Examples: "BTC", "LTC", "SOL", "DOGE", "USDC", "stETH". The allowlist hardcodes the ` +
+        `canonical CoinGecko ID for each symbol so scam tickers can't poison the result. For ` +
+        `assets not on the allowlist, use the \`coingeckoId\` field instead.`,
+    ),
+  coingeckoId: z
+    .string()
+    .min(1)
+    .max(64)
+    .optional()
+    .describe(
+      `CoinGecko ID (the URL slug from coingecko.com/en/coins/<id>). Examples: "litecoin", ` +
+        `"bitcoin", "monero". Bypasses the allowlist for long-tail assets. Pass exactly one of ` +
+        `\`symbol\` or \`coingeckoId\`.`,
+    ),
+});
+
+export type GetCoinPriceArgs = z.infer<typeof getCoinPriceInput>;
+
+export interface CoinPriceResponse {
+  /** Symbol the user passed (or the resolved upstream symbol when coingeckoId was used). */
+  symbol: string;
+  priceUsd: number;
+  /** Always "defillama-coingecko" in v1; future sources stay distinguishable. */
+  source: "defillama-coingecko";
+  /** Verbatim DefiLlama key the lookup used — useful for the agent to relay to the user transparently. */
+  resolvedKey: string;
+  /** Unix seconds — when DefiLlama observed this price. Absent on rare degraded responses. */
+  asOf?: number;
+  /** DefiLlama's 0–1 confidence score; absent for low-liquidity coins. */
+  confidence?: number;
+}
+
+export async function getCoinPriceTool(
+  args: GetCoinPriceArgs,
+): Promise<CoinPriceResponse> {
+  // XOR validation. Lives in the handler because the MCP SDK needs a
+  // plain ZodObject for `.shape` extraction at registration time, so
+  // we can't use `.refine()` on the schema.
+  const haveSymbol = !!args.symbol;
+  const haveId = !!args.coingeckoId;
+  if (haveSymbol === haveId) {
+    throw new Error(
+      "Pass exactly one of `symbol` (allowlist lookup) or `coingeckoId` (escape hatch). Both or neither is invalid.",
+    );
+  }
+  let coingeckoId: string;
+  let displaySymbol: string;
+  if (args.coingeckoId) {
+    coingeckoId = args.coingeckoId.trim().toLowerCase();
+    displaySymbol = coingeckoId; // upstream may overwrite via entry.symbol
+  } else if (args.symbol) {
+    const resolved = resolveSymbolToCoingeckoId(args.symbol);
+    if (!resolved) {
+      throw new Error(
+        `"${args.symbol}" is not on the curated symbol allowlist (~${allowlistSize()} entries). ` +
+          `Either use the canonical ticker (e.g. "BTC", "LTC", "SOL", "USDC", "DOGE") OR pass ` +
+          `\`coingeckoId\` directly with the CoinGecko URL slug from coingecko.com/en/coins/<id>. ` +
+          `Refusing to free-form-resolve symbols because tickers like "USDC" / "USDT" / "ETH" ` +
+          `collide with dozens of scam tokens on CoinGecko.`,
+      );
+    }
+    coingeckoId = resolved;
+    displaySymbol = args.symbol.toUpperCase();
+  } else {
+    // Schema-refine should prevent this; defensive throw for invariant safety.
+    throw new Error("Internal: neither symbol nor coingeckoId set after schema validation.");
+  }
+
+  const entry = await getDefillamaCoinPrice(coingeckoId);
+  if (!entry) {
+    throw new Error(
+      `DefiLlama returned no price for "coingecko:${coingeckoId}". The coin may be unlisted, ` +
+        `delisted, or the ID may be wrong (cross-check at https://www.coingecko.com/en/coins/${coingeckoId}).`,
+    );
+  }
+  return {
+    symbol: entry.symbol ?? displaySymbol,
+    priceUsd: entry.price,
+    source: "defillama-coingecko",
+    resolvedKey: `coingecko:${coingeckoId}`,
+    ...(entry.timestamp !== undefined ? { asOf: entry.timestamp } : {}),
+    ...(entry.confidence !== undefined ? { confidence: entry.confidence } : {}),
+  };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,12 @@ export interface PortfolioCoverage {
    * failed and BTC totals are missing.
    */
   bitcoin?: CoverageStatus;
+  /**
+   * Litecoin balance fetch coverage. Mirrors `bitcoin` — covered:false +
+   * errored:false means no LTC address was queried; errored:true means
+   * the indexer call failed and LTC totals are missing. Issue #274.
+   */
+  litecoin?: CoverageStatus;
   /** Number of token balances whose USD valuation could not be resolved. */
   unpricedAssets: number;
   /**
@@ -170,7 +176,7 @@ export interface PortfolioCoverage {
  * cross-chain set without needing per-chain buckets.
  */
 export interface UnpricedAsset {
-  chain: SupportedChain | "tron" | "solana" | "bitcoin";
+  chain: SupportedChain | "tron" | "solana" | "bitcoin" | "litecoin";
   symbol: string;
   /** Human-readable balance (already-decimals-applied), e.g. "705.141". */
   amount: string;

--- a/test/btc-pr4-portfolio-message-sign.test.ts
+++ b/test/btc-pr4-portfolio-message-sign.test.ts
@@ -99,7 +99,10 @@ afterEach(() => {
 
 describe("portfolio BTC integration", () => {
   it("folds BTC balance × price into breakdown.bitcoin + bitcoinUsd", async () => {
-    fetchBitcoinPriceMock.mockResolvedValueOnce(50_000);
+    // mockResolvedValue (not Once) — issue #274 moved BTC pricing into
+    // getBitcoinBalance (the per-address reader), so a multi-address call
+    // hits fetchBitcoinPrice once per address rather than once per slice.
+    fetchBitcoinPriceMock.mockResolvedValue(50_000);
     getBalanceMock.mockResolvedValueOnce({
       address: SEGWIT_ADDR,
       confirmedSats: 200_000n, // 0.002 BTC
@@ -171,7 +174,10 @@ describe("portfolio BTC integration", () => {
   });
 
   it("supports multiple BTC addresses (legacy + segwit + taproot)", async () => {
-    fetchBitcoinPriceMock.mockResolvedValueOnce(50_000);
+    // mockResolvedValue (not Once) — issue #274 moved BTC pricing into
+    // getBitcoinBalance (the per-address reader), so a multi-address call
+    // hits fetchBitcoinPrice once per address rather than once per slice.
+    fetchBitcoinPriceMock.mockResolvedValue(50_000);
     getBalanceMock
       .mockResolvedValueOnce({
         address: SEGWIT_ADDR,

--- a/test/get-coin-price.test.ts
+++ b/test/get-coin-price.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cache } from "../src/data/cache.js";
+
+/**
+ * Unit tests for `get_coin_price` (issue #274) and the underlying
+ * `getDefillamaCoinPrice` helper. The DefiLlama HTTP layer is mocked
+ * via `vi.stubGlobal("fetch", …)` so no real network is involved.
+ */
+
+const fetchMock = vi.fn(async (url: string) => {
+  // Default: empty response. Individual tests override.
+  return new Response(JSON.stringify({ coins: {} }));
+}) as unknown as typeof fetch;
+
+beforeEach(() => {
+  cache.clear();
+  vi.stubGlobal("fetch", fetchMock);
+  (fetchMock as unknown as ReturnType<typeof vi.fn>).mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resolveSymbolToCoingeckoId — allowlist", () => {
+  it("resolves canonical tickers (case-insensitive)", async () => {
+    const { resolveSymbolToCoingeckoId } = await import("../src/data/coin-allowlist.js");
+    expect(resolveSymbolToCoingeckoId("BTC")).toBe("bitcoin");
+    expect(resolveSymbolToCoingeckoId("btc")).toBe("bitcoin");
+    expect(resolveSymbolToCoingeckoId("ltc")).toBe("litecoin");
+    expect(resolveSymbolToCoingeckoId("SOL")).toBe("solana");
+    expect(resolveSymbolToCoingeckoId("USDC")).toBe("usd-coin");
+    // Trim whitespace.
+    expect(resolveSymbolToCoingeckoId("  doge  ")).toBe("dogecoin");
+  });
+
+  it("returns undefined for symbols not on the allowlist", async () => {
+    const { resolveSymbolToCoingeckoId } = await import("../src/data/coin-allowlist.js");
+    expect(resolveSymbolToCoingeckoId("FAKETICKER")).toBeUndefined();
+    expect(resolveSymbolToCoingeckoId("")).toBeUndefined();
+  });
+
+  it("knows about the issue's seed list (smoke check)", async () => {
+    const { resolveSymbolToCoingeckoId } = await import("../src/data/coin-allowlist.js");
+    // Spot-check the seed tickers from the issue body so a future PR
+    // that accidentally drops one of them surfaces here.
+    const required = ["btc", "eth", "sol", "ltc", "usdc", "usdt", "doge", "ada", "trx", "atom", "xmr", "etc", "xrp"];
+    for (const sym of required) {
+      expect(resolveSymbolToCoingeckoId(sym)).toBeDefined();
+    }
+  });
+
+  it("polygon ticker resolves to the post-rebrand id (POL not MATIC)", async () => {
+    const { resolveSymbolToCoingeckoId } = await import("../src/data/coin-allowlist.js");
+    // CoinGecko renamed `matic-network` → `polygon-ecosystem-token` in 2024.
+    // The `matic` legacy alias should still resolve to the new id.
+    expect(resolveSymbolToCoingeckoId("pol")).toBe("polygon-ecosystem-token");
+    expect(resolveSymbolToCoingeckoId("matic")).toBe("polygon-ecosystem-token");
+  });
+});
+
+describe("getDefillamaCoinPrice — DefiLlama integration", () => {
+  it("fetches and returns the price entry on a happy-path response", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          coins: {
+            "coingecko:litecoin": {
+              price: 100.5,
+              symbol: "LTC",
+              decimals: 8,
+              timestamp: 1750000000,
+              confidence: 0.95,
+            },
+          },
+        }),
+      ),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    const entry = await getDefillamaCoinPrice("litecoin");
+    expect(entry).toEqual({
+      price: 100.5,
+      symbol: "LTC",
+      decimals: 8,
+      timestamp: 1750000000,
+      confidence: 0.95,
+    });
+  });
+
+  it("normalizes the ID (trim + lowercase)", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ coins: { "coingecko:bitcoin": { price: 1 } } })),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    const entry = await getDefillamaCoinPrice("  Bitcoin  ");
+    expect(entry?.price).toBe(1);
+    // The mock URL should have used the lowercased + trimmed id.
+    const calledUrl = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(decodeURIComponent(calledUrl)).toContain("coingecko:bitcoin");
+    expect(decodeURIComponent(calledUrl)).not.toContain("Bitcoin");
+  });
+
+  it("returns undefined when DefiLlama has no entry", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ coins: {} })),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    expect(await getDefillamaCoinPrice("nonexistent-coin-xyz")).toBeUndefined();
+  });
+
+  it("returns undefined on HTTP error (degrades gracefully)", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("err", { status: 500 }),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    expect(await getDefillamaCoinPrice("litecoin")).toBeUndefined();
+  });
+
+  it("returns undefined on fetch throw (network error)", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("ENOTFOUND coins.llama.fi"),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    expect(await getDefillamaCoinPrice("litecoin")).toBeUndefined();
+  });
+
+  it("rejects empty IDs without hitting the network", async () => {
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    expect(await getDefillamaCoinPrice("")).toBeUndefined();
+    expect(await getDefillamaCoinPrice("   ")).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("caches successful responses (second call hits cache, no second fetch)", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ coins: { "coingecko:litecoin": { price: 100 } } })),
+    );
+    const { getDefillamaCoinPrice } = await import("../src/data/prices.js");
+    await getDefillamaCoinPrice("litecoin");
+    await getDefillamaCoinPrice("litecoin");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getCoinPriceTool — public tool surface", () => {
+  it("happy path: symbol → resolved price + envelope", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          coins: {
+            "coingecko:litecoin": {
+              price: 100,
+              symbol: "LTC",
+              timestamp: 1750000000,
+              confidence: 0.92,
+            },
+          },
+        }),
+      ),
+    );
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    const out = await getCoinPriceTool({ symbol: "LTC" });
+    expect(out).toEqual({
+      symbol: "LTC",
+      priceUsd: 100,
+      source: "defillama-coingecko",
+      resolvedKey: "coingecko:litecoin",
+      asOf: 1750000000,
+      confidence: 0.92,
+    });
+  });
+
+  it("happy path: coingeckoId escape hatch (long-tail asset)", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          coins: { "coingecko:nervous-system": { price: 0.42, symbol: "NRV" } },
+        }),
+      ),
+    );
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    const out = await getCoinPriceTool({ coingeckoId: "nervous-system" });
+    expect(out.symbol).toBe("NRV");
+    expect(out.priceUsd).toBe(0.42);
+    expect(out.resolvedKey).toBe("coingecko:nervous-system");
+    expect(out.confidence).toBeUndefined();
+  });
+
+  it("rejects unknown symbol with a helpful error pointing at coingeckoId escape", async () => {
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    await expect(getCoinPriceTool({ symbol: "THIS_IS_NOT_REAL" })).rejects.toThrow(
+      /not on the curated symbol allowlist/,
+    );
+    await expect(getCoinPriceTool({ symbol: "THIS_IS_NOT_REAL" })).rejects.toThrow(
+      /coingeckoId/,
+    );
+  });
+
+  it("rejects empty input (neither symbol nor coingeckoId)", async () => {
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    await expect(getCoinPriceTool({})).rejects.toThrow(/Pass exactly one/);
+  });
+
+  it("rejects both symbol AND coingeckoId (XOR enforcement)", async () => {
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    await expect(
+      getCoinPriceTool({ symbol: "LTC", coingeckoId: "litecoin" }),
+    ).rejects.toThrow(/Pass exactly one/);
+  });
+
+  it("surfaces a typo-friendly error when DefiLlama returns no entry", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ coins: {} })),
+    );
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    await expect(
+      getCoinPriceTool({ coingeckoId: "made-up-id-xyz" }),
+    ).rejects.toThrow(/no price for "coingecko:made-up-id-xyz"/);
+  });
+
+  it("uses the symbol's UPPERCASE display when no upstream symbol is provided", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ coins: { "coingecko:litecoin": { price: 100 } } }),
+      ),
+    );
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    // Pass lowercase — the response has no symbol field, so we should
+    // get back the user's input UPPERCASED.
+    const out = await getCoinPriceTool({ symbol: "ltc" });
+    expect(out.symbol).toBe("LTC");
+  });
+
+  it("omits asOf and confidence from envelope when DefiLlama doesn't return them", async () => {
+    (fetchMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ coins: { "coingecko:bitcoin": { price: 50000 } } }),
+      ),
+    );
+    const { getCoinPriceTool } = await import("../src/modules/prices/index.js");
+    const out = await getCoinPriceTool({ symbol: "BTC" });
+    expect(out.priceUsd).toBe(50000);
+    expect("asOf" in out).toBe(false);
+    expect("confidence" in out).toBe(false);
+  });
+});

--- a/test/portfolio-multi-wallet-non-evm.test.ts
+++ b/test/portfolio-multi-wallet-non-evm.test.ts
@@ -224,6 +224,10 @@ describe("get_portfolio_summary — multi-wallet + all three non-EVM (issue #201
       spl: [],
       walletBalancesUsd: 25,
     });
+    // Issue #274: pricing moved into the BTC reader, so the mocked
+    // balance now needs to include priceUsd / valueUsd directly. The
+    // separate fetchBitcoinPrice mock below is preserved for compat
+    // but is no longer load-bearing for this test path.
     (getBitcoinBalances as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
         ok: true as const,
@@ -238,6 +242,8 @@ describe("get_portfolio_summary — multi-wallet + all three non-EVM (issue #201
           symbol: "BTC",
           decimals: 8,
           txCount: 1,
+          priceUsd: 50_000,
+          valueUsd: 100,
         },
       },
       {
@@ -253,6 +259,8 @@ describe("get_portfolio_summary — multi-wallet + all three non-EVM (issue #201
           symbol: "BTC",
           decimals: 8,
           txCount: 1,
+          priceUsd: 50_000,
+          valueUsd: 50,
         },
       },
     ]);


### PR DESCRIPTION
Closes #274. Generic price reader for any well-known coin by ticker symbol (allowlist) or CoinGecko ID (escape hatch). EVM-only \`get_token_price\` still required a contract address; this tool covers the non-EVM natives (LTC, BTC, SOL, TRX, XMR, DOGE, …) and any asset without an EVM ERC-20 representation.

## What ships

### `get_coin_price` MCP tool

Symbol XOR coingeckoId. Returns the issue's exact response shape:
```json
{ "symbol": "LTC", "priceUsd": 100.5, "source": "defillama-coingecko",
  "resolvedKey": "coingecko:litecoin", "asOf": 1750000000, "confidence": 0.95 }
```
Backed by DefiLlama's `coingecko:{id}` key prefix. Reuses the same 30s in-process price cache as the EVM-side `getTokenPrices`.

### Symbol allowlist (~120 entries)

Hardcoded in `src/data/coin-allowlist.ts`. Covers:
- Native chain currencies VaultPilot supports (BTC/ETH/SOL/LTC/TRX/BNB/XRP/ADA/DOT/AVAX + chain L2s + many more)
- Top-100 by market cap as of 2026-04
- Major LSTs (stETH/wstETH/rETH/cbETH/mSOL/jitoSOL/bSOL/ezETH/weETH)
- Top stablecoins (USDC/USDT/DAI/PYUSD/FDUSD/USDe/USDS/FRAX/LUSD/GHO/crvUSD)
- Top DeFi governance (AAVE/COMP/MKR/UNI/SUSHI/CRV/CVX/BAL/PENDLE/GMX/LDO/RPL/ENA/MORPHO)
- Big memecoins (DOGE/SHIB/PEPE/BONK/WIF/FLOKI/MOG/TRUMP/POPCAT)

**Why hardcoded** rather than free-form-resolved: tickers like USDC/USDT/ETH collide with dozens of scam-token CoinGecko entries. Free-form `symbol → top-result` resolution would silently price the wrong asset. The escape hatch (`coingeckoId`) covers the rare legitimate need for non-allowlist coins.

### `get_btc_balance` + `get_ltc_balance` enrichment

Both readers now return `priceUsd` + `valueUsd` + `priceMissing` fields per the issue's "fold valueUsd into the readers" guidance. The portfolio aggregator now reads `b.valueUsd` from the balance instead of calling `fetchBitcoinPrice` / `fetchLitecoinPrice` independently — DRY refactor that eliminates a previously-redundant double fetch.

### `get_portfolio_summary` LTC integration

Full mirror of the BTC slice path:
- `litecoinAddress` / `litecoinAddresses` schema args (max 20, mutually exclusive)
- `litecoinUsd` rolled into per-wallet + multi-wallet totals
- `breakdown.litecoin` surfaced in single-wallet shape
- `nonEvm.litecoin` surfaced in multi-wallet shape
- `coverage.litecoin` flagged on indexer failures with the exact "check `litecoinIndexerUrl` config" remediation hint

Mirrors `bitcoinAddresses` 1:1 across all ~25 integration sites.

## Tool description excerpt (for the agent)

> "When the agent sees a portfolio response with `priceMissing: true` for a non-EVM asset, this is the tool to call." — explicit guidance so the agent doesn't reach for bash-curl (per `feedback_no_bash_for_chain_reads`).

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — **1398 / 115 green** (was 1379 / 114; +19 new).
- 19 new tests in `test/get-coin-price.test.ts`:
  - Allowlist resolution: case-insensitive, trim, unknown→undefined, seed-list smoke, MATIC→POL rebrand alias.
  - `getDefillamaCoinPrice`: happy path, ID normalization, no-entry, HTTP 5xx, network throw, empty-id no-fetch, cache hit on second call.
  - `getCoinPriceTool`: symbol path, coingeckoId escape, unknown-symbol helpful error, both-or-neither XOR rejection, no-entry typo-friendly error, UPPERCASE display when upstream omits symbol, optional fields omitted when absent.
- 2 existing tests updated for the new pricing locality (price now in the balance, not separately fetched by the slice).

## Out of scope (explicitly per the issue)

- Per-chain ERC-20 lookup by symbol — keep on `get_token_price` (contract address required for the dozens of "USDC"/"USDT" lookalikes per chain).
- Historical pricing / OHLC.
- Order-book / live-trade feeds.
- Long-tail memecoin pricing past the allowlist — covered by the `coingeckoId` escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)