### PR TITLE
feat(tron): widen tx expiration to 24h max (closes #280)

### DIFF
--- a/src/modules/tron/patch-expiration.ts
+++ b/src/modules/tron/patch-expiration.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Patch the `expiration` field of a TronGrid `raw_data_hex` protobuf in
+ * place. TronGrid's REST endpoints (createtransaction, triggersmartcontract,
+ * freezebalancev2, votewitnessaccount, …) bake in a ~60-second expiration
+ * by default — too tight for the prepare → CHECKS PERFORMED display →
+ * user reads → Ledger character-walk → broadcast loop. The TRON protocol
+ * permits expiration up to 24h after `timestamp`, so we widen it before
+ * issuing the handle.
+ *
+ * Why patch the wire bytes instead of building raw_data ourselves: TronGrid's
+ * trigger/createtransaction endpoints embed builder logic we don't want to
+ * reproduce (energy estimation, ref-block selection, contract-type framing).
+ * Patching one varint after the fact is the minimum-blast-radius change.
+ *
+ * Issue #280.
+ */
+
+/**
+ * Wire-format tag byte for Transaction.raw field 8 (expiration, varint int64):
+ *   tag = (fieldNum << 3) | wireType = (8 << 3) | 0 = 0x40
+ *
+ * This is the byte we scan for at the top level of Transaction.raw to
+ * locate the expiration varint that follows.
+ */
+const EXPIRATION_FIELD_TAG = 8;
+
+interface VarintRead {
+  value: bigint;
+  bytes: number;
+}
+
+function readVarint(buf: Uint8Array, offset: number): VarintRead {
+  let result = 0n;
+  let shift = 0n;
+  let i = 0;
+  for (;;) {
+    if (offset + i >= buf.length) throw new Error("patchExpirationInRawData: truncated varint");
+    const b = buf[offset + i++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 70n) throw new Error("patchExpirationInRawData: varint overflow");
+  }
+  return { value: result, bytes: i };
+}
+
+function encodeVarint(value: bigint): Uint8Array {
+  if (value < 0n) throw new Error("patchExpirationInRawData: negative varint");
+  const bytes: number[] = [];
+  let v = value;
+  while (v > 0x7fn) {
+    bytes.push(Number(v & 0x7fn) | 0x80);
+    v >>= 7n;
+  }
+  bytes.push(Number(v));
+  return new Uint8Array(bytes);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (!/^[0-9a-fA-F]*$/.test(stripped) || stripped.length % 2 !== 0) {
+    throw new Error("patchExpirationInRawData: invalid hex");
+  }
+  const buf = new Uint8Array(stripped.length / 2);
+  for (let i = 0; i < buf.length; i++) {
+    buf[i] = parseInt(stripped.substr(i * 2, 2), 16);
+  }
+  return buf;
+}
+
+function bytesToHex(buf: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < buf.length; i++) {
+    out += buf[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Replace the expiration varint in a Transaction.raw protobuf wire-form
+ * blob. Returns the new hex (no `0x` prefix); the caller can re-derive
+ * `txID = sha256(newRawDataHex)`.
+ *
+ * Walks the wire format at the top level only — expiration is always a
+ * top-level field of Transaction.raw, never nested inside Contract or
+ * auths. For each field we decode tag, skip the payload based on wire
+ * type, and continue until we hit field 8.
+ */
+export function patchExpirationInRawData(
+  rawDataHex: string,
+  newExpirationMs: bigint,
+): string {
+  const buf = hexToBytes(rawDataHex);
+  let offset = 0;
+  while (offset < buf.length) {
+    const tagRead = readVarint(buf, offset);
+    offset += tagRead.bytes;
+    const fieldNum = Number(tagRead.value >> 3n);
+    const wireType = Number(tagRead.value & 0x7n);
+
+    if (fieldNum === EXPIRATION_FIELD_TAG && wireType === 0) {
+      const oldVarint = readVarint(buf, offset);
+      const newVarint = encodeVarint(newExpirationMs);
+      const out = new Uint8Array(buf.length - oldVarint.bytes + newVarint.length);
+      out.set(buf.subarray(0, offset), 0);
+      out.set(newVarint, offset);
+      out.set(buf.subarray(offset + oldVarint.bytes), offset + newVarint.length);
+      return bytesToHex(out);
+    }
+
+    // Skip this field's payload based on wire type.
+    if (wireType === 0) {
+      const v = readVarint(buf, offset);
+      offset += v.bytes;
+    } else if (wireType === 2) {
+      const lenRead = readVarint(buf, offset);
+      offset += lenRead.bytes + Number(lenRead.value);
+      if (offset > buf.length) {
+        throw new Error("patchExpirationInRawData: length-delimited field overruns buffer");
+      }
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      throw new Error(`patchExpirationInRawData: unsupported wire type ${wireType}`);
+    }
+  }
+  // Field 8 absent — append it. Protobuf wire format permits fields in any
+  // order, so concatenating at the end is valid. This path is unreachable
+  // for real TronGrid responses (which always set expiration) but lets the
+  // patcher handle minimally-shaped synthetic protobuf inputs without
+  // forcing every test fixture to include the field.
+  const expirationTagByte = (EXPIRATION_FIELD_TAG << 3) | 0;
+  const newVarint = encodeVarint(newExpirationMs);
+  const out = new Uint8Array(buf.length + 1 + newVarint.length);
+  out.set(buf, 0);
+  out[buf.length] = expirationTagByte;
+  out.set(newVarint, buf.length + 1);
+  return bytesToHex(out);
+}
+
+/**
+ * Recompute txID from a (possibly patched) raw_data_hex. TronGrid's txID is
+ * the lowercase hex of `sha256(raw_data_bytes)` — same convention used by
+ * the TRON node when computing Transaction.id.
+ */
+export function txIdFromRawDataHex(rawDataHex: string): string {
+  const buf = hexToBytes(rawDataHex);
+  return createHash("sha256").update(buf).digest("hex");
+}

--- a/src/signing/tron-tx-store.ts
+++ b/src/signing/tron-tx-store.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  patchExpirationInRawData,
+  txIdFromRawDataHex,
+} from "../modules/tron/patch-expiration.js";
 import type { UnsignedTronTx } from "../types/index.js";
 import { buildTronVerification } from "./verification.js";
 
@@ -14,6 +18,20 @@ import { buildTronVerification } from "./verification.js";
  * Lifetime matches the EVM store (15 min from issue).
  */
 const TX_TTL_MS = 15 * 60_000;
+
+/**
+ * On-chain expiration window we apply to every TronGrid-built tx. TronGrid's
+ * default ~60s is too tight for the prepare → CHECKS PERFORMED display →
+ * Ledger character-walk → broadcast loop. The TRON protocol caps expiration
+ * at 24h after `timestamp`; we set it to the max so the user-facing
+ * verification step is never the thing that races the network.
+ *
+ * The agent-side handle TTL above (15 min) is independent — that bounds
+ * how long a stored handle remains valid for `send_transaction`, which is
+ * orthogonal to how long the signed-and-broadcast tx itself stays
+ * acceptable to the network. Issue #280.
+ */
+const TRON_TX_EXPIRATION_MS = 24 * 60 * 60 * 1000;
 
 interface StoredTx {
   tx: UnsignedTronTx;
@@ -31,11 +49,59 @@ function prune(now = Date.now()): void {
 export function issueTronHandle(tx: UnsignedTronTx): UnsignedTronTx {
   prune();
   const handle = randomUUID();
-  const verification = tx.verification ?? buildTronVerification(tx);
-  const withHandle: UnsignedTronTx = { ...tx, handle, verification };
+  // Widen the on-chain expiration to TRON's 24h max for every tx we own
+  // the rawData for. LiFi-swap txs (action: "lifi_swap", rawData absent)
+  // carry bytes built by LiFi with their own intent-binding window; we
+  // don't patch those — patching would invalidate LiFi's quote.
+  const widened = tx.rawData !== undefined ? widenExpiration(tx) : tx;
+  const verification = widened.verification ?? buildTronVerification(widened);
+  const withHandle: UnsignedTronTx = { ...widened, handle, verification };
   const { handle: _h, ...stored } = withHandle;
   store.set(handle, { tx: stored as UnsignedTronTx, expiresAt: Date.now() + TX_TTL_MS });
   return withHandle;
+}
+
+/**
+ * Patch rawDataHex's expiration field to 24h from now, then re-derive
+ * txID and the rawData JSON so all three stay in sync. The contract
+ * fields (addresses, amounts, parameter) are byte-identical before and
+ * after — patchExpirationInRawData touches only the field-8 varint, so
+ * the prior `assertTronRawDataMatches` verdict still holds for the
+ * patched bytes.
+ *
+ * Returns the original tx unchanged when:
+ *   - rawData.expiration is undefined (test stubs that don't simulate
+ *     a full TronGrid response — production responses always set it)
+ *   - rawDataHex isn't valid protobuf (test stubs with synthetic bytes)
+ *
+ * Both cases are test-only; in production every TronGrid response has
+ * a real protobuf rawDataHex and a numeric expiration, so the patch
+ * always applies.
+ */
+function widenExpiration(tx: UnsignedTronTx): UnsignedTronTx {
+  const oldRawData = tx.rawData as Record<string, unknown>;
+  if (typeof oldRawData.expiration !== "number") return tx;
+  const newExpirationMs = BigInt(Date.now() + TRON_TX_EXPIRATION_MS);
+  let newRawDataHex: string;
+  try {
+    newRawDataHex = patchExpirationInRawData(tx.rawDataHex, newExpirationMs);
+  } catch {
+    return tx;
+  }
+  const newTxID = txIdFromRawDataHex(newRawDataHex);
+  // rawData is the JSON object TronGrid returned alongside rawDataHex;
+  // broadcast.ts forwards it to /wallet/broadcasttransaction. Update its
+  // `expiration` field too so the broadcast body matches the bytes we
+  // signed. Use Number() — TronGrid returns expiration as a JSON number
+  // (ms-since-epoch fits comfortably in Number's 53-bit safe range until
+  // ~year 287000).
+  const newRawData = { ...oldRawData, expiration: Number(newExpirationMs) };
+  return {
+    ...tx,
+    rawDataHex: newRawDataHex,
+    rawData: newRawData,
+    txID: newTxID,
+  };
 }
 
 export function consumeTronHandle(handle: string): UnsignedTronTx {

--- a/test/tron-builders.test.ts
+++ b/test/tron-builders.test.ts
@@ -166,7 +166,10 @@ describe("buildTronNativeSend (network stubbed)", () => {
     expect(tx.chain).toBe("tron");
     expect(tx.action).toBe("native_send");
     expect(tx.from).toBe(ADDR_FROM);
-    expect(tx.txID).toBe("deadbeef".repeat(8));
+    // txID is now derived from the (post-expiration-patch) rawDataHex per
+    // TRON protocol — the stubbed response txID is overwritten in
+    // tron-tx-store. We just assert the shape.
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
     expect(tx.description).toBe(`Send 1.5 TRX to ${ADDR_TO}`);
     expect(tx.decoded.functionName).toBe("TransferContract");
     expect(tx.decoded.args).toEqual({ to: ADDR_TO, amount: "1.5", symbol: "TRX" });
@@ -270,7 +273,8 @@ describe("buildTronTokenSend (network stubbed)", () => {
       amount: "2",
     });
     expect(tx.action).toBe("trc20_send");
-    expect(tx.txID).toBe("cafebabe".repeat(8));
+    // See native_send test above for why we don't assert the stub txID.
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
     expect(tx.description).toBe(`Send 2 USDT to ${ADDR_TO}`);
     expect(tx.decoded.args.symbol).toBe("USDT");
     expect(tx.decoded.args.contract).toBe(ADDR_USDT);

--- a/test/tron-patch-expiration.test.ts
+++ b/test/tron-patch-expiration.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  patchExpirationInRawData,
+  txIdFromRawDataHex,
+} from "../src/modules/tron/patch-expiration.js";
+import { encodeTransferRawData } from "./helpers/tron-raw-data-encode.js";
+
+const ADDR_FROM = "TPoaKtYTEPMj4LxWE3J5q3NdZVcX6HYUay";
+const ADDR_TO = "TR2r4r7VzQrBopR9xpUU75HUijyLwcFar1";
+
+/**
+ * Append a varint expiration field (field 8) to an existing
+ * Transaction.raw protobuf hex blob. Used to seed the patcher with a
+ * "real-shape" raw_data_hex so the in-place patch path is exercised
+ * (the test helper's `wrapRaw` deliberately omits expiration so the
+ * builder fixtures stay minimal).
+ */
+function appendExpiration(rawDataHex: string, expirationMs: bigint): string {
+  // Field 8 (expiration), wire type 0 (varint): tag = (8 << 3) | 0 = 0x40
+  const tagByte = "40";
+  let v = expirationMs;
+  let varintHex = "";
+  while (v > 0x7fn) {
+    varintHex += (Number(v & 0x7fn) | 0x80).toString(16).padStart(2, "0");
+    v >>= 7n;
+  }
+  varintHex += Number(v).toString(16).padStart(2, "0");
+  return rawDataHex + tagByte + varintHex;
+}
+
+describe("patchExpirationInRawData", () => {
+  it("replaces an existing expiration field in place and preserves all other bytes", () => {
+    const baseHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1_500_000n,
+    });
+    const original = appendExpiration(baseHex, 1_000_000_000_000n);
+    const newExpiration = 1_761_545_478_000n; // ms-since-epoch around 2025-10-27
+    const patched = patchExpirationInRawData(original, newExpiration);
+
+    // Patched bytes round-trip back through the patcher: re-patching with
+    // a new value should yield a result whose only difference from `patched`
+    // is the new expiration varint. We assert this by re-patching and
+    // confirming the full buffer changes only in the expected slice.
+    const repatched = patchExpirationInRawData(patched, newExpiration);
+    expect(repatched).toBe(patched);
+
+    // The contract bytes (field 11) must be byte-identical to baseHex's
+    // contract section. Easiest assertion: baseHex is a prefix of patched
+    // (since the test helper appends nothing else, contract bytes sit at
+    // offset 0 of the original input).
+    expect(patched.startsWith(baseHex)).toBe(true);
+  });
+
+  it("appends an expiration field when the protobuf has none (synthetic minimal fixtures)", () => {
+    const baseHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1n,
+    });
+    // baseHex deliberately has no field 8.
+    const newExpiration = 1_761_545_478_000n;
+    const patched = patchExpirationInRawData(baseHex, newExpiration);
+
+    // Patched output preserves the original prefix and ends with a
+    // freshly-appended expiration field.
+    expect(patched.startsWith(baseHex)).toBe(true);
+    expect(patched.length).toBeGreaterThan(baseHex.length);
+
+    // Re-patching reproduces the same output (idempotent at the same
+    // expiration value).
+    const repatched = patchExpirationInRawData(patched, newExpiration);
+    expect(repatched).toBe(patched);
+  });
+
+  it("rejects malformed hex", () => {
+    expect(() => patchExpirationInRawData("not-hex-at-all", 1n)).toThrow(/invalid hex/);
+    expect(() => patchExpirationInRawData("0a01", 1n)).toThrow(/length-delimited field overruns/);
+  });
+});
+
+describe("issueTronHandle widens expiration on TronGrid-shaped tx", () => {
+  it("bumps rawData.expiration to ~24h from now and recomputes txID", async () => {
+    const { issueTronHandle } = await import("../src/signing/tron-tx-store.js");
+    const baseHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1_500_000n,
+    });
+    const tronGridReturnedExpiration = Date.now() + 60_000; // ~60s — what TronGrid bakes in
+    const rawDataHex = appendExpiration(baseHex, BigInt(tronGridReturnedExpiration));
+    const stamped = issueTronHandle({
+      chain: "tron",
+      action: "native_send",
+      from: ADDR_FROM,
+      txID: "00".repeat(32),
+      rawData: { expiration: tronGridReturnedExpiration } as Record<string, unknown>,
+      rawDataHex,
+      description: "test",
+      decoded: { functionName: "TransferContract", args: {} },
+    });
+    const widened = (stamped.rawData as Record<string, unknown>).expiration as number;
+    const now = Date.now();
+    // 24h ± a small tolerance for clock movement during the test
+    expect(widened).toBeGreaterThan(now + 23 * 60 * 60 * 1000);
+    expect(widened).toBeLessThanOrEqual(now + 24 * 60 * 60 * 1000 + 1000);
+    // txID must equal sha256 of the patched rawDataHex
+    expect(stamped.txID).toBe(txIdFromRawDataHex(stamped.rawDataHex));
+    expect(stamped.txID).not.toBe("00".repeat(32));
+  });
+
+  it("leaves lifi_swap txs untouched (rawData absent — LiFi controls the bytes)", async () => {
+    const { issueTronHandle } = await import("../src/signing/tron-tx-store.js");
+    const lifiRawDataHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1n,
+    });
+    const stamped = issueTronHandle({
+      chain: "tron",
+      action: "lifi_swap",
+      from: ADDR_FROM,
+      txID: "ab".repeat(32),
+      // rawData absent — LiFi-swap path uses /broadcasthex
+      rawDataHex: lifiRawDataHex,
+      description: "swap",
+      decoded: { functionName: "lifiBridge", args: {} },
+    });
+    expect(stamped.rawDataHex).toBe(lifiRawDataHex);
+    expect(stamped.txID).toBe("ab".repeat(32));
+  });
+});
+
+describe("txIdFromRawDataHex", () => {
+  it("matches sha256 of the raw bytes", () => {
+    const baseHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1n,
+    });
+    const expected = createHash("sha256").update(Buffer.from(baseHex, "hex")).digest("hex");
+    expect(txIdFromRawDataHex(baseHex)).toBe(expected);
+    expect(txIdFromRawDataHex("0x" + baseHex)).toBe(expected); // strips 0x prefix
+  });
+
+  it("changes when raw_data changes (i.e. when expiration is patched)", () => {
+    const baseHex = encodeTransferRawData({
+      from: ADDR_FROM,
+      to: ADDR_TO,
+      amountSun: 1n,
+    });
+    const original = appendExpiration(baseHex, 1_000_000_000_000n);
+    const patched = patchExpirationInRawData(original, 1_761_545_478_000n);
+    expect(txIdFromRawDataHex(patched)).not.toBe(txIdFromRawDataHex(original));
+  });
+});

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -251,9 +251,12 @@ describe("sendTransaction — TRON handle routing", () => {
     const result = await sendTransaction({ handle: tx.handle!, confirmed: true, userDecision: "send" });
     expect(result).toEqual({ txHash: "ab".repeat(32), chain: "tron" });
     expect(hasTronHandle(tx.handle!)).toBe(false);
+    // Signer receives the post-expiration-patch rawDataHex, not the
+    // raw TronGrid response. Assert against the live tx field rather
+    // than the original TRANSFER_1TRX_DEVICE_TO_OTHER fixture.
     expect(trxInstance.signTransaction).toHaveBeenCalledWith(
       "44'/195'/0'/0/0",
-      TRANSFER_1TRX_DEVICE_TO_OTHER,
+      tx.rawDataHex,
       []
     );
   });
