### PR TITLE
docs(roadmap): fold compare_yields v2 adapter expansion into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 - **`check_liquidation_risk`** — per-asset "ETH drops X% triggers liquidation" math across Aave V3 / Compound V3 / Morpho Blue. Replaces today's raw-HF-number output with actionable price deltas. ([plan](./claude-work/plan-health-factor-monitoring.md))
 - **`get_pnl_summary`** — wallet-level net PnL over preset periods across EVM / TRON / Solana. Balance-delta minus net user contribution, priced via DefiLlama historical. ([plan](./claude-work/plan-pnl-summary-tool.md))
 
+**`compare_yields` adapter expansion** — v1 covers Aave V3 + Compound V3 + Lido (PR #282). The remaining seven protocols on the original plan ship as separate adapters; full scope, ordering, and bundling rationale in [plan-yields-v2-followups.md](./claude-work/plan-yields-v2-followups.md).
+
+- **Marinade + Jito APY readers** — bundled, ~150 LoC, mirror `getLidoApr()`'s DefiLlama path. The quick-win.
+- **MarginFi + Kamino + Morpho Blue lending adapters** — wallet-less reader split-out from the existing wallet-aware position readers. Same shape `getCompoundMarketInfo` already establishes.
+- **EigenLayer + Solana native-stake adapters** — structurally different (per-operator / per-validator rows, not per-protocol APR); each needs its own plan file before implementation.
+
 **Wallet integrations**
 
 - **MetaMask Mobile** via WalletConnect v2 — alongside Ledger Live. Reduced final-mile anchor (software wallet) surfaced clearly in docs + pairing receipt. Browser-extension bridge deferred to a follow-up. ([plan](./claude-work/plan-metamask-mobile-walletconnect.md))
@@ -118,6 +124,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 
 **Recently shipped** (previously on this list)
 
+- **`compare_yields`** — ranked supply-side yield comparison across integrated lending / staking protocols. v1 covers Aave V3 (5 EVM chains), Compound V3 (5 EVM chains, multi-market), and Lido stETH. Surfaces data, doesn't pick — the user decides. Adapter expansion for the other 7 protocols on the roadmap above (#282).
 - **Nonce-aware dropped-tx polling** (Solana) — on-chain nonce is the authoritative signal for whether a durable-nonce tx can still land; replaces the `lastValidBlockHeight` path that's meaningless for nonce-protected sends (#137).
 - **Solana liquid + native staking** — Marinade / Jito / native stake-account reads (#141, portfolio fold-in #143), Marinade writes (#145), native SOL delegate / deactivate / withdraw (#149).
 - **LiFi cross-chain EVM ↔ Solana routing** (#153, #155).


### PR DESCRIPTION
## Summary

Adds two pieces to the README roadmap:

1. New \`compare_yields\` adapter expansion subsection under \"New tools\" — names the seven deferred protocols grouped by category (Solana liquid-staking quick-win bundle; lending adapters needing wallet-less reader split; validator/operator-aware adapters needing per-entity plans). Points at [\`claude-work/plan-yields-v2-followups.md\`](./claude-work/plan-yields-v2-followups.md) for full ordering + bundling + risk register.
2. \`compare_yields\` entry added to \"Recently shipped\" — v1 covers Aave V3 + Compound V3 + Lido per PR #282.

## Why this PR

Replaces 7 separate GitHub tracking issues (#287-#293) with a single roadmap entry. The full plan file (already in main as \`plan-yields-v2-followups.md\`) is the source of truth for per-adapter scope/risk; the README roadmap is the user-facing summary. The 7 issues will be closed with a comment pointing here once this lands.

## Test plan

- [x] Markdown renders correctly (verified locally — clean diff, no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)