### PR TITLE
feat(hosted): PR A — transport scaffolding (stdio/http dispatch)

### DIFF
--- a/src/hosted/server.ts
+++ b/src/hosted/server.ts
@@ -1,0 +1,262 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+/**
+ * Hosted-mode HTTP server scaffolding — PR A of the
+ * `claude-work/plan-hosted-mcp-endpoint.md` rollout.
+ *
+ * **What this does today:**
+ *   - Boots a Node `http` server when `VAULTPILOT_TRANSPORT=http`.
+ *   - Exposes `GET /` and `GET /healthz` returning a small JSON status
+ *     envelope so deployment liveness probes (Docker/k8s/Fly/Railway)
+ *     have something to hit.
+ *   - Returns `501 Not Implemented` for `POST /mcp` and every other
+ *     route, with a body explaining which subsequent PR (B-F) implements
+ *     each piece.
+ *
+ * **What this does NOT do** (deferred to subsequent PRs in the plan):
+ *   - **PR B**: per-user WalletConnect isolation — `WalletConnectRegistry`
+ *     replaces module-scoped state in `src/signing/walletconnect.ts`;
+ *     `userId` threading via `AsyncLocalStorage`.
+ *   - **PR C**: OAuth 2.1 provider + GitHub upstream + bearer-token
+ *     issuance + SQLite state + per-user rate limiting. The MCP
+ *     streamable-HTTP handler wires up here.
+ *   - **PR D**: hosted-mode tool gating — TRON / Solana / USB-HID
+ *     prepare tools return a structured "use local install" error.
+ *   - **PR E**: `SECURITY.md` addendum, README hosted-mode section,
+ *     Dockerfile, docker-compose, self-host docs.
+ *   - **PR F**: maintainer-run reference deployment (out of repo).
+ *
+ * Deliberately uses `node:http` (zero new deps). Hono lands in PR C
+ * when we need real OAuth routes + middleware composition.
+ */
+
+const DEFAULT_PORT = 3000;
+
+/**
+ * Resolve the package version once at module load. Same pattern as the
+ * setup binary's `readPackageVersion` — read `package.json` relative to
+ * this file's compiled location so it works for both global-install and
+ * source runs.
+ */
+function readVersion(): string {
+  try {
+    const here = fileURLToPath(import.meta.url);
+    const req = createRequire(here);
+    // Compiled location: dist/hosted/server.js → ../../package.json
+    const pkg = req("../../package.json") as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+const VERSION = readVersion();
+
+/**
+ * Status envelope returned on health-probe routes. Stable shape so a
+ * future deployment monitor can match against it.
+ */
+interface StatusEnvelope {
+  service: "vaultpilot-mcp";
+  mode: "hosted";
+  version: string;
+  status: "scaffolding-only";
+  prState: {
+    /** Which PR landed which capability. Mirrors the plan doc. */
+    transport: "PR A — done (this commit)";
+    walletConnectRegistry: "PR B — pending";
+    auth: "PR C — pending";
+    toolGating: "PR D — pending";
+    docs: "PR E — pending";
+    deployment: "PR F — pending";
+  };
+  /** Stable health flag for liveness probes. */
+  ready: boolean;
+}
+
+function buildStatus(): StatusEnvelope {
+  return {
+    service: "vaultpilot-mcp",
+    mode: "hosted",
+    version: VERSION,
+    status: "scaffolding-only",
+    prState: {
+      transport: "PR A — done (this commit)",
+      walletConnectRegistry: "PR B — pending",
+      auth: "PR C — pending",
+      toolGating: "PR D — pending",
+      docs: "PR E — pending",
+      deployment: "PR F — pending",
+    },
+    // Liveness probe: PR A is intentionally `ready: false` — the MCP
+    // surface isn't actually serving requests yet (auth + dispatch land
+    // in PR C). A future operator deploying PR A standalone should NOT
+    // route real traffic at it. Flips to `true` in PR C.
+    ready: false,
+  };
+}
+
+function jsonResponse(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+): void {
+  const payload = JSON.stringify(body, null, 2);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(payload),
+    // Conservative CORS posture for the placeholder. PR C will refine
+    // when actual auth flows + browser dashboard land.
+    "Cache-Control": "no-store",
+  });
+  res.end(payload);
+}
+
+function notImplemented(res: ServerResponse, route: string, plannedPr: string): void {
+  jsonResponse(res, 501, {
+    error: "not_implemented",
+    route,
+    message:
+      `The hosted endpoint scaffolding is in place (PR A), but ${route} is implemented in ${plannedPr}. ` +
+      `See claude-work/plan-hosted-mcp-endpoint.md for the rollout sequence.`,
+    plannedPr,
+  });
+}
+
+function handleRequest(req: IncomingMessage, res: ServerResponse): void {
+  const method = req.method ?? "GET";
+  const url = req.url ?? "/";
+  // Strip query string for routing.
+  const path = url.split("?")[0];
+  // Minimal access log — real structured logger lands in PR C with
+  // request-id + user-id + latency. Stderr so it doesn't pollute MCP
+  // stdout if anyone misroutes the streams.
+  process.stderr.write(`[vaultpilot-mcp:hosted] ${method} ${path}\n`);
+
+  if (method === "GET" && (path === "/" || path === "/healthz")) {
+    jsonResponse(res, 200, buildStatus());
+    return;
+  }
+
+  // OAuth discovery doc — populated for real in PR C. For now, return
+  // a stub that says "this endpoint is reserved" so Claude Desktop's
+  // OAuth probe gets a structured response instead of a 501 (which
+  // would break its discovery flow once real OAuth lands and confuse
+  // anyone testing).
+  if (method === "GET" && path === "/.well-known/oauth-authorization-server") {
+    jsonResponse(res, 503, {
+      error: "service_unavailable",
+      message: "OAuth provider not yet configured — lands in PR C.",
+      retryAfterPr: "C",
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/mcp") {
+    notImplemented(res, "POST /mcp", "PR C (auth + MCP streamable-HTTP handler)");
+    return;
+  }
+
+  if (path.startsWith("/authorize") || path.startsWith("/token") || path.startsWith("/revoke")) {
+    notImplemented(res, path, "PR C (OAuth 2.1 provider)");
+    return;
+  }
+
+  if (path.startsWith("/dashboard")) {
+    notImplemented(res, path, "PR C (operator dashboard for token management)");
+    return;
+  }
+
+  // Unknown route — keep the response shape consistent with the
+  // structured-error pattern above so an agent debugging "what does
+  // this endpoint expose?" gets a useful response, not a bare 404.
+  jsonResponse(res, 404, {
+    error: "not_found",
+    method,
+    path,
+    available: ["GET /", "GET /healthz"],
+    pending: [
+      "GET /.well-known/oauth-authorization-server (PR C)",
+      "GET /authorize, POST /token, POST /revoke (PR C)",
+      "GET /dashboard (PR C)",
+      "POST /mcp (PR C)",
+    ],
+  });
+}
+
+/**
+ * Start the hosted HTTP server. Returns the bound port (useful for
+ * tests where PORT=0 lets the OS pick a free port). Caller (typically
+ * `src/index.ts`'s transport dispatch) decides what to await on; we
+ * return both the server handle and a `ready` promise so tests can
+ * cleanly start + stop without races.
+ */
+export interface HostedServerHandle {
+  port: number;
+  close: () => Promise<void>;
+}
+
+export async function startHostedServer(opts: {
+  port?: number;
+  host?: string;
+} = {}): Promise<HostedServerHandle> {
+  const requestedPort = opts.port ?? Number(process.env.PORT ?? DEFAULT_PORT);
+  const host = opts.host ?? "0.0.0.0";
+
+  const server = createServer((req, res) => {
+    try {
+      handleRequest(req, res);
+    } catch (err) {
+      // Defensive: any throw in a handler shouldn't kill the process.
+      // Real error reporting lands with the structured logger in PR C.
+      process.stderr.write(
+        `[vaultpilot-mcp:hosted] handler error: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      try {
+        jsonResponse(res, 500, {
+          error: "internal_server_error",
+          message: "Unhandled error in request pipeline.",
+        });
+      } catch {
+        /* response already partially sent — give up */
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(requestedPort, host, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  const port =
+    addr && typeof addr === "object" ? addr.port : requestedPort;
+  process.stderr.write(
+    `[vaultpilot-mcp:hosted] listening on http://${host}:${port}/ (mode=scaffolding-only)\n`,
+  );
+
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}
+
+// Test-only export — lets unit tests assert envelope shape without
+// spinning up the HTTP listener.
+export const _testing = {
+  buildStatus,
+  handleRequest,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3168,6 +3168,34 @@ async function main() {
   );
   startOraclePoller();
 
+  // Transport dispatch — `claude-work/plan-hosted-mcp-endpoint.md` PR A.
+  //
+  // Default `stdio` (no behavior change for the npm-i-g use case).
+  // `VAULTPILOT_TRANSPORT=http` boots the placeholder HTTP server in
+  // src/hosted/server.ts. The HTTP path is scaffolding-only in this
+  // PR — auth + the MCP streamable-HTTP handler land in PR C; until
+  // then `POST /mcp` returns 501 with a structured envelope explaining
+  // which subsequent PR implements which piece.
+  //
+  // Why an env var rather than a CLI flag: matches the existing
+  // operator-supplied-secrets pattern (RPC URLs, API keys, etc. all
+  // come from env), and survives `pkg`-bundled binaries that don't
+  // pass argv reliably.
+  const transportMode = process.env.VAULTPILOT_TRANSPORT ?? "stdio";
+  if (transportMode === "http") {
+    const { startHostedServer } = await import("./hosted/server.js");
+    await startHostedServer();
+    return; // Don't connect stdio — the HTTP server holds the process open.
+  }
+  if (transportMode !== "stdio") {
+    // Unknown value: warn loudly + fall back to stdio. Better than
+    // crashing on a typo (`VAULTPILOT_TRANSPORT=stdo`) which would
+    // silently break the user's MCP-client integration.
+    process.stderr.write(
+      `[vaultpilot-mcp] WARNING: unknown VAULTPILOT_TRANSPORT="${transportMode}"; ` +
+        `falling back to stdio. Valid values: "stdio" (default), "http".\n`,
+    );
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/test/hosted-server.test.ts
+++ b/test/hosted-server.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  startHostedServer,
+  _testing,
+  type HostedServerHandle,
+} from "../src/hosted/server.js";
+
+/**
+ * Tests for the PR A hosted-mode transport scaffolding.
+ *
+ * The full MCP-over-HTTP surface lands in PR C (auth + dispatch);
+ * everything here covers the placeholder shape:
+ *   - status envelope on `/` and `/healthz`
+ *   - 501 with structured "PR X" hint for endpoints that aren't
+ *     implemented yet
+ *   - 404 with usage hint on unknown routes
+ *   - real HTTP smoke against a started server (PORT=0 → OS-picked port)
+ */
+
+let handle: HostedServerHandle | undefined;
+
+afterEach(async () => {
+  if (handle) {
+    await handle.close();
+    handle = undefined;
+  }
+});
+
+describe("buildStatus envelope (pure)", () => {
+  it("returns the scaffolding-only shape with all six PRs accounted for", () => {
+    const s = _testing.buildStatus();
+    expect(s.service).toBe("vaultpilot-mcp");
+    expect(s.mode).toBe("hosted");
+    expect(s.status).toBe("scaffolding-only");
+    // `ready: false` is intentional — PR A is not real-traffic-ready.
+    expect(s.ready).toBe(false);
+    // PR-state map covers the full plan.
+    expect(s.prState).toHaveProperty("transport");
+    expect(s.prState).toHaveProperty("walletConnectRegistry");
+    expect(s.prState).toHaveProperty("auth");
+    expect(s.prState).toHaveProperty("toolGating");
+    expect(s.prState).toHaveProperty("docs");
+    expect(s.prState).toHaveProperty("deployment");
+    // Only PR A is marked done.
+    expect(s.prState.transport).toMatch(/done/);
+    expect(s.prState.walletConnectRegistry).toMatch(/pending/);
+    expect(s.prState.auth).toMatch(/pending/);
+  });
+
+  it("version field is populated (or 'unknown' on resolution failure)", () => {
+    const s = _testing.buildStatus();
+    expect(typeof s.version).toBe("string");
+    expect(s.version.length).toBeGreaterThan(0);
+  });
+});
+
+describe("HTTP smoke — real server on a random port", () => {
+  it("GET / returns the status envelope (200)", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ReturnType<typeof _testing.buildStatus>;
+    expect(body.service).toBe("vaultpilot-mcp");
+    expect(body.status).toBe("scaffolding-only");
+  });
+
+  it("GET /healthz mirrors GET /", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ReturnType<typeof _testing.buildStatus>;
+    expect(body.ready).toBe(false);
+  });
+
+  it("POST /mcp returns 501 with a structured 'plannedPr: PR C' envelope", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json() as { error: string; plannedPr: string; route: string };
+    expect(body.error).toBe("not_implemented");
+    expect(body.plannedPr).toMatch(/PR C/);
+    expect(body.route).toBe("POST /mcp");
+  });
+
+  it("OAuth discovery returns 503 (reserved, lands in PR C)", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(
+      `http://127.0.0.1:${handle.port}/.well-known/oauth-authorization-server`,
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json() as { retryAfterPr: string };
+    expect(body.retryAfterPr).toBe("C");
+  });
+
+  it("OAuth flow routes (/authorize, /token, /revoke) all return 501 → PR C", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    for (const route of ["/authorize", "/token", "/revoke"]) {
+      const res = await fetch(`http://127.0.0.1:${handle.port}${route}`);
+      expect(res.status).toBe(501);
+      const body = await res.json() as { plannedPr: string };
+      expect(body.plannedPr).toMatch(/PR C/);
+    }
+  });
+
+  it("/dashboard returns 501 → PR C", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/dashboard`);
+    expect(res.status).toBe(501);
+    const body = await res.json() as { plannedPr: string };
+    expect(body.plannedPr).toMatch(/PR C/);
+  });
+
+  it("unknown route returns 404 with available + pending hints (no bare 404)", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/some/random/path`);
+    expect(res.status).toBe(404);
+    const body = await res.json() as {
+      error: string;
+      method: string;
+      path: string;
+      available: string[];
+      pending: string[];
+    };
+    expect(body.error).toBe("not_found");
+    expect(body.method).toBe("GET");
+    expect(body.path).toBe("/some/random/path");
+    expect(body.available).toContain("GET /");
+    expect(body.available).toContain("GET /healthz");
+    expect(body.pending.length).toBeGreaterThan(0);
+  });
+
+  it("Cache-Control: no-store on every response (avoid stale OAuth/health caching)", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("survives a malformed request body without crashing", async () => {
+    handle = await startHostedServer({ port: 0, host: "127.0.0.1" });
+    // Send a POST with an unparseable body — the placeholder doesn't
+    // parse JSON yet (it just 501s), but the server shouldn't choke.
+    const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{",
+    });
+    expect(res.status).toBe(501);
+    // Follow-up request still works.
+    const res2 = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
+    expect(res2.status).toBe(200);
+  });
+});


