### PR TITLE
chore(license): switch to BUSL-1.1, bump to 0.9.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,97 @@
-MIT License
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Copyright (c) 2026 Viacheslav Zhygulin
+Parameters
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensor:             Viacheslav Zhygulin
+Licensed Work:        vaultpilot-mcp Version 0.9.0 or later. The Licensed Work is
+                      (c) 2026 Viacheslav Zhygulin.
+Additional Use Grant: You may make production use of the Licensed Work for
+                      non-commercial purposes and for personal, individual
+                      self-custodial portfolio management, provided Your use
+                      does not include offering the Licensed Work, in whole or
+                      in part, to third parties on a hosted, managed, or
+                      embedded basis as part of a competitive offering. For
+                      purposes of this license:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                      A "competitive offering" is any product or service that
+                      is offered to third parties on a paid basis (including
+                      through paid support, subscription, hosting, or licensing
+                      arrangements) and that includes substantial features or
+                      functionality of the Licensed Work, whether by hosting,
+                      embedding, wrapping, or otherwise providing access to the
+                      Licensed Work or a Modified Version. Products that are
+                      not provided to third parties on a paid basis are not
+                      competitive offerings.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+                      "Embedded" means including the source code or executable
+                      code from the Licensed Work in a competitive offering.
+                      "Embedded" also means packaging the competitive offering
+                      in such a way that the Licensed Work must be accessed or
+                      downloaded for the competitive offering to operate.
+
+                      Hosting or using the Licensed Work for internal purposes
+                      within an organization is not considered a competitive
+                      offering. Licensor considers your organization to include
+                      all of your affiliates under common control.
+
+                      Personal use of the Licensed Work to manage Your own
+                      self-custodial crypto portfolio — including earning yield,
+                      swapping, lending, staking, or otherwise interacting with
+                      DeFi protocols on Your own behalf — is expressly permitted
+                      and is not a competitive offering, even if such activity
+                      generates monetary returns to You.
+
+                      For alternative licensing arrangements (including a
+                      commercial license that permits competitive offerings),
+                      please contact Licensor.
+Change Date:          2030-04-26
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact the Licensor.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/README.md
+++ b/README.md
@@ -248,4 +248,10 @@ npm run test:watch
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+**Business Source License 1.1** (BUSL-1.1) — see [LICENSE](./LICENSE).
+
+- **Personal self-custodial use is free.** Running `vaultpilot-mcp` on your own machine to manage your own portfolio — including earning yield, swapping, lending, or staking through DeFi protocols on your own behalf — is expressly permitted, even if it generates monetary returns to you.
+- **Internal organizational use is free.** Hosting or using the Licensed Work for internal purposes within an organization is not a competitive offering.
+- **Hosted services and embedded redistribution require a commercial license.** You may not offer the software (or substantial features of it) to third parties on a paid hosted, managed, or embedded basis without a separate agreement. Open an issue or contact the maintainer for licensing.
+- **Auto-converts to Apache 2.0 on 2030-04-26.** Each version's restrictions expire four years after its public release; on the Change Date the license switches to Apache 2.0.
+- **Versions ≤ 0.8.2 remain MIT-licensed.** The license change applies to v0.9.0 onward only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@kamino-finance/klend-sdk": "^7.3.22",
@@ -4383,6 +4383,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6399,6 +6414,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7274,6 +7296,21 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/jayson/node_modules/ws": {
@@ -9820,7 +9857,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",
@@ -128,7 +128,7 @@
     "url": "https://github.com/szhygulin/vaultpilot-mcp/issues"
   },
   "author": "Viacheslav Zhygulin",
-  "license": "MIT",
+  "license": "BUSL-1.1",
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@kamino-finance/klend-sdk": "^7.3.22",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Why

Switch from MIT to **Business Source License 1.1** to block third-party hosted competitors and paid embedded redistribution while keeping personal self-custodial use unrestricted. Stated intent (per chat):

> If someone uses this code for profit — it is prohibited and I can sue them.

BUSL-1.1 is the right shape for that: non-prod and personal use free, paid third-party offerings require a commercial license, auto-converts to a permissive license after a Change Date.

## Parameters

| Field | Value |
|---|---|
| Licensor | Viacheslav Zhygulin |
| Licensed Work | vaultpilot-mcp v0.9.0 or later |
| Change Date | 2030-04-26 (4 years — BUSL maximum) |
| Change License | Apache License, Version 2.0 |

The **Additional Use Grant** carves out:
- Personal self-custodial portfolio management — free, even if you earn yield / swap / lend / stake on your own behalf
- Internal organizational use — free
- Competitive offerings (paid hosted, managed, or embedded redistribution to third parties) — require a separate commercial license

Apache 2.0 as the change license rather than MIT because (a) MIT-licensed artifacts are already publicly forkable via versions ≤ 0.8.2, and (b) Apache 2.0 adds an explicit patent grant.

## What changes

- `LICENSE` — replaced with BUSL-1.1 template
- `package.json` — `"license": "BUSL-1.1"` (SPDX-recognized), `"version": "0.9.0"`
- `server.json` — version bumped to match
- `package-lock.json` — refreshed
- `README.md` — License section rewritten to spell out the four cases plainly

## Caveats (load-bearing)

1. **Versions ≤ 0.8.2 stay MIT forever.** Anything already on npm is MIT-licensed in perpetuity. Anyone can fork from the `0.8.2` tag and run it commercially under MIT, legally. The license change binds 0.9.0 onward only.
2. **The next `npm publish`** will carry the new license — make sure that's intended.
3. **Not OSI-approved.** `BUSL-1.1` is source-available, not "open source" by OSI definition. Some package scanners and corporate procurement processes treat that as a hard block.
4. **No CLA on contributors yet.** If you start accepting outside PRs, add a CLA or DCO so contributors grant relicensing rights — otherwise future license changes get stuck.
5. **Enforcement is real but expensive.** Lawsuits across borders are slow. Realistic deterrents are (in order): clear LICENSE + per-file headers, DMCA takedowns against npm/GitHub, public naming. Litigation is the last resort.

## Test plan

- [x] `npm install` — lockfile picks up version bump
- [x] `npm run build` — passes
- [x] `npm test` — 1434/1434 pass
- [ ] Manual: confirm the rendered LICENSE on GitHub looks right
- [ ] Manual: confirm npm registry shows `BUSL-1.1` after the next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)