### PR TITLE
chore(release): bump to 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Patch bump on top of #286 (BUSL-1.1) and #294 (CLA) so the next \`npm publish\` reflects both as a single release. Touches \`package.json\`, \`server.json\`, \`package-lock.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)