@@ -446,7 +449,7 @@ describe("pair_ledger_tron + get_ledger_status", () => {
     expect(result.txHash).toBe("ef".repeat(32));
     expect(trxInstance.signTransaction).toHaveBeenCalledWith(
       "44'/195'/1'/0/0",
-      TRANSFER_1TRX_OTHER_TO_DEVICE,
+      tx.rawDataHex,
       []
     );
   });

--- a/test/tron-trc20-approve.test.ts
+++ b/test/tron-trc20-approve.test.ts
@@ -94,7 +94,10 @@ describe("buildTronTrc20Approve — happy path", () => {
 
     expect(tx.action).toBe("trc20_approve");
     expect(tx.from).toBe(ADDR_FROM);
-    expect(tx.txID).toBe("deadbeef".repeat(8));
+    // txID is derived from the (post-expiration-patch) rawDataHex per
+    // TRON protocol — the stubbed response txID is overwritten in
+    // tron-tx-store. We just assert the shape.
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
     expect(tx.description).toBe(`Approve 10 USDT for spender ${TRON_LIFI_DIAMOND}`);
     expect(tx.decoded.functionName).toBe("approve(address,uint256)");
     expect(tx.decoded.args.spender).toBe(TRON_LIFI_DIAMOND);


### PR DESCRIPTION
Closes #280.

## Why

TronGrid bakes a ~60-second expiration into every `rawData` it returns. That window is too tight for the **prepare → CHECKS PERFORMED display → Ledger character-walk → broadcast** loop, especially on high-value sends where the user is supposed to verify the full recipient address character-by-character on-device. Live regression on 2026-04-26: a 5,929 USDT send expired twice in a row before the user could finish reading the verification block.

The character-walk on a fresh recipient is the single most important defense against address-substitution attacks (poison wallets, MCP compromise) — that step **cannot** be rushed. Forcing the user to sprint through a $5,929 confirmation defeats the entire point of the verification block.

## What

The issue's "one-line constant change" assumed an existing `EXPIRATION_MS` we could bump. There isn't one — TronGrid sets the expiration server-side and we just take whatever it returns. The actual fix patches the protobuf wire-format bytes after TronGrid returns them.

- **`src/modules/tron/patch-expiration.ts`** (new) — walks Transaction.raw at the top level, replaces field 8's varint with a new value (24h from now), or appends the field if absent. Touches **only** the expiration byte range; contract type, addresses, amounts, and parameter all stay byte-identical, so the prior `assertTronRawDataMatches` verdict still applies to the patched bytes.
- **`src/signing/tron-tx-store.ts`** — `issueTronHandle` calls the patcher centrally, so every `prepare_tron_*` flow (native_send, trc20_send, trc20_approve, claim_rewards, freeze, unfreeze, withdraw_expire_unfreeze, vote) gets the wider window with no per-call wiring. Also updates `rawData.expiration` JSON field (broadcast.ts forwards it to `/wallet/broadcasttransaction`) and re-derives `txID = sha256(patchedBytes)` per TRON spec.
- **LiFi swaps are skipped** — `rawData` is absent on those (LiFi controls the bytes including its own intent-binding window). Patching would invalidate LiFi's quote.

## Why this is safe

- **Protocol allows it**: TRON spec permits `expiration` up to 24h after `timestamp`. TronGrid accepts and broadcasts within this window.
- **`ref_block_hash` provides natural decay**: a tx's `ref_block_bytes` + `ref_block_hash` bind it to a recent block; these naturally invalidate as the chain advances past the reference window. Setting expiration to 24h matches what ref_block already enforces.
- **Verification is preserved**: `patchExpirationInRawData` is byte-narrow — only field 8's varint changes. The contract fields the verifier asserts against are byte-identical before and after.
- **Handle expiration is independent**: the agent-side 15-minute single-use handle TTL still applies — orthogonal to the on-chain tx expiration.
- **Replay risk doesn't change**: TRON txs include the txID hash; once mined, they can't be replayed. A signed-but-unbroadcast tx with a longer window is no different from any other off-chain signed payload.

## Test plan

- [x] **Patcher unit tests** — replace existing field, append when missing, reject malformed hex (3 cases)
- [x] **Idempotency** — re-patching with the same value yields identical bytes
- [x] **txID derivation** — `txIdFromRawDataHex(patched) !== txIdFromRawDataHex(original)` (changes when expiration changes)
- [x] **Integration: end-to-end widening** — `issueTronHandle` on a TronGrid-shape input bumps `rawData.expiration` to ~24h from now and recomputes `txID`
- [x] **Integration: lifi_swap untouched** — txs without rawData (LiFi path) pass through unchanged
- [x] **Full suite green**: 1495/1495 (was 1488; +7 from the new test file)
- [x] **Existing builder/signing test fixtures updated** — synthetic rawDataHex stubs that didn't include field 8 now exercise the append path; tests that asserted against stubbed txIDs now assert the post-patch shape (`/^[0-9a-f]{64}$/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)