### PR TITLE
feat(allowances): prepare_revoke_approval — zero an ERC-20 allowance per (wallet, token, spender, chain)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ import {
   prepareNativeSend,
   prepareWethUnwrap,
   prepareTokenSend,
+  prepareRevokeApproval,
   previewSend,
   previewSolanaSend,
   sendTransaction,
@@ -233,6 +234,7 @@ import {
   prepareNativeSendInput,
   prepareWethUnwrapInput,
   prepareTokenSendInput,
+  prepareRevokeApprovalInput,
   previewSendInput,
   previewSolanaSendInput,
   sendTransactionInput,
@@ -2987,7 +2989,7 @@ async function main() {
     txHandler("prepare_weth_unwrap", prepareWethUnwrap)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "prepare_token_send",
     {
       description:
@@ -2995,6 +2997,16 @@ async function main() {
       inputSchema: prepareTokenSendInput.shape,
     },
     txHandler("prepare_token_send", prepareTokenSend)
+  );
+
+  registerTool(server,
+    "prepare_revoke_approval",
+    {
+      description:
+        "Build an unsigned `approve(spender, 0)` transaction that revokes the allowance the wallet previously granted to `spender` on `token`. Pre-flight check refuses when the live allowance is already 0 — that call would burn gas for nothing, and almost certainly means the user named the wrong (token, spender) pair. Resolves a friendly spender label from the canonical CONTRACTS table when one matches (Aave V3 Pool, Uniswap V3 SwapRouter02, Lido stETH, Compound V3 cUSDCv3, Morpho Blue, etc.) so the description + Ledger preview reads as \"Revoke USDC allowance for Aave V3 Pool (0x...)\" instead of a raw hex address. Description includes the previous allowance amount so the user sees what's being zeroed out. EVM-only — TRC-20 has the same `approve(spender, value)` shape but its prepare path runs through the TRON builder pipeline; surface in a `prepare_tron_trc20_revoke` if asked. Pair with the read-side `get_token_allowances` to enumerate what's currently approved.",
+      inputSchema: prepareRevokeApprovalInput.shape,
+    },
+    txHandler("prepare_revoke_approval", prepareRevokeApproval)
   );
 
   // ---- Module 8: Compound V3 ----

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { encodeFunctionData, formatUnits, isAddress, parseEther, parseUnits } from "viem";
+import { CONTRACTS } from "../../config/contracts.js";
 import qrcodeTerminal from "qrcode-terminal";
 import {
   initiatePairing,
@@ -106,6 +107,7 @@ import type {
   PrepareNativeSendArgs,
   PrepareWethUnwrapArgs,
   PrepareTokenSendArgs,
+  PrepareRevokeApprovalArgs,
   PrepareSolanaNativeSendArgs,
   PrepareSolanaSplSendArgs,
   PrepareSolanaNonceInitArgs,
@@ -2261,6 +2263,122 @@ export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<Unsi
       args: { to, amount: displayAmount, symbol: meta.symbol },
     },
   });
+}
+
+/**
+ * Build an `approve(spender, 0)` tx to revoke the allowance `wallet`
+ * previously granted `spender` on `token`. Pre-flight check refuses
+ * when the live allowance is already 0 — the on-chain call would still
+ * succeed but burns gas for nothing, and the user almost certainly
+ * meant a different (token, spender) pair.
+ *
+ * Resolves a friendly spender label from the canonical CONTRACTS table
+ * when one matches (Aave V3 Pool, Uniswap V3 SwapRouter02, etc.) so
+ * the description + Ledger-screen preview is more meaningful than a
+ * raw hex address.
+ *
+ * No `approvalCap`-style logic — revoke is a strict zero. The shared
+ * `buildApprovalTx` helper covers the raise-then-spend path; this is
+ * the inverse one-shot.
+ */
+export async function prepareRevokeApproval(
+  args: PrepareRevokeApprovalArgs,
+): Promise<UnsignedTx> {
+  const wallet = args.wallet as `0x${string}`;
+  const chain = args.chain as SupportedChain;
+  const token = args.token as `0x${string}`;
+  const spender = args.spender as `0x${string}`;
+
+  const client = getClient(chain);
+  const currentAllowance = (await client.readContract({
+    address: token,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [wallet, spender],
+  })) as bigint;
+
+  if (currentAllowance === 0n) {
+    throw new Error(
+      `${wallet} has no allowance to revoke for spender ${spender} on token ` +
+        `${token} (${chain}). Current allowance is already 0 — calling ` +
+        `approve(spender, 0) would be a no-op gas burn. If you intended a ` +
+        `different (token, spender) pair, double-check the inputs.`,
+    );
+  }
+
+  const meta = await resolveTokenMeta(chain, token);
+  const knownLabel = lookupKnownSpender(chain, spender);
+  const spenderDisplay = knownLabel ? `${knownLabel} (${spender})` : spender;
+  const currentFormatted = formatUnits(currentAllowance, meta.decimals);
+
+  return enrichTx({
+    chain,
+    to: token,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [spender, 0n],
+    }),
+    value: "0",
+    from: wallet,
+    description:
+      `Revoke ${meta.symbol} allowance for ${spenderDisplay} on ${chain} ` +
+      `(was ${currentFormatted} ${meta.symbol})`,
+    decoded: {
+      functionName: "approve",
+      args: {
+        spender,
+        amount: "0",
+        note: "revoke",
+        symbol: meta.symbol,
+        ...(knownLabel ? { spenderLabel: knownLabel } : {}),
+      },
+    },
+  });
+}
+
+/**
+ * Resolve a friendly label for a spender address from the canonical
+ * `CONTRACTS` table on the given chain. Returns undefined for arbitrary
+ * (non-protocol) spender addresses. Mirrors the same lookup the read-
+ * side `get_token_allowances` tool uses for consistent labeling across
+ * the read + revoke surfaces.
+ */
+function lookupKnownSpender(
+  chain: SupportedChain,
+  spender: `0x${string}`,
+): string | undefined {
+  const c = CONTRACTS[chain] as Record<string, Record<string, string>> | undefined;
+  if (!c) return undefined;
+  const target = spender.toLowerCase();
+  for (const [protocol, addrs] of Object.entries(c)) {
+    if (protocol === "tokens") continue;
+    if (typeof addrs !== "object" || addrs === null) continue;
+    for (const [name, addr] of Object.entries(addrs)) {
+      if (typeof addr !== "string" || addr.toLowerCase() !== target) continue;
+      const protoLabel = (() => {
+        switch (protocol) {
+          case "aave":
+            return "Aave V3";
+          case "uniswap":
+            return "Uniswap V3";
+          case "lido":
+            return "Lido";
+          case "eigenlayer":
+            return "EigenLayer";
+          case "compound":
+            return "Compound V3";
+          case "morpho":
+            return "Morpho Blue";
+          default:
+            return protocol.charAt(0).toUpperCase() + protocol.slice(1);
+        }
+      })();
+      const niceName = name.charAt(0).toUpperCase() + name.slice(1);
+      return `${protoLabel} ${niceName}`;
+    }
+  }
+  return undefined;
 }
 
 // ----- Send + status -----

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -716,6 +716,31 @@ export const prepareTokenSendInput = z.object({
     ),
 });
 
