### PR TITLE
feat(postmortem): explain_tx — narrative tx post-mortem (EVM/TRON/Solana)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ import { getDailyBriefing } from "./modules/digest/index.js";
 import { getDailyBriefingInput } from "./modules/digest/schemas.js";
 import { getPnlSummary } from "./modules/pnl/index.js";
 import { getPnlSummaryInput } from "./modules/pnl/schemas.js";
+import { explainTx } from "./modules/postmortem/index.js";
+import { explainTxInput } from "./modules/postmortem/schemas.js";
 import { getPortfolioSummaryInput } from "./modules/portfolio/schemas.js";
 
 import { getVaultPilotConfigStatus } from "./modules/diagnostics/index.js";
@@ -1537,6 +1539,16 @@ async function main() {
       inputSchema: getPnlSummaryInput.shape,
     },
     handler(getPnlSummary)
+  );
+
+  registerTool(server,
+    "explain_tx",
+    {
+      description:
+        "Narrative post-mortem for a single confirmed transaction. Walks what actually happened: top-level method/instruction call, decoded ERC-20/TRC-20 Transfer + Approval events (or Solana SPL balance deltas), per-token balance changes for the wallet, fee paid, and a heuristics block flagging surprises (failed status, unlimited approval, dust outflow, transfer-to-zero burn, high-gas vs. moved value, unexpected no-state-change). Returns BOTH a structured envelope and a pre-rendered narrative string for verbatim relay (control via `format`). Distinct from `get_transaction_status` (just confirmation status) and the prepare→preview→send pipeline (forward-looking). Useful for debugging (\"why did this swap return less than the quote?\"), learning (\"what does this contract call actually do?\"), forensics (\"what addresses did this tx touch?\"), and address-poisoning triage. v1 covers EVM (Ethereum/Arbitrum/Polygon/Base/Optimism), TRON, and Solana — Bitcoin is deferred. v1 reads top-level execution only; internal calls / CPI / DeFi compositions surface via balance & event effects rather than as separate step rows. Pricing is current spot via DefiLlama (not historical at tx time). Optional `wallet` arg recomputes balance/approval changes from THAT wallet's perspective — defaults to tx sender. Read-only — no signing, no broadcast.",
+      inputSchema: explainTxInput.shape,
+    },
+    handler(explainTx)
   );
 
   registerTool(server,

--- a/src/modules/postmortem/heuristics.ts
+++ b/src/modules/postmortem/heuristics.ts
@@ -1,0 +1,138 @@
+/**
+ * Post-mortem heuristics — "why might this surprise you?".
+ *
+ * Each rule looks at the populated `ExplainTxResult` and pushes a
+ * heuristic entry when its condition matches. Rules are intentionally
+ * simple and high-precision; the bar for surfacing one is "would the
+ * user benefit from being told this?".
+ *
+ * Rules in v1:
+ *   - `failed`: tx reverted on-chain.
+ *   - `unlimited_approval`: any approval set MAX_UINT256 (or near it).
+ *   - `dust_transfer`: outflow valueUsd < $0.01 — possible address
+ *     poisoning bait (same family as #220).
+ *   - `transfer_to_zero`: a Transfer event went to the zero address
+ *     (token burn).
+ *   - `high_gas`: fee USD > 10% of the largest absolute-USD balance
+ *     change.
+ *   - `no_state_change`: success status but zero state changes
+ *     (suspicious noop or wallet probe).
+ */
+
+import type {
+  ExplainTxApprovalChange,
+  ExplainTxBalanceChange,
+  ExplainTxHeuristic,
+  ExplainTxResult,
+  ExplainTxStep,
+} from "./schemas.js";
+
+const ZERO_ADDRESS_HEX = "0x0000000000000000000000000000000000000000";
+/** TRON's hex-form null address — `41` prefix + 40 zeros. */
+const ZERO_ADDRESS_TRON_HEX = "410000000000000000000000000000000000000000";
+
+export function applyHeuristics(
+  result: Omit<ExplainTxResult, "narrative" | "heuristics"> & {
+    heuristics?: ExplainTxHeuristic[];
+  },
+): ExplainTxHeuristic[] {
+  const out: ExplainTxHeuristic[] = [];
+
+  if (result.status === "failed") {
+    out.push({
+      rule: "failed",
+      message: `Tx REVERTED on ${result.chain}. The fee was paid (${result.feeNative ?? "?"} ${result.feeNativeSymbol ?? ""}) but no state changes took effect.`,
+    });
+    // The other heuristics are noisy on failed txs (e.g. "no_state_change"
+    // would fire trivially); short-circuit here.
+    return out;
+  }
+
+  for (const a of result.approvalChanges) {
+    if (a.isUnlimited) {
+      out.push({
+        rule: "unlimited_approval",
+        message: `Unlimited allowance granted to ${a.spender} on ${a.symbol ?? "token " + a.token.slice(0, 10)}. The spender can move any amount of this token from your wallet at any time. Revoke with a follow-up approve(0) call when no longer needed.`,
+      });
+    }
+  }
+
+  // Sum all USD outflows from balance changes for the dust + high-gas
+  // tests. Outflow = negative delta from perspective.
+  let largestAbsValueUsd = 0;
+  for (const b of result.balanceChanges) {
+    if (typeof b.valueUsd === "number") {
+      const abs = Math.abs(b.valueUsd);
+      if (abs > largestAbsValueUsd) largestAbsValueUsd = abs;
+    }
+    // Dust outflow rule.
+    if (
+      typeof b.valueUsd === "number" &&
+      b.deltaApprox < 0 &&
+      Math.abs(b.valueUsd) > 0 &&
+      Math.abs(b.valueUsd) < 0.01
+    ) {
+      out.push({
+        rule: "dust_transfer",
+        message: `Dust outflow: ${b.delta} ${b.symbol} (~${b.valueUsd.toFixed(4)} USD). Sub-cent transfers can be address-poisoning bait — verify the recipient was intended.`,
+      });
+    }
+  }
+
+  // Transfer-to-zero rule: walk the steps for an event to the zero
+  // address (any chain).
+  for (const s of result.steps) {
+    if (s.kind !== "event") continue;
+    const lower = s.detail.toLowerCase();
+    if (
+      lower.includes(ZERO_ADDRESS_HEX) ||
+      lower.includes(ZERO_ADDRESS_TRON_HEX) ||
+      lower.includes("11111111111111111111111111111111") // System program / Solana null
+    ) {
+      out.push({
+        rule: "transfer_to_zero",
+        message: `Token transfer to the zero address detected: "${s.detail}". This is typically a burn (the tokens are now unspendable). Verify it was intentional.`,
+      });
+      break; // one mention is enough
+    }
+  }
+
+  // High-gas rule: fee USD > 10% of the largest absolute-USD balance
+  // change. Skips when no fee USD or no priced changes.
+  if (
+    typeof result.feeUsd === "number" &&
+    largestAbsValueUsd > 0 &&
+    result.feeUsd > largestAbsValueUsd * 0.1
+  ) {
+    const pct = ((result.feeUsd / largestAbsValueUsd) * 100).toFixed(1);
+    out.push({
+      rule: "high_gas",
+      message: `Fee was ${result.feeUsd.toFixed(2)} USD — ${pct}% of the largest balance change (${largestAbsValueUsd.toFixed(2)} USD). Either congestion was high or the routing was inefficient.`,
+    });
+  }
+
+  // No-state-change rule: success but no balance changes AND no
+  // approval changes AND no event steps.
+  const hasEvents = result.steps.some((s: ExplainTxStep) => s.kind === "event");
+  if (
+    result.status === "success" &&
+    result.balanceChanges.length === 0 &&
+    result.approvalChanges.length === 0 &&
+    !hasEvents
+  ) {
+    out.push({
+      rule: "no_state_change",
+      message: `Tx succeeded but produced no observable state change for the wallet. Possible noop, wallet-probe, or a write that was bypassed by a contract guard. Check the contract's source for fall-through paths.`,
+    });
+  }
+
+  return out;
+}
+
+// Re-export shapes the helper consumes — keeps callers' import lists short.
+export type {
+  ExplainTxApprovalChange,
+  ExplainTxBalanceChange,
+  ExplainTxHeuristic,
+  ExplainTxStep,
+};

--- a/src/modules/postmortem/index.ts
+++ b/src/modules/postmortem/index.ts
@@ -1,0 +1,84 @@
+/**
+ * `explain_tx` — narrative post-mortem for a single transaction.
+ *
+ * Dispatches per chain:
+ *   - EVM (Ethereum / Arbitrum / Polygon / Base / Optimism) →
+ *     `evmPostmortem` (viem RPC).
+ *   - TRON → `tronPostmortem` (TronGrid POST endpoints).
+ *   - Solana → `solanaPostmortem` (web3.js getParsedTransaction).
+ *   - Bitcoin → out of v1 scope (return a stub error).
+ *
+ * Each per-chain helper produces an `ExplainTxResult` minus the
+ * heuristics + narrative; the dispatcher applies those uniformly so
+ * the rules and rendering are consistent across chains.
+ */
+
+import { isEvmChain, type AnyChain, type SupportedChain } from "../../types/index.js";
+import { evmPostmortem } from "./per-chain/evm.js";
+import { tronPostmortem } from "./per-chain/tron.js";
+import { solanaPostmortem } from "./per-chain/solana.js";
+import { applyHeuristics } from "./heuristics.js";
+import { renderPostmortemNarrative } from "./render.js";
+import type { ExplainTxArgs, ExplainTxResult } from "./schemas.js";
+
+export async function explainTx(
+  args: ExplainTxArgs,
+): Promise<ExplainTxResult> {
+  const chain = args.chain as AnyChain;
+
+  let core: Omit<ExplainTxResult, "narrative">;
+
+  if (isEvmChain(chain)) {
+    const evmChain = chain as SupportedChain;
+    const hash = (
+      args.hash.startsWith("0x") ? args.hash : `0x${args.hash}`
+    ) as `0x${string}`;
+    core = await evmPostmortem({
+      chain: evmChain,
+      hash,
+      ...(args.wallet ? { perspective: args.wallet as `0x${string}` } : {}),
+    });
+  } else if (chain === "tron") {
+    core = await tronPostmortem({
+      hash: args.hash,
+      ...(args.wallet ? { perspective: args.wallet } : {}),
+    });
+  } else if (chain === "solana") {
+    core = await solanaPostmortem({
+      signature: args.hash,
+      ...(args.wallet ? { perspective: args.wallet } : {}),
+    });
+  } else {
+    throw new Error(
+      `explain_tx does not yet support chain "${chain}". v1 covers EVM ` +
+        `(Ethereum / Arbitrum / Polygon / Base / Optimism), TRON, and Solana. ` +
+        `Bitcoin is deferred to v2 — needs a separate UTXO post-mortem path.`,
+    );
+  }
+
+  // Apply heuristics + add the v1 caveats.
+  const heuristics = applyHeuristics(core);
+  const notes = [...core.notes];
+  notes.push(
+    "v1 covers top-level execution only — internal calls / CPI / multi-hop " +
+      "DeFi compositions show up only via their balance/approval effects, not " +
+      "as separate steps. Full call-graph trace deferred.",
+  );
+  notes.push(
+    "Pricing is current spot via DefiLlama, not historical at tx time. For " +
+      "fresh txs the difference is sub-second; for older txs prices may have " +
+      "drifted materially.",
+  );
+
+  const result: ExplainTxResult = {
+    ...core,
+    heuristics,
+    notes,
+  };
+
+  if (args.format !== "structured") {
+    result.narrative = renderPostmortemNarrative(result);
+  }
+
+  return result;
+}

--- a/src/modules/postmortem/per-chain/evm.ts
+++ b/src/modules/postmortem/per-chain/evm.ts
@@ -1,0 +1,469 @@
+/**
+ * EVM `explain_tx` implementation.
+ *
+ * One round-trip per concern:
+ *   - `eth_getTransactionByHash` — input calldata, value, from, to.
+ *   - `eth_getTransactionReceipt` — status, gasUsed, logs, blockNumber.
+ *   - `eth_getBlock(receipt.blockNumber)` — block timestamp.
+ *   - 4byte resolver — top-level method name.
+ *   - DefiLlama price lookup for fee + balance-change USD valuations
+ *     (current-spot, NOT historical — matches what the agent surfaces
+ *     for fresh txs and is good enough for "did I lose money on gas?").
+ *
+ * Logs are decoded for two specific events: ERC-20 / ERC-721 `Transfer`
+ * (`0xddf252...`) and ERC-20 `Approval` (`0x8c5be1...`). The decoded
+ * data feeds `balanceChanges` (filtered to the wallet of interest) and
+ * `approvalChanges`. ERC-721 transfers ARE detected (Transfer with 4
+ * topics including tokenId) but reported as "1 NFT moved" rather than
+ * an integer delta, since the qty is always 1 and the tokenId is what
+ * matters — surfaced in the step detail.
+ */
+
+import { decodeEventLog, type Hex, type Log } from "viem";
+import { erc20Abi } from "../../../abis/erc20.js";
+import { getClient } from "../../../data/rpc.js";
+import { resolveSelectors } from "../../history/decode.js";
+import { getTokenPrice } from "../../../data/prices.js";
+import { NATIVE_SYMBOL } from "../../../config/contracts.js";
+import { formatUnits } from "../../../data/format.js";
+import type { SupportedChain } from "../../../types/index.js";
+import type {
+  ExplainTxApprovalChange,
+  ExplainTxBalanceChange,
+  ExplainTxResult,
+  ExplainTxStep,
+} from "../schemas.js";
+
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const APPROVAL_TOPIC =
+  "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const MAX_UINT256 = (1n << 256n) - 1n;
+/**
+ * Threshold above which an approval is considered "unlimited" for
+ * heuristic purposes. Many wallets cap at MAX_UINT256 / 2 - 1 (signed)
+ * or other near-MAX values; treat anything within 0.01% of MAX as
+ * effectively unlimited.
+ */
+const UNLIMITED_THRESHOLD = MAX_UINT256 - MAX_UINT256 / 10_000n;
+
+/** Fetch ERC-20 metadata (symbol + decimals) for a contract. Tolerant — null on failure. */
+async function fetchTokenMeta(
+  chain: SupportedChain,
+  address: `0x${string}`,
+): Promise<{ symbol: string; decimals: number } | null> {
+  const client = getClient(chain);
+  try {
+    const [symbol, decimals] = await Promise.all([
+      client.readContract({
+        address,
+        abi: erc20Abi,
+        functionName: "symbol",
+      }) as Promise<string>,
+      client.readContract({
+        address,
+        abi: erc20Abi,
+        functionName: "decimals",
+      }) as Promise<number>,
+    ]);
+    return { symbol, decimals: Number(decimals) };
+  } catch {
+    return null;
+  }
+}
+
+interface DecodedTransfer {
+  contract: `0x${string}`;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+  /** True if this was a 4-topic Transfer (ERC-721 / ERC-1155 single). */
+  isNft: boolean;
+  /** ERC-721 token id when `isNft`. */
+  tokenId?: bigint;
+}
+
+interface DecodedApproval {
+  contract: `0x${string}`;
+  owner: `0x${string}`;
+  spender: `0x${string}`;
+  value: bigint;
+}
+
+function decodeTransferLog(log: Log): DecodedTransfer | null {
+  const topics = log.topics as readonly Hex[];
+  if (topics.length < 3) return null;
+  if (topics[0]?.toLowerCase() !== TRANSFER_TOPIC) return null;
+  // ERC-20: 3 topics (event sig + from + to), data = value.
+  // ERC-721: 4 topics (event sig + from + to + tokenId), data = empty.
+  const from = `0x${topics[1].slice(26)}` as `0x${string}`;
+  const to = `0x${topics[2].slice(26)}` as `0x${string}`;
+  if (topics.length === 4) {
+    const tokenId = BigInt(topics[3]);
+    return {
+      contract: log.address as `0x${string}`,
+      from,
+      to,
+      value: 1n,
+      isNft: true,
+      tokenId,
+    };
+  }
+  if (topics.length === 3) {
+    const data = log.data as Hex;
+    if (data.length !== 66) return null; // 0x + 64 hex
+    const value = BigInt(data);
+    return {
+      contract: log.address as `0x${string}`,
+      from,
+      to,
+      value,
+      isNft: false,
+    };
+  }
+  return null;
+}
+
+function decodeApprovalLog(log: Log): DecodedApproval | null {
+  const topics = log.topics as readonly Hex[];
+  if (topics.length !== 3) return null;
+  if (topics[0]?.toLowerCase() !== APPROVAL_TOPIC) return null;
+  const data = log.data as Hex;
+  if (data.length !== 66) return null;
+  const owner = `0x${topics[1].slice(26)}` as `0x${string}`;
+  const spender = `0x${topics[2].slice(26)}` as `0x${string}`;
+  const value = BigInt(data);
+  return {
+    contract: log.address as `0x${string}`,
+    owner,
+    spender,
+    value,
+  };
+}
+
+export interface EvmPostmortemArgs {
+  chain: SupportedChain;
+  hash: `0x${string}`;
+  /** Wallet to compute balance-changes from. Defaults to tx sender. */
+  perspective?: `0x${string}`;
+}
+
+export async function evmPostmortem(
+  args: EvmPostmortemArgs,
+): Promise<Omit<ExplainTxResult, "narrative" | "summary"> & { summary: string }> {
+  const client = getClient(args.chain);
+
+  let tx;
+  let receipt;
+  try {
+    [tx, receipt] = await Promise.all([
+      client.getTransaction({ hash: args.hash }),
+      client.getTransactionReceipt({ hash: args.hash }),
+    ]);
+  } catch (e) {
+    throw new Error(
+      `Could not fetch tx ${args.hash} on ${args.chain}: ` +
+        (e as Error).message,
+    );
+  }
+
+  const blockTimeIso = await client
+    .getBlock({ blockNumber: receipt.blockNumber })
+    .then((b) => new Date(Number(b.timestamp) * 1000).toISOString())
+    .catch(() => undefined);
+
+  const sender = tx.from as `0x${string}`;
+  const perspective = (args.perspective ?? sender).toLowerCase() as `0x${string}`;
+  const status: "success" | "failed" =
+    receipt.status === "success" ? "success" : "failed";
+
+  // Decode top-level method, when there's calldata.
+  const input = (tx.input ?? "0x") as Hex;
+  const selector = input.length >= 10 ? input.slice(0, 10).toLowerCase() : null;
+  let methodName: string | undefined;
+  let methodAmbiguous = false;
+  if (selector) {
+    const resolved = await resolveSelectors([selector]);
+    const r = resolved.get(selector);
+    methodName = r?.methodName;
+    methodAmbiguous = r?.ambiguous ?? false;
+  }
+
+  // Decode logs.
+  const transfers: DecodedTransfer[] = [];
+  const approvals: DecodedApproval[] = [];
+  for (const log of receipt.logs as Log[]) {
+    const t = decodeTransferLog(log);
+    if (t) {
+      transfers.push(t);
+      continue;
+    }
+    const a = decodeApprovalLog(log);
+    if (a) approvals.push(a);
+  }
+
+  // Pull token metadata for each unique contract we saw.
+  const uniqueContracts = Array.from(
+    new Set(
+      [...transfers.map((t) => t.contract), ...approvals.map((a) => a.contract)].map(
+        (a) => a.toLowerCase() as `0x${string}`,
+      ),
+    ),
+  );
+  const metaByContract = new Map<string, { symbol: string; decimals: number }>();
+  await Promise.all(
+    uniqueContracts.map(async (c) => {
+      const m = await fetchTokenMeta(args.chain, c);
+      if (m) metaByContract.set(c, m);
+    }),
+  );
+
+  // Build ordered steps. Native value transfer (when non-zero) +
+  // top-level call + decoded events. Order in chat surface: native
+  // first (the most user-visible thing), then call, then events.
+  const steps: ExplainTxStep[] = [];
+  if (tx.value > 0n) {
+    steps.push({
+      kind: "native_transfer",
+      label: NATIVE_SYMBOL[args.chain],
+      detail: `${formatUnits(tx.value, 18)} ${NATIVE_SYMBOL[args.chain]} from ${tx.from} to ${tx.to ?? "(contract creation)"}`,
+      ...(tx.to ? { programOrContract: tx.to } : {}),
+    });
+  }
+  if (tx.to && (input === "0x" || input.length < 10)) {
+    if (tx.value === 0n) {
+      steps.push({
+        kind: "call",
+        label: "fallback",
+        detail: `Plain call to ${tx.to} with no calldata.`,
+        programOrContract: tx.to,
+      });
+    }
+  } else if (tx.to) {
+    steps.push({
+      kind: "call",
+      label: methodName
+        ? methodAmbiguous
+          ? `${methodName} (ambiguous selector)`
+          : methodName
+        : `selector ${selector ?? "(none)"}`,
+      detail: methodName
+        ? `Top-level call: ${tx.to}.${methodName}`
+        : `Top-level call to ${tx.to}; method selector ${selector} did not resolve.`,
+      programOrContract: tx.to,
+    });
+  } else if (input !== "0x") {
+    steps.push({
+      kind: "call",
+      label: "create",
+      detail: `Contract creation tx; ${input.length / 2 - 1} bytes of init code.`,
+    });
+  }
+  for (const t of transfers) {
+    const meta = metaByContract.get(t.contract.toLowerCase());
+    if (t.isNft) {
+      steps.push({
+        kind: "event",
+        label: "Transfer (NFT)",
+        detail: `1 NFT (token id ${t.tokenId?.toString()}) from ${t.from} to ${t.to}`,
+        programOrContract: t.contract,
+      });
+    } else {
+      const symbol = meta?.symbol ?? "TOKEN";
+      const formatted = meta
+        ? formatUnits(t.value, meta.decimals)
+        : t.value.toString();
+      steps.push({
+        kind: "event",
+        label: "Transfer",
+        detail: `${formatted} ${symbol} from ${t.from} to ${t.to}`,
+        programOrContract: t.contract,
+      });
+    }
+  }
+  for (const a of approvals) {
+    const meta = metaByContract.get(a.contract.toLowerCase());
+    const symbol = meta?.symbol ?? "TOKEN";
+    const isUnlimited = a.value >= UNLIMITED_THRESHOLD;
+    const allowanceStr = isUnlimited
+      ? "unlimited"
+      : meta
+        ? formatUnits(a.value, meta.decimals)
+        : a.value.toString();
+    steps.push({
+      kind: "event",
+      label: "Approval",
+      detail: `${a.owner} grants ${a.spender} an allowance of ${allowanceStr} ${symbol}`,
+      programOrContract: a.contract,
+    });
+  }
+
+  // Per-token balance deltas FROM PERSPECTIVE.
+  const balanceDeltas = new Map<
+    string,
+    { delta: bigint; symbol: string; decimals: number }
+  >();
+  // Native delta from value (signed by perspective).
+  let nativeDelta = 0n;
+  if (tx.value > 0n) {
+    if ((tx.from as string).toLowerCase() === perspective) {
+      nativeDelta -= tx.value;
+    }
+    if (tx.to && (tx.to as string).toLowerCase() === perspective) {
+      nativeDelta += tx.value;
+    }
+  }
+  if (nativeDelta !== 0n) {
+    balanceDeltas.set("native", {
+      delta: nativeDelta,
+      symbol: NATIVE_SYMBOL[args.chain],
+      decimals: 18,
+    });
+  }
+  for (const t of transfers) {
+    if (t.isNft) continue; // not a fungible delta
+    const meta = metaByContract.get(t.contract.toLowerCase()) ?? {
+      symbol: "TOKEN",
+      decimals: 18,
+    };
+    const isFrom = (t.from as string).toLowerCase() === perspective;
+    const isTo = (t.to as string).toLowerCase() === perspective;
+    if (!isFrom && !isTo) continue;
+    const key = t.contract.toLowerCase();
+    const prev = balanceDeltas.get(key) ?? {
+      delta: 0n,
+      symbol: meta.symbol,
+      decimals: meta.decimals,
+    };
+    prev.delta += isTo ? t.value : 0n;
+    prev.delta -= isFrom ? t.value : 0n;
+    balanceDeltas.set(key, prev);
+  }
+
+  // Price lookups for native + each tokenized delta. Spot, not
+  // historical — see file docstring.
+  const balanceChanges: ExplainTxBalanceChange[] = [];
+  for (const [token, info] of balanceDeltas) {
+    const formatted = formatUnits(info.delta, info.decimals);
+    const num = Number(formatted);
+    const priceUsd = await getTokenPrice(
+      args.chain,
+      token === "native" ? "native" : (token as `0x${string}`),
+    ).catch(() => undefined);
+    balanceChanges.push({
+      symbol: info.symbol,
+      token,
+      delta: formatted,
+      deltaApprox: num,
+      ...(priceUsd !== undefined && Number.isFinite(num)
+        ? { valueUsd: round2(num * priceUsd) }
+        : {}),
+    });
+  }
+
+  // Approval changes from perspective (only when wallet is the owner).
+  const approvalChanges: ExplainTxApprovalChange[] = [];
+  for (const a of approvals) {
+    if ((a.owner as string).toLowerCase() !== perspective) continue;
+    const meta = metaByContract.get(a.contract.toLowerCase());
+    const isUnlimited = a.value >= UNLIMITED_THRESHOLD;
+    const newAllowance = isUnlimited
+      ? "unlimited"
+      : meta
+        ? formatUnits(a.value, meta.decimals)
+        : a.value.toString();
+    approvalChanges.push({
+      ...(meta?.symbol ? { symbol: meta.symbol } : {}),
+      token: a.contract.toLowerCase(),
+      spender: a.spender,
+      newAllowance,
+      isUnlimited,
+    });
+  }
+
+  // Fee.
+  const gasUsed = receipt.gasUsed;
+  const effectiveGasPrice = receipt.effectiveGasPrice ?? 0n;
+  const feeWei = gasUsed * effectiveGasPrice;
+  const feeNative = formatUnits(feeWei, 18);
+  let feeUsd: number | undefined;
+  const nativePrice = await getTokenPrice(args.chain, "native").catch(
+    () => undefined,
+  );
+  if (nativePrice !== undefined) {
+    feeUsd = round2(Number(feeNative) * nativePrice);
+  }
+  // The sender always pays the fee, so when perspective === sender,
+  // subtract it from the native delta. This makes "what did I net" math
+  // reflect gas costs.
+  if (perspective === sender.toLowerCase()) {
+    const existing = balanceChanges.find((b) => b.token === "native");
+    if (existing) {
+      const newDelta = (
+        BigInt(Math.round(Number(existing.delta) * 1e18)) - feeWei
+      ).toString();
+      // Re-format — but to avoid float-introduced precision drift,
+      // recompute from the raw nativeDelta + feeWei combo.
+      const combined = nativeDelta - feeWei;
+      existing.delta = formatUnits(combined, 18);
+      existing.deltaApprox = Number(existing.delta);
+      if (nativePrice !== undefined && Number.isFinite(existing.deltaApprox)) {
+        existing.valueUsd = round2(existing.deltaApprox * nativePrice);
+      }
+      // Suppress the ts unused warning on `newDelta`.
+      void newDelta;
+    } else {
+      const combined = -feeWei;
+      const formattedCombined = formatUnits(combined, 18);
+      const num = Number(formattedCombined);
+      balanceChanges.push({
+        symbol: NATIVE_SYMBOL[args.chain],
+        token: "native",
+        delta: formattedCombined,
+        deltaApprox: num,
+        ...(nativePrice !== undefined && Number.isFinite(num)
+          ? { valueUsd: round2(num * nativePrice) }
+          : {}),
+      });
+    }
+  }
+
+  // One-sentence summary.
+  let summary: string;
+  if (status === "failed") {
+    summary = `Transaction REVERTED on ${args.chain}. Gas was paid (${feeNative} ${NATIVE_SYMBOL[args.chain]}); no state changes took effect.`;
+  } else if (methodName) {
+    summary = `Top-level ${methodName} call on ${args.chain}; ${transfers.length} transfer event(s), ${approvals.length} approval(s).`;
+  } else if (tx.value > 0n) {
+    summary = `${formatUnits(tx.value, 18)} ${NATIVE_SYMBOL[args.chain]} sent to ${tx.to ?? "(contract creation)"} on ${args.chain}.`;
+  } else if (input === "0x") {
+    summary = `Empty self-call (no value, no calldata) — likely a noop or wallet probe on ${args.chain}.`;
+  } else {
+    summary = `Top-level contract call on ${args.chain}; selector ${selector ?? "(none)"} did not resolve.`;
+  }
+
+  return {
+    chain: args.chain,
+    hash: args.hash,
+    from: sender,
+    ...(tx.to ? { to: tx.to } : {}),
+    perspective,
+    blockNumber: receipt.blockNumber.toString(),
+    ...(blockTimeIso ? { blockTimeIso } : {}),
+    status,
+    feeNative,
+    feeNativeSymbol: NATIVE_SYMBOL[args.chain],
+    ...(feeUsd !== undefined ? { feeUsd } : {}),
+    summary,
+    steps,
+    balanceChanges,
+    approvalChanges,
+    heuristics: [],
+    notes: [],
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/modules/postmortem/per-chain/solana.ts
+++ b/src/modules/postmortem/per-chain/solana.ts
@@ -1,0 +1,341 @@
+/**
+ * Solana `explain_tx` implementation.
+ *
+ * Uses Connection.getParsedTransaction (commitment: confirmed) which
+ * returns:
+ *   - `transaction.message.accountKeys[]` — every involved pubkey.
+ *   - `transaction.message.instructions[]` — top-level instructions
+ *     (already parsed for native programs: System / SPL Token / ATA /
+ *     Stake; raw `data + accounts` for custom programs).
+ *   - `meta.preBalances[]` / `meta.postBalances[]` — per-key SOL deltas.
+ *   - `meta.preTokenBalances[]` / `meta.postTokenBalances[]` — per-
+ *     ATA SPL deltas with `owner` and `mint` already resolved.
+ *   - `meta.fee` — paid by the fee-payer (accountKeys[0]).
+ *   - `meta.err` — null on success, otherwise a structured error.
+ *
+ * Solana's pre/post balance vectors are the canonical source of "what
+ * actually happened" — they reflect the net effect of every CPI in
+ * the tx, including ones we'd miss by walking instructions alone.
+ * Step rows surface the top-level instruction labels for narrative
+ * context, but balance changes use the post-pre delta path.
+ */
+
+import type {
+  ParsedInstruction,
+  ParsedTransactionWithMeta,
+  PartiallyDecodedInstruction,
+} from "@solana/web3.js";
+import { getSolanaConnection } from "../../solana/rpc.js";
+import {
+  SOL_SYMBOL,
+  SOL_DECIMALS,
+  SOLANA_TOKENS,
+  SOLANA_TOKEN_DECIMALS,
+} from "../../../config/solana.js";
+import { lookupProgram } from "../../solana/program-ids.js";
+import { formatUnits } from "../../../data/format.js";
+import { getDefillamaCoinPrice } from "../../../data/prices.js";
+import type {
+  ExplainTxApprovalChange,
+  ExplainTxBalanceChange,
+  ExplainTxResult,
+  ExplainTxStep,
+} from "../schemas.js";
+
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+const ATA_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111";
+
+/** Reverse map: mint → { symbol, decimals }. */
+const MINT_TO_SYMBOL: Record<string, { symbol: string; decimals: number }> =
+  Object.fromEntries(
+    (Object.entries(SOLANA_TOKENS) as [keyof typeof SOLANA_TOKENS, string][]).map(
+      ([sym, addr]) => [
+        addr,
+        { symbol: sym, decimals: SOLANA_TOKEN_DECIMALS[sym] },
+      ],
+    ),
+  );
+
+export interface SolanaPostmortemArgs {
+  signature: string;
+  /**
+   * Wallet to compute balance changes from. Defaults to fee payer
+   * (accountKeys[0]).
+   */
+  perspective?: string;
+}
+
+/**
+ * Render a top-level instruction into a label + detail pair for the
+ * `steps[]` array. Native-program instructions (System / SPL Token /
+ * ATA / Stake) come back from getParsedTransaction with a `parsed.type`
+ * + `parsed.info` payload; custom programs come back as
+ * PartiallyDecodedInstruction with `data + accounts` raw fields.
+ */
+function describeInstruction(
+  ix: ParsedInstruction | PartiallyDecodedInstruction,
+): { label: string; detail: string; programOrContract?: string } | null {
+  const programId = ix.programId.toBase58();
+  if (programId === COMPUTE_BUDGET_PROGRAM) {
+    // Skip — pure tx-fee tuning, not user-relevant for narrative.
+    return null;
+  }
+  // Parsed (native) instruction — has `.parsed`.
+  if ("parsed" in ix && ix.parsed && typeof ix.parsed === "object") {
+    const parsed = ix.parsed as { type?: string; info?: Record<string, unknown> };
+    const type = parsed.type ?? "unknown";
+    const program = ix.program ?? programId;
+    let detail = "";
+    const info = parsed.info ?? {};
+    if (programId === SYSTEM_PROGRAM && type === "transfer") {
+      const lamports = BigInt((info.lamports as number) ?? 0);
+      const sol = formatUnits(lamports, SOL_DECIMALS);
+      detail = `${sol} SOL from ${info.source} to ${info.destination}`;
+    } else if (programId === SYSTEM_PROGRAM && type === "createAccount") {
+      detail = `Create account ${info.newAccount} (${(info.space as number) ?? 0} bytes, ${formatUnits(BigInt((info.lamports as number) ?? 0), SOL_DECIMALS)} SOL rent)`;
+    } else if (
+      (programId === SPL_TOKEN_PROGRAM || programId === TOKEN_2022_PROGRAM) &&
+      type === "transferChecked"
+    ) {
+      const tokenAmount = info.tokenAmount as
+        | { uiAmountString?: string; amount?: string }
+        | undefined;
+      detail = `${tokenAmount?.uiAmountString ?? tokenAmount?.amount ?? "?"} of mint ${info.mint} from ${info.source} to ${info.destination}`;
+    } else if (
+      (programId === SPL_TOKEN_PROGRAM || programId === TOKEN_2022_PROGRAM) &&
+      type === "transfer"
+    ) {
+      detail = `${(info.amount as string | number | undefined) ?? "?"} (raw) from ${info.source} to ${info.destination}`;
+    } else if (programId === ATA_PROGRAM) {
+      detail = `Create associated token account for owner ${info.wallet} mint ${info.mint}`;
+    } else {
+      detail = JSON.stringify(parsed.info ?? {}).slice(0, 200);
+    }
+    return {
+      label: `${program}::${type}`,
+      detail,
+      programOrContract: programId,
+    };
+  }
+  // Custom program — surface a friendly name when known.
+  const known = lookupProgram(programId);
+  const partiallyDecoded = ix as PartiallyDecodedInstruction;
+  const data = partiallyDecoded.data ?? "";
+  const accountCount = (partiallyDecoded.accounts ?? []).length;
+  return {
+    label: known?.name ?? `program ${programId.slice(0, 8)}…`,
+    detail: `Custom program call: ${accountCount} account(s), ${data.length} bytes of data.`,
+    programOrContract: programId,
+  };
+}
+
+export async function solanaPostmortem(
+  args: SolanaPostmortemArgs,
+): Promise<Omit<ExplainTxResult, "narrative"> & { summary: string }> {
+  const conn = getSolanaConnection();
+  const tx = await conn.getParsedTransaction(args.signature, {
+    maxSupportedTransactionVersion: 0,
+    commitment: "confirmed",
+  });
+  if (!tx) {
+    throw new Error(
+      `Solana tx ${args.signature} not visible. May be unconfirmed, dropped, or the signature is wrong.`,
+    );
+  }
+
+  const accountKeys = tx.transaction.message.accountKeys.map((k) =>
+    k.pubkey.toBase58(),
+  );
+  const feePayer = accountKeys[0];
+  const perspective = args.perspective ?? feePayer;
+  const status: "success" | "failed" = tx.meta?.err ? "success" : "success";
+  // ^ Wait — the parsed err === null when success, set when fail.
+  const realStatus: "success" | "failed" = tx.meta?.err == null ? "success" : "failed";
+  void status;
+
+  // Build steps from top-level instructions.
+  const steps: ExplainTxStep[] = [];
+  for (const ix of tx.transaction.message.instructions) {
+    const desc = describeInstruction(ix);
+    if (!desc) continue;
+    steps.push({
+      kind: "instruction",
+      label: desc.label,
+      detail: desc.detail,
+      ...(desc.programOrContract
+        ? { programOrContract: desc.programOrContract }
+        : {}),
+    });
+  }
+
+  // Pick a "to" — the first non-native, non-ComputeBudget program is
+  // the usual target; falls back to System program for pure transfers.
+  const programIds = new Set<string>();
+  for (const ix of tx.transaction.message.instructions) {
+    const pid = ix.programId.toBase58();
+    if (pid !== COMPUTE_BUDGET_PROGRAM) programIds.add(pid);
+  }
+  const nativePrograms = new Set([
+    SYSTEM_PROGRAM,
+    SPL_TOKEN_PROGRAM,
+    TOKEN_2022_PROGRAM,
+    ATA_PROGRAM,
+  ]);
+  const nonNative = [...programIds].find((p) => !nativePrograms.has(p));
+  const to = nonNative ?? [...programIds][0];
+
+  // Native-SOL delta for perspective.
+  const balanceDeltas = new Map<
+    string,
+    { delta: bigint; symbol: string; decimals: number }
+  >();
+  const perspectiveIdx = accountKeys.indexOf(perspective);
+  if (
+    perspectiveIdx >= 0 &&
+    tx.meta?.preBalances &&
+    tx.meta?.postBalances &&
+    perspectiveIdx < tx.meta.preBalances.length &&
+    perspectiveIdx < tx.meta.postBalances.length
+  ) {
+    const pre = BigInt(tx.meta.preBalances[perspectiveIdx]);
+    const post = BigInt(tx.meta.postBalances[perspectiveIdx]);
+    const delta = post - pre;
+    if (delta !== 0n) {
+      balanceDeltas.set("native", {
+        delta,
+        symbol: SOL_SYMBOL,
+        decimals: SOL_DECIMALS,
+      });
+    }
+  }
+
+  // SPL deltas: aggregate by mint, owner === perspective.
+  const preTokens = tx.meta?.preTokenBalances ?? [];
+  const postTokens = tx.meta?.postTokenBalances ?? [];
+  type Sum = { preRaw: bigint; postRaw: bigint; decimals: number; symbol: string };
+  const byMint = new Map<string, Sum>();
+  for (const b of preTokens) {
+    if (b.owner !== perspective) continue;
+    const entry = byMint.get(b.mint) ?? {
+      preRaw: 0n,
+      postRaw: 0n,
+      decimals: b.uiTokenAmount?.decimals ?? 0,
+      symbol: MINT_TO_SYMBOL[b.mint]?.symbol ?? "UNKNOWN",
+    };
+    entry.preRaw += BigInt(b.uiTokenAmount?.amount ?? "0");
+    byMint.set(b.mint, entry);
+  }
+  for (const b of postTokens) {
+    if (b.owner !== perspective) continue;
+    const entry = byMint.get(b.mint) ?? {
+      preRaw: 0n,
+      postRaw: 0n,
+      decimals: b.uiTokenAmount?.decimals ?? 0,
+      symbol: MINT_TO_SYMBOL[b.mint]?.symbol ?? "UNKNOWN",
+    };
+    entry.postRaw += BigInt(b.uiTokenAmount?.amount ?? "0");
+    byMint.set(b.mint, entry);
+  }
+  for (const [mint, sum] of byMint) {
+    const delta = sum.postRaw - sum.preRaw;
+    if (delta === 0n) continue;
+    balanceDeltas.set(mint, {
+      delta,
+      symbol: sum.symbol,
+      decimals: sum.decimals,
+    });
+  }
+
+  // Pricing.
+  const solPriceEntry = await getDefillamaCoinPrice("solana").catch(
+    () => undefined,
+  );
+  const solPrice = solPriceEntry?.price;
+
+  const balanceChanges: ExplainTxBalanceChange[] = [];
+  for (const [token, info] of balanceDeltas) {
+    const formatted = formatUnits(info.delta, info.decimals);
+    const num = Number(formatted);
+    let priceUsd: number | undefined;
+    if (token === "native") priceUsd = solPrice;
+    balanceChanges.push({
+      symbol: info.symbol,
+      token,
+      delta: formatted,
+      deltaApprox: num,
+      ...(priceUsd !== undefined && Number.isFinite(num)
+        ? { valueUsd: round2(num * priceUsd) }
+        : {}),
+    });
+  }
+
+  // Approval changes — Solana doesn't have ERC-20-style approvals as a
+  // common surface. SPL Token's `approve` instruction exists (delegate
+  // pattern) but is rarely used in retail flows; surfacing it requires
+  // walking the parsed `approve`/`approveChecked` info. v1 deferred —
+  // leave empty.
+  const approvalChanges: ExplainTxApprovalChange[] = [];
+
+  // Fee.
+  const feeLamports = BigInt(tx.meta?.fee ?? 0);
+  const feeNative = formatUnits(feeLamports, SOL_DECIMALS);
+  const feeUsd =
+    solPrice !== undefined && Number.isFinite(Number(feeNative))
+      ? round2(Number(feeNative) * solPrice)
+      : undefined;
+
+  // Block time.
+  const blockTimeIso = tx.blockTime
+    ? new Date(tx.blockTime * 1000).toISOString()
+    : undefined;
+
+  let summary: string;
+  if (realStatus === "failed") {
+    const errStr = JSON.stringify(tx.meta?.err ?? "unknown").slice(0, 100);
+    summary = `Solana tx FAILED (${errStr}). ${feeNative} SOL paid as fee.`;
+  } else if (programIds.has(SYSTEM_PROGRAM) && programIds.size === 1) {
+    summary = `Native SOL transfer on Solana.`;
+  } else if (
+    (programIds.has(SPL_TOKEN_PROGRAM) ||
+      programIds.has(TOKEN_2022_PROGRAM)) &&
+    [...programIds].every((p) =>
+      [SYSTEM_PROGRAM, SPL_TOKEN_PROGRAM, TOKEN_2022_PROGRAM, ATA_PROGRAM].includes(
+        p,
+      ),
+    )
+  ) {
+    summary = `SPL token transfer on Solana.`;
+  } else if (nonNative) {
+    const known = lookupProgram(nonNative);
+    summary = `Solana program call to ${known?.name ?? nonNative.slice(0, 12) + "…"}.`;
+  } else {
+    summary = `Solana transaction (${steps.length} top-level instruction(s)).`;
+  }
+
+  return {
+    chain: "solana",
+    hash: args.signature,
+    from: feePayer,
+    ...(to ? { to } : {}),
+    perspective,
+    blockNumber: tx.slot.toString(),
+    ...(blockTimeIso ? { blockTimeIso } : {}),
+    status: realStatus,
+    feeNative,
+    feeNativeSymbol: SOL_SYMBOL,
+    ...(feeUsd !== undefined ? { feeUsd } : {}),
+    summary,
+    steps,
+    balanceChanges,
+    approvalChanges,
+    heuristics: [],
+    notes: [],
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/modules/postmortem/per-chain/tron.ts
+++ b/src/modules/postmortem/per-chain/tron.ts
@@ -1,0 +1,509 @@
+/**
+ * TRON `explain_tx` implementation.
+ *
+ * Uses the same TronGrid endpoints as `getTronTransactionStatus`:
+ *   - `/wallet/gettransactionbyid` — signed envelope (raw_data.contract,
+ *     ret[].contractRet for native txs).
+ *   - `/wallet/gettransactioninfobyid` — block number, fee, smart-
+ *     contract receipt (SUCCESS / REVERT / OUT_OF_ENERGY), and `log` —
+ *     the array of decoded events.
+ *
+ * Coverage in v1: native TRX transfers (TransferContract), TRC-20
+ * transfers (TriggerSmartContract emitting Transfer events on a TRC-20
+ * contract). Smart-contract calls beyond TRC-20 (e.g. TRC-721, JustLend
+ * actions) surface as a generic "TriggerSmartContract on <addr>" step
+ * — the contract type is decoded but per-call event parsing beyond
+ * Transfer is out of scope.
+ */
+
+import { fetchWithTimeout } from "../../../data/http.js";
+import {
+  TRONGRID_BASE_URL,
+  TRX_DECIMALS,
+} from "../../../config/tron.js";
+import {
+  resolveTronApiKey,
+  readUserConfig,
+} from "../../../config/user-config.js";
+import { formatUnits } from "../../../data/format.js";
+import { getDefillamaCoinPrice } from "../../../data/prices.js";
+import type {
+  ExplainTxApprovalChange,
+  ExplainTxBalanceChange,
+  ExplainTxResult,
+  ExplainTxStep,
+} from "../schemas.js";
+
+/**
+ * TRON addresses on TronGrid arrive in two shapes: hex (`41` + 20-byte
+ * EVM-style address, 42 hex chars) on raw_data fields, and EVM-padded
+ * 32-byte topics (64 hex chars, last 20 bytes are the address) in
+ * event logs. We normalize everything to the hex form for the
+ * post-mortem readout — base58check encoding requires double-sha256 +
+ * a base58 alphabet sweep, which adds dep weight for a forensic
+ * surface where the agent's user is likely cross-referencing TronScan
+ * anyway. Hex with the `41` prefix is unambiguous and decodable both
+ * ways.
+ */
+function topicToTronHex(topic: string): string {
+  return `41${topic.slice(-40)}`.toLowerCase();
+}
+
+function logAddressToTronHex(addr: string | undefined): string {
+  if (!addr) return "";
+  // Some TronGrid responses include the leading 41, others don't.
+  // Normalize: pad to 42 chars total with 41 prefix.
+  const lower = addr.toLowerCase();
+  if (lower.length === 42 && lower.startsWith("41")) return lower;
+  if (lower.length === 40) return `41${lower}`;
+  return lower;
+}
+
+function rawAddressToTronHex(addr: string | undefined): string {
+  if (!addr) return "";
+  return addr.toLowerCase();
+}
+
+const TRANSFER_TOPIC =
+  "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const APPROVAL_TOPIC =
+  "8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+// MAX_UINT256 minus a 0.01% sliver — same threshold as EVM.
+const MAX_UINT256 = (1n << 256n) - 1n;
+const UNLIMITED_THRESHOLD = MAX_UINT256 - MAX_UINT256 / 10_000n;
+
+interface GetTxByIdResponse {
+  txID?: string;
+  blockTimeStamp?: number;
+  raw_data?: {
+    timestamp?: number;
+    contract?: Array<{
+      type?: string;
+      parameter?: {
+        value?: {
+          owner_address?: string;
+          to_address?: string;
+          contract_address?: string;
+          amount?: number;
+          data?: string;
+        };
+      };
+    }>;
+  };
+  ret?: Array<{ contractRet?: string }>;
+}
+
+interface TronLog {
+  address?: string;
+  topics?: string[];
+  data?: string;
+}
+
+interface GetTxInfoResponse {
+  id?: string;
+  blockNumber?: number;
+  blockTimeStamp?: number;
+  fee?: number;
+  receipt?: {
+    result?: string;
+    energy_usage?: number;
+    energy_usage_total?: number;
+    net_usage?: number;
+  };
+  contract_address?: string;
+  log?: TronLog[];
+  contractResult?: string[];
+}
+
+async function trongridPost<T>(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (apiKey) headers["TRON-PRO-API-KEY"] = apiKey;
+  const res = await fetchWithTimeout(`${TRONGRID_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `TronGrid ${path} returned ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+interface DecodedTransfer {
+  contract: string;
+  from: string;
+  to: string;
+  value: bigint;
+}
+
+interface DecodedApproval {
+  contract: string;
+  owner: string;
+  spender: string;
+  value: bigint;
+}
+
+function decodeTransferLog(log: TronLog): DecodedTransfer | null {
+  const topics = log.topics ?? [];
+  if (topics.length < 3) return null;
+  if ((topics[0] ?? "").toLowerCase() !== TRANSFER_TOPIC) return null;
+  if (!log.data || log.data.length === 0) return null;
+  const value = BigInt("0x" + log.data);
+  return {
+    contract: logAddressToTronHex(log.address),
+    from: topicToTronHex(topics[1]),
+    to: topicToTronHex(topics[2]),
+    value,
+  };
+}
+
+function decodeApprovalLog(log: TronLog): DecodedApproval | null {
+  const topics = log.topics ?? [];
+  if (topics.length !== 3) return null;
+  if ((topics[0] ?? "").toLowerCase() !== APPROVAL_TOPIC) return null;
+  if (!log.data || log.data.length === 0) return null;
+  const value = BigInt("0x" + log.data);
+  return {
+    contract: logAddressToTronHex(log.address),
+    owner: topicToTronHex(topics[1]),
+    spender: topicToTronHex(topics[2]),
+    value,
+  };
+}
+
+interface TrcMetaCache {
+  symbol?: string;
+  decimals?: number;
+}
+
+/**
+ * Fetch TRC-20 metadata via triggerconstantcontract. Best-effort —
+ * returns empty object on failure (the post-mortem still functions
+ * with a generic "TOKEN" symbol).
+ */
+async function fetchTrc20Meta(addressBase58: string): Promise<TrcMetaCache> {
+  try {
+    const symbolRes = await trongridPost<{ constant_result?: string[] }>(
+      "/wallet/triggerconstantcontract",
+      {
+        owner_address: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb", // burn address — read-only
+        contract_address: addressBase58,
+        function_selector: "symbol()",
+        visible: true,
+      },
+    );
+    const decimalsRes = await trongridPost<{ constant_result?: string[] }>(
+      "/wallet/triggerconstantcontract",
+      {
+        owner_address: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+        contract_address: addressBase58,
+        function_selector: "decimals()",
+        visible: true,
+      },
+    );
+    const symbolHex = symbolRes.constant_result?.[0];
+    const decimalsHex = decimalsRes.constant_result?.[0];
+    return {
+      ...(symbolHex ? { symbol: parseSolidityString(symbolHex) } : {}),
+      ...(decimalsHex ? { decimals: Number(BigInt(`0x${decimalsHex}`)) } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Decode an ABI-encoded `string` returned by a `view` function. The
+ * encoding is offset(32) || length(32) || data || padding.
+ */
+function parseSolidityString(hex: string): string {
+  if (hex.length < 128) return "";
+  const lengthHex = hex.slice(64, 128);
+  const length = Number(BigInt(`0x${lengthHex}`));
+  if (length === 0 || length > 64) return "";
+  const dataHex = hex.slice(128, 128 + length * 2);
+  let out = "";
+  for (let i = 0; i < dataHex.length; i += 2) {
+    const code = parseInt(dataHex.slice(i, i + 2), 16);
+    if (code >= 32 && code < 127) out += String.fromCharCode(code);
+  }
+  return out;
+}
+
+export interface TronPostmortemArgs {
+  hash: string;
+  /** Wallet to compute balance-changes from. Defaults to tx sender (owner_address). */
+  perspective?: string;
+}
+
+export async function tronPostmortem(
+  args: TronPostmortemArgs,
+): Promise<Omit<ExplainTxResult, "narrative"> & { summary: string }> {
+  const normalized = args.hash.replace(/^0x/, "").toLowerCase();
+
+  const [byId, info] = await Promise.all([
+    trongridPost<GetTxByIdResponse>("/wallet/gettransactionbyid", {
+      value: normalized,
+    }),
+    trongridPost<GetTxInfoResponse>("/wallet/gettransactioninfobyid", {
+      value: normalized,
+    }),
+  ]);
+
+  if (!byId?.txID && !info?.blockNumber) {
+    throw new Error(
+      `TRON tx ${normalized} not visible to TronGrid. May be too fresh, or the txID is wrong.`,
+    );
+  }
+
+  const contractWrap = byId.raw_data?.contract?.[0];
+  const contractType = contractWrap?.type ?? "Unknown";
+  const cParam = contractWrap?.parameter?.value ?? {};
+
+  const senderHex = rawAddressToTronHex(cParam.owner_address);
+  const perspective = (args.perspective ?? senderHex).toLowerCase();
+
+  const receiptResult = info.receipt?.result;
+  const contractRet = byId.ret?.[0]?.contractRet;
+  const successTag =
+    receiptResult === "SUCCESS" ||
+    (!receiptResult && contractRet === "SUCCESS");
+  const status: "success" | "failed" = successTag ? "success" : "failed";
+
+  // Decode TRON logs (events emitted by smart contracts in TriggerSmartContract).
+  const logs = info.log ?? [];
+  const transfers = logs
+    .map(decodeTransferLog)
+    .filter((t): t is DecodedTransfer => t !== null);
+  const approvals = logs
+    .map(decodeApprovalLog)
+    .filter((a): a is DecodedApproval => a !== null);
+
+  // Resolve TRC-20 metadata for unique contracts.
+  const uniqueContracts = Array.from(
+    new Set([
+      ...transfers.map((t) => t.contract),
+      ...approvals.map((a) => a.contract),
+    ]),
+  ).filter((c) => c.length > 0);
+  const metaByContract = new Map<string, TrcMetaCache>();
+  await Promise.all(
+    uniqueContracts.map(async (c) => {
+      metaByContract.set(c, await fetchTrc20Meta(c));
+    }),
+  );
+
+  // Build steps.
+  const steps: ExplainTxStep[] = [];
+  if (contractType === "TransferContract") {
+    const toHex = rawAddressToTronHex(cParam.to_address);
+    const amountSun = BigInt(cParam.amount ?? 0);
+    steps.push({
+      kind: "native_transfer",
+      label: "TRX",
+      detail: `${formatUnits(amountSun, TRX_DECIMALS)} TRX from ${senderHex} to ${toHex}`,
+    });
+  } else if (contractType === "TriggerSmartContract") {
+    const contractAddrHex = rawAddressToTronHex(cParam.contract_address);
+    const dataHex = cParam.data ?? "";
+    const selector =
+      dataHex && dataHex.length >= 8 ? `0x${dataHex.slice(0, 8)}` : null;
+    steps.push({
+      kind: "call",
+      label: selector ? `selector ${selector}` : "TriggerSmartContract",
+      detail: `Smart-contract call to ${contractAddrHex}${selector ? ` (selector ${selector})` : ""}`,
+      programOrContract: contractAddrHex,
+    });
+  } else if (contractType !== "Unknown") {
+    steps.push({
+      kind: "call",
+      label: contractType,
+      detail: `${contractType} system contract`,
+    });
+  }
+  for (const t of transfers) {
+    const meta = metaByContract.get(t.contract) ?? {};
+    const symbol = meta.symbol ?? "TRC20";
+    const decimals = meta.decimals ?? 6;
+    steps.push({
+      kind: "event",
+      label: "Transfer",
+      detail: `${formatUnits(t.value, decimals)} ${symbol} from ${t.from} to ${t.to}`,
+      programOrContract: t.contract,
+    });
+  }
+  for (const a of approvals) {
+    const meta = metaByContract.get(a.contract) ?? {};
+    const symbol = meta.symbol ?? "TRC20";
+    const decimals = meta.decimals ?? 6;
+    const isUnlimited = a.value >= UNLIMITED_THRESHOLD;
+    const allowanceStr = isUnlimited
+      ? "unlimited"
+      : formatUnits(a.value, decimals);
+    steps.push({
+      kind: "event",
+      label: "Approval",
+      detail: `${a.owner} grants ${a.spender} an allowance of ${allowanceStr} ${symbol}`,
+      programOrContract: a.contract,
+    });
+  }
+
+  // Balance deltas FROM PERSPECTIVE.
+  const balanceDeltas = new Map<
+    string,
+    { delta: bigint; symbol: string; decimals: number }
+  >();
+  if (contractType === "TransferContract") {
+    const toHex = rawAddressToTronHex(cParam.to_address);
+    const amountSun = BigInt(cParam.amount ?? 0);
+    let nativeDelta = 0n;
+    if (senderHex.toLowerCase() === perspective) nativeDelta -= amountSun;
+    if (toHex.toLowerCase() === perspective) nativeDelta += amountSun;
+    if (nativeDelta !== 0n) {
+      balanceDeltas.set("native", {
+        delta: nativeDelta,
+        symbol: "TRX",
+        decimals: TRX_DECIMALS,
+      });
+    }
+  }
+  for (const t of transfers) {
+    const meta = metaByContract.get(t.contract) ?? {};
+    const isFrom = t.from.toLowerCase() === perspective;
+    const isTo = t.to.toLowerCase() === perspective;
+    if (!isFrom && !isTo) continue;
+    const prev = balanceDeltas.get(t.contract) ?? {
+      delta: 0n,
+      symbol: meta.symbol ?? "TRC20",
+      decimals: meta.decimals ?? 6,
+    };
+    prev.delta += isTo ? t.value : 0n;
+    prev.delta -= isFrom ? t.value : 0n;
+    balanceDeltas.set(t.contract, prev);
+  }
+
+  // Fee math. TronGrid surfaces `fee` in SUN (1e-6 TRX). Subtract from
+  // sender's native delta when perspective === sender.
+  const feeSun = BigInt(info.fee ?? 0);
+  const feeNative = formatUnits(feeSun, TRX_DECIMALS);
+
+  let feeUsd: number | undefined;
+  const trxPriceEntry = await getDefillamaCoinPrice("tron").catch(
+    () => undefined,
+  );
+  const trxPrice = trxPriceEntry?.price;
+  if (trxPrice !== undefined) {
+    feeUsd = round2(Number(feeNative) * trxPrice);
+  }
+
+  if (perspective === senderHex.toLowerCase() && feeSun > 0n) {
+    const existing = balanceDeltas.get("native");
+    if (existing) {
+      existing.delta -= feeSun;
+    } else {
+      balanceDeltas.set("native", {
+        delta: -feeSun,
+        symbol: "TRX",
+        decimals: TRX_DECIMALS,
+      });
+    }
+  }
+
+  const balanceChanges: ExplainTxBalanceChange[] = [];
+  for (const [token, info2] of balanceDeltas) {
+    const formatted = formatUnits(info2.delta, info2.decimals);
+    const num = Number(formatted);
+    let priceUsd: number | undefined;
+    if (token === "native") {
+      priceUsd = trxPrice;
+    }
+    balanceChanges.push({
+      symbol: info2.symbol,
+      token,
+      delta: formatted,
+      deltaApprox: num,
+      ...(priceUsd !== undefined && Number.isFinite(num)
+        ? { valueUsd: round2(num * priceUsd) }
+        : {}),
+    });
+  }
+
+  // Approval changes from perspective.
+  const approvalChanges: ExplainTxApprovalChange[] = [];
+  for (const a of approvals) {
+    if (a.owner.toLowerCase() !== perspective) continue;
+    const meta = metaByContract.get(a.contract) ?? {};
+    const isUnlimited = a.value >= UNLIMITED_THRESHOLD;
+    const newAllowance = isUnlimited
+      ? "unlimited"
+      : formatUnits(a.value, meta.decimals ?? 6);
+    approvalChanges.push({
+      ...(meta.symbol ? { symbol: meta.symbol } : {}),
+      token: a.contract,
+      spender: a.spender,
+      newAllowance,
+      isUnlimited,
+    });
+  }
+
+  // To-field for the response.
+  const toField =
+    contractType === "TransferContract"
+      ? rawAddressToTronHex(cParam.to_address) || undefined
+      : contractType === "TriggerSmartContract"
+        ? rawAddressToTronHex(cParam.contract_address) || undefined
+        : undefined;
+
+  const blockTimeIso = info.blockTimeStamp
+    ? new Date(info.blockTimeStamp).toISOString()
+    : byId.blockTimeStamp
+      ? new Date(byId.blockTimeStamp).toISOString()
+      : undefined;
+
+  let summary: string;
+  if (status === "failed") {
+    summary = `TRON tx FAILED (${receiptResult ?? contractRet ?? "unknown reason"}). ${feeNative} TRX paid as fee.`;
+  } else if (contractType === "TransferContract") {
+    const toHex = rawAddressToTronHex(cParam.to_address) || "?";
+    const amountSun = BigInt(cParam.amount ?? 0);
+    summary = `${formatUnits(amountSun, TRX_DECIMALS)} TRX sent from ${senderHex} to ${toHex}.`;
+  } else if (contractType === "TriggerSmartContract") {
+    summary = `TRON smart-contract call (${transfers.length} transfer event(s), ${approvals.length} approval(s)).`;
+  } else {
+    summary = `TRON ${contractType} transaction.`;
+  }
+
+  return {
+    chain: "tron",
+    hash: normalized,
+    from: senderHex,
+    ...(toField ? { to: toField } : {}),
+    perspective,
+    ...(info.blockNumber !== undefined
+      ? { blockNumber: info.blockNumber.toString() }
+      : {}),
+    ...(blockTimeIso ? { blockTimeIso } : {}),
+    status,
+    feeNative,
+    feeNativeSymbol: "TRX",
+    ...(feeUsd !== undefined ? { feeUsd } : {}),
+    summary,
+    steps,
+    balanceChanges,
+    approvalChanges,
+    heuristics: [],
+    notes: [],
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/modules/postmortem/render.ts
+++ b/src/modules/postmortem/render.ts
@@ -1,0 +1,98 @@
+/**
+ * Render a `ExplainTxResult` to a narrative string suitable for
+ * verbatim relay. Format mirrors the agent-facing convention used by
+ * `get_portfolio_diff` — a heading, one-sentence summary, then bullet
+ * sections. Values are formatted for terminal width; long contract
+ * addresses are truncated to head/tail.
+ */
+
+import type { ExplainTxResult } from "./schemas.js";
+
+function shortAddr(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function signed(n: number): string {
+  if (n > 0) return `+${n.toFixed(6).replace(/0+$/, "").replace(/\.$/, "")}`;
+  if (n < 0) return n.toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
+  return "0";
+}
+
+function signedUsd(n: number): string {
+  if (n > 0) return `+$${n.toFixed(2)}`;
+  if (n < 0) return `-$${Math.abs(n).toFixed(2)}`;
+  return "$0.00";
+}
+
+export function renderPostmortemNarrative(r: ExplainTxResult): string {
+  const lines: string[] = [];
+  const chainLabel =
+    r.chain.charAt(0).toUpperCase() + r.chain.slice(1);
+  lines.push(`TRANSACTION POST-MORTEM (${chainLabel})`);
+  lines.push("");
+  lines.push(`Hash: ${r.hash}`);
+  lines.push(`Status: ${r.status.toUpperCase()}`);
+  if (r.blockNumber) {
+    lines.push(
+      `Block: ${r.blockNumber}${r.blockTimeIso ? ` (${r.blockTimeIso})` : ""}`,
+    );
+  }
+  lines.push(`From: ${r.from}`);
+  if (r.to) lines.push(`To:   ${r.to}`);
+  if (r.feeNative) {
+    const feeBit = `${r.feeNative} ${r.feeNativeSymbol ?? ""}`;
+    const usdBit =
+      r.feeUsd !== undefined ? ` (~$${r.feeUsd.toFixed(2)} USD)` : "";
+    lines.push(`Fee:  ${feeBit}${usdBit}`);
+  }
+  lines.push("");
+  lines.push(`Summary: ${r.summary}`);
+  lines.push("");
+
+  if (r.steps.length > 0) {
+    lines.push("Step-by-step:");
+    for (let i = 0; i < r.steps.length; i++) {
+      const s = r.steps[i];
+      lines.push(`  ${i + 1}. [${s.kind}] ${s.label} — ${s.detail}`);
+    }
+    lines.push("");
+  }
+
+  if (r.balanceChanges.length > 0) {
+    lines.push(`Balance changes (perspective: ${shortAddr(r.perspective)}):`);
+    for (const b of r.balanceChanges) {
+      const usd =
+        b.valueUsd !== undefined ? ` (${signedUsd(b.valueUsd)})` : "";
+      lines.push(`  • ${b.symbol}: ${signed(b.deltaApprox)}${usd}`);
+    }
+    lines.push("");
+  }
+
+  if (r.approvalChanges.length > 0) {
+    lines.push("Approval changes:");
+    for (const a of r.approvalChanges) {
+      const allowance = a.isUnlimited ? "UNLIMITED" : a.newAllowance;
+      lines.push(
+        `  • ${a.symbol ?? shortAddr(a.token)} → ${shortAddr(a.spender)}: ${allowance}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (r.heuristics.length > 0) {
+    lines.push("Things you might want to know:");
+    for (const h of r.heuristics) {
+      lines.push(`  ⚠ [${h.rule}] ${h.message}`);
+    }
+    lines.push("");
+  }
+
+  if (r.notes.length > 0) {
+    lines.push("Notes:");
+    for (const n of r.notes) lines.push(`  · ${n}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/src/modules/postmortem/schemas.ts
+++ b/src/modules/postmortem/schemas.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+import {
+  EVM_ADDRESS,
+  SOLANA_ADDRESS,
+  TRON_ADDRESS,
+} from "../../shared/address-patterns.js";
+
+/**
+ * `explain_tx` — narrative post-mortem for a single transaction.
+ *
+ * v1 covers EVM (Ethereum / Arbitrum / Polygon / Base / Optimism), TRON,
+ * and Solana. Bitcoin is deferred — the indexer surface for in-chain
+ * inputs/outputs needs more thought than v1 has scope for.
+ *
+ * Output shape is deliberately flat: a one-sentence summary, ordered
+ * step rows, balance + approval changes, and a heuristics block. Both
+ * a structured envelope and a pre-rendered narrative string are
+ * returned, with the agent picking the right one for the user-facing
+ * surface.
+ */
+
+const POSTMORTEM_CHAINS = [
+  ...SUPPORTED_CHAINS,
+  "tron",
+  "solana",
+] as unknown as [string, ...string[]];
+
+/**
+ * Tx-hash regex per chain family. EVM hashes are 64-hex with optional
+ * 0x prefix. TRON hashes are 64-hex bare. Solana signatures are
+ * base58, 86-88 chars. We accept all three forms in the schema and
+ * rely on the chain dispatcher to pick the right parser.
+ */
+const TX_HASH_PATTERN =
+  /^(0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64}|[1-9A-HJ-NP-Za-km-z]{86,88})$/;
+
+const walletSchema = z.union([
+  z.string().regex(EVM_ADDRESS),
+  z.string().regex(TRON_ADDRESS),
+  z.string().regex(SOLANA_ADDRESS),
+]);
+
+export const explainTxInput = z.object({
+  hash: z
+    .string()
+    .regex(TX_HASH_PATTERN)
+    .describe(
+      "Transaction identifier. EVM: 32-byte hex (with or without `0x`). " +
+        "TRON: 32-byte bare hex. Solana: 64-byte signature as base58 (86–88 chars)."
+    ),
+  chain: z
+    .enum(POSTMORTEM_CHAINS)
+    .describe(
+      "Which chain the tx lives on. Required because EVM / TRON / Solana " +
+        "post-mortems use different RPC paths and payload shapes."
+    ),
+  wallet: walletSchema
+    .optional()
+    .describe(
+      "Optional. When supplied, balance + approval changes are computed " +
+        "FROM THIS WALLET'S PERSPECTIVE — outflows are negative, inflows " +
+        "positive. When omitted, defaults to the tx sender (the canonical " +
+        "perspective). Pass an explicit wallet for recipient-side narratives."
+    ),
+  format: z
+    .enum(["structured", "narrative", "both"])
+    .default("both")
+    .describe(
+      '"structured" returns the JSON envelope only. "narrative" returns ' +
+        'only the pre-rendered string. "both" (default) returns both — ' +
+        "agents typically use the narrative for verbatim relay and the " +
+        "structured for follow-up questions."
+    ),
+});
+
+export type ExplainTxArgs = z.infer<typeof explainTxInput>;
+
+/** One decoded step in the tx's top-level execution path. */
+export interface ExplainTxStep {
+  /**
+   * Step kind:
+   *   - `call`: a top-level contract call (EVM / TRON contract calls).
+   *   - `native_transfer`: native-coin transfer (ETH / TRX / SOL).
+   *   - `instruction`: Solana instruction.
+   *   - `event`: a parsed log/event emitted by the tx.
+   */
+  kind: "call" | "native_transfer" | "instruction" | "event";
+  /**
+   * Decoded label — method name (`transfer`, `swap`, ...), event name
+   * (`Transfer`, `Approval`), or instruction name (`SystemProgram::transfer`).
+   * Best-effort; falls back to a hex selector or program-id fragment when
+   * decoding fails.
+   */
+  label: string;
+  /** Plain-text summary of the step's effect. */
+  detail: string;
+  /** Source program / contract address — surfaced for forensic context. */
+  programOrContract?: string;
+}
+
+/**
+ * One row per token (or native coin) the wallet's holdings changed by.
+ * Signed: positive = received, negative = sent.
+ */
+export interface ExplainTxBalanceChange {
+  symbol: string;
+  /**
+   * Token identifier — EVM contract address, Solana mint, "native" for
+   * the chain's native coin.
+   */
+  token: string;
+  /** Decimal-adjusted signed amount as a string (preserves bigint precision). */
+  delta: string;
+  /** Same value as a JS number for convenience — may lose precision on huge amounts. */
+  deltaApprox: number;
+  /** USD valuation of the delta when a price is available. */
+  valueUsd?: number;
+}
+
+/** Approval change for an ERC-20 / TRC-20 owner → spender pair. */
+export interface ExplainTxApprovalChange {
+  symbol?: string;
+  token: string;
+  spender: string;
+  /** New allowance as a decimal string. `unlimited` = MAX_UINT256. */
+  newAllowance: string;
+  isUnlimited: boolean;
+}
+
+/**
+ * One heuristic flag the post-mortem fired. v1 surfaces:
+ *   - `failed`: tx reverted on-chain.
+ *   - `unlimited_approval`: an approval set MAX_UINT256.
+ *   - `dust_transfer`: outflow < $0.01 USD-equivalent (potential
+ *     poisoning bait — same heuristic family as #220).
+ *   - `transfer_to_zero`: a Transfer event went to the zero address
+ *     (token burn or contract self-destruct cleanup).
+ *   - `high_gas`: gas cost > 10% of the transferred USD value (something
+ *     unusual in routing or congestion).
+ *   - `no_state_change`: receipt is success but no Transfer / native
+ *     value moved — the tx might have been a no-op.
+ */
+export interface ExplainTxHeuristic {
+  rule:
+    | "failed"
+    | "unlimited_approval"
+    | "dust_transfer"
+    | "transfer_to_zero"
+    | "high_gas"
+    | "no_state_change";
+  message: string;
+}
+
+export interface ExplainTxResult {
+  chain: string;
+  hash: string;
+  /** Tx sender / signer. */
+  from: string;
+  /**
+   * Tx target. EVM: contract / EOA called. TRON: same. Solana: first
+   * non-system program invoked when one exists; otherwise the first
+   * destination of a SystemProgram::transfer.
+   */
+  to?: string;
+  /**
+   * Wallet whose perspective `balanceChanges` are computed from. Echoes
+   * `args.wallet` when supplied; otherwise `from`.
+   */
+  perspective: string;
+  /** Mined block / slot. */
+  blockNumber?: string;
+  /** ISO timestamp when the block confirmed. */
+  blockTimeIso?: string;
+  status: "success" | "failed" | "unknown";
+  /** Native-coin gas / fee burn in human units. */
+  feeNative?: string;
+  feeNativeSymbol?: string;
+  feeUsd?: number;
+  summary: string;
+  steps: ExplainTxStep[];
+  balanceChanges: ExplainTxBalanceChange[];
+  approvalChanges: ExplainTxApprovalChange[];
+  heuristics: ExplainTxHeuristic[];
+  /** Free-form scope reminders / partial-data flags. */
+  notes: string[];
+  /** Pre-rendered narrative string. Absent when `format === "structured"`. */
+  narrative?: string;
+}

--- a/test/postmortem.test.ts
+++ b/test/postmortem.test.ts
@@ -1,0 +1,447 @@
+/**
+ * `explain_tx` post-mortem tests. Per-chain RPC is mocked at the
+ * module boundary so no live HTTP fires. Coverage:
+ *   - EVM happy path: ERC-20 transfer with priced fee + balance delta.
+ *   - EVM heuristic: unlimited approval surfaces.
+ *   - EVM failed tx: status flips, "failed" heuristic fires.
+ *   - TRON happy path: TransferContract native TRX transfer.
+ *   - Solana happy path: SPL token transfer with balance deltas.
+ *   - Render: narrative includes summary + step-by-step + balance
+ *     section + heuristics block.
+ *   - Bitcoin chain rejected with explicit "deferred" error.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const evmGetTransactionMock = vi.fn();
+const evmGetTransactionReceiptMock = vi.fn();
+const evmGetBlockMock = vi.fn();
+const evmReadContractMock = vi.fn();
+const getTokenPriceMock = vi.fn();
+const resolveSelectorsMock = vi.fn();
+const fetchWithTimeoutMock = vi.fn();
+const getDefillamaCoinPriceMock = vi.fn();
+const solanaGetParsedTransactionMock = vi.fn();
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    getTransaction: (...a: unknown[]) => evmGetTransactionMock(...a),
+    getTransactionReceipt: (...a: unknown[]) =>
+      evmGetTransactionReceiptMock(...a),
+    getBlock: (...a: unknown[]) => evmGetBlockMock(...a),
+    readContract: (...a: unknown[]) => evmReadContractMock(...a),
+  }),
+  resetClients: () => {},
+}));
+
+vi.mock("../src/data/prices.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/data/prices.js")>();
+  return {
+    ...actual,
+    getTokenPrice: (...a: unknown[]) => getTokenPriceMock(...a),
+    getDefillamaCoinPrice: (...a: unknown[]) =>
+      getDefillamaCoinPriceMock(...a),
+  };
+});
+
+vi.mock("../src/modules/history/decode.js", () => ({
+  resolveSelectors: (...a: unknown[]) => resolveSelectorsMock(...a),
+}));
+
+vi.mock("../src/data/http.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/data/http.js")>();
+  return {
+    ...actual,
+    fetchWithTimeout: (...a: unknown[]) => fetchWithTimeoutMock(...a),
+  };
+});
+
+vi.mock("../src/modules/solana/rpc.js", () => ({
+  getSolanaConnection: () => ({
+    getParsedTransaction: (...a: unknown[]) =>
+      solanaGetParsedTransactionMock(...a),
+  }),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const TX_HASH =
+  "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const APPROVAL_TOPIC =
+  "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+
+function pad32(addrLower: string): `0x${string}` {
+  return `0x000000000000000000000000${addrLower.replace(/^0x/, "").toLowerCase()}` as `0x${string}`;
+}
+
+function encUint(n: bigint): `0x${string}` {
+  return `0x${n.toString(16).padStart(64, "0")}` as `0x${string}`;
+}
+
+beforeEach(() => {
+  evmGetTransactionMock.mockReset();
+  evmGetTransactionReceiptMock.mockReset();
+  evmGetBlockMock.mockReset();
+  evmReadContractMock.mockReset();
+  getTokenPriceMock.mockReset();
+  resolveSelectorsMock.mockReset();
+  fetchWithTimeoutMock.mockReset();
+  getDefillamaCoinPriceMock.mockReset();
+  solanaGetParsedTransactionMock.mockReset();
+
+  // Default: no method resolves, no prices.
+  resolveSelectorsMock.mockResolvedValue(new Map());
+  getTokenPriceMock.mockResolvedValue(undefined);
+  evmGetBlockMock.mockResolvedValue({ timestamp: 1714128000n });
+  // ERC-20 metadata defaults: USDC.
+  evmReadContractMock.mockImplementation(async (call: { functionName: string }) => {
+    if (call.functionName === "symbol") return "USDC";
+    if (call.functionName === "decimals") return 6;
+    throw new Error(`unexpected readContract: ${call.functionName}`);
+  });
+  getDefillamaCoinPriceMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("explainTx — EVM happy path", () => {
+  it("decodes an ERC-20 USDC transfer with balance delta + priced fee", async () => {
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: USDC,
+      value: 0n,
+      input:
+        "0xa9059cbb" +
+        RECIPIENT.slice(2).toLowerCase().padStart(64, "0") +
+        (1_000_000n).toString(16).padStart(64, "0"), // transfer(recipient, 1 USDC)
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 65_000n,
+      effectiveGasPrice: 20_000_000_000n, // 20 gwei
+      from: WALLET,
+      to: USDC,
+      logs: [
+        {
+          address: USDC.toLowerCase(),
+          topics: [
+            TRANSFER_TOPIC,
+            pad32(WALLET),
+            pad32(RECIPIENT),
+          ],
+          data: encUint(1_000_000n),
+        },
+      ],
+    });
+    resolveSelectorsMock.mockResolvedValue(
+      new Map([["0xa9059cbb", { methodName: "transfer" }]]),
+    );
+    // ETH price.
+    getTokenPriceMock.mockImplementation(async (_chain: string, addr: string) => {
+      if (addr === "native") return 4000;
+      if (addr.toLowerCase() === USDC.toLowerCase()) return 1;
+      return undefined;
+    });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.status).toBe("success");
+    expect(r.summary).toContain("transfer");
+    expect(r.from).toBe(WALLET);
+    expect(r.to).toBe(USDC);
+    // Step rows: top-level call + Transfer event.
+    expect(r.steps.find((s) => s.kind === "call" && s.label === "transfer")).toBeDefined();
+    expect(r.steps.find((s) => s.kind === "event" && s.label === "Transfer")).toBeDefined();
+    // Balance delta: -1 USDC (sender) + native gas burn (~0.0013 ETH).
+    const usdcRow = r.balanceChanges.find((b) => b.symbol === "USDC")!;
+    expect(usdcRow.delta).toBe("-1");
+    const ethRow = r.balanceChanges.find((b) => b.symbol === "ETH")!;
+    expect(Number(ethRow.delta)).toBeLessThan(0); // gas paid
+    expect(r.feeNative).toBeDefined();
+    expect(r.feeUsd).toBeGreaterThan(0);
+    expect(r.heuristics.find((h) => h.rule === "failed")).toBeUndefined();
+  });
+});
+
+describe("explainTx — EVM unlimited approval heuristic", () => {
+  it("flags unlimited_approval when approve(spender, MAX_UINT256) is observed", async () => {
+    const MAX = (1n << 256n) - 1n;
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: USDC,
+      value: 0n,
+      input:
+        "0x095ea7b3" +
+        RECIPIENT.slice(2).toLowerCase().padStart(64, "0") +
+        MAX.toString(16).padStart(64, "0"),
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 50_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: USDC,
+      logs: [
+        {
+          address: USDC.toLowerCase(),
+          topics: [APPROVAL_TOPIC, pad32(WALLET), pad32(RECIPIENT)],
+          data: encUint(MAX),
+        },
+      ],
+    });
+    resolveSelectorsMock.mockResolvedValue(
+      new Map([["0x095ea7b3", { methodName: "approve" }]]),
+    );
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.approvalChanges).toHaveLength(1);
+    expect(r.approvalChanges[0].isUnlimited).toBe(true);
+    expect(r.approvalChanges[0].newAllowance).toBe("unlimited");
+    expect(
+      r.heuristics.find((h) => h.rule === "unlimited_approval"),
+    ).toBeDefined();
+  });
+});
+
+describe("explainTx — EVM failed tx", () => {
+  it("flags failed status and short-circuits other heuristics", async () => {
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: USDC,
+      value: 0n,
+      input: "0xa9059cbb" + "0".repeat(128),
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "reverted",
+      blockNumber: 19_000_000n,
+      gasUsed: 30_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: USDC,
+      logs: [],
+    });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.summary).toMatch(/REVERTED/i);
+    expect(r.heuristics.find((h) => h.rule === "failed")).toBeDefined();
+    // Other heuristics are short-circuited on failed:
+    expect(r.heuristics).toHaveLength(1);
+  });
+});
+
+describe("explainTx — TRON happy path", () => {
+  it("decodes a native TRX TransferContract", async () => {
+    fetchWithTimeoutMock.mockImplementation(async (url: string) => {
+      if (url.includes("gettransactionbyid")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            txID: "abc",
+            blockTimeStamp: 1714128000000,
+            raw_data: {
+              contract: [
+                {
+                  type: "TransferContract",
+                  parameter: {
+                    value: {
+                      owner_address: "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+                      to_address: "41b614f803b6fd780986a42c78ec9c7f77e6ded13c",
+                      amount: 1_000_000, // 1 TRX (in SUN)
+                    },
+                  },
+                },
+              ],
+            },
+            ret: [{ contractRet: "SUCCESS" }],
+          }),
+        };
+      }
+      // gettransactioninfobyid
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          id: "abc",
+          blockNumber: 60_000_000,
+          blockTimeStamp: 1714128000000,
+          fee: 100_000, // 0.1 TRX
+          log: [],
+        }),
+      };
+    });
+    getDefillamaCoinPriceMock.mockResolvedValue({ price: 0.1 });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: "abcdef".padEnd(64, "0"),
+      chain: "tron",
+      format: "structured",
+    });
+
+    expect(r.chain).toBe("tron");
+    expect(r.status).toBe("success");
+    expect(r.summary).toContain("1 TRX");
+    expect(r.feeNative).toBe("0.1");
+    // Native delta: -1 TRX (transferred) - 0.1 TRX (fee) = -1.1 TRX.
+    const trx = r.balanceChanges.find((b) => b.symbol === "TRX")!;
+    expect(trx).toBeDefined();
+    expect(Number(trx.delta)).toBeCloseTo(-1.1, 5);
+  });
+});
+
+describe("explainTx — Solana happy path", () => {
+  it("decodes an SPL token transfer with balance deltas", async () => {
+    const FEE_PAYER = "11111111111111111111111111111112";
+    const RECIPIENT_OWNER = "1111111111111111111111111111111R";
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const SIG = "5".repeat(88);
+
+    solanaGetParsedTransactionMock.mockResolvedValue({
+      slot: 250_000_000,
+      blockTime: 1714128000,
+      meta: {
+        err: null,
+        fee: 5000,
+        preBalances: [1_000_000_000],
+        postBalances: [994_000],
+        preTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: USDC_MINT,
+            owner: FEE_PAYER,
+            uiTokenAmount: { amount: "10000000", decimals: 6, uiAmountString: "10" },
+          },
+        ],
+        postTokenBalances: [
+          {
+            accountIndex: 0,
+            mint: USDC_MINT,
+            owner: FEE_PAYER,
+            uiTokenAmount: { amount: "5000000", decimals: 6, uiAmountString: "5" },
+          },
+        ],
+      },
+      transaction: {
+        message: {
+          accountKeys: [
+            { pubkey: { toBase58: () => FEE_PAYER } },
+            { pubkey: { toBase58: () => RECIPIENT_OWNER } },
+          ],
+          instructions: [
+            {
+              programId: { toBase58: () => "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" },
+              program: "spl-token",
+              parsed: {
+                type: "transferChecked",
+                info: {
+                  source: "src-ata",
+                  destination: "dst-ata",
+                  mint: USDC_MINT,
+                  tokenAmount: { uiAmountString: "5", amount: "5000000" },
+                },
+              },
+            },
+          ],
+        },
+        signatures: [SIG],
+      },
+    });
+    getDefillamaCoinPriceMock.mockResolvedValue({ price: 200 });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: SIG,
+      chain: "solana",
+      format: "structured",
+    });
+
+    expect(r.chain).toBe("solana");
+    expect(r.status).toBe("success");
+    // SOL delta: -5000 lamports of fee + the post/pre delta of accountKeys[0].
+    // post=994000, pre=1000000000 → delta=-999006000 lamports = -0.999006 SOL.
+    const sol = r.balanceChanges.find((b) => b.symbol === "SOL")!;
+    expect(sol).toBeDefined();
+    expect(Number(sol.delta)).toBeCloseTo(-0.999006, 4);
+    // USDC delta: -5 (sent 5).
+    const usdc = r.balanceChanges.find((b) => b.symbol === "USDC")!;
+    expect(usdc).toBeDefined();
+    expect(usdc.delta).toBe("-5");
+    expect(r.steps.find((s) => s.kind === "instruction")).toBeDefined();
+  });
+});
+
+describe("explainTx — narrative output", () => {
+  it("includes a pre-rendered narrative when format !== 'structured'", async () => {
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: RECIPIENT,
+      value: 1_000_000_000_000_000n, // 0.001 ETH
+      input: "0x",
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 21_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: RECIPIENT,
+      logs: [],
+    });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "both",
+    });
+    expect(typeof r.narrative).toBe("string");
+    expect(r.narrative!).toContain("TRANSACTION POST-MORTEM");
+    expect(r.narrative!).toContain("Hash:");
+    expect(r.narrative!).toContain("Status: SUCCESS");
+    expect(r.narrative!).toContain("Summary:");
+  });
+});
+
+describe("explainTx — Bitcoin deferred", () => {
+  it("rejects the request before the chain enum even allows it", async () => {
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    // The schema only allows EVM/TRON/Solana, so the Zod layer would
+    // reject "bitcoin" upstream — but the dispatcher also has a clear
+    // error if reached directly.
+    await expect(
+      explainTx({
+        hash: "0".repeat(64),
+        chain: "bitcoin" as never,
+        format: "structured",
+      }),
+    ).rejects.toThrow(/does not yet support|deferred|Bitcoin/);
+  });
+});


### PR DESCRIPTION
## Summary
New `explain_tx(hash, chain, wallet?, format?)` tool. Walks a confirmed transaction and emits a narrative-friendly post-mortem: status, decoded top-level call, step-by-step events/instructions, per-token balance changes from a chosen perspective, approval changes, and a heuristics block.

Use it for the agent-natural questions like:
- *"why did this swap return less than the quote?"*
- *"what does this contract call actually do?"*
- *"did I just grant unlimited approval to this random contract?"*

Distinct from `get_transaction_status` (just confirmation status) and the prepare→preview→send pipeline (forward-looking). Returns BOTH a structured envelope and a pre-rendered narrative — agent picks the right surface.

## Coverage matrix (v1)

| Chain | Path | Steps | Balance Δ | Approvals | Heuristics |
|---|---|---|---|---|---|
| EVM (5 chains) | viem `getTransaction` + receipt + logs | top-level method + Transfer + Approval | from logs + native gas | ERC-20 Approval | all |
| TRON | TronGrid `gettransactionbyid` + `gettransactioninfobyid` | TransferContract / TriggerSmartContract + decoded TRC-20 events | TRX + TRC-20 | TRC-20 Approval | all |
| Solana | web3.js `getParsedTransaction` | parsed instructions (System / SPL Token / ATA / known programs) | `meta.pre/postBalances` + `meta.pre/postTokenBalances` | (deferred — SPL approve rare in retail) | failed / dust / high_gas / no_state_change |
| Bitcoin | **deferred to v2** | — | — | — | — |

## Heuristics

| Rule | Fires when |
|---|---|
| `failed` | Receipt says revert / Solana `meta.err` set / TRON receipt non-SUCCESS |
| `unlimited_approval` | Approval value ≥ MAX_UINT256 − 0.01% (catches MAX and near-MAX) |
| `dust_transfer` | Outflow with priced USD value ∈ (0, $0.01) — possible address poisoning bait |
| `transfer_to_zero` | Transfer event `to` is zero address (token burn) |
| `high_gas` | Fee USD > 10% of largest priced balance change |
| `no_state_change` | Success but zero balance changes, zero approvals, zero events |

`failed` short-circuits the others to avoid noise (the trivial "no_state_change" would always fire on reverts).

## v1 caveats (in `notes`)

- Top-level execution only — internal calls / CPI / DeFi compositions surface via balance & event effects, not as separate step rows. Full call-graph trace deferred.
- Pricing is **current spot** via DefiLlama, not historical at tx time. For fresh txs the difference is sub-second; for older txs prices may have drifted materially.
- TRON addresses returned in hex form (`41` + 40 hex chars). Base58check encode deferred to keep deps light; agents that need base58 should cross-reference TronScan.
- Solana SPL `approve`/`approveChecked` (delegate pattern) is parsed but not surfaced as `approvalChanges` — rare in retail flows; deferred.
- "What you signed" Ledger hash re-derivation is out of scope (forward-looking concern; this tool is post-mortem).

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/postmortem.test.ts` — 7/7 pass
- [x] `npx vitest run` (full suite) — **1441/1441 pass**

Test cases:
- EVM happy path: USDC transfer → method decoded, Transfer event parsed, native gas folded into sender's native delta, fee USD computed.
- EVM unlimited approval: `approve(spender, MAX_UINT256)` → `approvalChanges[0].isUnlimited === true` AND heuristic fires.
- EVM failed tx: status flips, `failed` heuristic fires alone (others short-circuited).
- TRON native TRX TransferContract: 1 TRX transfer + 0.1 TRX fee → balance delta = -1.1 TRX from sender.
- Solana SPL transfer: lamport delta + SPL delta math (post − pre, owner-filtered, mint-aggregated).
- Narrative output non-empty when `format === "both"`.
- Bitcoin chain rejected with explicit "deferred to v2" error.

## Plan

`claude-work/plan-tx-postmortem.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)