### PR TITLE
chore(cla): add CLA + CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,58 @@
+# CLA Assistant — every external PR must sign CLA.md before merge.
+#
+# Stores signatures as `signatures/version1/cla.json` on the
+# `cla-signatures` branch (auto-created on first sign), so main stays
+# free of bot-generated commits.
+#
+# NOTE on action choice: contributor-assistant/github-action was archived
+# 2026-03-23. v2.6.1 still works — the GitHub APIs it uses (PR comments,
+# OAuth identity) are stable. If it ever breaks, the migration paths are
+# (a) the hosted https://cla-assistant.io GitHub App (signatures via web
+# UI instead of in-repo), or (b) replace this workflow with a custom
+# action that scans PR comments for the sign-off line and writes to
+# the signatures file directly.
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# pull_request_target runs in the base repo's context with write
+# permissions even for fork PRs — required so the bot can comment on
+# fork PRs and update signatures. The workflow itself does NOT execute
+# any code from the PR (no checkout of PR head, no install/build), so
+# the elevated permissions stay safe.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: |
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: 'https://github.com/szhygulin/vaultpilot-mcp/blob/main/CLA.md'
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'cla-signatures'
+          # Repo owner doesn't sign their own CLA. Dependabot bumps are
+          # mechanical (not "contributions" in the IP sense) so we skip
+          # them too — same pattern most BUSL projects use.
+          allowlist: 'szhygulin,dependabot[bot]'
+          custom-notsigned-prcomment: |
+            Thanks for the contribution! Before this PR can be merged, please sign the [Contributor License Agreement](https://github.com/szhygulin/vaultpilot-mcp/blob/main/CLA.md). The CLA grants the project the right to relicense your contribution under future license terms (the project ships under [BUSL-1.1](https://github.com/szhygulin/vaultpilot-mcp/blob/main/LICENSE) today, auto-converting to Apache 2.0 in 2030).
+
+            To sign, **post a new comment on this PR with exactly the following text**:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: '✅ All contributors have signed the CLA — thank you!'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,45 @@
+# vaultpilot-mcp Contributor License Agreement (CLA)
+
+By signing below, I (**Contributor**) agree to the following terms for any contribution I submit to the **vaultpilot-mcp** project (the **Project**), owned by **Viacheslav Zhygulin** (the **Licensor**).
+
+## 1. Definitions
+
+**"Contribution"** means any original work of authorship — including any modifications or additions to existing work — that I intentionally submit to the Project for inclusion in the Project, in any form (pull requests, patches, code in issue comments, etc.).
+
+## 2. Grant of Copyright License
+
+I grant Licensor and recipients of the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and **distribute my Contributions and any derivative works thereof under any license terms Licensor chooses, including license terms different from those under which the Project is currently distributed.**
+
+This explicit relicensing right means Licensor may distribute the Project (including my Contributions) under the Business Source License 1.1 today, under the Apache License 2.0 after the BUSL Change Date, or under any other license Licensor selects in the future, without further consent from me.
+
+## 3. Grant of Patent License
+
+I grant Licensor and recipients of the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by me that are necessarily infringed by my Contribution(s) alone or by combination of my Contribution(s) with the Project to which the Contribution was submitted.
+
+If any entity institutes patent litigation against me or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that my Contribution, or the Project to which I have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this CLA terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+I represent that:
+
+1. I am legally entitled to grant the above licenses. If my employer(s) has rights to intellectual property that I create that includes my Contributions, I have received permission to make Contributions on behalf of that employer, **or** my employer has waived such rights for my Contributions to the Project.
+2. Each Contribution is my original creation, **or** I have clearly identified the source of any third-party material (including its license) in the Contribution.
+3. I am not aware of any claims, suits, or actions that may affect my Contribution or the Project.
+
+## 5. No Warranty / No Obligation
+
+I provide my Contributions on an "AS IS" basis, without warranties or conditions of any kind, either express or implied.
+
+Licensor is under no obligation to accept or use my Contributions, and may remove or modify them at any time.
+
+## 6. Notice of Changes
+
+I agree to notify Licensor of any facts or circumstances of which I become aware that would make the representations in Section 4 inaccurate in any respect.
+
+---
+
+## How to sign
+
+When you open your first pull request to the Project, the CLA Assistant bot will comment on the PR with a link to this document and ask you to reply with a specific sign-off comment. Your GitHub username, the date, and the SHA of the PR head will be recorded in `signatures/version1/cla.json` on the `cla-signatures` branch as your acceptance — one signature per contributor, valid for all future contributions.
+
+If you cannot sign (e.g., your employer has not granted you the right to make Contributions), please open an issue rather than a pull request — we can usually find a path that works for both sides.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ npm test         # vitest run
 npm run test:watch
 ```
 
+## Contributing
+
+Pull requests are welcome. Before your first contribution, the CLA Assistant bot will ask you to sign the [Contributor License Agreement](./CLA.md) by replying to your PR with a sign-off comment — one signature covers all your future PRs. The CLA grants the project the right to relicense your contribution under future license terms (since the project ships under BUSL-1.1 today and auto-converts to Apache 2.0 in 2030, the relicensing right matters); without it, future license changes get stuck.
+
+The repo owner and Dependabot are exempt from the CLA check.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Why

Companion to #286. A CLA closes the missing piece that keeps the *next* license change from getting stuck: without a contributor license agreement, the project owner cannot unilaterally relicense contributions made by outside developers, and any future license change requires tracking down every contributor individually for consent.

## What

| File | Role |
|---|---|
| [`CLA.md`](./CLA.md) | Apache-style ICLA, trimmed. Section 2 is the load-bearing clause: contributors grant a perpetual, irrevocable right to relicense their contributions under any future license terms. Calls out BUSL-1.1 → Apache 2.0 conversion explicitly. Section 3 includes the standard patent-litigation termination clause. |
| [`.github/workflows/cla.yml`](./.github/workflows/cla.yml) | CLA Assistant Lite workflow. Comments on first-time contributor PRs, requires a specific sign-off comment, stores signatures in `signatures/version1/cla.json` on a separate `cla-signatures` branch (auto-created on first sign). Allowlists `szhygulin` (repo owner doesn't sign their own CLA) and `dependabot[bot]`. |
| `README.md` | New "Contributing" section pointing at the flow. |

## Action choice & risk

Uses [`contributor-assistant/github-action@v2.6.1`](https://github.com/contributor-assistant/github-action). The repo was **archived 2026-03-23** — no new features, but v2.6.1 still works because the GitHub APIs it depends on (PR comments, OAuth identity) are stable.

Fallback paths if it ever breaks (documented in the workflow comments):
1. **Hosted [cla-assistant.io](https://cla-assistant.io) GitHub App** — same UX, signatures stored via web service rather than in-repo. Requires you to install + configure the App via their web UI.
2. **Custom action** — replace this workflow with one that scans PR comments for the sign-off line and writes to the signatures file directly. ~50 lines of GitHub Actions YAML + a small script.

## Security

The workflow uses `pull_request_target` (so it has write access for fork PRs — required for the bot to comment + update signatures). The workflow does **NOT** check out the PR head, run `npm install`, or execute any PR code — only the action's own logic runs. This is the safe pattern for `pull_request_target`; the [GitHub Actions security advisory](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) flags the unsafe pattern as "checkout PR head + run code with elevated privileges", which we don't do.

## Test plan

This PR can't fully self-test because the workflow only fires on PRs FROM forks (the `cla.yml` only matters when external contributors arrive). Manual verification once merged:

- [ ] Open a test PR from a fork → the bot should comment with the sign-off request
- [ ] Comment "I have read the CLA Document and I hereby sign the CLA" → bot should add you to `signatures/version1/cla.json` on the `cla-signatures` branch
- [ ] Comment "recheck" on the same PR → bot should re-evaluate and pass
- [ ] Internal PRs from `szhygulin` (allowlisted) should pass without signing

## What you need to do after merge

1. **Nothing for the action to start working** — it picks up automatically on the next PR.
2. **Optional but recommended**: enable [branch protection](https://github.com/szhygulin/vaultpilot-mcp/settings/branches) on `main` requiring the `CLA Assistant` status check to pass before merge. Without that, you could accidentally merge a PR before the contributor signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)