### PR TITLE
fix(allowances): preview_send accepts approve(spender, 0) revokes (closes #305)

### DIFF
--- a/src/signing/pre-sign-check.ts
+++ b/src/signing/pre-sign-check.ts
@@ -233,21 +233,34 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
       );
     }
     let spender: string;
+    let amount: bigint;
     try {
       const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
       spender = (decoded.args?.[0] as string).toLowerCase();
+      amount = decoded.args?.[1] as bigint;
     } catch {
       throw new Error(
         `Pre-sign check: could not decode approve() calldata on ${tx.to}. Refusing to sign.`
       );
     }
+    // Revokes — `approve(spender, 0)` — bypass the spender allowlist. Setting
+    // an allowance to zero cannot grant any authority, so the canonical
+    // phishing/drain pattern doesn't apply. Without this carve-out
+    // `prepare_revoke_approval` is unusable for its primary use case:
+    // cleaning up obsolete allowances to spenders the allowlist doesn't
+    // recognize (Permit2, dead router versions, deprecated routers) — those
+    // are exactly the spenders users want OFF, not added to the allowlist.
+    // Issue #305.
+    if (amount === 0n) return;
     const allowlist = buildSpenderAllowlist(tx.chain);
     if (!allowlist.has(spender)) {
       throw new Error(
         `Pre-sign check: refusing approve(spender=${spender}, ...) on ${tx.chain} — spender is ` +
           `not in the protocol allowlist (Aave Pool, Compound Comet, Morpho Blue, Lido Queue, ` +
           `EigenLayer, Uniswap NPM, Uniswap SwapRouter02, LiFi Diamond). This is the canonical phishing/prompt-injection ` +
-          `pattern. If you need to approve a different spender, do it from the Ledger Live app directly.`
+          `pattern. If you need to approve a different spender, do it from the Ledger Live app directly. ` +
+          `(Revokes — approve(spender, 0) — bypass this check; if you want to revoke an existing ` +
+          `allowance, run prepare_revoke_approval instead of crafting your own approve.)`
       );
     }
     return;

--- a/test/pre-sign-check.test.ts
+++ b/test/pre-sign-check.test.ts
@@ -165,6 +165,79 @@ describe("Pre-sign check: approve() spender allowlist", () => {
     ).rejects.toThrow(/token is not in our recognized set/);
   });
 
+  it("ACCEPTS approve(non-allowlisted-spender, 0) — the revoke pattern (issue #305)", async () => {
+    // prepare_revoke_approval emits approve(spender, 0) targeting whatever
+    // spender the user wants to revoke — Permit2, dead routers, deprecated
+    // contracts. Those spenders are NOT on the protocol allowlist (the user
+    // is revoking precisely because they want them off), so the allowlist
+    // check would block the cleanup. amount=0 cannot grant any authority,
+    // so the canonical phishing pattern doesn't apply — short-circuit.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const PERMIT2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [PERMIT2 as `0x${string}`, 0n],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: USDC_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "Revoke USDC allowance for Permit2",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("ACCEPTS approve(arbitrary-attacker-address, 0) — even maximally suspicious revokes are safe", async () => {
+    // Defensive: revoke to a literally-attacker-controlled address still
+    // grants no authority (amount=0). The allowlist is for grants of
+    // authority; revokes are the inverse operation and have no analogous
+    // attack surface.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [ATTACKER as `0x${string}`, 0n],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: USDC_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "Revoke USDC allowance for ATTACKER (cleanup)",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("STILL REJECTS approve(non-allowlisted-spender, 1) — only the exact-zero amount short-circuits", async () => {
+    // Belt-and-suspenders: confirm the carve-out is keyed on amount === 0n
+    // exactly, not on "amount that looks small". A 1-wei approval to an
+    // attacker still grants authority over 1 wei (and the attack surface
+    // typically isn't the size of the grant — it's that the grant exists
+    // at all, since wormholes / delegatecall paths can amplify it).
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [ATTACKER as `0x${string}`, 1n],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: USDC_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "[malicious] dust approval",
+      })
+    ).rejects.toThrow(/spender is not in the protocol allowlist|phishing|prompt-injection/);
+  });
+
   it("rejects approve() aimed at a protocol contract (Aave Pool)", async () => {
     // Nonsensical: approve() on a non-ERC-20. A real ERC-20 approval would
     // hit the token, not the Pool; an agent pointing `to` at the Pool is off-rails.


### PR DESCRIPTION
Closes #305.

## Why

\`prepare_revoke_approval\` (#303) emits \`approve(spender, 0)\` against whatever spender the user wants to clean up — Permit2, dead Uniswap routers, deprecated contracts. Those are precisely the spenders the protocol allowlist (Aave Pool, Compound Comet, Morpho Blue, Lido Queue, EigenLayer, Uniswap NPM, Uniswap SwapRouter02, LiFi Diamond) doesn't recognize, because the user is revoking to *get them off* the allowlist.

\`preview_send\`'s anti-phishing defense (\`assertTransactionSafe\`) correctly refuses \`approve(non-allowlisted-spender, ...)\` — that's the canonical drain pattern. But it didn't distinguish:

| Calldata | Effect | Allowlist correct response |
|---|---|---|
| \`approve(0xATTACKER, MAX_UINT256)\` | Drain entire balance | Refuse ✓ |
| \`approve(0xANYTHING, 0)\` | None — this is a **revoke** | **Should ALLOW** |

The two features (#303 + the existing allowlist check) shipped on the same day; the integration just wasn't tested end-to-end.

## What

In \`src/signing/pre-sign-check.ts\`, decode the second arg of \`approve()\` and short-circuit when it's exactly \`0n\`:

\`\`\`ts
if (amount === 0n) return;  // revoke — cannot grant any authority
\`\`\`

The error message for the non-zero non-allowlisted case now also points users at \`prepare_revoke_approval\` so future agents that *try* to roll their own \`approve(spender, 0)\` get a hint about the right tool.

## Why \`amount === 0n\` is sufficient

The carve-out is keyed strictly on the exact-zero invariant, not \"small amount looks safe\". A 1-wei approval still grants authority over 1 wei (and the attack surface typically isn't the size of the grant — it's that the grant *exists*, since wormhole / delegatecall / hook paths can amplify it). Belt-and-suspenders test confirms \`approve(ATTACKER, 1)\` is still rejected.

## Test surface

- ACCEPT \`approve(Permit2, 0)\` — the canonical revoke (issue's example)
- ACCEPT \`approve(ATTACKER, 0)\` — even maximally suspicious revokes grant nothing
- REJECT \`approve(ATTACKER, 1)\` — dust approvals still grant authority
- All existing approve allowlist + token-shape checks unchanged
- Full suite: 1508/1508 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)