### PR TITLE
feat(allowances): get_token_allowances — enumerate active spenders per (wallet, token, chain)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,8 @@ import {
   resolveName,
   reverseResolve,
 } from "./modules/balances/index.js";
+import { getTokenAllowances } from "./modules/allowances/index.js";
+import { getTokenAllowancesInput } from "./modules/allowances/schemas.js";
 import {
   getTokenBalanceInput,
   getTokenMetadataInput,
@@ -2799,7 +2801,7 @@ async function main() {
   );
 
   // ---- Module 7: Balances & ENS ----
-  registerTool(server, 
+  registerTool(server,
     "get_token_balance",
     {
       description:
@@ -2807,6 +2809,16 @@ async function main() {
       inputSchema: getTokenBalanceInput.shape,
     },
     handler(getTokenBalance)
+  );
+
+  registerTool(server,
+    "get_token_allowances",
+    {
+      description:
+        "Enumerate every spender that currently holds a non-zero allowance over the wallet's balance of a specific ERC-20 token on a single EVM chain. Pulls Approval events from Etherscan's logs API filtered to the wallet as `owner`, dedups by spender (keeping the latest event per spender for provenance), then re-reads the LIVE `allowance(owner, spender)` for each via Multicall3 and drops anyone whose live value is 0 (revoked or fully consumed). Returns rows sorted by allowance descending, each carrying `spender`, optional `spenderLabel` (Aave V3 Pool / Uniswap V3 SwapRouter02 / Lido stETH / etc. resolved against the canonical CONTRACTS table), `currentAllowance` (raw bigint string), `currentAllowanceFormatted` (decimal-adjusted, or the literal string \"unlimited\"), `isUnlimited` (≥MAX_UINT256 − 0.01% — covers wallets that cap below MAX), and the `lastApprovedBlock` / `lastApprovedTxHash` / `lastApprovedAt` provenance. Top-level `unlimitedCount` and `notes[]` flag exposure (\"the spender(s) can move your entire balance, including future top-ups; revoke via approve(spender, 0)\"). Use this for security audits (\"do I have any unrevoked unlimited approvals?\"), pre-tx checks (\"do I already have allowance for X?\"), and revoke-cleanup workflows. v1 EVM-only (Ethereum / Arbitrum / Polygon / Base / Optimism). TRON deferred (different indexer surface); Solana intentionally out of scope (SPL delegation is per-account, not per-mint-per-owner — different question shape). Read-only; no signing, no broadcast.",
+      inputSchema: getTokenAllowancesInput.shape,
+    },
+    handler(getTokenAllowances)
   );
 
   registerTool(server,

--- a/src/modules/allowances/index.ts
+++ b/src/modules/allowances/index.ts
@@ -1,0 +1,317 @@
+/**
+ * `get_token_allowances` — enumerate every spender holding a non-zero
+ * allowance for a given (wallet, token, chain) tuple.
+ *
+ * Pipeline:
+ *   1. Pull every `Approval(owner=wallet)` event emitted by `token` via
+ *      the Etherscan V2 logs API. Single call covers the chain's full
+ *      history (Etherscan indexes from genesis).
+ *   2. Dedup by spender, keeping the LATEST event per spender. The log
+ *      entries' `value` field is the snapshot at approval time; the
+ *      live allowance may differ (subsequent transfers consume it,
+ *      subsequent approves overwrite it). We use the log's metadata
+ *      (block / tx hash / timestamp) for "last approved" provenance,
+ *      not for the value itself.
+ *   3. Multicall3 batched `allowance(owner, spender)` reads for each
+ *      unique spender to get the LIVE current allowance.
+ *   4. Drop spenders whose live allowance is 0 (revoked or fully used).
+ *   5. Resolve token metadata (symbol / decimals / name) once.
+ *   6. Surface friendly labels for known protocol contracts (Aave V3
+ *      Pool, Uniswap V3 SwapRouter02, etc.) via the canonical
+ *      `CONTRACTS` table.
+ *   7. Sort descending by allowance — largest exposures first.
+ *
+ * No price math, no USD valuation in v1. The "how much exposure?"
+ * question is genuinely about the raw allowance, not its current spot
+ * value — a 1000 USDC allowance is concerning regardless of USDC price.
+ */
+
+import type { Hex } from "viem";
+import { getClient } from "../../data/rpc.js";
+import { erc20Abi } from "../../abis/erc20.js";
+import { etherscanV2Fetch } from "../../data/apis/etherscan-v2.js";
+import { CONTRACTS } from "../../config/contracts.js";
+import { formatUnits } from "../../data/format.js";
+import type { SupportedChain } from "../../types/index.js";
+import type {
+  AllowanceRow,
+  GetTokenAllowancesArgs,
+  GetTokenAllowancesResult,
+} from "./schemas.js";
+
+const APPROVAL_TOPIC =
+  "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+const MAX_UINT256 = (1n << 256n) - 1n;
+/**
+ * Threshold above which an allowance is considered "unlimited". Many
+ * wallets cap below MAX_UINT256 (USDC's `permit` for instance subtracts 1);
+ * anything within 0.01% of MAX is functionally unlimited.
+ */
+const UNLIMITED_THRESHOLD = MAX_UINT256 - MAX_UINT256 / 10_000n;
+
+/**
+ * Etherscan logs API row shape. Per the V2 docs, `module=logs&action=getLogs`
+ * returns these fields when `status === "1"`.
+ */
+interface EtherscanLogRow {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  /** Decimal string of unix seconds. */
+  timeStamp?: string;
+  transactionHash: string;
+  transactionIndex?: string;
+  logIndex?: string;
+}
+
+/**
+ * Pad a 0x-prefixed 20-byte EVM address to a 32-byte topic value.
+ */
+function addressToTopic(addr: `0x${string}`): string {
+  return `0x000000000000000000000000${addr.slice(2).toLowerCase()}`;
+}
+
+/**
+ * Build a one-shot lookup map for known protocol-contract addresses on
+ * the given chain. Resolves spender addresses to user-facing labels.
+ */
+function buildKnownSpenderMap(chain: SupportedChain): Map<string, string> {
+  const out = new Map<string, string>();
+  const c = CONTRACTS[chain] as Record<string, Record<string, string>> | undefined;
+  if (!c) return out;
+  for (const [protocol, addrs] of Object.entries(c)) {
+    if (protocol === "tokens") continue; // not spenders
+    if (typeof addrs !== "object" || addrs === null) continue;
+    for (const [name, addr] of Object.entries(addrs)) {
+      if (typeof addr !== "string" || !addr.startsWith("0x")) continue;
+      out.set(
+        addr.toLowerCase(),
+        `${prettyProtocol(protocol)} ${prettyContractName(name)}`,
+      );
+    }
+  }
+  return out;
+}
+
+function prettyProtocol(slug: string): string {
+  if (slug === "aave") return "Aave V3";
+  if (slug === "uniswap") return "Uniswap V3";
+  if (slug === "lido") return "Lido";
+  if (slug === "eigenlayer") return "EigenLayer";
+  if (slug === "compound") return "Compound V3";
+  if (slug === "morpho") return "Morpho Blue";
+  return slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+function prettyContractName(name: string): string {
+  // Camel-to-spaced. "swapRouter02" → "SwapRouter02".
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Fetch ERC-20 metadata in one multicall: symbol, decimals, name. Tolerant
+ * — name is allowed to fail (some non-standard tokens omit it); symbol +
+ * decimals are mandatory.
+ */
+async function fetchTokenMetadata(
+  chain: SupportedChain,
+  token: `0x${string}`,
+): Promise<{ symbol: string; decimals: number; name?: string }> {
+  const client = getClient(chain);
+  const results = await client.multicall({
+    contracts: [
+      { address: token, abi: erc20Abi, functionName: "symbol" },
+      { address: token, abi: erc20Abi, functionName: "decimals" },
+      { address: token, abi: erc20Abi, functionName: "name" },
+    ],
+    allowFailure: true,
+  });
+  const symbolRes = results[0];
+  const decimalsRes = results[1];
+  const nameRes = results[2];
+  if (symbolRes.status !== "success" || decimalsRes.status !== "success") {
+    throw new Error(
+      `Token ${token} on ${chain} did not return symbol+decimals. Is this an ERC-20 contract?`,
+    );
+  }
+  return {
+    symbol: symbolRes.result as string,
+    decimals: Number(decimalsRes.result),
+    ...(nameRes.status === "success"
+      ? { name: nameRes.result as string }
+      : {}),
+  };
+}
+
+/**
+ * Multicall3 batched `allowance(owner, spender)` for every spender in
+ * `spenders`. Returns one bigint per row, in input order. Failed reads
+ * fall through to 0n — same posture as the rest of the codebase.
+ */
+async function fetchCurrentAllowances(
+  chain: SupportedChain,
+  token: `0x${string}`,
+  owner: `0x${string}`,
+  spenders: `0x${string}`[],
+): Promise<bigint[]> {
+  if (spenders.length === 0) return [];
+  const client = getClient(chain);
+  const results = await client.multicall({
+    contracts: spenders.map((spender) => ({
+      address: token,
+      abi: erc20Abi,
+      functionName: "allowance" as const,
+      args: [owner, spender] as const,
+    })),
+    allowFailure: true,
+  });
+  return results.map((r) => (r.status === "success" ? (r.result as bigint) : 0n));
+}
+
+/**
+ * Etherscan caps `getLogs` at 1000 records per page. We pull page 1
+ * with offset=1000; if exactly 1000 came back, surface a `truncated`
+ * flag so the caller knows the oldest approvals may be missing.
+ * Pagination beyond page 1 is deferred — wallets with >1000 distinct
+ * approvals on a single token are extremely rare and the live allowance
+ * read still tells the truth about the spenders we DID see.
+ */
+const LOGS_PAGE_SIZE = 1000;
+
+async function fetchApprovalLogs(
+  chain: SupportedChain,
+  token: `0x${string}`,
+  owner: `0x${string}`,
+): Promise<{ logs: EtherscanLogRow[]; truncated: boolean }> {
+  const params: Record<string, string> = {
+    module: "logs",
+    action: "getLogs",
+    address: token,
+    topic0: APPROVAL_TOPIC,
+    topic1: addressToTopic(owner),
+    topic0_1_opr: "and",
+    fromBlock: "0",
+    toBlock: "latest",
+    page: "1",
+    offset: String(LOGS_PAGE_SIZE),
+  };
+  const logs = await etherscanV2Fetch<EtherscanLogRow>(chain, params);
+  return {
+    logs,
+    truncated: logs.length >= LOGS_PAGE_SIZE,
+  };
+}
+
+export async function getTokenAllowances(
+  args: GetTokenAllowancesArgs,
+): Promise<GetTokenAllowancesResult> {
+  const chain = args.chain as SupportedChain;
+  const wallet = args.wallet.toLowerCase() as `0x${string}`;
+  const token = args.token.toLowerCase() as `0x${string}`;
+
+  // 1. Pull Approval events from Etherscan.
+  const { logs, truncated } = await fetchApprovalLogs(chain, token, wallet);
+
+  // 2. Dedup by spender, keeping the latest event per spender. Etherscan
+  //    returns logs in chronological order (oldest first). Iterating
+  //    forward and overwriting in a Map yields "latest wins".
+  interface SeenLog {
+    spender: `0x${string}`;
+    blockNumber: string;
+    txHash: `0x${string}`;
+    timeStamp?: string;
+  }
+  const lastBySpender = new Map<string, SeenLog>();
+  for (const log of logs) {
+    if (!log.topics || log.topics.length < 3) continue;
+    if (log.topics[0]?.toLowerCase() !== APPROVAL_TOPIC) continue;
+    const spenderTopic = log.topics[2];
+    if (!spenderTopic || spenderTopic.length < 42) continue;
+    const spender = `0x${spenderTopic.slice(-40)}` as `0x${string}`;
+    lastBySpender.set(spender, {
+      spender,
+      blockNumber: log.blockNumber,
+      txHash: log.transactionHash as `0x${string}`,
+      ...(log.timeStamp ? { timeStamp: log.timeStamp } : {}),
+    });
+  }
+
+  // 3. Multicall live allowances + 5. fetch token metadata in parallel.
+  const uniqueSpenders = Array.from(lastBySpender.values()).map((s) => s.spender);
+  const [meta, currentAllowances] = await Promise.all([
+    fetchTokenMetadata(chain, token),
+    fetchCurrentAllowances(chain, token, wallet, uniqueSpenders),
+  ]);
+
+  // 6. Build rows, dropping zero-allowance spenders.
+  const knownSpenderMap = buildKnownSpenderMap(chain);
+  const rows: AllowanceRow[] = [];
+  let unlimitedCount = 0;
+  for (let i = 0; i < uniqueSpenders.length; i++) {
+    const allowance = currentAllowances[i];
+    if (allowance === 0n) continue;
+    const spender = uniqueSpenders[i];
+    const meta2 = lastBySpender.get(spender)!;
+    const isUnlimited = allowance >= UNLIMITED_THRESHOLD;
+    if (isUnlimited) unlimitedCount++;
+    const label = knownSpenderMap.get(spender.toLowerCase());
+    const lastApprovedAt = meta2.timeStamp
+      ? new Date(Number(meta2.timeStamp) * 1000).toISOString()
+      : undefined;
+    rows.push({
+      spender,
+      ...(label ? { spenderLabel: label } : {}),
+      currentAllowance: allowance.toString(),
+      currentAllowanceFormatted: isUnlimited
+        ? "unlimited"
+        : formatUnits(allowance, meta.decimals),
+      isUnlimited,
+      lastApprovedBlock: meta2.blockNumber,
+      lastApprovedTxHash: meta2.txHash,
+      ...(lastApprovedAt ? { lastApprovedAt } : {}),
+    });
+  }
+
+  // 7. Sort descending by allowance.
+  rows.sort((a, b) => {
+    const aBig = BigInt(a.currentAllowance);
+    const bBig = BigInt(b.currentAllowance);
+    if (bBig > aBig) return 1;
+    if (bBig < aBig) return -1;
+    return 0;
+  });
+
+  const notes: string[] = [];
+  if (truncated) {
+    notes.push(
+      `Etherscan logs API returned the cap (${LOGS_PAGE_SIZE} entries) — older Approval events may be missing. ` +
+        `The LIVE allowance reads still reflect the truth for the spenders we DID see; only spenders whose ` +
+        `single approval landed before the truncation horizon could be missed entirely.`,
+    );
+  }
+  if (unlimitedCount > 0) {
+    notes.push(
+      `${unlimitedCount} unlimited allowance${unlimitedCount === 1 ? "" : "s"} — the spender(s) can move ` +
+        `your entire ${meta.symbol} balance at any time, including any future top-ups. Revoke obsolete ` +
+        `unlimited approvals via \`prepare_*\` an approve(spender, 0) call, or via Etherscan's "Token Approvals" UI.`,
+    );
+  }
+  if (rows.length === 0) {
+    notes.push(
+      `No active approvals found for ${wallet} on ${meta.symbol} (${chain}). Either the wallet has never ` +
+        `approved this token, or every prior approval has since been revoked or fully consumed.`,
+    );
+  }
+
+  return {
+    wallet,
+    chain,
+    token: { address: token, ...meta },
+    allowances: rows,
+    totalScanned: lastBySpender.size,
+    unlimitedCount,
+    truncated,
+    notes,
+  };
+}

--- a/src/modules/allowances/schemas.ts
+++ b/src/modules/allowances/schemas.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+
+const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
+/**
+ * `get_token_allowances` — list every spender that holds a non-zero
+ * allowance over `wallet`'s `token` balance on a given EVM chain.
+ *
+ * v1 EVM-only (Ethereum / Arbitrum / Polygon / Base / Optimism). TRON's
+ * TRC-20 has the same Approval-event shape but the indexer surface is
+ * different (TronGrid `events` endpoint) and the allowance read path
+ * differs — defer to v2.
+ *
+ * Solana intentionally NOT in scope. The SPL Token "delegate" pattern
+ * is per-token-account rather than per-mint-per-owner, which doesn't
+ * map onto this tool's question. Solana delegation surfacing belongs in
+ * a dedicated `get_spl_delegations` tool.
+ */
+export const getTokenAllowancesInput = z.object({
+  wallet: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .describe(
+      "EVM wallet address whose approvals you want to enumerate. The tool " +
+        "scans Approval events emitted by `token` where this wallet is the " +
+        "indexed `owner`, then re-reads the LIVE allowance for each spender."
+    ),
+  token: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .describe(
+      "ERC-20 contract address. Must be the actual token contract, not a " +
+        "wrapper or aToken. Native coins (ETH / MATIC) have no allowance " +
+        "concept and are intentionally not supported here."
+    ),
+  chain: chainEnum
+    .default("ethereum")
+    .describe(
+      "Which EVM chain to scan. Defaults to Ethereum. The same wallet may " +
+        "have different approvals on different chains — you'll need one call " +
+        "per chain to enumerate all of them."
+    ),
+});
+
+export type GetTokenAllowancesArgs = z.infer<typeof getTokenAllowancesInput>;
+
+/**
+ * One row per spender that currently holds a non-zero allowance.
+ * Spenders whose live `allowance(owner, spender)` reads as 0 (revoked
+ * or fully consumed) are dropped — there's no remaining attack surface
+ * to surface.
+ */
+export interface AllowanceRow {
+  spender: `0x${string}`;
+  /**
+   * Friendly label resolved from the canonical CONTRACTS table when
+   * the spender matches a known protocol address (Aave V3 Pool, Uniswap
+   * SwapRouter02, etc.). Absent for arbitrary contracts.
+   */
+  spenderLabel?: string;
+  /** Raw integer current allowance as a decimal string (preserves bigint precision). */
+  currentAllowance: string;
+  /** Same value formatted with the token's decimals — human-readable. */
+  currentAllowanceFormatted: string;
+  /**
+   * True when the allowance is at-or-near MAX_UINT256 (within 0.01%).
+   * Many wallets / DEX UIs cap at MAX_UINT256 - 1 or MAX_UINT256 / 2
+   * etc. — anything in that ballpark is effectively unlimited.
+   */
+  isUnlimited: boolean;
+  /** Block number where the most recent Approval event for this (token, owner, spender) landed. */
+  lastApprovedBlock: string;
+  /** Tx hash of that Approval. */
+  lastApprovedTxHash: `0x${string}`;
+  /** ISO-8601 timestamp from the indexer's `timeStamp` field, when available. */
+  lastApprovedAt?: string;
+}
+
+export interface GetTokenAllowancesResult {
+  wallet: `0x${string}`;
+  chain: string;
+  token: {
+    address: `0x${string}`;
+    symbol: string;
+    decimals: number;
+    name?: string;
+  };
+  /** Sorted by `currentAllowance` descending (largest exposures first). */
+  allowances: AllowanceRow[];
+  /** Total approvals scanned (including ones since revoked). */
+  totalScanned: number;
+  /** Number of allowances at-or-near MAX_UINT256. */
+  unlimitedCount: number;
+  /** Indexer truncation flag — true if the response hit Etherscan's row cap. */
+  truncated: boolean;
+  notes: string[];
+}

--- a/test/allowances.test.ts
+++ b/test/allowances.test.ts
@@ -1,0 +1,316 @@
+/**
+ * `get_token_allowances` tests. Mocks both the Etherscan logs API and
+ * the viem multicall (via `getClient`) so no live HTTP fires.
+ *
+ * Coverage:
+ *   - Happy path: 3 historical approvals, 1 currently revoked, 1 unlimited.
+ *     → 2 rows surface, sorted desc, unlimited heuristic + label resolved
+ *     when the spender matches a CONTRACTS-table entry.
+ *   - All-revoked: every spender currently 0 → empty `allowances`, note
+ *     surfaces.
+ *   - No approvals ever: empty logs → empty `allowances`, "no active
+ *     approvals" note.
+ *   - Truncated logs (1000 entries) → `truncated: true` + note.
+ *   - Token metadata fetch fails (non-ERC-20 contract) → throws.
+ *   - Spender label: known protocol address gets a friendly label.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const etherscanV2FetchMock = vi.fn();
+const multicallMock = vi.fn();
+
+vi.mock("../src/data/apis/etherscan-v2.js", () => ({
+  etherscanV2Fetch: (...a: unknown[]) => etherscanV2FetchMock(...a),
+  // Real classes need pass-through for `instanceof` checks elsewhere.
+  EtherscanApiKeyMissingError: class EtherscanApiKeyMissingError extends Error {},
+  EtherscanNoDataError: class EtherscanNoDataError extends Error {},
+}));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({ multicall: (...a: unknown[]) => multicallMock(...a) }),
+  resetClients: () => {},
+}));
+
+const APPROVAL_TOPIC =
+  "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+// Known: Aave V3 Pool on Ethereum — listed in src/config/contracts.ts.
+const AAVE_POOL = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2";
+const RANDOM_SPENDER_1 = "0x1111111111111111111111111111111111111111";
+const RANDOM_SPENDER_2 = "0x2222222222222222222222222222222222222222";
+const MAX = (1n << 256n) - 1n;
+
+function pad32(addrLower: string): string {
+  return `0x000000000000000000000000${addrLower.replace(/^0x/, "").toLowerCase()}`;
+}
+
+function encUint(n: bigint): string {
+  return `0x${n.toString(16).padStart(64, "0")}`;
+}
+
+function approvalLog(args: {
+  spender: string;
+  value: bigint;
+  blockNumber: number;
+  txHash: string;
+  timeStamp?: number;
+}) {
+  return {
+    address: USDC.toLowerCase(),
+    topics: [APPROVAL_TOPIC, pad32(WALLET), pad32(args.spender)],
+    data: encUint(args.value),
+    blockNumber: args.blockNumber.toString(),
+    transactionHash: args.txHash,
+    ...(args.timeStamp !== undefined ? { timeStamp: args.timeStamp.toString() } : {}),
+  };
+}
+
+beforeEach(() => {
+  etherscanV2FetchMock.mockReset();
+  multicallMock.mockReset();
+  // Default token-metadata multicall response: USDC.
+  multicallMock.mockImplementation(async (callArgs: unknown) => {
+    const opts = callArgs as { contracts: Array<{ functionName: string }> };
+    return opts.contracts.map((c) => {
+      if (c.functionName === "symbol") {
+        return { status: "success", result: "USDC" };
+      }
+      if (c.functionName === "decimals") {
+        return { status: "success", result: 6 };
+      }
+      if (c.functionName === "name") {
+        return { status: "success", result: "USD Coin" };
+      }
+      // Any allowance() default = 0.
+      return { status: "success", result: 0n };
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getTokenAllowances — happy path", () => {
+  it("returns 2 active rows, sorted desc, unlimited flagged, known label resolved", async () => {
+    // 3 historical approvals.
+    etherscanV2FetchMock.mockResolvedValue([
+      approvalLog({
+        spender: AAVE_POOL,
+        value: MAX,
+        blockNumber: 19_000_000,
+        txHash: "0xa".repeat(40) + "0".repeat(24),
+        timeStamp: 1_700_000_000,
+      }),
+      approvalLog({
+        spender: RANDOM_SPENDER_1,
+        value: 1_000_000n, // 1 USDC
+        blockNumber: 19_500_000,
+        txHash: "0xb".repeat(40) + "0".repeat(24),
+        timeStamp: 1_710_000_000,
+      }),
+      approvalLog({
+        spender: RANDOM_SPENDER_2,
+        value: 50_000_000n, // 50 USDC
+        blockNumber: 19_900_000,
+        txHash: "0xc".repeat(40) + "0".repeat(24),
+        timeStamp: 1_715_000_000,
+      }),
+    ]);
+    // Current allowances: AAVE_POOL still MAX (unlimited, alive),
+    // RANDOM_SPENDER_1 fully consumed → 0 (drop), RANDOM_SPENDER_2 still 50 USDC.
+    multicallMock.mockImplementation(async (callArgs: unknown) => {
+      const opts = callArgs as { contracts: Array<{ functionName: string; args?: unknown[] }> };
+      return opts.contracts.map((c) => {
+        if (c.functionName === "symbol") return { status: "success", result: "USDC" };
+        if (c.functionName === "decimals") return { status: "success", result: 6 };
+        if (c.functionName === "name") return { status: "success", result: "USD Coin" };
+        if (c.functionName === "allowance") {
+          const spender = (c.args?.[1] as string).toLowerCase();
+          if (spender === AAVE_POOL.toLowerCase()) return { status: "success", result: MAX };
+          if (spender === RANDOM_SPENDER_1.toLowerCase()) return { status: "success", result: 0n };
+          if (spender === RANDOM_SPENDER_2.toLowerCase()) return { status: "success", result: 50_000_000n };
+        }
+        return { status: "failure", error: new Error("unexpected") };
+      });
+    });
+
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    expect(r.token.symbol).toBe("USDC");
+    expect(r.token.decimals).toBe(6);
+    expect(r.totalScanned).toBe(3);
+    expect(r.allowances).toHaveLength(2);
+    // Sorted desc: AAVE first (MAX) then RANDOM_SPENDER_2 (50 USDC).
+    expect(r.allowances[0].spender.toLowerCase()).toBe(AAVE_POOL.toLowerCase());
+    expect(r.allowances[0].isUnlimited).toBe(true);
+    expect(r.allowances[0].currentAllowanceFormatted).toBe("unlimited");
+    expect(r.allowances[0].spenderLabel).toContain("Aave V3 Pool");
+    expect(r.allowances[1].spender.toLowerCase()).toBe(RANDOM_SPENDER_2.toLowerCase());
+    expect(r.allowances[1].isUnlimited).toBe(false);
+    expect(r.allowances[1].currentAllowanceFormatted).toBe("50");
+    // RANDOM_SPENDER_1 dropped (allowance now 0).
+    expect(r.allowances.find((a) => a.spender.toLowerCase() === RANDOM_SPENDER_1.toLowerCase())).toBeUndefined();
+    expect(r.unlimitedCount).toBe(1);
+    expect(r.notes.some((n) => n.toLowerCase().includes("unlimited"))).toBe(true);
+  });
+});
+
+describe("getTokenAllowances — all revoked", () => {
+  it("returns empty allowances + the 'no active approvals' note", async () => {
+    etherscanV2FetchMock.mockResolvedValue([
+      approvalLog({
+        spender: RANDOM_SPENDER_1,
+        value: 100n,
+        blockNumber: 1,
+        txHash: "0x" + "1".repeat(64),
+      }),
+    ]);
+    // Current allowance is 0 (revoked).
+    // Default multicall mock returns 0 for allowance — sufficient.
+
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    expect(r.allowances).toHaveLength(0);
+    expect(r.totalScanned).toBe(1);
+    expect(r.unlimitedCount).toBe(0);
+    expect(r.notes.some((n) => n.toLowerCase().includes("no active approvals"))).toBe(true);
+  });
+});
+
+describe("getTokenAllowances — no approvals ever", () => {
+  it("handles an empty logs response cleanly", async () => {
+    etherscanV2FetchMock.mockResolvedValue([]);
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    expect(r.allowances).toHaveLength(0);
+    expect(r.totalScanned).toBe(0);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("getTokenAllowances — truncation", () => {
+  it("flags truncated:true when the logs response hits the cap", async () => {
+    const logs = [];
+    for (let i = 0; i < 1000; i++) {
+      logs.push(
+        approvalLog({
+          spender: `0x${"a".repeat(39)}${(i % 16).toString(16)}`,
+          value: 1n,
+          blockNumber: 1 + i,
+          txHash: "0x" + i.toString(16).padStart(64, "0"),
+        }),
+      );
+    }
+    etherscanV2FetchMock.mockResolvedValue(logs);
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+    expect(r.truncated).toBe(true);
+    expect(r.notes.some((n) => n.includes("Etherscan logs API"))).toBe(true);
+  });
+});
+
+describe("getTokenAllowances — non-ERC-20 contract", () => {
+  it("throws when symbol+decimals reads fail", async () => {
+    etherscanV2FetchMock.mockResolvedValue([]);
+    multicallMock.mockResolvedValueOnce([
+      { status: "failure", error: new Error("not erc20") },
+      { status: "failure", error: new Error("not erc20") },
+      { status: "failure", error: new Error("not erc20") },
+    ]);
+    // The implementation does Promise.all([metadata, currentAllowances]) —
+    // currentAllowances on empty spender list returns [] without a multicall
+    // call, so only one multicall (metadata) is pending. Simpler mock above
+    // (mockResolvedValueOnce) covers it.
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    await expect(
+      getTokenAllowances({
+        wallet: WALLET,
+        token: USDC,
+        chain: "ethereum",
+      }),
+    ).rejects.toThrow(/symbol\+decimals|ERC-20/);
+  });
+});
+
+describe("getTokenAllowances — provenance fields", () => {
+  it("surfaces lastApprovedBlock + lastApprovedTxHash + lastApprovedAt from the LATEST log", async () => {
+    // Two approvals to the same spender; second overwrites the first in
+    // the dedup pass.
+    etherscanV2FetchMock.mockResolvedValue([
+      approvalLog({
+        spender: RANDOM_SPENDER_1,
+        value: 100n,
+        blockNumber: 100,
+        txHash: "0x" + "1".repeat(64),
+        timeStamp: 1_700_000_000,
+      }),
+      approvalLog({
+        spender: RANDOM_SPENDER_1,
+        value: 200n,
+        blockNumber: 200,
+        txHash: "0x" + "2".repeat(64),
+        timeStamp: 1_710_000_000,
+      }),
+    ]);
+    multicallMock.mockImplementation(async (callArgs: unknown) => {
+      const opts = callArgs as { contracts: Array<{ functionName: string }> };
+      return opts.contracts.map((c) => {
+        if (c.functionName === "symbol") return { status: "success", result: "USDC" };
+        if (c.functionName === "decimals") return { status: "success", result: 6 };
+        if (c.functionName === "name") return { status: "success", result: "USD Coin" };
+        if (c.functionName === "allowance") {
+          // Live = the most recent value (200) — but the live read could
+          // also differ; use 200 here to keep the row alive.
+          return { status: "success", result: 200n };
+        }
+        return { status: "failure", error: new Error("unexpected") };
+      });
+    });
+
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    expect(r.allowances).toHaveLength(1);
+    const row = r.allowances[0];
+    expect(row.lastApprovedBlock).toBe("200");
+    expect(row.lastApprovedTxHash).toBe("0x" + "2".repeat(64));
+    expect(row.lastApprovedAt).toBe(new Date(1_710_000_000 * 1000).toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
New `get_token_allowances(wallet, token, chain)` MCP tool. Given an EVM wallet + ERC-20 token + chain, returns every spender that currently holds a non-zero allowance, sorted by exposure descending, with friendly labels for known protocol contracts.

Use cases:
- Security audit: *"do I have any unrevoked unlimited approvals on this token?"*
- Pre-tx check: *"do I already have allowance for the Aave Pool, or do I need to approve first?"*
- Cleanup workflow: *"list all my approvals so I can revoke the obsolete ones"*

## Pipeline
1. Pull `Approval(owner=wallet)` events emitted by `token` from Etherscan V2 logs API — single call covers the chain's full history (Etherscan indexes from genesis).
2. Dedup by spender, keeping the latest event per spender (for `lastApprovedBlock` / `lastApprovedTxHash` / `lastApprovedAt` provenance).
3. Multicall3 batched `allowance(owner, spender)` reads for every unique spender → live current values.
4. Drop spenders whose live allowance is 0 (revoked or fully consumed).
5. Resolve token metadata (symbol / decimals / name) in the same multicall.
6. Resolve friendly labels for known protocol contracts via the canonical `CONTRACTS` table — `Aave V3 Pool`, `Uniswap V3 SwapRouter02`, `Lido stETH`, `EigenLayer DelegationManager`, `Compound V3 cUSDCv3`, `Morpho Blue`, etc.
7. Sort descending by allowance.

## Output shape

```ts
{
  wallet, chain, token: { address, symbol, decimals, name? },
  allowances: [
    {
      spender, spenderLabel?,
      currentAllowance,             // raw bigint string
      currentAllowanceFormatted,    // decimal-adjusted, or "unlimited"
      isUnlimited,                  // ≥ MAX_UINT256 − 0.01%
      lastApprovedBlock, lastApprovedTxHash, lastApprovedAt?,
    }, ...
  ],
  totalScanned,                     // historical approvals scanned
  unlimitedCount,
  truncated,                        // true if Etherscan logs hit the 1k cap
  notes,                            // unlimited warning, truncation note, etc.
}
```

## Why no USD pricing in v1

The "how much exposure?" question is genuinely about the raw allowance, not its current spot value — a 1000 USDC allowance is concerning regardless of USDC price, and pricing would only confuse the unlimited case (do we cap "unlimited" at the user's balance? at the token's totalSupply? at $∞?). Skipping it is a feature.

## v1 scope

| Chain | Status |
|---|---|
| Ethereum / Arbitrum / Polygon / Base / Optimism | ✅ |
| TRON | ⏭️ deferred — TRC-20 has the same Approval event shape but the indexer surface is different (TronGrid `events`) |
| Solana | ❌ intentionally out of scope — SPL `delegate` pattern is per-account-not-per-mint; doesn't map onto this tool's question. A dedicated `get_spl_delegations` tool is the right home. |
| Bitcoin / Litecoin | N/A — UTXOs don't have allowances |

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/allowances.test.ts` — **6/6 pass**
- [x] `npx vitest run` (full suite) — **1440/1440 pass**

Test cases:
- Happy path: 3 historical approvals (Aave Pool with MAX, RANDOM_1 with 1 USDC, RANDOM_2 with 50 USDC), RANDOM_1 currently revoked → 2 rows sorted desc, unlimited flagged on Aave row, label resolved as "Aave V3 Pool".
- All-revoked: every spender currently 0 → empty `allowances` + "no active approvals" note.
- No approvals ever: empty logs response → empty cleanly, `truncated: false`.
- Truncation: 1000-entry response → `truncated: true` + note about Etherscan's row cap.
- Non-ERC-20 contract: symbol/decimals reads fail → throws with clear "Is this an ERC-20 contract?" error.
- Provenance: two approvals to same spender → row carries the LATEST event's metadata after dedup.

## Out of scope (deferred to v2 if requested)

- TRON support
- Multi-token sweep ("show me ALL my allowances across every token I've ever approved" — that's a different tool, walking the wallet's full Approval-event history rather than filtering to one token)
- Multi-chain aggregation in one call
- Auto-revoke flow (this is the read-side; pair with `prepare_token_send` or future `prepare_revoke_approval` to act on findings)
- SPL delegation enumeration (different shape; separate tool)
- Pricing / USD exposure scoring (intentionally skipped — see PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)