### PR TITLE
feat(tron): extend raw_data.expiration to 24h (closes #280)

### DIFF
--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -9,7 +9,46 @@ import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
 import { issueTronHandle } from "../../signing/tron-tx-store.js";
 import { encodeTrc20TransferParam } from "./address.js";
 import { assertTronRawDataMatches } from "./verify-raw-data.js";
+import { extendRawDataExpiration } from "./expiration.js";
 import type { UnsignedTronTx } from "../../types/index.js";
+
+/**
+ * In-place mutate a TronGrid response so its `raw_data.expiration` is
+ * extended to the TRON protocol max (24h after `timestamp`). Issue #280.
+ *
+ * TronGrid's `/wallet/createtransaction` and `/wallet/triggersmartcontract`
+ * stamp expiration server-side via the fullnode's `defaultExpirationTime`
+ * config — typically 60s. Too tight for the prepare → CHECKS PERFORMED →
+ * user-verifies-on-Ledger → broadcast loop, especially for high-value
+ * sends where the on-device character-walk is the canonical defense
+ * against address substitution. Live evidence: a 5,929 USDT send
+ * round-tripped over the 60s ceiling on multiple consecutive attempts.
+ *
+ * Splice strategy: surgically replace field 8's varint in `raw_data_hex`
+ * (rather than re-encoding the whole protobuf, which would require
+ * decoding every contract type's nested message). Recompute
+ * `txID = sha256(raw_data_hex)`; mirror the new value on
+ * `raw_data.expiration` so the broadcast-time JSON matches the signed
+ * bytes. The extended bytes still pass `assertTronRawDataMatches`
+ * (which checks contract type / addresses / amounts / fee_limit, not
+ * timing).
+ *
+ * No-op when `raw_data_hex` is absent (TronGrid returned an error
+ * shape; the caller's existing `Error` checks will throw).
+ */
+function extendTronGridExpiration(res: {
+  txID?: string;
+  raw_data?: unknown;
+  raw_data_hex?: string;
+}): void {
+  if (!res.raw_data_hex) return;
+  const ext = extendRawDataExpiration(res.raw_data_hex);
+  res.raw_data_hex = ext.rawDataHex;
+  res.txID = ext.txID;
+  if (res.raw_data && typeof res.raw_data === "object") {
+    (res.raw_data as { expiration?: number }).expiration = ext.expirationMs;
+  }
+}
 
 /**
  * Default fee limit (100 TRX) for TRC-20 transfers. TronGrid's
@@ -369,6 +408,7 @@ export async function buildTronNativeSend(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid createtransaction returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   assertTronRawDataMatches(res.raw_data_hex, {
     kind: "native_send",
@@ -472,6 +512,7 @@ export async function buildTronTokenSend(
   if (!ttx?.txID || !ttx.raw_data_hex) {
     throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(ttx);
 
   assertTronRawDataMatches(ttx.raw_data_hex, {
     kind: "trc20_send",
@@ -611,6 +652,7 @@ export async function buildTronTrc20Approve(
   if (!ttx?.txID || !ttx.raw_data_hex) {
     throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(ttx);
 
   assertTronRawDataMatches(ttx.raw_data_hex, {
     kind: "trc20_approve",
@@ -713,6 +755,7 @@ export async function buildTronVote(args: BuildTronVoteArgs): Promise<UnsignedTr
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid votewitnessaccount returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   const totalVotes = args.votes.reduce((s, v) => s + v.count, 0);
   const description =
@@ -793,6 +836,7 @@ export async function buildTronFreeze(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid freezebalancev2 returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   assertTronRawDataMatches(res.raw_data_hex, {
     kind: "freeze",
@@ -856,6 +900,7 @@ export async function buildTronUnfreeze(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid unfreezebalancev2 returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   assertTronRawDataMatches(res.raw_data_hex, {
     kind: "unfreeze",
@@ -906,6 +951,7 @@ export async function buildTronWithdrawExpireUnfreeze(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid withdrawexpireunfreeze returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   assertTronRawDataMatches(res.raw_data_hex, {
     kind: "withdraw_expire_unfreeze",
@@ -970,6 +1016,7 @@ export async function buildTronClaimRewards(
   if (!res.txID || !res.raw_data_hex) {
     throw new Error("TronGrid withdrawbalance returned no transaction — unexpected shape.");
   }
+  extendTronGridExpiration(res);
 
   assertTronRawDataMatches(res.raw_data_hex, {
     kind: "claim_rewards",

--- a/src/modules/tron/expiration.ts
+++ b/src/modules/tron/expiration.ts
@@ -1,0 +1,287 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Extend a TRON `raw_data_hex` envelope's `expiration` field client-side.
+ *
+ * Issue #280. TronGrid's `/wallet/createtransaction` (and the trigger /
+ * freeze / unfreeze / vote / claim siblings) stamps `raw_data.expiration`
+ * server-side from its `defaultExpirationTime` config — typically 60s
+ * after `timestamp`. That window is too tight for the
+ * prepare → CHECKS PERFORMED display → user verifies → Ledger
+ * character-walk → broadcast loop, especially for fresh recipients
+ * where the user is supposed to verify the recipient address
+ * character-by-character on-device. Live evidence: a 5,929 USDT send
+ * round-tripped over the 60s ceiling on multiple consecutive attempts.
+ *
+ * TronGrid's HTTP surface doesn't accept an `expiration` parameter,
+ * so we extend client-side: surgically replace field 8's varint in the
+ * protobuf-encoded `raw_data_hex`, recompute the `txID =
+ * sha256(raw_data_hex)`, and update the JSON `raw_data.expiration`
+ * mirror. The extended bytes still pass `assertTronRawDataMatches`
+ * (which checks contract type / addresses / amounts / fee_limit, not
+ * timing).
+ *
+ * Why 24h is safe:
+ *
+ *   - Protocol max: TRON spec permits `expiration` up to 24h after
+ *     `timestamp`. Full nodes accept and broadcast within this window.
+ *   - Natural decay via ref_block: `ref_block_bytes` + `ref_block_hash`
+ *     bind the tx to a specific recent block; these naturally
+ *     invalidate as the chain advances past the reference window
+ *     (~24h). Practical liveness is gated by ref_block, not by the
+ *     explicit expiration field. Setting expiration to 24h matches
+ *     what ref_block already enforces.
+ *   - Replay: TRON txs include the txID hash; once mined they can't be
+ *     replayed. A signed-but-unbroadcast tx with a longer window is no
+ *     different from any other off-chain signed payload — same
+ *     security model the user already accepts.
+ *   - Handle TTL is independent: the MCP's own 15-minute single-use
+ *     handle still applies; this only relaxes the on-chain field.
+ */
+
+/**
+ * 24 hours in milliseconds — TRON protocol max for the
+ * `expiration` field measured from `timestamp`.
+ */
+export const EXTENDED_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Wire-format primitives for surgically replacing field 8 in a
+ * Transaction.raw protobuf envelope.
+ *
+ * Transaction.raw fields the encoder needs to know about:
+ *
+ *   1   ref_block_bytes      bytes        wireType 2
+ *   4   ref_block_hash       bytes        wireType 2
+ *   8   expiration           int64        wireType 0   ← target
+ *   11  contract             repeated     wireType 2
+ *   14  timestamp            int64        wireType 0
+ *   18  fee_limit            int64 opt    wireType 0
+ *
+ * We don't decode the contract content — only locate field 8's start
+ * + end byte offsets to splice. Other fields ride through unchanged.
+ */
+
+function readVarint(
+  buf: Uint8Array,
+  offset: number,
+): { value: bigint; next: number } {
+  let result = 0n;
+  let shift = 0n;
+  let next = offset;
+  for (;;) {
+    if (next >= buf.length) {
+      throw new Error("TRON expiration extend: truncated varint");
+    }
+    const b = buf[next++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 70n) {
+      throw new Error("TRON expiration extend: varint overflow");
+    }
+  }
+  return { value: result, next };
+}
+
+function encodeVarint(value: bigint): Uint8Array {
+  if (value < 0n) {
+    throw new Error("TRON expiration extend: negative varint not supported");
+  }
+  const out: number[] = [];
+  let v = value;
+  while (v >= 0x80n) {
+    out.push(Number((v & 0x7fn) | 0x80n));
+    v >>= 7n;
+  }
+  out.push(Number(v));
+  return Uint8Array.from(out);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length % 2 !== 0) {
+    throw new Error("TRON expiration extend: raw_data_hex is not valid hex");
+  }
+  return Uint8Array.from(Buffer.from(clean, "hex"));
+}
+
+function bytesToHex(buf: Uint8Array): string {
+  return Buffer.from(buf).toString("hex");
+}
+
+/**
+ * Locate field 8 (expiration, varint) in a Transaction.raw protobuf
+ * buffer. Returns `{ tagOffset, bodyOffset, endOffset, value }` where:
+ *   - tagOffset: byte index of the 1-byte field tag (always 0x40 for
+ *     field 8 wire type 0).
+ *   - bodyOffset: byte index where the varint payload starts (= tagOffset + 1).
+ *   - endOffset: byte index just past the varint (= bodyOffset + varint.length).
+ *   - value: decoded expiration as bigint (ms since epoch).
+ *
+ * Throws if field 8 is missing — every TRON transaction we build has
+ * an expiration set by TronGrid, so absence is malformed input.
+ */
+function locateField8(buf: Uint8Array): {
+  tagOffset: number;
+  bodyOffset: number;
+  endOffset: number;
+  value: bigint;
+} {
+  let offset = 0;
+  while (offset < buf.length) {
+    const tagStart = offset;
+    const { value: tag, next } = readVarint(buf, offset);
+    offset = next;
+    const fieldNum = Number(tag >> 3n);
+    const wireType = Number(tag & 0x7n);
+    if (fieldNum === 8) {
+      if (wireType !== 0) {
+        throw new Error(
+          `TRON expiration extend: field 8 wire type ${wireType}, expected 0 (varint)`,
+        );
+      }
+      const v = readVarint(buf, offset);
+      return {
+        tagOffset: tagStart,
+        bodyOffset: offset,
+        endOffset: v.next,
+        value: v.value,
+      };
+    }
+    // Skip this field's body.
+    if (wireType === 0) {
+      const v = readVarint(buf, offset);
+      offset = v.next;
+    } else if (wireType === 2) {
+      const l = readVarint(buf, offset);
+      offset = l.next;
+      const len = Number(l.value);
+      if (offset + len > buf.length) {
+        throw new Error(
+          "TRON expiration extend: length-delimited field overruns buffer",
+        );
+      }
+      offset += len;
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      throw new Error(
+        `TRON expiration extend: unsupported wire type ${wireType}`,
+      );
+    }
+  }
+  throw new Error(
+    "TRON expiration extend: field 8 (expiration) not found in raw_data_hex",
+  );
+}
+
+export interface ExtendedTronTx {
+  /** Updated protobuf bytes as a hex string (no 0x prefix). */
+  rawDataHex: string;
+  /** Recomputed txID — sha256(rawDataHex). Hex string, no prefix. */
+  txID: string;
+  /** New expiration value (ms since epoch). */
+  expirationMs: number;
+}
+
+/**
+ * Surgically extend the `expiration` field of a TRON Transaction.raw
+ * envelope to `timestamp + EXTENDED_EXPIRATION_MS` (or the value
+ * passed in `expirationMs`, capped to the protocol max).
+ *
+ * Why surgical splice rather than full re-encode: the protobuf carries
+ * fields we don't fully decode (the contract body is itself a nested
+ * message that varies per contract type — TransferContract /
+ * TriggerSmartContract / FreezeBalanceV2Contract / etc.). Re-encoding
+ * the whole message means re-encoding every contract type. Splicing
+ * one varint preserves every other byte of the original TronGrid
+ * response — including any future fields TronGrid adds that our
+ * decoder doesn't know about.
+ *
+ * The new expiration is computed from the existing `timestamp` field
+ * (also a varint at field 14) plus the requested offset. We re-read
+ * `timestamp` rather than calling `Date.now()` so the math matches
+ * what's in the protobuf — TronGrid stamps `timestamp` and
+ * `expiration` together, and the user/Ledger sees them both.
+ */
+export function extendRawDataExpiration(
+  rawDataHex: string,
+  expirationOffsetMs: number = EXTENDED_EXPIRATION_MS,
+): ExtendedTronTx {
+  if (!Number.isFinite(expirationOffsetMs) || expirationOffsetMs <= 0) {
+    throw new Error(
+      `TRON expiration extend: expirationOffsetMs must be a positive finite number, got ${expirationOffsetMs}`,
+    );
+  }
+  if (expirationOffsetMs > EXTENDED_EXPIRATION_MS) {
+    throw new Error(
+      `TRON expiration extend: requested ${expirationOffsetMs} ms exceeds protocol max ${EXTENDED_EXPIRATION_MS} ms (24h)`,
+    );
+  }
+  const buf = hexToBytes(rawDataHex);
+  const f8 = locateField8(buf);
+  // Read timestamp (field 14, wire type 0). It's somewhere in the
+  // buffer — we don't care about its position, just its value.
+  const timestampMs = readField14Timestamp(buf);
+  const newExpirationMs = timestampMs + BigInt(expirationOffsetMs);
+
+  const newVarint = encodeVarint(newExpirationMs);
+  const out = new Uint8Array(
+    buf.length - (f8.endOffset - f8.bodyOffset) + newVarint.length,
+  );
+  // Prefix (everything up to and including the field tag).
+  out.set(buf.subarray(0, f8.bodyOffset), 0);
+  // New varint body.
+  out.set(newVarint, f8.bodyOffset);
+  // Suffix (everything after the old varint body).
+  out.set(buf.subarray(f8.endOffset), f8.bodyOffset + newVarint.length);
+
+  const txID = createHash("sha256").update(out).digest("hex");
+  return {
+    rawDataHex: bytesToHex(out),
+    txID,
+    expirationMs: Number(newExpirationMs),
+  };
+}
+
+/**
+ * Read field 14 (timestamp, wire type 0 / varint) from the buffer.
+ * Throws if missing — every TRON transaction we build has a
+ * timestamp set by TronGrid.
+ */
+function readField14Timestamp(buf: Uint8Array): bigint {
+  let offset = 0;
+  while (offset < buf.length) {
+    const { value: tag, next } = readVarint(buf, offset);
+    offset = next;
+    const fieldNum = Number(tag >> 3n);
+    const wireType = Number(tag & 0x7n);
+    if (fieldNum === 14 && wireType === 0) {
+      const v = readVarint(buf, offset);
+      return v.value;
+    }
+    if (wireType === 0) {
+      const v = readVarint(buf, offset);
+      offset = v.next;
+    } else if (wireType === 2) {
+      const l = readVarint(buf, offset);
+      offset = l.next;
+      const len = Number(l.value);
+      offset += len;
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      throw new Error(
+        `TRON expiration extend: unsupported wire type ${wireType}`,
+      );
+    }
+  }
+  throw new Error(
+    "TRON expiration extend: field 14 (timestamp) not found in raw_data_hex",
+  );
+}

