### PR TITLE
docs(contributing): add CONTRIBUTING.md with bounty-bot filter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Real contributions from real people are very welcome. This document exists to filter the unreal kind.
+
+## Before opening a PR
+
+- **Sign the [CLA](./CLA.md).** The CLA Assistant bot prompts you on your first PR — one signature covers all future contributions.
+- **Read [CLAUDE.md](./CLAUDE.md).** It documents the worktree-per-feature rule, the PR-based workflow, the chat-output conventions, and the security posture this repo cares about.
+- **Run the tests.** `npm install && npm run build && npx vitest run`. PRs that don't keep the suite green won't be reviewed.
+- **Use a worktree, not the main checkout.** `.claude/worktrees/<short-name>` per feature. Multiple agents share this repo and race on the index otherwise.
+
+## What kinds of PRs land
+
+Bug fixes against an open issue, small focused features matching an existing tracked plan, test or doc improvements, and dependency upgrades that pass the existing checks. PRs that touch fewer than ~500 lines, do one thing, and come with tests have the highest land rate.
+
+## What kinds of comments and PRs are off-topic
+
+Tracking issues — those tagged for design discussion or roadmap follow-up rather than work-ready scope — are **not bounty surfaces**. Unsolicited "I have experience with X, want me to build this?" comments on tracking issues are off-topic and will be hidden as such. The same applies to drive-by PRs from automated bounty-fishing pipelines (templated credentials list + verbatim restate of the issue's own decisions table + closing CTA).
+
+This is not a comment on legitimate contributors who happen to be new — those are welcome. The filter is on the bot pattern: opaque GitHub profile, no prior project context, generic boilerplate that adds no information beyond what the issue already says, and a "let me know if you'd like a PR" closer.
+
+If you genuinely want to contribute on a tracking issue, demonstrate it by:
+
+1. Opening a small, focused PR against an actual bug or already-scoped task first, so we have signal that you understand the codebase.
+2. Asking a specific clarifying question that shows you read the issue and the linked code — pick one of the open decisions in the issue and propose a defensible answer with reasoning.
+
+## Reporting security issues
+
+Do **not** open a public issue for vulnerabilities. See [SECURITY.md](./SECURITY.md) for the disclosure process.


### PR DESCRIPTION
## Summary
Adds a short top-level `CONTRIBUTING.md` that GitHub surfaces in the issue / PR creation flow. Acts as a filter at the funnel entrance against automated bounty-fishing comments on tracking issues.

## What's in it
- **Before opening a PR:** sign the CLA, read `CLAUDE.md`, run the tests, use a worktree.
- **What lands:** bug fixes against open issues, small focused tracked-plan work, test/doc improvements, dep upgrades. Single-concern, ~<500 LoC, with tests.
- **What's off-topic:** unsolicited "I have experience with X, want me to build this?" comments on tracking issues (which are design-discussion surfaces, not bounty surfaces), and drive-by PRs from automated bounty-fishing pipelines.
- **Path for legitimate first-time contributors:** open a small focused PR first to demonstrate codebase familiarity, or ask a specific clarifying question proving the issue + linked code was read.
- **Security issues:** points at `SECURITY.md`.

## Why now
Triggered by an automated bounty-fishing comment on [issue #292](https://github.com/szhygulin/vaultpilot-mcp/issues/292#issuecomment-4321961100) from `jshaofa-ui` — a ~6mo-old GitHub account with `null` profile fields, **0 followers**, **22 prior comments all on bounty-labeled issues across other repos**, and a public `bounty-monitor` repo describing itself as a *"Local dashboard for ASDLC pipeline — live agent tracking, bounty leaderboard, and AI judge verdicts"*. The comment text was the textbook bounty-bot shape: vague credentials list ("DeFi protocol integration", "Python data pipelines" — but this project is Node/TS), verbatim restate of the issue's own decisions table, and a "let me know if you'd like a PR" closer.

The filter is calibrated against the **bot pattern**, not against new contributors. Opaque profile + zero project context + generic boilerplate that adds no information + bounty-CTA closer ≠ legitimate first contribution.

## Out of scope
- An issue template that auto-rejects bounty-shaped comments (tempting; deferred — false-positive risk on legitimate first-timers).
- A label-based hiding workflow.
- Editing `CLA.md` to add tone guidance — keeping the CLA scoped to IP terms (it's a legal doc).

## Test plan
- [x] Markdown renders cleanly in GitHub preview.
- [x] All linked files exist (`CLA.md`, `CLAUDE.md`, `SECURITY.md`).
- [ ] Verify GitHub surfaces it in the New Issue / New PR flow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)