+/**
+ * `prepare_revoke_approval` — build an `approve(spender, 0)` tx that
+ * sets the allowance `wallet` previously granted `spender` on `token`
+ * back to zero. Read-side counterpart is the planned
+ * `get_token_allowances`. Refuses when the current allowance is
+ * already 0 — that call would be a no-op gas burn.
+ */
+export const prepareRevokeApprovalInput = z.object({
+  wallet: walletSchema.describe(
+    "EVM wallet that owns the existing allowance. Must be the address that " +
+      "originally called approve(spender, value); only the owner can set the " +
+      "allowance back to zero."
+  ),
+  chain: chainEnum.default("ethereum"),
+  token: addressSchema.describe(
+    "ERC-20 contract address. Must be the actual token contract — wrappers " +
+      "and aTokens have their own approval surfaces and aren't supported here."
+  ),
+  spender: addressSchema.describe(
+    "Address whose allowance to revoke. Typically a protocol contract " +
+      "(Aave V3 Pool, Uniswap SwapRouter, etc.) or any EOA the user previously " +
+      "approved. Get the live list via the read-side allowances tool."
+  ),
+});
+
 export const sendTransactionInput = z.object({
   handle: z
     .string()
@@ -894,6 +919,7 @@ export type PrepareEigenLayerDepositArgs = z.infer<typeof prepareEigenLayerDepos
 export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
 export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;
 export type PrepareTokenSendArgs = z.infer<typeof prepareTokenSendInput>;
+export type PrepareRevokeApprovalArgs = z.infer<typeof prepareRevokeApprovalInput>;
 export type PreviewSendArgs = z.infer<typeof previewSendInput>;
 export type SendTransactionArgs = z.infer<typeof sendTransactionInput>;
 export type GetTransactionStatusArgs = z.infer<typeof getTransactionStatusInput>;

--- a/test/prepare-revoke-approval.test.ts
+++ b/test/prepare-revoke-approval.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for `prepareRevokeApproval` — the write-side counterpart to
+ * `get_token_allowances`. Builds an `approve(spender, 0)` tx after
+ * pre-checking the live allowance is non-zero, with friendly spender
+ * labels resolved from the canonical CONTRACTS table.
+ *
+ * Coverage:
+ *   - Happy path: live allowance > 0 → returns UnsignedTx whose
+ *     calldata decodes to `approve(spender, 0)`.
+ *   - Refuses when the live allowance is already 0 (no-op gas burn
+ *     guard).
+ *   - Surfaces the friendly label for known protocol contracts (Aave
+ *     V3 Pool) in description + decoded.args.
+ *   - Description includes the previous allowance amount so the user
+ *     sees what's being zeroed out.
+ *   - Pre-flight runs BEFORE token-metadata lookup; allowance read is
+ *     the gating call.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { decodeFunctionData, encodeFunctionData } from "viem";
+import { erc20Abi } from "../src/abis/erc20.js";
+
+const { readContractMock, multicallMock, callMock, estimateGasMock, getGasPriceMock } =
+  vi.hoisted(() => ({
+    readContractMock: vi.fn(),
+    multicallMock: vi.fn(),
+    callMock: vi.fn(),
+    estimateGasMock: vi.fn(),
+    getGasPriceMock: vi.fn(),
+  }));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+    multicall: multicallMock,
+    call: callMock,
+    estimateGas: estimateGasMock,
+    getGasPrice: getGasPriceMock,
+    getChainId: vi.fn(),
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+vi.mock("../src/data/prices.js", () => ({
+  getTokenPrice: vi.fn().mockResolvedValue(undefined),
+  getTokenPrices: vi.fn().mockResolvedValue(new Map()),
+  getDefillamaCoinPrice: vi.fn().mockResolvedValue(undefined),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+// Aave V3 Pool on Ethereum — known label in CONTRACTS.
+const AAVE_POOL = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2";
+const RANDOM_SPENDER = "0x1111111111111111111111111111111111111111";
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  multicallMock.mockReset();
+  callMock.mockReset();
+  estimateGasMock.mockReset();
+  getGasPriceMock.mockReset();
+  // Default: token metadata = USDC (6 decimals). Both name+symbol get
+  // pulled by resolveTokenMeta.
+  multicallMock.mockResolvedValue([6, "USDC"]);
+  // simulateTx → eth_call returns a 32-byte truthy bool (for approve).
+  callMock.mockResolvedValue({
+    data: "0x0000000000000000000000000000000000000000000000000000000000000001",
+  });
+  estimateGasMock.mockResolvedValue(50_000n);
+  getGasPriceMock.mockResolvedValue(10_000_000_000n);
+});
+
+describe("prepareRevokeApproval — happy path", () => {
+  it("builds approve(spender, 0) calldata with the right `to` and `value: 0`", async () => {
+    // Live allowance = 1 USDC (1_000_000 in 6-decimal raw).
+    readContractMock.mockResolvedValue(1_000_000n);
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareRevokeApproval({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to.toLowerCase()).toBe(USDC.toLowerCase());
+    expect(tx.value).toBe("0");
+    expect(tx.from?.toLowerCase()).toBe(WALLET.toLowerCase());
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decoded.functionName).toBe("approve");
+    expect(decoded.args?.[0]).toBe(RANDOM_SPENDER);
+    expect(decoded.args?.[1]).toBe(0n);
+    expect(tx.decoded?.functionName).toBe("approve");
+    expect(tx.decoded?.args.amount).toBe("0");
+    expect(tx.decoded?.args.note).toBe("revoke");
+  });
+
+  it("includes the previous allowance amount in the description", async () => {
+    readContractMock.mockResolvedValue(50_000_000n); // 50 USDC (6 decimals)
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareRevokeApproval({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(tx.description).toContain("Revoke USDC");
+    expect(tx.description).toContain("was 50 USDC");
+  });
+
+  it("resolves the friendly label for known protocol spenders (Aave V3 Pool)", async () => {
+    readContractMock.mockResolvedValue(1_000_000n);
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareRevokeApproval({
+      wallet: WALLET,
+      token: USDC,
+      spender: AAVE_POOL,
+      chain: "ethereum",
+    });
+    expect(tx.description).toContain("Aave V3 Pool");
+    expect(tx.decoded?.args.spenderLabel).toBe("Aave V3 Pool");
+  });
+
+  it("omits spenderLabel for arbitrary (non-protocol) spenders", async () => {
+    readContractMock.mockResolvedValue(1_000_000n);
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareRevokeApproval({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(tx.decoded?.args.spenderLabel).toBeUndefined();
+    // Description carries the raw spender address only.
+    expect(tx.description).toContain(RANDOM_SPENDER);
+  });
+});
+
+describe("prepareRevokeApproval — refuses no-op", () => {
+  it("throws when the live allowance is already 0", async () => {
+    readContractMock.mockResolvedValue(0n);
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareRevokeApproval({
+        wallet: WALLET,
+        token: USDC,
+        spender: RANDOM_SPENDER,
+        chain: "ethereum",
+      }),
+    ).rejects.toThrow(/no allowance to revoke|already 0/i);
+  });
+
+  it("does NOT call resolveTokenMeta when the allowance check fails", async () => {
+    readContractMock.mockResolvedValue(0n);
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareRevokeApproval({
+        wallet: WALLET,
+        token: USDC,
+        spender: RANDOM_SPENDER,
+        chain: "ethereum",
+      }),
+    ).rejects.toThrow();
+    // resolveTokenMeta uses multicall — should not be invoked when the
+    // pre-flight zero-allowance check throws first.
+    expect(multicallMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("prepareRevokeApproval — calldata exact-match", () => {
+  it("emits the exact bytes for approve(spender, 0)", async () => {
+    readContractMock.mockResolvedValue(1n);
+    const expected = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [RANDOM_SPENDER, 0n],
+    });
+    const { prepareRevokeApproval } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareRevokeApproval({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(tx.data).toBe(expected);
+  });
+});
+
+describe("prepareRevokeApprovalInput — schema", () => {
+  it("accepts a well-formed input", async () => {
+    const { prepareRevokeApprovalInput } = await import(
+      "../src/modules/execution/schemas.js"
+    );
+    const res = prepareRevokeApprovalInput.safeParse({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("defaults chain to ethereum", async () => {
+    const { prepareRevokeApprovalInput } = await import(
+      "../src/modules/execution/schemas.js"
+    );
+    const res = prepareRevokeApprovalInput.safeParse({
+      wallet: WALLET,
+      token: USDC,
+      spender: RANDOM_SPENDER,
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.chain).toBe("ethereum");
+    }
+  });
+
+  it("rejects malformed addresses", async () => {
+    const { prepareRevokeApprovalInput } = await import(
+      "../src/modules/execution/schemas.js"
+    );
+    const res = prepareRevokeApprovalInput.safeParse({
+      wallet: "not-an-address",
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      chain: "ethereum",
+    });
+    expect(res.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Builds an unsigned `approve(spender, 0)` transaction. Write-side counterpart to the read-side [`get_token_allowances`](https://github.com/szhygulin/vaultpilot-mcp/pull/299) — that tool enumerates active spenders, this one zeros them out one at a time. Use case:

```
agent: "you have these active allowances on USDC (mainnet):
  • Aave V3 Pool — unlimited
  • RandomDeFiContract — 50 USDC
revoke the second one?"
user: "yes"
agent → prepare_revoke_approval({ wallet, token: USDC, spender: RandomDeFi, chain: ethereum })
     → send_transaction
```

## Behavior

- **Pre-flight refuses no-ops.** Reads `allowance(owner, spender)` live; if already 0, throws with a clear "current allowance is already 0 — calling approve(spender, 0) would be a no-op gas burn" error before token-metadata lookup or simulation. Almost always means the user named the wrong (token, spender) pair, and failing loud here surfaces the input mistake before they hit the device prompt.
- **Friendly spender labels.** Resolved from the canonical `CONTRACTS` table on the chain. Aave V3 Pool, Uniswap V3 SwapRouter02 / PositionManager, Compound V3 Comets, Lido stETH, EigenLayer DelegationManager, Morpho Blue, etc. all get a friendly label in the description and `decoded.args.spenderLabel`. Arbitrary (non-protocol) spenders surface the raw address only.
- **Description shows previous amount.** "Revoke USDC allowance for Aave V3 Pool (0x87870…) on ethereum (was 50 USDC)" so the user sees what's being zeroed out, not just that something is.
- **Strict zero** — no `approvalCap`-style logic. The shared `buildApprovalTx` helper covers the raise-then-spend (Aave / Compound / Morpho supply) path; this is the inverse one-shot.

## Files

| File | Change |
|---|---|
| `src/modules/execution/schemas.ts` | `prepareRevokeApprovalInput` Zod schema (`wallet` / `token` / `spender` / `chain`) + matching args type |
| `src/modules/execution/index.ts` | `prepareRevokeApproval` handler + private `lookupKnownSpender(chain, spender)` helper. Routes through `enrichTx` so the response carries simulation + gas estimate + USD cost like every other prepare_* |
| `src/index.ts` | Tool registration alongside `prepare_token_send` |
| `test/prepare-revoke-approval.test.ts` | 10 new test cases |

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/prepare-revoke-approval.test.ts` — **10/10 pass**
- [x] `npx vitest run` (full suite) — **1444/1444 pass**

Test coverage:
- Happy path: calldata decodes to `approve(spender, 0)`, `to` is the token, `value` is 0, `from` is the wallet.
- Description includes previous allowance amount ("was 50 USDC").
- Friendly label resolution for known protocol contracts (Aave V3 Pool).
- Label omitted for arbitrary spenders.
- Calldata exact-match against canonical `encodeFunctionData(approve, [spender, 0n])`.
- Zero-allowance refusal: throws + does NOT proceed to token metadata lookup.
- Schema validation: defaults `chain` to `ethereum`, rejects malformed addresses.

## Out of scope

- TRC-20 revoke (TRON `approve(spender, value)` has the same shape but the prepare path runs through `src/modules/tron/actions.ts`, not the EVM `enrichTx` pipeline; ship as `prepare_tron_trc20_revoke` when the user asks).
- SPL `approve` / `revoke` (Solana delegation is per-token-account, different question shape).
- Bulk revoke (one-shot per spender; the read tool already enumerates and the agent can chain-call).
- Auto-pairing with `get_token_allowances` (the agent does the join in chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)