--- a/src/modules/tron/lifi-swap.ts
+++ b/src/modules/tron/lifi-swap.ts
@@ -1,8 +1,8 @@
-import { createHash } from "node:crypto";
 import { fetchQuote } from "../swap/lifi.js";
 import { base58ToHex } from "./address.js";
 import { isTronAddress } from "../../config/tron.js";
 import { issueTronHandle } from "../../signing/tron-tx-store.js";
+import { extendRawDataExpiration } from "./expiration.js";
 import {
   decodeTronTriggerSmartContract,
   type DecodedTronTriggerSmartContract,
@@ -133,11 +133,6 @@ export interface PreparedTronLifiSwapTx {
   description: string;
   decoded: { functionName: string; args: Record<string, string> };
   feeLimitSun?: string;
-}
-
-function sha256Hex(hex: string): string {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  return createHash("sha256").update(Buffer.from(clean, "hex")).digest("hex");
 }
 
 function assertCrossChainAddressing(p: PrepareTronLifiSwapParams): void {
@@ -278,13 +273,21 @@ export async function buildTronLifiSwap(
     : String(txReq.data);
   const trigger = decodeTronTriggerSmartContract(rawDataHex);
 
-  // Cross-check bridge intent on the inner ABI calldata.
+  // Cross-check bridge intent on the inner ABI calldata. Runs against
+  // the original LiFi-built bytes so the verifier sees what LiFi
+  // actually shaped — expiration extension below doesn't touch
+  // contract-side fields.
   const bridgeData = verifyTronLifiBridgeIntent(p, trigger);
 
-  // Compute txID. Same convention TronGrid uses: sha256 of the raw_data
-  // protobuf bytes. Ledger TRON app displays this on-device when
-  // blind-signing; user matches against the prepare receipt.
-  const txID = sha256Hex(rawDataHex);
+  // Issue #280: extend raw_data.expiration to the protocol max (24h).
+  // LiFi's quote-built rawData inherits the same ~60s window as
+  // TronGrid's defaults, which is too tight for the
+  // prepare → CHECKS PERFORMED → user-verifies-on-Ledger → broadcast
+  // loop. Recomputed txID is what the device displays for the user
+  // to match against the prepare receipt.
+  const extended = extendRawDataExpiration(rawDataHex);
+  const finalRawDataHex = extended.rawDataHex;
+  const txID = extended.txID;
 
   const fromSym =
     p.fromToken === "native"
@@ -302,7 +305,7 @@ export async function buildTronLifiSwap(
     from: p.wallet,
     txID,
     // rawData intentionally absent — broadcast.ts uses /broadcasthex.
-    rawDataHex,
+    rawDataHex: finalRawDataHex,
     description,
     decoded: {
       functionName: "lifi.tron.bridge",

--- a/test/helpers/tron-raw-data-encode.ts
+++ b/test/helpers/tron-raw-data-encode.ts
@@ -77,9 +77,23 @@ function wrapContract(type: number, innerBytes: Uint8Array, typeUrl: string): Ui
 }
 
 function wrapRaw(contractBytes: Uint8Array, feeLimit?: bigint): Uint8Array {
-  // Transaction.raw { contract (11, repeated bytes), fee_limit (18, int64) }
+  // Transaction.raw { expiration (8, int64), contract (11, repeated bytes),
+  //                   timestamp (14, int64), fee_limit (18, int64) }
+  //
+  // Issue #280 added a client-side `extendRawDataExpiration` step that
+  // requires fields 8 and 14 to be present (it surgically rewrites field 8
+  // based on field 14). Real TronGrid responses always include both —
+  // this fixture used to omit them because the verifier didn't care, but
+  // the extension step does, so we now stamp realistic values: a fixed
+  // timestamp (so the fixture is reproducible across test runs) and an
+  // initial 60s expiration (matching TronGrid's default and giving the
+  // extender a "from" value to bump).
+  const FIXTURE_TIMESTAMP_MS = 1_714_128_000_000n;
+  const INITIAL_EXPIRATION_MS = FIXTURE_TIMESTAMP_MS + 60_000n;
   const parts: number[] = [];
+  parts.push(...writeVarintField(8, INITIAL_EXPIRATION_MS));
   parts.push(...writeBytesField(11, contractBytes));
+  parts.push(...writeVarintField(14, FIXTURE_TIMESTAMP_MS));
   if (feeLimit !== undefined) parts.push(...writeVarintField(18, feeLimit));
   return Uint8Array.from(parts);
 }

--- a/test/integration-security.test.ts
+++ b/test/integration-security.test.ts
@@ -172,6 +172,17 @@ describe("security: narrow agent-compromise (prompt injection, malicious skill)"
     vi.doMock("../src/modules/tron/verify-raw-data.js", () => ({
       assertTronRawDataMatches: () => {},
     }));
+    // Same posture for the expiration extender (issue #280). It also
+    // parses the protobuf and would reject our 50-zero-bytes mock.
+    // Make it a no-op return that satisfies the in-place mutator.
+    vi.doMock("../src/modules/tron/expiration.js", () => ({
+      EXTENDED_EXPIRATION_MS: 24 * 60 * 60 * 1000,
+      extendRawDataExpiration: (rawDataHex: string) => ({
+        rawDataHex,
+        txID: "f".repeat(64),
+        expirationMs: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    }));
 
     // Mock TronGrid HTTP surface. buildTronNativeSend hits three endpoints:
     //   (1) /wallet/createtransaction — tx builder

--- a/test/tron-builders.test.ts
+++ b/test/tron-builders.test.ts
@@ -166,7 +166,10 @@ describe("buildTronNativeSend (network stubbed)", () => {
     expect(tx.chain).toBe("tron");
     expect(tx.action).toBe("native_send");
     expect(tx.from).toBe(ADDR_FROM);
-    expect(tx.txID).toBe("deadbeef".repeat(8));
+    // txID is recomputed after the issue-#280 expiration extension
+    // (sha256 of the rewritten raw_data_hex) — assert canonical shape
+    // rather than the original sentinel from the mocked TronGrid response.
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
     expect(tx.description).toBe(`Send 1.5 TRX to ${ADDR_TO}`);
     expect(tx.decoded.functionName).toBe("TransferContract");
     expect(tx.decoded.args).toEqual({ to: ADDR_TO, amount: "1.5", symbol: "TRX" });
@@ -270,7 +273,7 @@ describe("buildTronTokenSend (network stubbed)", () => {
       amount: "2",
     });
     expect(tx.action).toBe("trc20_send");
-    expect(tx.txID).toBe("cafebabe".repeat(8));
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/); // recomputed post #280 extension
     expect(tx.description).toBe(`Send 2 USDT to ${ADDR_TO}`);
     expect(tx.decoded.args.symbol).toBe("USDT");
     expect(tx.decoded.args.contract).toBe(ADDR_USDT);

--- a/test/tron-expiration.test.ts
+++ b/test/tron-expiration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for `extendRawDataExpiration` (issue #280).
+ *
+ * The function does a surgical splice on TRON's `raw_data_hex` protobuf:
+ * locate field 8 (expiration varint) and replace its bytes so the new
+ * value is `timestamp + offsetMs`. Recompute txID = sha256 of the new
+ * bytes. The fixtures here are crafted to exercise:
+ *   - The happy path: input has 60s expiration → extended to 24h.
+ *   - The varint-length-change case: original expiration encodes in 3
+ *     bytes (60_000), extended to ~86_400_000 which encodes in 4 bytes.
+ *     The splice must handle the byte-length difference.
+ *   - All other fields (ref_block, contract, fee_limit) ride through
+ *     byte-exact.
+ *   - txID is the canonical sha256 of the new bytes.
+ *   - Missing field 8 throws.
+ *   - Missing field 14 (timestamp) throws.
+ *   - Out-of-range offsets reject (negative, > 24h).
+ */
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  EXTENDED_EXPIRATION_MS,
+  extendRawDataExpiration,
+} from "../src/modules/tron/expiration.js";
+
+/**
+ * Build a minimal Transaction.raw protobuf:
+ *   field 8  varint expiration
+ *   field 11 bytes  contract (opaque payload)
+ *   field 14 varint timestamp
+ *   field 18 varint fee_limit (optional)
+ *
+ * Uses tag-then-value protobuf wire encoding. Returns the hex string.
+ */
+function encodeFixture(args: {
+  expirationMs: bigint;
+  contractBytes: Uint8Array;
+  timestampMs: bigint;
+  feeLimitSun?: bigint;
+}): string {
+  function writeVarint(n: bigint): number[] {
+    const out: number[] = [];
+    let v = n;
+    do {
+      let byte = Number(v & 0x7fn);
+      v >>= 7n;
+      if (v > 0n) byte |= 0x80;
+      out.push(byte);
+    } while (v > 0n);
+    return out;
+  }
+  function writeTag(field: number, wire: number): number[] {
+    return writeVarint(BigInt((field << 3) | wire));
+  }
+  const parts: number[] = [];
+  parts.push(...writeTag(8, 0), ...writeVarint(args.expirationMs));
+  parts.push(
+    ...writeTag(11, 2),
+    ...writeVarint(BigInt(args.contractBytes.length)),
+    ...args.contractBytes,
+  );
+  parts.push(...writeTag(14, 0), ...writeVarint(args.timestampMs));
+  if (args.feeLimitSun !== undefined) {
+    parts.push(...writeTag(18, 0), ...writeVarint(args.feeLimitSun));
+  }
+  return Buffer.from(parts).toString("hex");
+}
+
+const TS_MS = 1_714_128_000_000n; // fixed timestamp for reproducibility
+const ORIGINAL_EXPIRATION = TS_MS + 60_000n; // 60s — TronGrid default
+const CONTRACT_PAYLOAD = Uint8Array.from([
+  // 16 arbitrary bytes — the contract body is opaque to the extender,
+  // we just want to verify it rides through byte-exact.
+  0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+  0x0d, 0x0e, 0x0f, 0x10,
+]);
+
+describe("extendRawDataExpiration — happy path", () => {
+  it("extends 60s expiration to 24h, keeps every other field byte-exact", () => {
+    const original = encodeFixture({
+      expirationMs: ORIGINAL_EXPIRATION,
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: TS_MS,
+      feeLimitSun: 100_000_000n,
+    });
+    const extended = extendRawDataExpiration(original);
+    // expirationMs is timestamp + 24h.
+    expect(extended.expirationMs).toBe(
+      Number(TS_MS) + EXTENDED_EXPIRATION_MS,
+    );
+    // txID is sha256 of new bytes.
+    const expectedTxID = createHash("sha256")
+      .update(Buffer.from(extended.rawDataHex, "hex"))
+      .digest("hex");
+    expect(extended.txID).toBe(expectedTxID);
+    // Output must NOT equal input (extension actually fired).
+    expect(extended.rawDataHex).not.toBe(original);
+    // Every byte BEFORE field 8 + every byte AFTER field 8 must be
+    // byte-exact (we only spliced the expiration varint). The simplest
+    // way to assert this without re-implementing the protobuf walker
+    // here: re-encode the same fixture with the new expiration value,
+    // confirm that's what we got back.
+    const reEncoded = encodeFixture({
+      expirationMs: BigInt(extended.expirationMs),
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: TS_MS,
+      feeLimitSun: 100_000_000n,
+    });
+    expect(extended.rawDataHex).toBe(reEncoded);
+  });
+
+  it("handles the varint-length-change case (3-byte → 4-byte)", () => {
+    // 60_000 ms encodes as 3 varint bytes (0xe0 0xea 0x04 — wait no, depends
+    // on TS-relative absolute value). What matters: TS+60_000 is roughly
+    // 1.7T, encoded as varint 6-7 bytes; TS+24h is roughly 1.7T+86M ≈ same
+    // 7-ish bytes. The varint-length-change is real but typically small.
+    // Use a smaller timestamp to force a clear length change.
+    const smallTs = 1n;
+    const original = encodeFixture({
+      expirationMs: smallTs + 60_000n, // ~3 bytes
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: smallTs,
+    });
+    const extended = extendRawDataExpiration(original);
+    expect(extended.expirationMs).toBe(Number(smallTs) + EXTENDED_EXPIRATION_MS);
+    // Decoded value matches; bytes differ in length (encoder produced
+    // a longer varint for the larger value).
+    expect(extended.rawDataHex.length).toBeGreaterThan(original.length);
+  });
+
+  it("accepts a custom offset within the protocol max", () => {
+    const original = encodeFixture({
+      expirationMs: TS_MS + 60_000n,
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: TS_MS,
+    });
+    const oneHourMs = 60 * 60 * 1000;
+    const extended = extendRawDataExpiration(original, oneHourMs);
+    expect(extended.expirationMs).toBe(Number(TS_MS) + oneHourMs);
+  });
+});
+
+describe("extendRawDataExpiration — input validation", () => {
+  it("rejects offsets ≤ 0", () => {
+    const fixture = encodeFixture({
+      expirationMs: TS_MS + 60_000n,
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: TS_MS,
+    });
+    expect(() => extendRawDataExpiration(fixture, 0)).toThrow(/positive/);
+    expect(() => extendRawDataExpiration(fixture, -1)).toThrow(/positive/);
+  });
+
+  it("rejects offsets exceeding the 24h protocol max", () => {
+    const fixture = encodeFixture({
+      expirationMs: TS_MS + 60_000n,
+      contractBytes: CONTRACT_PAYLOAD,
+      timestampMs: TS_MS,
+    });
+    expect(() =>
+      extendRawDataExpiration(fixture, EXTENDED_EXPIRATION_MS + 1),
+    ).toThrow(/protocol max/);
+  });
+
+  it("throws when field 8 (expiration) is missing", () => {
+    // Encode a minimal fixture WITHOUT field 8 — only contract + timestamp.
+    // We can't reuse encodeFixture (it always emits field 8), so
+    // hand-roll.
+    const tagF11 = 11 << 3 | 2;
+    const tagF14 = 14 << 3 | 0;
+    const bytes = [
+      tagF11, CONTRACT_PAYLOAD.length, ...CONTRACT_PAYLOAD,
+      tagF14, ...encodeVarintLocal(TS_MS),
+    ];
+    const hex = Buffer.from(bytes).toString("hex");
+    expect(() => extendRawDataExpiration(hex)).toThrow(
+      /field 8 \(expiration\) not found/,
+    );
+  });
+
+  it("throws when field 14 (timestamp) is missing", () => {
+    const tagF8 = 8 << 3 | 0;
+    const tagF11 = 11 << 3 | 2;
+    const bytes = [
+      tagF8, ...encodeVarintLocal(TS_MS + 60_000n),
+      tagF11, CONTRACT_PAYLOAD.length, ...CONTRACT_PAYLOAD,
+    ];
+    const hex = Buffer.from(bytes).toString("hex");
+    expect(() => extendRawDataExpiration(hex)).toThrow(
+      /field 14 \(timestamp\) not found/,
+    );
+  });
+
+  it("throws on malformed hex", () => {
+    expect(() => extendRawDataExpiration("not-hex")).toThrow(/not valid hex/);
+    expect(() => extendRawDataExpiration("0xabc")).toThrow(/not valid hex/); // odd length
+  });
+});
+
+function encodeVarintLocal(n: bigint): number[] {
+  const out: number[] = [];
+  let v = n;
+  do {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) byte |= 0x80;
+    out.push(byte);
+  } while (v > 0n);
+  return out;
+}

--- a/test/tron-lifi-swap.test.ts
+++ b/test/tron-lifi-swap.test.ts
@@ -83,25 +83,28 @@ function encodeTronTriggerSmartContractRawData(
   diamondHex: string,
   abiCalldata: `0x${string}`,
 ): string {
-  function varint(n: number): string {
+  // BigInt-aware varint encoder. The original 32-bit `>>>=` form
+  // works for tags + small payloads but breaks on millisecond
+  // timestamps (~1.7T > 2^31), which the issue-#280 expiration
+  // extender requires.
+  function varint(n: bigint | number): string {
     let s = "";
-    let v = n;
-    while (v > 0x7f) {
-      s += (0x80 | (v & 0x7f)).toString(16).padStart(2, "0");
-      v >>>= 7;
+    let v = typeof n === "bigint" ? n : BigInt(n);
+    while (v > 0x7fn) {
+      s += (Number(0x80n | (v & 0x7fn))).toString(16).padStart(2, "0");
+      v >>= 7n;
     }
-    s += v.toString(16).padStart(2, "0");
+    s += Number(v).toString(16).padStart(2, "0");
     return s;
   }
   function tagBytes(tag: number, wireType: number): string {
-    // Tag itself is varint-encoded; for tag>=16 it needs multi-byte form.
     return varint((tag << 3) | wireType);
   }
   function lenDelim(tag: number, payloadHex: string): string {
     const len = payloadHex.length / 2;
     return tagBytes(tag, 2) + varint(len) + payloadHex;
   }
-  function tagVarint(tag: number, value: number): string {
+  function tagVarint(tag: number, value: bigint | number): string {
     return tagBytes(tag, 0) + varint(value);
   }
 
@@ -121,8 +124,22 @@ function encodeTronTriggerSmartContractRawData(
   // Contract: { type (1, varint=31), parameter (2, Any) }
   const contractInner = tagVarint(1, 31) + lenDelim(2, anyMessage);
 
-  // Transaction.raw: contract[0] (tag 11), fee_limit (tag 18, varint)
-  return lenDelim(11, contractInner) + tagVarint(18, 100_000_000);
+  // Transaction.raw: expiration (tag 8, varint), contract[0] (tag 11),
+  // timestamp (tag 14, varint), fee_limit (tag 18, varint).
+  //
+  // Issue #280 added a client-side `extendRawDataExpiration` step that
+  // requires fields 8 and 14 to be present (it surgically rewrites
+  // field 8 based on field 14). LiFi's quote-built rawData inherits
+  // these from TronGrid. Stamp realistic values: a fixed timestamp (so
+  // the fixture is reproducible) and an initial 60s expiration window.
+  const FIXTURE_TIMESTAMP_MS = 1_714_128_000_000n;
+  const INITIAL_EXPIRATION_MS = FIXTURE_TIMESTAMP_MS + 60_000n;
+  return (
+    tagVarint(8, INITIAL_EXPIRATION_MS) +
+    lenDelim(11, contractInner) +
+    tagVarint(14, FIXTURE_TIMESTAMP_MS) +
+    tagVarint(18, 100_000_000)
+  );
 }
 
 function makeTronLifiQuote(opts: {

--- a/test/tron-phase3-signing.test.ts
+++ b/test/tron-phase3-signing.test.ts
@@ -5,6 +5,7 @@ import { join as pjoin } from "node:path";
 import { encodeTransferRawData } from "./helpers/tron-raw-data-encode.js";
 import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
 import { setConfigDirForTesting } from "../src/config/user-config.js";
+import { extendRawDataExpiration } from "../src/modules/tron/expiration.js";
 
 /**
  * Phase-3 (TRON USB HID signing) tests.
@@ -45,6 +46,17 @@ const TRANSFER_1TRX_OTHER_TO_DEVICE = encodeTransferRawData({
   to: DEVICE_ADDRESS,
   amountSun: 1_000_000n,
 });
+// Issue #280: buildTronNativeSend now extends raw_data.expiration to
+// the protocol max (24h) after TronGrid returns. The bytes the Ledger
+// signs are the EXTENDED form, not the original fixture. Pre-compute
+// the extended versions so signTransaction-call assertions match what
+// the production path actually hands to the device.
+const TRANSFER_1TRX_DEVICE_TO_OTHER_EXTENDED = extendRawDataExpiration(
+  TRANSFER_1TRX_DEVICE_TO_OTHER,
+).rawDataHex;
+const TRANSFER_1TRX_OTHER_TO_DEVICE_EXTENDED = extendRawDataExpiration(
+  TRANSFER_1TRX_OTHER_TO_DEVICE,
+).rawDataHex;
 const GOOD_SIG = "a".repeat(130);
 
 function makeTrxStub(overrides: Partial<TrxStub> = {}): TrxStub {
@@ -253,7 +265,7 @@ describe("sendTransaction — TRON handle routing", () => {
     expect(hasTronHandle(tx.handle!)).toBe(false);
     expect(trxInstance.signTransaction).toHaveBeenCalledWith(
       "44'/195'/0'/0/0",
-      TRANSFER_1TRX_DEVICE_TO_OTHER,
+      TRANSFER_1TRX_DEVICE_TO_OTHER_EXTENDED,
       []
     );
   });
@@ -446,7 +458,7 @@ describe("pair_ledger_tron + get_ledger_status", () => {
     expect(result.txHash).toBe("ef".repeat(32));
     expect(trxInstance.signTransaction).toHaveBeenCalledWith(
       "44'/195'/1'/0/0",
-      TRANSFER_1TRX_OTHER_TO_DEVICE,
+      TRANSFER_1TRX_OTHER_TO_DEVICE_EXTENDED,
       []
     );
   });

--- a/test/tron-trc20-approve.test.ts
+++ b/test/tron-trc20-approve.test.ts
@@ -94,7 +94,7 @@ describe("buildTronTrc20Approve — happy path", () => {
 
     expect(tx.action).toBe("trc20_approve");
     expect(tx.from).toBe(ADDR_FROM);
-    expect(tx.txID).toBe("deadbeef".repeat(8));
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/); // recomputed post #280 extension
     expect(tx.description).toBe(`Approve 10 USDT for spender ${TRON_LIFI_DIAMOND}`);
     expect(tx.decoded.functionName).toBe("approve(address,uint256)");
     expect(tx.decoded.args.spender).toBe(TRON_LIFI_DIAMOND);


### PR DESCRIPTION
## Summary
Closes #280. Bumps the TRON tx `raw_data.expiration` window from TronGrid's ~60s default to the **TRON protocol max of 24h** so the prepare → CHECKS PERFORMED → user-verifies-on-Ledger → broadcast loop has a comfortable timing budget. Live evidence in #280: a 5,929 USDT send hit `TRANSACTION_EXPIRATION_ERROR` two times in a row because the round-trip exceeded 60s — forcing the user to sprint through the on-device address-character verification, which is the canonical defense against substitution attacks (poison wallets, MCP compromise) and **cannot** be rushed.

## Why the fix shape diverges from the issue's "one-line constant change"

The issue claimed there was a hardcoded `EXPIRATION_MS = 60 * 1000` constant in our code. There isn't — confirmed by grep across all of `src/`. The 60s comes from TronGrid's server-side `defaultExpirationTime` config; we never set it client-side. TronGrid's `/wallet/createtransaction` and `/wallet/triggersmartcontract` HTTP surfaces don't accept an `expiration` parameter, so the fix is **client-side surgical re-encoding** of the protobuf-encoded `raw_data_hex` after TronGrid returns it.

## Implementation

| File | Change |
|---|---|
| `src/modules/tron/expiration.ts` (new) | `extendRawDataExpiration(rawDataHex, offset?)` + `EXTENDED_EXPIRATION_MS = 24h`. Walks Transaction.raw fields via the same protobuf primitives `verify-raw-data.ts` uses; locates field 8's tag/body/end offsets, replaces the varint, recomputes `txID = sha256(...)`. |
| `src/modules/tron/actions.ts` | Local `extendTronGridExpiration` wrapper that in-place mutates a TronGrid response. Applied at all **8 build sites** (`buildTronNativeSend`, `buildTronTokenSend`, `buildTronTrc20Approve`, `buildTronVote`, `buildTronFreeze`, `buildTronUnfreeze`, `buildTronWithdrawExpireUnfreeze`, `buildTronClaimRewards`). |
| `src/modules/tron/lifi-swap.ts` | Same extension applied to LiFi-built TRON tx envelopes. Removed the now-redundant local `sha256Hex` helper. |

### Why surgical splice, not full re-encode
The Transaction.raw `contract` field carries a nested message that varies per contract type (TransferContract / TriggerSmartContract / FreezeBalanceV2Contract / VoteWitnessContract / WithdrawBalanceContract / etc.). Re-encoding the whole envelope would mean re-encoding every contract type. Splicing one varint preserves every other byte of the original TronGrid response — including any future fields TronGrid adds that our decoder doesn't know about. Single-byte-position aware, dependency-light, easy to audit.

### Why 24h is safe (per #280)

- **Protocol max:** TRON spec permits `expiration` up to 24h after `timestamp`. Full nodes accept and broadcast within this window.
- **`ref_block_bytes` + `ref_block_hash`** bind the tx to a specific recent block; these naturally invalidate as the chain advances past the reference window (~24h). The practical liveness gate is `ref_block`, not the explicit expiration field — setting expiration to 24h matches what `ref_block` already enforces.
- **Replay risk doesn't change:** TRON txs include the txID hash; once mined they can't be replayed. A signed-but-unbroadcast tx with a longer window is no different from any other off-chain signed payload — same security model the user already accepts.
- **Handle TTL is independent:** the MCP's own 15-minute single-use handle still applies; this only relaxes the on-chain field.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/tron-expiration.test.ts` — **8/8 pass** (happy path, varint-length-change splice, custom-offset within max, all input validation: non-positive, > 24h, missing field 8, missing field 14, malformed hex)
- [x] `npx vitest run` (full suite) — **1496/1496 pass**
- [ ] Live retest: re-run the original $5,929 USDT scenario end-to-end and confirm the 24h window absorbs a comfortable verification pause.

### Test-side changes
- `test/helpers/tron-raw-data-encode.ts`: fixture helper now emits fields 8 (expiration) + 14 (timestamp) so production code paths through unchanged.
- `test/tron-lifi-swap.test.ts`: local varint encoder upgraded to bigint (the original 32-bit `>>>=` form broke on millisecond timestamps ~1.7T > 2^31).
- 3 tests with hardcoded txID sentinels (`"deadbeef".repeat(8)`, `"cafebabe".repeat(8)`) loosened to `/^[0-9a-f]{64}$/` — txID is recomputed post-extension.
- 2 `tron-phase3-signing` tests with hardcoded raw_data_hex assertions pre-compute the EXTENDED bytes — that's what's actually handed to Ledger.
- 1 `integration-security` test with a 50-zero-bytes mock hex stubs the extender (same posture as the existing verifier stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)