### PR TITLE
feat(allowances): recursively enumerate Permit2 sub-allowances + EIP-2612 note (closes #304)

### DIFF
--- a/src/modules/allowances/index.ts
+++ b/src/modules/allowances/index.ts
@@ -24,6 +24,7 @@
  * No price math, no USD valuation in v1. The "how much exposure?"
  * question is genuinely about the raw allowance, not its current spot
  * value — a 1000 USDC allowance is concerning regardless of USDC price.
+ * bump
  */
 
 import type { Hex } from "viem";

--- a/src/modules/allowances/index.ts
+++ b/src/modules/allowances/index.ts
@@ -38,6 +38,49 @@ import type {
   GetTokenAllowancesArgs,
   GetTokenAllowancesResult,
 } from "./schemas.js";
+import {
+  PERMIT2_ADDRESS,
+  fetchPermit2SubAllowances,
+} from "./permit2.js";
+
+/**
+ * Minimal EIP-2612 ABI fragment for the `nonces(owner)` view. Reverts
+ * cleanly on tokens that don't implement EIP-2612 — we use that as the
+ * support detection signal.
+ */
+const EIP2612_NONCES_ABI = [
+  {
+    type: "function",
+    name: "nonces",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+/**
+ * Try `nonces(owner)` on the token contract. Returns the current nonce
+ * when the token supports EIP-2612, or undefined when it reverts (the
+ * token doesn't implement permit). USDC, DAI, AAVE, COMP, UNI all
+ * support; older tokens (USDT, WBTC, LINK) don't.
+ */
+async function tryReadEip2612Nonce(
+  chain: SupportedChain,
+  token: `0x${string}`,
+  owner: `0x${string}`,
+): Promise<bigint | undefined> {
+  const client = getClient(chain);
+  try {
+    return (await client.readContract({
+      address: token,
+      abi: EIP2612_NONCES_ABI,
+      functionName: "nonces",
+      args: [owner],
+    })) as bigint;
+  } catch {
+    return undefined;
+  }
+}
 
 const APPROVAL_TOPIC =
   "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
@@ -282,6 +325,35 @@ export async function getTokenAllowances(
     return 0;
   });
 
+  // 8. Issue #304 — Permit2 sub-allowance enumeration. If any row's
+  //    spender is the Permit2 contract, the wallet's direct approval
+  //    is functionally a permission granted to MANY downstream
+  //    contracts via Permit2's own ledger. The primary scan returning
+  //    just "Permit2 — unlimited" is correct but radically incomplete;
+  //    populate the sub-list so the answer reflects the actual attack
+  //    surface.
+  //
+  //    EIP-2612 nonce read runs in parallel — independent risk axis
+  //    (signed-but-unsubmitted off-chain permits, not enumerable on-
+  //    chain).
+  const permit2Row = rows.find(
+    (r) => r.spender.toLowerCase() === PERMIT2_ADDRESS,
+  );
+  const [permit2Result, eip2612Nonce] = await Promise.all([
+    permit2Row
+      ? fetchPermit2SubAllowances({
+          chain,
+          owner: wallet,
+          token,
+          decimals: meta.decimals,
+        }).catch(() => null)
+      : Promise.resolve(null),
+    tryReadEip2612Nonce(chain, token, wallet),
+  ]);
+  if (permit2Row && permit2Result) {
+    permit2Row.permit2SubAllowances = permit2Result.rows;
+  }
+
   const notes: string[] = [];
   if (truncated) {
     notes.push(
@@ -297,6 +369,50 @@ export async function getTokenAllowances(
         `unlimited approvals via \`prepare_*\` an approve(spender, 0) call, or via Etherscan's "Token Approvals" UI.`,
     );
   }
+  if (permit2Row && permit2Result) {
+    const subCount = permit2Result.rows.length;
+    if (subCount > 0) {
+      notes.push(
+        `${subCount} active Permit2 sub-allowance${subCount === 1 ? "" : "s"} for downstream spenders ` +
+          `(see \`allowances[].permit2SubAllowances[]\` on the Permit2 row). Permit2 is an intermediary — ` +
+          `the wallet's direct approval to Permit2 grants permission to every downstream spender listed. ` +
+          `Revoke a Permit2 sub-allowance with a Permit2.approve(token, spender, amount=0, expiration=any) ` +
+          `call, NOT by zeroing the parent ERC-20 approval.`,
+      );
+    } else if (permit2Result.expiredCount > 0) {
+      notes.push(
+        `Permit2 holds ${permit2Result.expiredCount} expired sub-allowance(s) for this token — those ` +
+          `entries are functionally revoked even though the storage slot is still populated.`,
+      );
+    } else {
+      notes.push(
+        `Permit2 has no active sub-allowances for this token. The direct ERC-20 approval to Permit2 is ` +
+          `still live — any future Permit2.approve / permit() submission would activate downstream spend ` +
+          `without a fresh ERC-20 approval.`,
+      );
+    }
+    if (permit2Result.truncated) {
+      notes.push(
+        `Permit2 logs scan also returned the cap (${LOGS_PAGE_SIZE} entries) — older sub-allowance events ` +
+          `may be missing.`,
+      );
+    }
+  }
+  if (eip2612Nonce !== undefined) {
+    notes.push(
+      `${meta.symbol} supports EIP-2612 \`permit()\`. Off-chain permit signatures (signed but not yet ` +
+        `submitted) are NOT enumerable on-chain — if you've ever signed an EIP-712 message naming this ` +
+        `token on a site you don't fully trust, consider invalidating any outstanding signatures by ` +
+        `submitting a permit() that bumps the nonce. Current nonce: ${eip2612Nonce.toString()}.`,
+    );
+  }
+  notes.push(
+    `Completeness caveat: the Etherscan logs scan and the Permit2 logs scan are both subject to the ` +
+      `indexer's row cap and to any missed-block edge cases on the indexer's side. The LIVE allowance ` +
+      `re-reads catch stale-revoked entries, but cannot catch a spender whose only Approval/Permit event ` +
+      `falls outside the indexer's returned set. To rule that out, an independent indexer would need to ` +
+      `cross-check.`,
+  );
   if (rows.length === 0) {
     notes.push(
       `No active approvals found for ${wallet} on ${meta.symbol} (${chain}). Either the wallet has never ` +

--- a/src/modules/allowances/permit2.ts
+++ b/src/modules/allowances/permit2.ts
@@ -1,0 +1,378 @@
+/**
+ * Permit2 sub-allowance enumeration. Issue #304.
+ *
+ * Permit2 (Uniswap, deployed identically at the same address on every
+ * supported EVM chain) is an intermediary: a wallet grants Permit2 a
+ * single ERC-20 allowance via the standard `approve()`, then Permit2
+ * maintains its OWN per-(owner, token, spender) allowance ledger
+ * inside its own storage. When a downstream contract (Universal
+ * Router, 1inch, a phishing site) gets authorized to pull tokens via
+ * Permit2, the grant emits a Permit2 event — NOT the ERC-20 standard
+ * `Approval` that `get_token_allowances`'s primary scan looks for.
+ *
+ * The result: a wallet that's used Uniswap once typically shows ONE
+ * row in the primary scan ("Permit2 — unlimited"), and every actual
+ * downstream attack surface is invisible. This module closes the gap
+ * by re-running the same Etherscan-logs + Multicall3 pattern against
+ * the Permit2 contract instead.
+ *
+ * Permit2 emits two relevant events:
+ *
+ *   event Approval(
+ *     address indexed owner,
+ *     address indexed token,
+ *     address indexed spender,
+ *     uint160 amount,
+ *     uint48 expiration
+ *   );
+ *
+ *   event Permit(
+ *     address indexed owner,
+ *     address indexed token,
+ *     address indexed spender,
+ *     uint160 amount,
+ *     uint48 expiration,
+ *     uint48 nonce
+ *   );
+ *
+ * Both index `owner`, `token`, and `spender`. The Etherscan logs API
+ * filter for our purposes is `topic1=owner, topic2=token`, no
+ * topic0 (we want both Approval and Permit events). The downstream
+ * spender lives in topic3.
+ *
+ * Live-allowance read:
+ *
+ *   function allowance(address user, address token, address spender)
+ *     external view
+ *     returns (uint160 amount, uint48 expiration, uint48 nonce);
+ *
+ * `expiration` is a Unix-seconds timestamp; allowances past their
+ * expiration are functionally revoked even though the storage slot is
+ * still populated. We drop expired rows to match the user's mental
+ * model ("show me what someone could pull from me right now").
+ */
+
+import { etherscanV2Fetch } from "../../data/apis/etherscan-v2.js";
+import { getClient } from "../../data/rpc.js";
+import { CONTRACTS } from "../../config/contracts.js";
+import { formatUnits } from "../../data/format.js";
+import type { SupportedChain } from "../../types/index.js";
+
+/**
+ * Permit2 deployment address. The contract is deployed at this address
+ * on every supported EVM chain (Ethereum, Arbitrum, Polygon, Base,
+ * Optimism — and beyond). Lowercased here for direct case-insensitive
+ * comparison against an event-topic-decoded spender.
+ */
+export const PERMIT2_ADDRESS =
+  "0x000000000022d473030f116ddee9f6b43ac78ba3" as `0x${string}`;
+
+/**
+ * Topic0 hashes for the two Permit2 events we care about. These are
+ * `keccak256(<canonical event signature>)` — recomputed in the test
+ * suite as a guard against drift if Permit2 ever ships a v2 with
+ * tweaked signatures (it hasn't, but the test catches it for free).
+ */
+export const PERMIT2_APPROVAL_TOPIC =
+  "0xda9fa7c1b00402c17d0161b249b1ab8bbec047c5a52207b9c112deffd817036b" as const;
+export const PERMIT2_PERMIT_TOPIC =
+  "0xc6a377bfc4eb120024a8ac08eef205be16b817020812c73223e81d1bdb9708ec" as const;
+
+/**
+ * Permit2 ABI fragment for the live-allowance read. Pulled inline (not
+ * promoted into `src/abis/`) because Permit2 is the only consumer in
+ * this codebase and the surface is tiny.
+ */
+const PERMIT2_ABI = [
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "user", type: "address" },
+      { name: "token", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [
+      { name: "amount", type: "uint160" },
+      { name: "expiration", type: "uint48" },
+      { name: "nonce", type: "uint48" },
+    ],
+  },
+] as const;
+
+const UINT160_MAX = (1n << 160n) - 1n;
+/**
+ * Permit2 caps at uint160 (not uint256), so the unlimited threshold
+ * differs from the primary tool's. Uniswap's own UI sets the literal
+ * MAX_UINT160 for "unlimited"; others may cap a few hundred under it.
+ * 0.01% margin matches the primary tool's posture.
+ */
+const PERMIT2_UNLIMITED_THRESHOLD = UINT160_MAX - UINT160_MAX / 10_000n;
+
+/** One downstream spender that holds a non-zero, non-expired Permit2 sub-allowance. */
+export interface Permit2SubAllowanceRow {
+  /** The downstream contract authorized to pull `token` via Permit2. */
+  downstreamSpender: `0x${string}`;
+  /**
+   * Friendly label when the downstream spender matches a known protocol
+   * contract in the canonical CONTRACTS table (Uniswap V3 SwapRouter,
+   * Universal Router, etc.). Absent for arbitrary contracts.
+   */
+  downstreamSpenderLabel?: string;
+  /** Raw current allowance (uint160) as decimal string. */
+  amount: string;
+  /** Same value formatted with the token's decimals. */
+  amountFormatted: string;
+  /** True when amount is at-or-near `MAX_UINT160`. */
+  isUnlimited: boolean;
+  /**
+   * Permit2's per-allowance expiration (uint48 unix seconds). When
+   * `expiration === 0`, Permit2 treats the allowance as REQUIRING a
+   * fresh signature — the on-chain allowance is unusable on its own
+   * and we drop the row. When `expiration > 0` and ≤ now, the
+   * allowance has expired and is dropped. Surviving rows have
+   * `expiration > now`; we surface the ISO timestamp.
+   */
+  expirationIso: string;
+  /** Block number where the most recent Permit2 event for this triple landed. */
+  lastEventBlock: string;
+  /** Tx hash of that event. */
+  lastEventTxHash: `0x${string}`;
+  /** ISO timestamp from the indexer's `timeStamp` field, when available. */
+  lastEventAt?: string;
+}
+
+interface EtherscanLogRow {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  timeStamp?: string;
+  transactionHash: string;
+}
+
+function addressToTopic(addr: `0x${string}`): string {
+  return `0x000000000000000000000000${addr.slice(2).toLowerCase()}`;
+}
+
+const LOGS_PAGE_SIZE = 1000;
+
+/**
+ * Fetch every Permit2 Approval + Permit event filtered to (owner,
+ * token). Both event types index those fields at topic1 and topic2,
+ * so a single Etherscan logs call (no topic0 filter) catches both —
+ * we partition by topic0 client-side. The downstream spender is at
+ * topic3 in both events.
+ */
+async function fetchPermit2Logs(
+  chain: SupportedChain,
+  owner: `0x${string}`,
+  token: `0x${string}`,
+): Promise<{ logs: EtherscanLogRow[]; truncated: boolean }> {
+  const params: Record<string, string> = {
+    module: "logs",
+    action: "getLogs",
+    address: PERMIT2_ADDRESS,
+    topic1: addressToTopic(owner),
+    topic2: addressToTopic(token),
+    topic1_2_opr: "and",
+    fromBlock: "0",
+    toBlock: "latest",
+    page: "1",
+    offset: String(LOGS_PAGE_SIZE),
+  };
+  const logs = await etherscanV2Fetch<EtherscanLogRow>(chain, params);
+  return { logs, truncated: logs.length >= LOGS_PAGE_SIZE };
+}
+
+/**
+ * Resolve a friendly label for a downstream spender from the
+ * `CONTRACTS` table on the given chain. Mirrors the primary tool's
+ * label resolution so the read surfaces consistent names across both
+ * direct and via-Permit2 rows.
+ */
+function lookupKnownSpender(
+  chain: SupportedChain,
+  spender: `0x${string}`,
+): string | undefined {
+  const c = CONTRACTS[chain] as Record<string, Record<string, string>> | undefined;
+  if (!c) return undefined;
+  const target = spender.toLowerCase();
+  for (const [protocol, addrs] of Object.entries(c)) {
+    if (protocol === "tokens") continue;
+    if (typeof addrs !== "object" || addrs === null) continue;
+    for (const [name, addr] of Object.entries(addrs)) {
+      if (typeof addr !== "string" || addr.toLowerCase() !== target) continue;
+      const protoLabel = (() => {
+        switch (protocol) {
+          case "aave":
+            return "Aave V3";
+          case "uniswap":
+            return "Uniswap V3";
+          case "lido":
+            return "Lido";
+          case "eigenlayer":
+            return "EigenLayer";
+          case "compound":
+            return "Compound V3";
+          case "morpho":
+            return "Morpho Blue";
+          default:
+            return protocol.charAt(0).toUpperCase() + protocol.slice(1);
+        }
+      })();
+      const niceName = name.charAt(0).toUpperCase() + name.slice(1);
+      return `${protoLabel} ${niceName}`;
+    }
+  }
+  return undefined;
+}
+
+export interface FetchPermit2SubAllowancesResult {
+  rows: Permit2SubAllowanceRow[];
+  /** Distinct downstream spenders observed in events (including ones now expired or revoked). */
+  totalScanned: number;
+  truncated: boolean;
+  /** Sub-allowances that read non-zero on-chain but have expired (now ≥ expiration). */
+  expiredCount: number;
+  /** Sub-allowances at-or-near MAX_UINT160 — unlimited within Permit2's per-spender ledger. */
+  unlimitedCount: number;
+}
+
+/**
+ * Enumerate downstream spenders authorized via Permit2 for the
+ * (owner, token) pair. Pipeline mirrors the primary tool:
+ *
+ *   1. Pull Approval + Permit events from Permit2 via Etherscan logs,
+ *      filtered to (owner, token). Single call covers full history.
+ *   2. Dedup by downstream spender, keeping the latest event per
+ *      spender for provenance.
+ *   3. Multicall3 batched `Permit2.allowance(owner, token, spender)`
+ *      reads for each unique downstream → live (amount, expiration,
+ *      nonce) tuple.
+ *   4. Drop rows where `amount === 0` (revoked) OR `expiration === 0`
+ *      (Permit2 treats this as "fresh signature required") OR
+ *      `expiration ≤ now` (expired).
+ *   5. Resolve friendly labels for known protocol contracts.
+ *   6. Sort descending by amount.
+ */
+export async function fetchPermit2SubAllowances(args: {
+  chain: SupportedChain;
+  owner: `0x${string}`;
+  token: `0x${string}`;
+  decimals: number;
+}): Promise<FetchPermit2SubAllowancesResult> {
+  const { chain, owner, token, decimals } = args;
+
+  const { logs, truncated } = await fetchPermit2Logs(chain, owner, token);
+
+  // Dedup by downstream spender, keeping the latest event per spender.
+  // Etherscan returns oldest-first; iterating forward and overwriting
+  // yields "latest wins".
+  interface SeenLog {
+    downstreamSpender: `0x${string}`;
+    blockNumber: string;
+    txHash: `0x${string}`;
+    timeStamp?: string;
+  }
+  const lastBySpender = new Map<string, SeenLog>();
+  for (const log of logs) {
+    if (!log.topics || log.topics.length < 4) continue;
+    const topic0 = log.topics[0]?.toLowerCase();
+    if (
+      topic0 !== PERMIT2_APPROVAL_TOPIC.toLowerCase() &&
+      topic0 !== PERMIT2_PERMIT_TOPIC.toLowerCase()
+    ) {
+      continue;
+    }
+    const spenderTopic = log.topics[3];
+    if (!spenderTopic || spenderTopic.length < 42) continue;
+    const downstreamSpender = `0x${spenderTopic.slice(-40)}` as `0x${string}`;
+    lastBySpender.set(downstreamSpender, {
+      downstreamSpender,
+      blockNumber: log.blockNumber,
+      txHash: log.transactionHash as `0x${string}`,
+      ...(log.timeStamp ? { timeStamp: log.timeStamp } : {}),
+    });
+  }
+
+  const uniqueSpenders = Array.from(lastBySpender.values()).map(
+    (s) => s.downstreamSpender,
+  );
+
+  if (uniqueSpenders.length === 0) {
+    return {
+      rows: [],
+      totalScanned: 0,
+      truncated,
+      expiredCount: 0,
+      unlimitedCount: 0,
+    };
+  }
+
+  const client = getClient(chain);
+  const allowances = await client.multicall({
+    contracts: uniqueSpenders.map((spender) => ({
+      address: PERMIT2_ADDRESS,
+      abi: PERMIT2_ABI,
+      functionName: "allowance" as const,
+      args: [owner, token, spender] as const,
+    })),
+    allowFailure: true,
+  });
+
+  const nowSec = BigInt(Math.floor(Date.now() / 1000));
+  const rows: Permit2SubAllowanceRow[] = [];
+  let expiredCount = 0;
+  let unlimitedCount = 0;
+  for (let i = 0; i < uniqueSpenders.length; i++) {
+    const r = allowances[i];
+    if (r.status !== "success") continue;
+    // viem returns the struct as a tuple; cast.
+    const tuple = r.result as readonly [bigint, number, number];
+    const amount = tuple[0];
+    const expiration = BigInt(tuple[1]);
+    if (amount === 0n) continue; // revoked / fully consumed
+    if (expiration === 0n) continue; // Permit2 marker for "fresh signature required"
+    if (expiration <= nowSec) {
+      expiredCount += 1;
+      continue;
+    }
+    const downstreamSpender = uniqueSpenders[i];
+    const meta = lastBySpender.get(downstreamSpender)!;
+    const isUnlimited = amount >= PERMIT2_UNLIMITED_THRESHOLD;
+    if (isUnlimited) unlimitedCount += 1;
+    const label = lookupKnownSpender(chain, downstreamSpender);
+    const lastEventAt = meta.timeStamp
+      ? new Date(Number(meta.timeStamp) * 1000).toISOString()
+      : undefined;
+    rows.push({
+      downstreamSpender,
+      ...(label ? { downstreamSpenderLabel: label } : {}),
+      amount: amount.toString(),
+      amountFormatted: isUnlimited ? "unlimited" : formatUnits(amount, decimals),
+      isUnlimited,
+      expirationIso: new Date(Number(expiration) * 1000).toISOString(),
+      lastEventBlock: meta.blockNumber,
+      lastEventTxHash: meta.txHash,
+      ...(lastEventAt ? { lastEventAt } : {}),
+    });
+  }
+
+  rows.sort((a, b) => {
+    const aBig = BigInt(a.amount);
+    const bBig = BigInt(b.amount);
+    if (bBig > aBig) return 1;
+    if (bBig < aBig) return -1;
+    return 0;
+  });
+
+  return {
+    rows,
+    totalScanned: lastBySpender.size,
+    truncated,
+    expiredCount,
+    unlimitedCount,
+  };
+}

--- a/src/modules/allowances/schemas.ts
+++ b/src/modules/allowances/schemas.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
 import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+import type { Permit2SubAllowanceRow } from "./permit2.js";
+
+export type { Permit2SubAllowanceRow };
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 
@@ -76,6 +79,18 @@ export interface AllowanceRow {
   lastApprovedTxHash: `0x${string}`;
   /** ISO-8601 timestamp from the indexer's `timeStamp` field, when available. */
   lastApprovedAt?: string;
+  /**
+   * Populated when `spender` is the Permit2 contract — the wallet's
+   * direct ERC-20 approval to Permit2 is functionally a permission
+   * granted to MANY downstream contracts. Each entry here is one
+   * non-zero, non-expired sub-allowance the wallet has authorized via
+   * Permit2's own ledger. Issue #304 — without this field, the primary
+   * tool's promise of "show me all my unrevoked allowances" is
+   * radically incomplete for any wallet that has touched Uniswap.
+   *
+   * Absent for non-Permit2 spenders.
+   */
+  permit2SubAllowances?: Permit2SubAllowanceRow[];
 }
 
 export interface GetTokenAllowancesResult {

--- a/test/allowances-permit2.test.ts
+++ b/test/allowances-permit2.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Tests for the Permit2 sub-allowance extension to `get_token_allowances`.
+ * Issue #304.
+ *
+ * Coverage:
+ *   - Topic constants match the canonical keccak256 of their event
+ *     signatures (drift guard).
+ *   - When the primary scan finds Permit2 as a spender, the tool
+ *     populates `permit2SubAllowances[]` on that row.
+ *   - Permit2 events are partitioned correctly by topic0 (Approval +
+ *     Permit both surface; unrelated topics ignored).
+ *   - Sub-allowances with `expiration === 0` are dropped (Permit2's
+ *     "fresh signature required" marker).
+ *   - Sub-allowances with `expiration ≤ now` are dropped + counted as
+ *     expired in notes.
+ *   - Sub-allowances at-or-near MAX_UINT160 surface as
+ *     `isUnlimited: true` with `amountFormatted: "unlimited"`.
+ *   - Friendly label resolution works on downstream spenders too.
+ *   - Non-Permit2 spender rows remain unaffected (no
+ *     `permit2SubAllowances` field).
+ *   - EIP-2612 nonce note surfaces when the token supports `nonces()`.
+ *   - Completeness footnote always present.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { keccak256, toBytes } from "viem";
+
+const etherscanV2FetchMock = vi.fn();
+const multicallMock = vi.fn();
+const readContractMock = vi.fn();
+
+vi.mock("../src/data/apis/etherscan-v2.js", () => ({
+  etherscanV2Fetch: (...a: unknown[]) => etherscanV2FetchMock(...a),
+  EtherscanApiKeyMissingError: class EtherscanApiKeyMissingError extends Error {},
+  EtherscanNoDataError: class EtherscanNoDataError extends Error {},
+}));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    multicall: (...a: unknown[]) => multicallMock(...a),
+    readContract: (...a: unknown[]) => readContractMock(...a),
+  }),
+  resetClients: () => {},
+}));
+
+const APPROVAL_TOPIC =
+  "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
+const PERMIT2_ADDRESS = "0x000000000022d473030f116ddee9f6b43ac78ba3";
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const UNIVERSAL_ROUTER = "0x66a9893cc07d91d95644aedd05d03f95e1dba8af";
+const SOME_OTHER_DOWNSTREAM = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PHISHY_DOWNSTREAM = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const UINT160_MAX = (1n << 160n) - 1n;
+const UINT256_MAX = (1n << 256n) - 1n;
+
+function pad32(addrLower: string): string {
+  return `0x000000000000000000000000${addrLower.replace(/^0x/, "").toLowerCase()}`;
+}
+
+function encUint(n: bigint): string {
+  return `0x${n.toString(16).padStart(64, "0")}`;
+}
+
+/** Standard ERC-20 Approval log (3 topics — the primary scan). */
+function erc20ApprovalLog(args: {
+  spender: string;
+  value: bigint;
+  blockNumber: number;
+  txHash: string;
+  timeStamp?: number;
+}) {
+  return {
+    address: USDC.toLowerCase(),
+    topics: [APPROVAL_TOPIC, pad32(WALLET), pad32(args.spender)],
+    data: encUint(args.value),
+    blockNumber: args.blockNumber.toString(),
+    transactionHash: args.txHash,
+    ...(args.timeStamp !== undefined ? { timeStamp: args.timeStamp.toString() } : {}),
+  };
+}
+
+/**
+ * Permit2 Approval / Permit log (4 topics — owner, token, spender all
+ * indexed). Permit2 emits events with ALL three addresses as indexed
+ * fields, so the on-the-wire layout is topic[0]=eventSig,
+ * topic[1]=owner, topic[2]=token, topic[3]=spender.
+ *
+ * The `data` payload differs between Approval (uint160 amount + uint48
+ * expiration) and Permit (adds uint48 nonce). We don't decode it
+ * client-side — the tool reads live state via Multicall — so the data
+ * value is irrelevant for our test purposes.
+ */
+function permit2Log(args: {
+  topic0: string;
+  downstreamSpender: string;
+  blockNumber: number;
+  txHash: string;
+  timeStamp?: number;
+}) {
+  return {
+    address: PERMIT2_ADDRESS,
+    topics: [
+      args.topic0,
+      pad32(WALLET),
+      pad32(USDC),
+      pad32(args.downstreamSpender),
+    ],
+    data: "0x", // not parsed by the tool
+    blockNumber: args.blockNumber.toString(),
+    transactionHash: args.txHash,
+    ...(args.timeStamp !== undefined ? { timeStamp: args.timeStamp.toString() } : {}),
+  };
+}
+
+beforeEach(() => {
+  etherscanV2FetchMock.mockReset();
+  multicallMock.mockReset();
+  readContractMock.mockReset();
+  // Default token-metadata multicall response: USDC.
+  multicallMock.mockImplementation(async (callArgs: unknown) => {
+    const opts = callArgs as {
+      contracts: Array<{ functionName: string; args?: unknown[]; address?: string }>;
+    };
+    return opts.contracts.map((c) => {
+      if (c.functionName === "symbol") return { status: "success", result: "USDC" };
+      if (c.functionName === "decimals") return { status: "success", result: 6 };
+      if (c.functionName === "name") return { status: "success", result: "USD Coin" };
+      // Default ERC-20 allowance() = 0.
+      return { status: "success", result: 0n };
+    });
+  });
+  // Default: token doesn't support EIP-2612 (most don't, like WETH/USDT).
+  readContractMock.mockRejectedValue(new Error("not eip2612"));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Permit2 topic constants", () => {
+  it("PERMIT2_APPROVAL_TOPIC matches keccak256(canonical event signature)", async () => {
+    const { PERMIT2_APPROVAL_TOPIC } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    const expected = keccak256(
+      toBytes("Approval(address,address,address,uint160,uint48)"),
+    );
+    expect(PERMIT2_APPROVAL_TOPIC.toLowerCase()).toBe(expected.toLowerCase());
+  });
+
+  it("PERMIT2_PERMIT_TOPIC matches keccak256(canonical event signature)", async () => {
+    const { PERMIT2_PERMIT_TOPIC } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    const expected = keccak256(
+      toBytes("Permit(address,address,address,uint160,uint48,uint48)"),
+    );
+    expect(PERMIT2_PERMIT_TOPIC.toLowerCase()).toBe(expected.toLowerCase());
+  });
+});
+
+describe("getTokenAllowances — Permit2 sub-allowance enumeration", () => {
+  it("populates permit2SubAllowances[] when the primary scan finds Permit2 as spender", async () => {
+    const { PERMIT2_APPROVAL_TOPIC, PERMIT2_PERMIT_TOPIC } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    // Primary scan: 1 row — Permit2 as spender, unlimited.
+    etherscanV2FetchMock.mockImplementation(async (_chain, params: Record<string, string>) => {
+      if (params.address === USDC.toLowerCase()) {
+        // Primary scan
+        return [
+          erc20ApprovalLog({
+            spender: PERMIT2_ADDRESS,
+            value: UINT256_MAX,
+            blockNumber: 19_000_000,
+            txHash: "0xa".repeat(40) + "0".repeat(24),
+            timeStamp: 1_700_000_000,
+          }),
+        ];
+      }
+      if (params.address === PERMIT2_ADDRESS) {
+        // Permit2 sub-scan: 3 events — Universal Router (active), some
+        // expired, one with the Permit topic to verify both topics work.
+        return [
+          permit2Log({
+            topic0: PERMIT2_APPROVAL_TOPIC,
+            downstreamSpender: UNIVERSAL_ROUTER,
+            blockNumber: 19_100_000,
+            txHash: "0xd".repeat(40) + "0".repeat(24),
+            timeStamp: 1_710_000_000,
+          }),
+          permit2Log({
+            topic0: PERMIT2_PERMIT_TOPIC,
+            downstreamSpender: SOME_OTHER_DOWNSTREAM,
+            blockNumber: 19_200_000,
+            txHash: "0xe".repeat(40) + "0".repeat(24),
+            timeStamp: 1_715_000_000,
+          }),
+          permit2Log({
+            topic0: PERMIT2_APPROVAL_TOPIC,
+            downstreamSpender: PHISHY_DOWNSTREAM,
+            blockNumber: 19_300_000,
+            txHash: "0xf".repeat(40) + "0".repeat(24),
+            timeStamp: 1_720_000_000,
+          }),
+        ];
+      }
+      return [];
+    });
+
+    // Multicall responses: token metadata (3 entries, in symbol/decimals/name order),
+    // then primary allowance reads (1 entry — Permit2 has unlimited),
+    // then Permit2 sub-allowance reads (3 entries).
+    const futureExpiration = Math.floor(Date.now() / 1000) + 86400;
+    const pastExpiration = Math.floor(Date.now() / 1000) - 100;
+    multicallMock.mockImplementation(async (callArgs: unknown) => {
+      const opts = callArgs as {
+        contracts: Array<{
+          functionName: string;
+          args?: unknown[];
+          address?: string;
+        }>;
+      };
+      return opts.contracts.map((c) => {
+        if (c.functionName === "symbol") return { status: "success", result: "USDC" };
+        if (c.functionName === "decimals") return { status: "success", result: 6 };
+        if (c.functionName === "name") return { status: "success", result: "USD Coin" };
+        if (c.functionName === "allowance") {
+          // Args length distinguishes ERC-20 vs Permit2:
+          // - ERC-20 allowance(owner, spender): 2 args
+          // - Permit2 allowance(user, token, spender): 3 args
+          if ((c.args ?? []).length === 2) {
+            return { status: "success", result: UINT256_MAX };
+          }
+          // Permit2 sub-allowance read.
+          const spender = ((c.args as unknown[])[2] as string).toLowerCase();
+          if (spender === UNIVERSAL_ROUTER.toLowerCase()) {
+            // Active: 1000 USDC, future expiration.
+            return {
+              status: "success",
+              result: [1_000_000_000n, futureExpiration, 0],
+            };
+          }
+          if (spender === SOME_OTHER_DOWNSTREAM.toLowerCase()) {
+            // Expired.
+            return {
+              status: "success",
+              result: [500_000_000n, pastExpiration, 0],
+            };
+          }
+          if (spender === PHISHY_DOWNSTREAM.toLowerCase()) {
+            // Active: unlimited.
+            return {
+              status: "success",
+              result: [UINT160_MAX, futureExpiration, 0],
+            };
+          }
+          return { status: "success", result: [0n, 0, 0] };
+        }
+        return { status: "success", result: 0n };
+      });
+    });
+
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    // Primary row: Permit2 itself.
+    expect(r.allowances).toHaveLength(1);
+    const permit2Row = r.allowances[0];
+    expect(permit2Row.spender.toLowerCase()).toBe(PERMIT2_ADDRESS);
+    expect(permit2Row.permit2SubAllowances).toBeDefined();
+    // 2 active sub-allowances (Universal Router + Phishy); 1 expired
+    // dropped.
+    expect(permit2Row.permit2SubAllowances).toHaveLength(2);
+    // Sorted desc by amount: Phishy (UINT160_MAX) first, Universal
+    // Router (1000 USDC) second.
+    expect(
+      permit2Row.permit2SubAllowances![0].downstreamSpender.toLowerCase(),
+    ).toBe(PHISHY_DOWNSTREAM.toLowerCase());
+    expect(permit2Row.permit2SubAllowances![0].isUnlimited).toBe(true);
+    expect(permit2Row.permit2SubAllowances![0].amountFormatted).toBe("unlimited");
+    expect(
+      permit2Row.permit2SubAllowances![1].downstreamSpender.toLowerCase(),
+    ).toBe(UNIVERSAL_ROUTER.toLowerCase());
+    expect(permit2Row.permit2SubAllowances![1].amountFormatted).toBe("1000");
+    expect(permit2Row.permit2SubAllowances![1].isUnlimited).toBe(false);
+    // Notes flag the Permit2 sub-allowance presence.
+    expect(
+      r.notes.some((n) =>
+        n.toLowerCase().includes("active permit2 sub-allowance"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT populate permit2SubAllowances on non-Permit2 rows", async () => {
+    const someRandomSpender = "0x9999999999999999999999999999999999999999";
+    etherscanV2FetchMock.mockResolvedValue([
+      erc20ApprovalLog({
+        spender: someRandomSpender,
+        value: 50_000_000n,
+        blockNumber: 19_000_000,
+        txHash: "0xa".repeat(40) + "0".repeat(24),
+      }),
+    ]);
+    multicallMock.mockImplementation(async (callArgs: unknown) => {
+      const opts = callArgs as {
+        contracts: Array<{ functionName: string; args?: unknown[] }>;
+      };
+      return opts.contracts.map((c) => {
+        if (c.functionName === "symbol") return { status: "success", result: "USDC" };
+        if (c.functionName === "decimals") return { status: "success", result: 6 };
+        if (c.functionName === "name") return { status: "success", result: "USD Coin" };
+        if (c.functionName === "allowance") {
+          return { status: "success", result: 50_000_000n };
+        }
+        return { status: "success", result: 0n };
+      });
+    });
+
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+
+    expect(r.allowances).toHaveLength(1);
+    expect(r.allowances[0].permit2SubAllowances).toBeUndefined();
+  });
+
+  it("surfaces an EIP-2612 nonce note when nonces(owner) succeeds", async () => {
+    etherscanV2FetchMock.mockResolvedValue([]);
+    readContractMock.mockResolvedValue(12n); // current nonce
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+    const eip2612Note = r.notes.find((n) =>
+      n.toLowerCase().includes("eip-2612"),
+    );
+    expect(eip2612Note).toBeDefined();
+    expect(eip2612Note).toContain("Current nonce: 12");
+  });
+
+  it("OMITS the EIP-2612 note when nonces(owner) reverts", async () => {
+    etherscanV2FetchMock.mockResolvedValue([]);
+    readContractMock.mockRejectedValue(new Error("not eip2612"));
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+    expect(r.notes.find((n) => n.toLowerCase().includes("eip-2612"))).toBeUndefined();
+  });
+
+  it("includes the completeness footnote in notes", async () => {
+    etherscanV2FetchMock.mockResolvedValue([]);
+    const { getTokenAllowances } = await import(
+      "../src/modules/allowances/index.ts"
+    );
+    const r = await getTokenAllowances({
+      wallet: WALLET,
+      token: USDC,
+      chain: "ethereum",
+    });
+    expect(
+      r.notes.some((n) => n.toLowerCase().includes("completeness caveat")),
+    ).toBe(true);
+  });
+});
+
+describe("fetchPermit2SubAllowances — drop semantics", () => {
+  it("drops sub-allowances with expiration === 0 (Permit2's 'fresh signature required' marker)", async () => {
+    const { PERMIT2_APPROVAL_TOPIC, fetchPermit2SubAllowances } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    etherscanV2FetchMock.mockResolvedValue([
+      permit2Log({
+        topic0: PERMIT2_APPROVAL_TOPIC,
+        downstreamSpender: UNIVERSAL_ROUTER,
+        blockNumber: 19_100_000,
+        txHash: "0xd".repeat(40) + "0".repeat(24),
+      }),
+    ]);
+    multicallMock.mockResolvedValue([
+      { status: "success", result: [1_000_000n, 0, 0] },
+    ]);
+    const result = await fetchPermit2SubAllowances({
+      chain: "ethereum",
+      owner: WALLET as `0x${string}`,
+      token: USDC as `0x${string}`,
+      decimals: 6,
+    });
+    // expiration === 0 → drop, but it's a "fresh signature required"
+    // marker rather than expired, so expiredCount stays 0.
+    expect(result.rows).toHaveLength(0);
+    expect(result.expiredCount).toBe(0);
+  });
+
+  it("counts sub-allowances with expiration ≤ now as expired (and drops them)", async () => {
+    const { PERMIT2_APPROVAL_TOPIC, fetchPermit2SubAllowances } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    etherscanV2FetchMock.mockResolvedValue([
+      permit2Log({
+        topic0: PERMIT2_APPROVAL_TOPIC,
+        downstreamSpender: UNIVERSAL_ROUTER,
+        blockNumber: 19_100_000,
+        txHash: "0xd".repeat(40) + "0".repeat(24),
+      }),
+    ]);
+    const past = Math.floor(Date.now() / 1000) - 100;
+    multicallMock.mockResolvedValue([
+      { status: "success", result: [1_000_000n, past, 0] },
+    ]);
+    const result = await fetchPermit2SubAllowances({
+      chain: "ethereum",
+      owner: WALLET as `0x${string}`,
+      token: USDC as `0x${string}`,
+      decimals: 6,
+    });
+    expect(result.rows).toHaveLength(0);
+    expect(result.expiredCount).toBe(1);
+  });
+
+  it("ignores logs with non-Permit2 topic0 values (defensive)", async () => {
+    const { fetchPermit2SubAllowances } = await import(
+      "../src/modules/allowances/permit2.ts"
+    );
+    etherscanV2FetchMock.mockResolvedValue([
+      // A log that happens to come from the Permit2 address but with an
+      // unexpected topic0 (e.g. a future Permit2 v2 event we don't
+      // know about). Should be silently ignored.
+      permit2Log({
+        topic0: "0x" + "ff".repeat(32),
+        downstreamSpender: UNIVERSAL_ROUTER,
+        blockNumber: 19_100_000,
+        txHash: "0xd".repeat(40) + "0".repeat(24),
+      }),
+    ]);
+    const result = await fetchPermit2SubAllowances({
+      chain: "ethereum",
+      owner: WALLET as `0x${string}`,
+      token: USDC as `0x${string}`,
+      decimals: 6,
+    });
+    // The unknown-topic log is filtered → no spenders to scan → no
+    // multicall fired → empty result.
+    expect(result.rows).toHaveLength(0);
+    expect(result.totalScanned).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #304. Now based on `main` (the `get_token_allowances` tool from the prior PR has already landed).

The primary scan in `get_token_allowances` stops at the first layer of ERC-20 `Approval` events. For any wallet that has touched Uniswap (or any UI that uses Permit2), the result is ONE row — *"Permit2 — unlimited"* — with the actual downstream attack surface invisible:

```
You ──unlimited USDC approval──▶ Permit2 ──per-spender sub-allowance──▶ <real spender>
                                                                       ^^^^^^^^^^^^^^
                                                        primary scan stops here
```

This PR closes that gap by recursively enumerating Permit2's per-(owner, token, spender) ledger and surfacing each downstream spender on the parent Permit2 row.

## Implementation

### `src/modules/allowances/permit2.ts` (new)

- **Permit2 mainnet address** (`0x000000000022d473030f116ddee9f6b43ac78ba3` — same on every supported EVM chain) + Approval/Permit topic0 constants. The constants are `keccak256(<canonical event signature>)` and the test suite recomputes them from the signature string as a drift guard.
- **`fetchPermit2SubAllowances`** walks Permit2 events via Etherscan logs filtered to `topic1=owner, topic2=token`. Both `Approval` and `Permit` events captured. Dedups by downstream spender; Multicall3 reads live `Permit2.allowance(user, token, spender) → (uint160 amount, uint48 expiration, uint48 nonce)`.
- **Drop semantics:**
  - `amount === 0` → revoked or consumed
  - `expiration === 0` → Permit2's "fresh signature required" marker (storage slot populated but unusable on its own)
  - `expiration ≤ now` → expired (counted separately, surfaced in notes)
- Sorts surviving rows desc by amount; flags `isUnlimited` at `≥ MAX_UINT160 − 0.01%` (Permit2 caps at uint160, not uint256).
- Mirrors the primary tool's friendly-label resolution so downstream rows get protocol names too (Uniswap V3 SwapRouter02, etc.).

### `src/modules/allowances/schemas.ts`

- New optional field `AllowanceRow.permit2SubAllowances?: Permit2SubAllowanceRow[]`. Populated only when `spender === Permit2`. Backwards-compatible.

### `src/modules/allowances/index.ts`

- After the primary rows are built, gates the Permit2 fetch on a string compare (only runs when Permit2 actually appears as a spender — no extra Etherscan call for tokens the user has only ever approved to non-Permit2 contracts).
- In parallel: `tryReadEip2612Nonce(token, owner)` — if `nonces()` succeeds, surfaces a note with the current nonce + the off-chain-permit risk reminder. Reverts cleanly on tokens that don't implement EIP-2612 (USDT, WBTC, LINK, etc.).
- New note classes:
  - `"N active Permit2 sub-allowances ..."` — with revoke instructions (`Permit2.approve(token, spender, 0, expiration=any)`, NOT zeroing the parent ERC-20 approval).
  - EIP-2612 nonce note when supported.
  - **Completeness footnote always present** — explicitly names the irreducible limitation (Etherscan row cap + missed-block edge cases + "would need an independent indexer to fully cross-check"). Per the issue's tertiary ask: "Document this honestly in `notes[]` rather than fix; it's irreducible without running our own indexer."

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/allowances-permit2.test.ts` — 10/10 pass
- [x] `npx vitest run test/allowances.test.ts` (existing primary-tool tests) — 6/6 pass (backwards-compat)
- [x] `npx vitest run` (full suite) — 1450/1450 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