### PR DESCRIPTION
First of **6 sequential PRs** in the hosted-MCP-endpoint rollout — see [`claude-work/plan-hosted-mcp-endpoint.md`](claude-work/plan-hosted-mcp-endpoint.md). The plan explicitly mandates 6 PRs ("NOT one mega-PR") since the diff is large; **PR A is the foundation everything else builds on**.

## What this PR does

- **`src/hosted/server.ts` (new)** — Node `http` server scaffolding. Exposes:
  - `GET /` + `GET /healthz` → structured `StatusEnvelope` with service name, version, per-PR rollout state, and a `ready: false` flag (deliberately false — PR A is NOT real-traffic-ready; flips to true in PR C).
  - `POST /mcp` → 501 with `plannedPr: "PR C (auth + MCP streamable-HTTP handler)"`.
  - `/.well-known/oauth-authorization-server` → 503 (reserved, lands in PR C).
  - `/authorize`, `/token`, `/revoke`, `/dashboard` → 501 with PR C hints.
  - Unknown route → 404 with `available[]` + `pending[]` arrays so a debugger gets a useful response, not a bare 404.
- **`VAULTPILOT_TRANSPORT` env-var dispatch in `src/index.ts`** — default `stdio` (zero behavior change for npm-i-g users). `VAULTPILOT_TRANSPORT=http` boots the hosted server. Unknown values fall back to stdio with a stderr warning (typo-tolerant — won't silently break someone's setup on `stdo` instead of `stdio`).

