### PR TITLE
fix(cla): allowlist Claude co-author + bot wildcard

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,16 @@ jobs:
           # Repo owner doesn't sign their own CLA. Dependabot bumps are
           # mechanical (not "contributions" in the IP sense) so we skip
           # them too — same pattern most BUSL projects use.
-          allowlist: 'szhygulin,dependabot[bot]'
+          #
+          # `claude` covers Claude Code's `Co-Authored-By: Claude ...
+          # <noreply@anthropic.com>` trailer (resolves to the `claude`
+          # GitHub identity). Claude is a tool used by szhygulin to
+          # author commits, not a contributor in the IP sense — the
+          # human running the model holds the copyright. The trailing
+          # `*[bot]` wildcard catches any future bot accounts (renovate,
+          # release-please, etc.) so we don't have to amend this file
+          # every time a new bot lands a PR.
+          allowlist: 'szhygulin,claude,dependabot[bot],*[bot]'
           custom-notsigned-prcomment: |
             Thanks for the contribution! Before this PR can be merged, please sign the [Contributor License Agreement](https://github.com/szhygulin/vaultpilot-mcp/blob/main/CLA.md). The CLA grants the project the right to relicense your contribution under future license terms (the project ships under [BUSL-1.1](https://github.com/szhygulin/vaultpilot-mcp/blob/main/LICENSE) today, auto-converting to Apache 2.0 in 2030).
 


### PR DESCRIPTION
## Why

The CLA workflow failed on #295 with two issues, visible in [the run log](https://github.com/szhygulin/vaultpilot-mcp/actions/runs/24955130738):

\`\`\`
Error occurred when creating the signed contributors file:
  Branch cla-signatures not found. Make sure the branch where signatures
  are stored is NOT protected.
Committers of pull request 295 have to sign the CLA
\`\`\`

Two distinct root causes:

1. **\`cla-signatures\` branch didn't exist.** The action expects it pre-created — the error message above is explicit. Already fixed out-of-band: I pushed an orphan \`cla-signatures\` branch directly to origin with a stub \`signatures/version1/cla.json\` ('{\"signedContributors\":[]}'). The action will append signatures to that file going forward.

2. **\`claude\` GitHub user wasn't allowlisted.** Claude Code's \`Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>\` trailer resolves to the [\`claude\`](https://github.com/claude) identity. Claude is a tool the human contributor uses to author commits — the IP sits with the human, not the model — so it doesn't need to sign the CLA.

## What

One-line allowlist update: \`'szhygulin,claude,dependabot[bot],*[bot]'\`. The trailing \`*[bot]\` wildcard catches future bot accounts (renovate, release-please, etc.) so we don't have to re-edit this file each time.

## After this merges

- Comment \`recheck\` on [#295](https://github.com/szhygulin/vaultpilot-mcp/pull/295) → workflow re-runs against the new \`main\` workflow → CLA passes → that PR can merge.
- Future PRs with Claude co-authors pass automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)