## What this PR does NOT do (deferred — each PR's home named explicitly in 501 envelopes)

| PR | Capability |
|---|---|
| **B** | WC registry refactor — `WalletConnectRegistry` replaces module-scoped state in `src/signing/walletconnect.ts`; userId threading via `AsyncLocalStorage`. Required before multi-user is safe. |
| **C** | OAuth 2.1 provider + GitHub upstream + bearer-token issuance + SQLite state + per-user rate limiting. The MCP streamable-HTTP handler wires up here. |
| **D** | Hosted-mode tool gating — TRON / Solana / USB-HID prepare tools return a structured "use local install" error. |
| **E** | `SECURITY.md` addendum, README hosted-mode section, Dockerfile, docker-compose, self-host docs. |
| **F** | Maintainer-run reference deployment (out of repo). |

## Design choices worth flagging

- **`node:http` (zero new deps).** Hono lands in PR C when real OAuth routes + middleware composition are needed. PR A's surface is small enough that the framework choice doesn't matter yet, and avoiding the dep keeps this PR maximally reviewable.
- **`ready: false` is intentional.** Liveness probes that check for `ready: true` will correctly skip a PR-A-only deploy. Flips to `true` in PR C.
- **Access log goes to stderr** (not stdout) so it can't pollute MCP stdout if someone misroutes transport streams.
- **`_testing` export** lets unit tests assert envelope shape without spinning up the listener.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — **1445 / 119 green** (was 1398 / 115; +11 new hosted tests + 36 digest/strategy/pnl tests that landed in main between branches).
- 11 tests in `test/hosted-server.test.ts`:
  - `buildStatus` envelope shape + version field
  - GET / + GET /healthz → 200 with envelope
  - POST /mcp → 501 with `plannedPr: "PR C ..."`
  - `/.well-known/oauth-authorization-server` → 503 with `retryAfterPr: "C"`
  - /authorize, /token, /revoke, /dashboard → all 501 → PR C
  - Unknown route → 404 with usage hints (no bare 404)
  - `Cache-Control: no-store` on every response
  - Survives a malformed POST body without crashing
- [x] Manual end-to-end smoke: `VAULTPILOT_TRANSPORT=http PORT=4568 node dist/index.js` — `curl /healthz` returns the envelope, `curl -X POST /mcp` returns 501 with the PR C hint, stderr shows the access log. stdio path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)