### PR TITLE
feat(nft): get_nft_portfolio + get_nft_collection + get_nft_history (read-only, EVM)

### DIFF
--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -153,6 +153,17 @@ export function resolveOneInchApiKey(userConfig: UserConfig | null): string | un
 }
 
 /**
+ * Pull the Reservoir API key (NFT data) from env or user config; undefined
+ * if none set. An undefined key falls back to Reservoir's anonymous tier,
+ * which the NFT handlers' multi-chain fan-out can hit the rate limit on —
+ * the rate-limit error is surfaced with a "set RESERVOIR_API_KEY" hint so
+ * the user has a clear remediation path.
+ */
+export function resolveReservoirApiKey(userConfig: UserConfig | null): string | undefined {
+  return process.env.RESERVOIR_API_KEY || userConfig?.reservoirApiKey;
+}
+
+/**
  * Pull the TronGrid API key from env or user config; undefined if none set.
  * An undefined key means TRON reads are either disabled or fall back to
  * anonymous TronGrid (rate-limited — the reader flags that in its errored

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,16 @@ import {
 import { getTokenAllowances } from "./modules/allowances/index.js";
 import { getTokenAllowancesInput } from "./modules/allowances/schemas.js";
 import {
+  getNftCollection,
+  getNftHistory,
+  getNftPortfolio,
+} from "./modules/nft/index.js";
+import {
+  getNftCollectionInput,
+  getNftHistoryInput,
+  getNftPortfolioInput,
+} from "./modules/nft/schemas.js";
+import {
   getTokenBalanceInput,
   getTokenMetadataInput,
   resolveNameInput,
@@ -2865,6 +2875,36 @@ async function main() {
       inputSchema: getTokenAllowancesInput.shape,
     },
     handler(getTokenAllowances)
+  );
+
+  registerTool(server,
+    "get_nft_portfolio",
+    {
+      description:
+        "List the NFT collections a wallet owns across one or more supported EVM chains, with per-collection floor price and a rolled-up total floor value. Source: Reservoir. Multi-chain fan-out via `Promise.allSettled` so a per-chain rate-limit or 5xx degrades to a `coverage[].errored` flag rather than aborting the whole call. Each row aggregates per-collection (one row per (chain, contract)), summing `tokenCount` across token IDs the wallet holds. Optional filters: `minFloorEth` drops dust / spam / scam collections; `collections[]` whitelists a specific contract set. Results sorted by `totalFloorUsd` descending. v1 read-only EVM-only — Solana NFT support needs a different API surface (Helius DAS / Magic Eden) and is deferred. NFT signing actions (list, sweep, accept-bid, transfer) deferred — separate plan; biggest UX risk because of approval / proxy patterns. Caveat surfaced in `notes[]`: floor != liquidation; `totalFloorUsd` is an upper-bound, not what the wallet would net selling everything immediately. Optional `RESERVOIR_API_KEY` env var avoids the anonymous-tier rate limit on multi-chain fan-out.",
+      inputSchema: getNftPortfolioInput.shape,
+    },
+    handler(getNftPortfolio)
+  );
+
+  registerTool(server,
+    "get_nft_collection",
+    {
+      description:
+        "Wallet-less NFT collection metadata: name, symbol, image, description, current floor ask + top bid (in native asset and USD), volume by 24h / 7d / 30d / all-time windows, owner count, total supply, secondary-sale royalty (basis points + recipient address). Source: Reservoir. Use this for \"what's this collection's vitals?\" lookups before adding it to a watchlist or evaluating exposure. EVM-only in v1 — Solana NFTs need a different API surface and are deferred. Pass the contract address on its deployed chain (defaults to ethereum). Read-only.",
+      inputSchema: getNftCollectionInput.shape,
+    },
+    handler(getNftCollection)
+  );
+
+  registerTool(server,
+    "get_nft_history",
+    {
+      description:
+        "Recent NFT activity for a wallet across one or more supported EVM chains: mints, sales, transfers, listings (asks), bids, and cancels. Source: Reservoir's `/users/{user}/activity/v6`. Multi-chain results are merged + sorted by timestamp descending; capped at `limit` (default 25, max 100). Mirrors `get_transaction_history`'s shape but limited to NFT-relevant events — same agent ergonomics, scoped to the NFT side of the wallet. EVM-only in v1; Solana deferred. Read-only.",
+      inputSchema: getNftHistoryInput.shape,
+    },
+    handler(getNftHistory)
   );
 
   registerTool(server,

--- a/src/modules/nft/index.ts
+++ b/src/modules/nft/index.ts
@@ -1,0 +1,465 @@
+/**
+ * `get_nft_portfolio` / `get_nft_collection` / `get_nft_history`
+ * handlers. Read-only, EVM-only in v1. Reservoir is the source of
+ * truth for all three tools.
+ *
+ * Multi-chain fan-out is `Promise.allSettled` — one chain's 429 or
+ * 5xx degrades to a `coverage[].errored: true` entry rather than
+ * aborting the whole call. Single-chain rate limits surface a
+ * structured `setupHint` so the agent can tell the user how to
+ * remediate (set RESERVOIR_API_KEY).
+ */
+
+import { SUPPORTED_CHAINS, type SupportedChain } from "../../types/index.js";
+import {
+  reservoirFetch,
+  ReservoirRateLimitedError,
+  RESERVOIR_SETUP_HINT,
+  type ReservoirActivityItem,
+  type ReservoirCollection,
+  type ReservoirCollectionsResponse,
+  type ReservoirUserToken,
+  type ReservoirUserTokensResponse,
+  type ReservoirUsersActivityResponse,
+} from "./reservoir.js";
+import type {
+  GetNftCollectionArgs,
+  GetNftHistoryArgs,
+  GetNftPortfolioArgs,
+  NftCollectionInfo,
+  NftHistoryItem,
+  NftHistoryItemType,
+  NftHistoryResult,
+  NftPortfolioResult,
+  NftPortfolioRow,
+} from "./schemas.js";
+
+/** Reservoir's `/users/{user}/tokens/v10` page size cap. */
+const PORTFOLIO_PAGE_SIZE = 200;
+/** Reservoir's `/users/{user}/activity/v6` page size cap. */
+const ACTIVITY_PAGE_SIZE = 100;
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ---- get_nft_portfolio ---------------------------------------------
+
+interface ChainScanOk {
+  chain: SupportedChain;
+  ok: true;
+  rows: NftPortfolioRow[];
+}
+interface ChainScanErr {
+  chain: SupportedChain;
+  ok: false;
+  reason: string;
+}
+
+async function scanChain(
+  chain: SupportedChain,
+  wallet: string,
+): Promise<ChainScanOk | ChainScanErr> {
+  try {
+    const res = await reservoirFetch<ReservoirUserTokensResponse>({
+      chain,
+      path: `/users/${wallet}/tokens/v10`,
+      query: {
+        limit: PORTFOLIO_PAGE_SIZE,
+        // Aggregate per-collection rather than emit one row per token —
+        // the v1 question is "how much NFT exposure do I have?", not
+        // "list every token id". Reservoir's response carries
+        // `ownership.tokenCount` so we can collapse to per-collection
+        // rows after fetching.
+        sortBy: "lastAppraisalValue",
+      },
+    });
+    const byCollection = new Map<string, NftPortfolioRow>();
+    for (const t of res.tokens) {
+      const row = projectToken(chain, t);
+      if (!row) continue;
+      const key = row.contractAddress.toLowerCase();
+      const existing = byCollection.get(key);
+      if (!existing) {
+        byCollection.set(key, row);
+      } else {
+        // Multiple tokens in the same collection — merge counts and
+        // recompute totals.
+        existing.tokenCount += row.tokenCount;
+        if (existing.floorEth !== undefined) {
+          existing.totalFloorEth = round2(existing.floorEth * existing.tokenCount);
+        }
+        if (existing.floorUsd !== undefined) {
+          existing.totalFloorUsd = round2(existing.floorUsd * existing.tokenCount);
+        }
+      }
+    }
+    return { chain, ok: true, rows: Array.from(byCollection.values()) };
+  } catch (e) {
+    if (e instanceof ReservoirRateLimitedError) {
+      return { chain, ok: false, reason: "rate_limited" };
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    return { chain, ok: false, reason: msg };
+  }
+}
+
+function projectToken(
+  chain: SupportedChain,
+  t: ReservoirUserToken,
+): NftPortfolioRow | null {
+  const tokenCount = Number(t.ownership.tokenCount ?? "0");
+  if (!Number.isFinite(tokenCount) || tokenCount <= 0) return null;
+  const floorEth = t.token.collection.floorAskPrice?.amount?.decimal;
+  const floorUsd = t.token.collection.floorAskPrice?.amount?.usd;
+  const floorCurrency = t.token.collection.floorAskPrice?.currency?.symbol;
+  return {
+    chain,
+    contractAddress: t.token.contract,
+    ...(t.token.collection.name ? { collectionName: t.token.collection.name } : {}),
+    ...(t.token.collection.slug ? { collectionSlug: t.token.collection.slug } : {}),
+    ...(t.token.collection.imageUrl ? { collectionImage: t.token.collection.imageUrl } : {}),
+    tokenCount,
+    ...(typeof floorEth === "number" ? { floorEth } : {}),
+    ...(typeof floorUsd === "number" ? { floorUsd: round2(floorUsd) } : {}),
+    ...(typeof floorEth === "number"
+      ? { totalFloorEth: round2(floorEth * tokenCount) }
+      : {}),
+    ...(typeof floorUsd === "number"
+      ? { totalFloorUsd: round2(floorUsd * tokenCount) }
+      : {}),
+    ...(floorCurrency ? { floorCurrency } : {}),
+  };
+}
+
+export async function getNftPortfolio(
+  args: GetNftPortfolioArgs,
+): Promise<NftPortfolioResult> {
+  const wallet = args.wallet;
+  const chains = (args.chains ?? SUPPORTED_CHAINS) as SupportedChain[];
+
+  const results = await Promise.allSettled(
+    chains.map((c) => scanChain(c, wallet)),
+  );
+
+  const rows: NftPortfolioRow[] = [];
+  const coverage: NftPortfolioResult["coverage"] = [];
+  let rateLimitedAny = false;
+  for (let i = 0; i < results.length; i++) {
+    const c = chains[i];
+    const r = results[i];
+    if (r.status === "rejected") {
+      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      coverage.push({ chain: c, errored: true, reason });
+      continue;
+    }
+    if (!r.value.ok) {
+      coverage.push({ chain: c, errored: true, reason: r.value.reason });
+      if (r.value.reason === "rate_limited") rateLimitedAny = true;
+      continue;
+    }
+    coverage.push({ chain: c, errored: false });
+    rows.push(...r.value.rows);
+  }
+
+  // Apply filters.
+  let filtered = rows;
+  if (typeof args.minFloorEth === "number") {
+    filtered = filtered.filter(
+      (r) =>
+        typeof r.floorEth === "number" && r.floorEth >= args.minFloorEth!,
+    );
+  }
+  if (args.collections && args.collections.length > 0) {
+    const allow = new Set(args.collections.map((a) => a.toLowerCase()));
+    filtered = filtered.filter((r) =>
+      allow.has(r.contractAddress.toLowerCase()),
+    );
+  }
+
+  // Sort by total floor USD descending — biggest-exposure-first matches
+  // the security-audit / portfolio-rollup framing.
+  filtered.sort((a, b) => (b.totalFloorUsd ?? 0) - (a.totalFloorUsd ?? 0));
+
+  const totalFloorUsd = round2(
+    filtered.reduce((sum, r) => sum + (r.totalFloorUsd ?? 0), 0),
+  );
+  const totalTokenCount = filtered.reduce((sum, r) => sum + r.tokenCount, 0);
+
+  const notes: string[] = [];
+  notes.push(
+    "Floor != liquidation. The `totalFloorUsd` rollup is an upper-bound " +
+      "estimate based on each collection's lowest currently-listed ask. " +
+      "Selling a held NFT typically means hitting an existing bid (a few " +
+      "percent below floor) or accepting a sweep at a discount; treat the " +
+      "total as 'best case before slippage', not 'what I'd net selling now'.",
+  );
+  if (rateLimitedAny) {
+    notes.push(RESERVOIR_SETUP_HINT);
+  }
+  if (filtered.length === 0) {
+    if (rows.length > 0) {
+      notes.push(
+        "All collections were filtered out by `minFloorEth` and/or " +
+          "`collections`. Loosen the filter to see them.",
+      );
+    } else {
+      notes.push(
+        "No NFTs found for this wallet on the requested chain(s). Either " +
+          "the wallet doesn't hold any, or all per-chain Reservoir reads " +
+          "errored — check `coverage[]`.",
+      );
+    }
+  }
+
+  return {
+    wallet,
+    chains: chains as string[],
+    totalFloorUsd,
+    collectionCount: filtered.length,
+    totalTokenCount,
+    rows: filtered,
+    coverage,
+    notes,
+  };
+}
+
+// ---- get_nft_collection --------------------------------------------
+
+function projectCollection(
+  chain: SupportedChain,
+  contractAddress: string,
+  c: ReservoirCollection,
+): NftCollectionInfo {
+  const floor = c.floorAsk?.price;
+  const topBid = c.topBid?.price;
+  const info: NftCollectionInfo = {
+    chain,
+    contractAddress,
+    ...(c.name ? { name: c.name } : {}),
+    ...(c.slug ? { slug: c.slug } : {}),
+    ...(c.symbol ? { symbol: c.symbol } : {}),
+    ...(c.description ? { description: c.description } : {}),
+    ...(c.image ? { image: c.image } : {}),
+    ...(c.tokenCount !== undefined
+      ? { tokenCount: Number(c.tokenCount) }
+      : {}),
+    ...(c.ownerCount !== undefined ? { ownerCount: c.ownerCount } : {}),
+    ...(typeof floor?.amount?.decimal === "number"
+      ? { floorEth: floor.amount.decimal }
+      : {}),
+    ...(typeof floor?.amount?.usd === "number"
+      ? { floorUsd: round2(floor.amount.usd) }
+      : {}),
+    ...(floor?.currency?.symbol ? { floorCurrency: floor.currency.symbol } : {}),
+    ...(typeof topBid?.amount?.decimal === "number"
+      ? { topBidEth: topBid.amount.decimal }
+      : {}),
+    ...(typeof topBid?.amount?.usd === "number"
+      ? { topBidUsd: round2(topBid.amount.usd) }
+      : {}),
+    ...(typeof c.volume?.["1day"] === "number"
+      ? { volume24hEth: c.volume["1day"] }
+      : {}),
+    ...(typeof c.volume?.["7day"] === "number"
+      ? { volume7dEth: c.volume["7day"] }
+      : {}),
+    ...(typeof c.volume?.["30day"] === "number"
+      ? { volume30dEth: c.volume["30day"] }
+      : {}),
+    ...(typeof c.volume?.allTime === "number"
+      ? { volumeAllTimeEth: c.volume.allTime }
+      : {}),
+    ...(typeof c.royalties?.bps === "number"
+      ? { royaltyBps: c.royalties.bps }
+      : {}),
+    ...(c.royalties?.recipient
+      ? { royaltyRecipient: c.royalties.recipient }
+      : {}),
+    notes: [],
+  };
+  return info;
+}
+
+export async function getNftCollection(
+  args: GetNftCollectionArgs,
+): Promise<NftCollectionInfo> {
+  const chain = args.chain as SupportedChain;
+  const contractAddress = args.contractAddress;
+  let res: ReservoirCollectionsResponse;
+  try {
+    res = await reservoirFetch<ReservoirCollectionsResponse>({
+      chain,
+      path: `/collections/v7`,
+      query: { contract: contractAddress, limit: 1 },
+    });
+  } catch (e) {
+    if (e instanceof ReservoirRateLimitedError) {
+      throw new Error(
+        `Reservoir rate-limited the collection lookup. ${RESERVOIR_SETUP_HINT}`,
+      );
+    }
+    throw e;
+  }
+  const c = res.collections[0];
+  if (!c) {
+    throw new Error(
+      `No Reservoir collection found at ${contractAddress} on ${chain}. ` +
+        `Either the contract isn't an NFT, isn't indexed, or the chain is wrong.`,
+    );
+  }
+  const info = projectCollection(chain, contractAddress, c);
+  if (info.floorEth === undefined) {
+    info.notes.push(
+      "No active listings — `floorEth` / `floorUsd` are absent. The " +
+        "collection may exist on-chain but currently have no asks.",
+    );
+  }
+  if (info.royaltyBps !== undefined && info.royaltyBps > 0) {
+    info.notes.push(
+      `Secondary-sale royalty: ${(info.royaltyBps / 100).toFixed(2)}% to ${info.royaltyRecipient ?? "(creator)"}.`,
+    );
+  }
+  return info;
+}
+
+// ---- get_nft_history -----------------------------------------------
+
+const ACTIVITY_TYPE_MAP: Record<string, NftHistoryItemType> = {
+  mint: "mint",
+  sale: "sale",
+  transfer: "transfer",
+  ask: "ask",
+  bid: "bid",
+  ask_cancel: "ask_cancel",
+  bid_cancel: "bid_cancel",
+};
+
+function projectActivity(
+  chain: SupportedChain,
+  a: ReservoirActivityItem,
+): NftHistoryItem {
+  const type =
+    ACTIVITY_TYPE_MAP[a.type as keyof typeof ACTIVITY_TYPE_MAP] ?? "other";
+  const priceEth = a.price?.amount?.decimal;
+  const priceUsd = a.price?.amount?.usd;
+  return {
+    chain,
+    type,
+    timestamp: a.timestamp,
+    timestampIso: new Date(a.timestamp * 1000).toISOString(),
+    ...(a.contract ? { contractAddress: a.contract } : {}),
+    ...(a.collection?.collectionName
+      ? { collectionName: a.collection.collectionName }
+      : {}),
+    ...(a.token?.tokenId ? { tokenId: a.token.tokenId } : {}),
+    ...(a.token?.tokenName ? { tokenName: a.token.tokenName } : {}),
+    ...(a.fromAddress ? { fromAddress: a.fromAddress } : {}),
+    ...(a.toAddress ? { toAddress: a.toAddress } : {}),
+    ...(typeof priceEth === "number" ? { priceEth } : {}),
+    ...(typeof priceUsd === "number" ? { priceUsd: round2(priceUsd) } : {}),
+    ...(a.price?.currency?.symbol
+      ? { priceCurrency: a.price.currency.symbol }
+      : {}),
+    ...(a.txHash ? { txHash: a.txHash } : {}),
+  };
+}
+
+interface HistoryScanOk {
+  chain: SupportedChain;
+  ok: true;
+  items: NftHistoryItem[];
+}
+interface HistoryScanErr {
+  chain: SupportedChain;
+  ok: false;
+  reason: string;
+}
+
+async function scanHistoryChain(
+  chain: SupportedChain,
+  wallet: string,
+  limit: number,
+): Promise<HistoryScanOk | HistoryScanErr> {
+  try {
+    const res = await reservoirFetch<ReservoirUsersActivityResponse>({
+      chain,
+      path: `/users/${wallet}/activity/v6`,
+      query: {
+        limit: Math.min(limit, ACTIVITY_PAGE_SIZE),
+        sortBy: "eventTimestamp",
+      },
+    });
+    return {
+      chain,
+      ok: true,
+      items: res.activities.map((a) => projectActivity(chain, a)),
+    };
+  } catch (e) {
+    if (e instanceof ReservoirRateLimitedError) {
+      return { chain, ok: false, reason: "rate_limited" };
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    return { chain, ok: false, reason: msg };
+  }
+}
+
+export async function getNftHistory(
+  args: GetNftHistoryArgs,
+): Promise<NftHistoryResult> {
+  const wallet = args.wallet;
+  const chains = (args.chains ?? SUPPORTED_CHAINS) as SupportedChain[];
+  const limit = args.limit;
+
+  const results = await Promise.allSettled(
+    chains.map((c) => scanHistoryChain(c, wallet, limit)),
+  );
+
+  const items: NftHistoryItem[] = [];
+  const coverage: NftHistoryResult["coverage"] = [];
+  let rateLimitedAny = false;
+  for (let i = 0; i < results.length; i++) {
+    const c = chains[i];
+    const r = results[i];
+    if (r.status === "rejected") {
+      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      coverage.push({ chain: c, errored: true, reason });
+      continue;
+    }
+    if (!r.value.ok) {
+      coverage.push({ chain: c, errored: true, reason: r.value.reason });
+      if (r.value.reason === "rate_limited") rateLimitedAny = true;
+      continue;
+    }
+    coverage.push({ chain: c, errored: false });
+    items.push(...r.value.items);
+  }
+
+  // Merge desc by timestamp; truncate to the requested limit.
+  items.sort((a, b) => b.timestamp - a.timestamp);
+  let truncated = false;
+  let finalItems = items;
+  if (items.length > limit) {
+    finalItems = items.slice(0, limit);
+    truncated = true;
+  }
+
+  const notes: string[] = [];
+  if (rateLimitedAny) notes.push(RESERVOIR_SETUP_HINT);
+  if (finalItems.length === 0) {
+    notes.push(
+      "No NFT activity found on the requested chain(s). Either the wallet " +
+        "has no NFT history, or per-chain Reservoir reads errored — check " +
+        "`coverage[]`.",
+    );
+  }
+
+  return {
+    wallet,
+    chains: chains as string[],
+    items: finalItems,
+    truncated,
+    coverage,
+    notes,
+  };
+}

--- a/src/modules/nft/reservoir.ts
+++ b/src/modules/nft/reservoir.ts
@@ -1,0 +1,232 @@
+/**
+ * Reservoir API client. Read-only. Used by the three NFT tools
+ * (`get_nft_portfolio`, `get_nft_collection`, `get_nft_history`) to
+ * pull holdings, collection metadata, and per-wallet activity across
+ * EVM chains.
+ *
+ * Reservoir hosts one base URL per chain (the chain id is part of the
+ * subdomain). The free tier serves anonymous requests but rate-limits
+ * at a ceiling that doesn't survive multi-chain portfolio fan-out;
+ * configuring `RESERVOIR_API_KEY` avoids 429s. The `RateLimitedError`
+ * carries a structured `setupHint` so the agent can tell the user
+ * exactly what to do when limits hit.
+ *
+ * No retry-on-429 here — Reservoir's `Retry-After` header would tell
+ * us how long to back off, but multi-chain fan-out means a 429 on one
+ * chain shouldn't stall the others. The handlers gather results via
+ * `Promise.allSettled` so per-chain failures degrade rather than abort.
+ */
+
+import { fetchWithTimeout } from "../../data/http.js";
+import {
+  resolveReservoirApiKey,
+  readUserConfig,
+} from "../../config/user-config.js";
+import type { SupportedChain } from "../../types/index.js";
+
+/** Match the existing per-API guardrail. */
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Reservoir's per-chain hostnames. The chain selector is encoded in
+ * the subdomain rather than a query param, mirroring Reservoir's own
+ * API docs. Optimism is `optimism`, not `op`. Avalanche is intentionally
+ * NOT in the supported set yet — vaultpilot's chain enum doesn't carry
+ * it, and adding it is out of scope until the rest of the EVM stack
+ * does.
+ */
+const RESERVOIR_HOSTS: Record<SupportedChain, string> = {
+  ethereum: "api.reservoir.tools",
+  arbitrum: "api-arbitrum.reservoir.tools",
+  polygon: "api-polygon.reservoir.tools",
+  base: "api-base.reservoir.tools",
+  optimism: "api-optimism.reservoir.tools",
+};
+
+/**
+ * Public — agent-facing setup hint for any rate-limit / auth surface.
+ * Kept short; the agent surfaces it verbatim to the user.
+ */
+export const RESERVOIR_SETUP_HINT =
+  "Reservoir rate-limited the request. Free anonymous tier is generous " +
+  "but multi-chain fan-out can hit the ceiling. Set RESERVOIR_API_KEY in " +
+  "the MCP server env (free key at https://reservoir.tools/) and retry.";
+
+export class ReservoirRateLimitedError extends Error {
+  readonly setupHint: string;
+  constructor(public readonly chain: SupportedChain, public readonly path: string) {
+    super(`Reservoir ${chain} ${path} returned 429 (rate limited)`);
+    this.name = "ReservoirRateLimitedError";
+    this.setupHint = RESERVOIR_SETUP_HINT;
+  }
+}
+
+export class ReservoirHttpError extends Error {
+  constructor(
+    public readonly chain: SupportedChain,
+    public readonly path: string,
+    public readonly status: number,
+    public readonly body: string,
+  ) {
+    super(
+      `Reservoir ${chain} ${path} returned ${status}: ${body.slice(0, 200)}`,
+    );
+    this.name = "ReservoirHttpError";
+  }
+}
+
+/**
+ * GET against the chain's Reservoir host. Throws structured errors on
+ * HTTP non-2xx; passes through JSON-parse errors unchanged. The query
+ * params are appended verbatim — caller is responsible for properly
+ * encoding any addresses / contract IDs.
+ *
+ * Reservoir endpoints accept addresses with or without a `0x` prefix
+ * and are case-insensitive. We pass them through as-given; no
+ * normalization here.
+ */
+export async function reservoirFetch<T>(args: {
+  chain: SupportedChain;
+  path: string;
+  query?: Record<string, string | number | undefined>;
+}): Promise<T> {
+  const apiKey = resolveReservoirApiKey(readUserConfig());
+  const headers: Record<string, string> = {
+    accept: "*/*",
+  };
+  if (apiKey) headers["x-api-key"] = apiKey;
+
+  const params = new URLSearchParams();
+  if (args.query) {
+    for (const [k, v] of Object.entries(args.query)) {
+      if (v === undefined || v === null) continue;
+      params.set(k, String(v));
+    }
+  }
+  const qs = params.toString();
+  const url = `https://${RESERVOIR_HOSTS[args.chain]}${args.path}${qs ? "?" + qs : ""}`;
+
+  const res = await fetchWithTimeout(url, { headers });
+  if (res.status === 429) {
+    throw new ReservoirRateLimitedError(args.chain, args.path);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ReservoirHttpError(args.chain, args.path, res.status, body);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(
+      `Reservoir ${args.chain} ${args.path} response exceeds ${MAX_RESPONSE_BYTES} bytes (got ${text.length}). ` +
+        `Reduce the requested page size.`,
+    );
+  }
+  return JSON.parse(text) as T;
+}
+
+// ---- Response shapes used by the handlers ------------------------------
+//
+// Stripped to the fields we actually surface. Reservoir's own response
+// envelopes carry many more fields; using a narrow projection means a
+// future Reservoir field rename only matters if we touch THIS file.
+
+export interface ReservoirUserToken {
+  token: {
+    contract: string;
+    tokenId: string;
+    name?: string;
+    image?: string;
+    media?: string;
+    collection: {
+      id: string;
+      name?: string;
+      slug?: string;
+      imageUrl?: string;
+      floorAskPrice?: { amount?: { decimal?: number; usd?: number }; currency?: { symbol?: string } };
+    };
+  };
+  ownership: {
+    tokenCount: string;
+    onSaleCount?: string;
+    floorAsk?: {
+      price?: { amount?: { decimal?: number; usd?: number } };
+    };
+    acquiredAt?: string;
+  };
+}
+
+export interface ReservoirUserTokensResponse {
+  tokens: ReservoirUserToken[];
+  continuation?: string;
+}
+
+export interface ReservoirCollection {
+  id: string;
+  name?: string;
+  slug?: string;
+  symbol?: string;
+  description?: string;
+  image?: string;
+  banner?: string;
+  primaryContract?: string;
+  tokenCount?: string;
+  onSaleCount?: string;
+  ownerCount?: number;
+  floorAsk?: {
+    price?: {
+      amount?: { decimal?: number; usd?: number };
+      currency?: { symbol?: string };
+    };
+  };
+  topBid?: {
+    price?: {
+      amount?: { decimal?: number; usd?: number };
+      currency?: { symbol?: string };
+    };
+  };
+  volume?: {
+    "1day"?: number;
+    "7day"?: number;
+    "30day"?: number;
+    allTime?: number;
+  };
+  royalties?: {
+    bps?: number;
+    recipient?: string;
+  };
+  creator?: string;
+  rank?: { "1day"?: number; "7day"?: number; "30day"?: number; allTime?: number };
+}
+
+export interface ReservoirCollectionsResponse {
+  collections: ReservoirCollection[];
+}
+
+export interface ReservoirActivityItem {
+  type: string; // "mint" | "sale" | "transfer" | "ask" | "bid" | "ask_cancel" | ...
+  fromAddress?: string;
+  toAddress?: string;
+  price?: {
+    amount?: { decimal?: number; usd?: number };
+    currency?: { symbol?: string };
+  };
+  amount?: number;
+  timestamp: number;
+  contract?: string;
+  token?: {
+    tokenId?: string;
+    tokenName?: string;
+    tokenImage?: string;
+  };
+  collection?: {
+    collectionId?: string;
+    collectionName?: string;
+    collectionImage?: string;
+  };
+  txHash?: string;
+}
+
+export interface ReservoirUsersActivityResponse {
+  activities: ReservoirActivityItem[];
+  continuation?: string;
+}

--- a/src/modules/nft/schemas.ts
+++ b/src/modules/nft/schemas.ts
@@ -1,0 +1,221 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+
+const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+
+/**
+ * `get_nft_portfolio` — list NFTs the wallet owns across one or more
+ * EVM chains, with per-collection floor and a rolled-up total floor
+ * value. v1 read-only.
+ *
+ * Floor != liquidation: the floor is the lowest currently-listed ask.
+ * Selling a held NFT typically means hitting an existing bid (a few
+ * percent below floor) or accepting a sweep at a discount; the
+ * rolled-up `totalFloorEth` is best read as "upper bound on
+ * disposal proceeds before slippage", not "what I could sell for
+ * right now". The handler's `notes[]` says so.
+ */
+export const getNftPortfolioInput = z.object({
+  wallet: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .describe(
+      "EVM wallet to enumerate. Reservoir is the source of truth; the " +
+        "tool fans out one HTTP call per requested chain in parallel.",
+    ),
+  chains: z
+    .array(chainEnum)
+    .min(1)
+    .max(5)
+    .optional()
+    .describe(
+      "Subset of supported EVM chains to scan (ethereum / arbitrum / " +
+        "polygon / base / optimism). Omit to scan all five. Per-chain " +
+        "errors degrade rather than abort the whole call — the response's " +
+        "`coverage` field flags which chains errored.",
+    ),
+  minFloorEth: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Drop NFTs whose collection floor is below this value (in the " +
+        "chain's native asset). Useful for filtering out airdrop / spam / " +
+        "scam collections that pollute the headline. Default: no filter.",
+    ),
+  collections: z
+    .array(z.string().regex(EVM_ADDRESS))
+    .max(50)
+    .optional()
+    .describe(
+      "Whitelist a specific set of collection contract addresses. When " +
+        "supplied, ALL other collections are dropped. Useful for spot-" +
+        "checking a particular collection. Mutually composable with " +
+        "`minFloorEth` (both filters apply).",
+    ),
+});
+
+export type GetNftPortfolioArgs = z.infer<typeof getNftPortfolioInput>;
+
+/**
+ * `get_nft_collection` — wallet-less collection metadata (floor, top
+ * bid, volume by window, holder count, royalty). For "what's this
+ * collection's vitals?" lookups before deciding to add it.
+ */
+export const getNftCollectionInput = z.object({
+  contractAddress: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .describe("EVM contract address of the NFT collection."),
+  chain: chainEnum
+    .default("ethereum")
+    .describe(
+      "EVM chain the collection is deployed on. Defaults to ethereum.",
+    ),
+});
+
+export type GetNftCollectionArgs = z.infer<typeof getNftCollectionInput>;
+
+/**
+ * `get_nft_history` — recent NFT activity for the wallet (mints, buys,
+ * sells, transfers, listings). Mirrors the EVM `get_transaction_history`
+ * shape but limited to NFT-relevant events.
+ */
+export const getNftHistoryInput = z.object({
+  wallet: z.string().regex(EVM_ADDRESS),
+  chains: z
+    .array(chainEnum)
+    .min(1)
+    .max(5)
+    .optional()
+    .describe(
+      "Subset of supported EVM chains to scan. Omit for all five. " +
+        "Multi-chain results are merged + sorted desc by timestamp.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(25)
+    .describe(
+      "Max merged items to return (newest-first). Default 25, capped " +
+        "at 100 to keep the cross-chain merge bounded.",
+    ),
+});
+
+export type GetNftHistoryArgs = z.infer<typeof getNftHistoryInput>;
+
+// ---- Result types ---------------------------------------------------
+
+/**
+ * One row per (collection, contractAddress) the wallet holds. Even
+ * for ERC-1155 collections where the wallet holds multiple ids, the
+ * row is per-collection — `tokenCount` aggregates across token IDs.
+ * Flattening per-tokenId is out of scope for v1; the rollup is what
+ * users actually need ("how much NFT exposure do I have?").
+ */
+export interface NftPortfolioRow {
+  chain: string;
+  contractAddress: string;
+  collectionName?: string;
+  collectionSlug?: string;
+  collectionImage?: string;
+  /** How many tokens the wallet holds in this collection (sum across token IDs). */
+  tokenCount: number;
+  /** Floor ask in the chain's native asset. Absent when the collection has no listings. */
+  floorEth?: number;
+  /** Floor ask in USD via Reservoir's own pricing. Absent when no listings. */
+  floorUsd?: number;
+  /**
+   * Estimated total value: `floorEth * tokenCount`. Same caveat as
+   * floor — a top-of-book approximation, not "what I'd net selling all".
+   */
+  totalFloorEth?: number;
+  totalFloorUsd?: number;
+  /** Currency symbol for the floor — typically "ETH" / "MATIC" / "ETH" (Base) etc. */
+  floorCurrency?: string;
+}
+
+export interface NftPortfolioResult {
+  wallet: string;
+  chains: string[];
+  /** Total floor value across every row, in USD (when priced). */
+  totalFloorUsd: number;
+  /** Number of NFT collections the wallet holds at least one token in. */
+  collectionCount: number;
+  /** Sum of `tokenCount` across rows (total NFTs held). */
+  totalTokenCount: number;
+  rows: NftPortfolioRow[];
+  /** Per-chain coverage — `errored` flags which chains failed. */
+  coverage: Array<{ chain: string; errored: boolean; reason?: string }>;
+  notes: string[];
+}
+
+export interface NftCollectionInfo {
+  chain: string;
+  contractAddress: string;
+  name?: string;
+  slug?: string;
+  symbol?: string;
+  description?: string;
+  image?: string;
+  tokenCount?: number;
+  ownerCount?: number;
+  /** Lowest currently-listed ask, in native + USD. */
+  floorEth?: number;
+  floorUsd?: number;
+  floorCurrency?: string;
+  /** Highest currently-active offer (collection bid), in native + USD. */
+  topBidEth?: number;
+  topBidUsd?: number;
+  /** Volume by window in native units. */
+  volume24hEth?: number;
+  volume7dEth?: number;
+  volume30dEth?: number;
+  volumeAllTimeEth?: number;
+  /** Royalty in basis points (250 = 2.5%) — what the creator earns per secondary sale. */
+  royaltyBps?: number;
+  /** Royalty recipient address. */
+  royaltyRecipient?: string;
+  notes: string[];
+}
+
+export type NftHistoryItemType =
+  | "mint"
+  | "sale"
+  | "transfer"
+  | "ask"
+  | "bid"
+  | "ask_cancel"
+  | "bid_cancel"
+  | "other";
+
+export interface NftHistoryItem {
+  chain: string;
+  type: NftHistoryItemType;
+  /** Unix seconds. */
+  timestamp: number;
+  timestampIso: string;
+  contractAddress?: string;
+  collectionName?: string;
+  tokenId?: string;
+  tokenName?: string;
+  fromAddress?: string;
+  toAddress?: string;
+  /** Sale / ask / bid price in native asset. Absent on transfers / mints without a recorded price. */
+  priceEth?: number;
+  priceUsd?: number;
+  priceCurrency?: string;
+  txHash?: string;
+}
+
+export interface NftHistoryResult {
+  wallet: string;
+  chains: string[];
+  items: NftHistoryItem[];
+  truncated: boolean;
+  coverage: Array<{ chain: string; errored: boolean; reason?: string }>;
+  notes: string[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1534,6 +1534,14 @@ export interface UserConfig {
   /** Optional 1inch Developer Portal API key for intra-chain swap-quote comparison. */
   oneInchApiKey?: string;
   /**
+   * Optional Reservoir API key for the NFT-portfolio tools (`get_nft_*`).
+   * Reservoir's free tier serves anonymous requests but rate-limits at
+   * a tight ceiling that doesn't survive multi-chain portfolio fan-out;
+   * configuring a key avoids 429s. Free key at https://reservoir.tools/.
+   * Env var `RESERVOIR_API_KEY` takes priority over this field.
+   */
+  reservoirApiKey?: string;
+  /**
    * Safe Transaction Service API key. Required to call `get_safe_positions` and
    * the v2/v3 propose/execute Safe tools — modern `*.safe.global` endpoints
    * authenticate every request. Get one at https://developer.safe.global/.

--- a/test/nft.test.ts
+++ b/test/nft.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Tests for the three NFT tools (`get_nft_portfolio`,
+ * `get_nft_collection`, `get_nft_history`). Mocks the global `fetch`
+ * via `fetchWithTimeout`'s underlying call so no live HTTP fires.
+ *
+ * Coverage:
+ *   - get_nft_portfolio happy path: 2-chain fan-out, per-collection
+ *     aggregation, USD rollup, sort desc by total value.
+ *   - get_nft_portfolio rate-limit: 429 on one chain → coverage flags
+ *     it, other chain still surfaces, setup hint in notes.
+ *   - get_nft_portfolio filters: minFloorEth, collections whitelist.
+ *   - get_nft_collection happy path: floor, top bid, volume rollups,
+ *     royalty.
+ *   - get_nft_collection — no listings → notes flag + floor absent.
+ *   - get_nft_history happy path: 2-chain merge, sorted desc by
+ *     timestamp, capped at limit.
+ *   - get_nft_history truncation flag.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../src/data/http.js", () => ({
+  fetchWithTimeout: (...a: unknown[]) => fetchMock(...a),
+}));
+
+const fetchMock = vi.fn();
+
+vi.mock("../src/config/user-config.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/config/user-config.ts")>();
+  return {
+    ...actual,
+    readUserConfig: vi.fn().mockReturnValue(null),
+    resolveReservoirApiKey: vi.fn().mockReturnValue(undefined),
+  };
+});
+
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const BAYC = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
+const PUDGY = "0xBd3531dA5CF5857e7CfAA92426877b022e612cf8";
+const PHISHY = "0x9999999999999999999999999999999999999999";
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Build a vitest-friendly `Response`-like stub from the mocked
+ * `fetchWithTimeout`. Has the minimal shape the Reservoir client uses:
+ * `ok` / `status` / `text()`.
+ */
+function fakeResponse(opts: MockResponse): {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+} {
+  return {
+    ok: opts.status >= 200 && opts.status < 300,
+    status: opts.status,
+    text: async () => JSON.stringify(opts.body),
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("get_nft_portfolio — happy path", () => {
+  it("merges 2-chain results, aggregates per collection, sorts desc by total floor USD", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      // Ethereum: 2 BAYCs (one row) + 1 PUDGY → 2 collections
+      if (url.includes("api.reservoir.tools")) {
+        return fakeResponse({
+          status: 200,
+          body: {
+            tokens: [
+              {
+                token: {
+                  contract: BAYC,
+                  tokenId: "100",
+                  name: "BAYC #100",
+                  collection: {
+                    id: BAYC,
+                    name: "Bored Ape Yacht Club",
+                    slug: "boredapeyachtclub",
+                    floorAskPrice: {
+                      amount: { decimal: 25, usd: 65000 },
+                      currency: { symbol: "ETH" },
+                    },
+                  },
+                },
+                ownership: { tokenCount: "1" },
+              },
+              {
+                token: {
+                  contract: BAYC,
+                  tokenId: "101",
+                  collection: {
+                    id: BAYC,
+                    name: "Bored Ape Yacht Club",
+                    floorAskPrice: {
+                      amount: { decimal: 25, usd: 65000 },
+                      currency: { symbol: "ETH" },
+                    },
+                  },
+                },
+                ownership: { tokenCount: "1" },
+              },
+              {
+                token: {
+                  contract: PUDGY,
+                  tokenId: "1",
+                  collection: {
+                    id: PUDGY,
+                    name: "Pudgy Penguins",
+                    floorAskPrice: {
+                      amount: { decimal: 8, usd: 20800 },
+                      currency: { symbol: "ETH" },
+                    },
+                  },
+                },
+                ownership: { tokenCount: "1" },
+              },
+            ],
+          },
+        });
+      }
+      // Arbitrum: 1 random collection
+      if (url.includes("api-arbitrum.reservoir.tools")) {
+        return fakeResponse({
+          status: 200,
+          body: {
+            tokens: [
+              {
+                token: {
+                  contract: PHISHY,
+                  tokenId: "1",
+                  collection: {
+                    id: PHISHY,
+                    name: "Some L2 Collection",
+                    floorAskPrice: {
+                      amount: { decimal: 0.05, usd: 130 },
+                      currency: { symbol: "ETH" },
+                    },
+                  },
+                },
+                ownership: { tokenCount: "1" },
+              },
+            ],
+          },
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const { getNftPortfolio } = await import("../src/modules/nft/index.ts");
+    const r = await getNftPortfolio({
+      wallet: WALLET,
+      chains: ["ethereum", "arbitrum"],
+    });
+
+    expect(r.coverage).toHaveLength(2);
+    expect(r.coverage.every((c) => !c.errored)).toBe(true);
+
+    // 3 unique collections, 4 tokens.
+    expect(r.collectionCount).toBe(3);
+    expect(r.totalTokenCount).toBe(4);
+
+    // Sorted desc: BAYC ($130k) > PUDGY ($20.8k) > L2 ($130).
+    expect(r.rows[0].collectionName).toBe("Bored Ape Yacht Club");
+    expect(r.rows[0].tokenCount).toBe(2);
+    expect(r.rows[0].totalFloorUsd).toBe(130_000);
+    expect(r.rows[1].collectionName).toBe("Pudgy Penguins");
+    expect(r.rows[2].chain).toBe("arbitrum");
+
+    expect(r.totalFloorUsd).toBe(130_000 + 20_800 + 130);
+    // Floor != liquidation note always present.
+    expect(r.notes.some((n) => n.toLowerCase().includes("floor"))).toBe(true);
+  });
+});
+
+describe("get_nft_portfolio — rate-limit + filters", () => {
+  it("flags rate-limited chains in coverage and surfaces the setup hint", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("api.reservoir.tools")) {
+        // Ethereum returns one row.
+        return fakeResponse({
+          status: 200,
+          body: {
+            tokens: [
+              {
+                token: {
+                  contract: BAYC,
+                  tokenId: "100",
+                  collection: {
+                    id: BAYC,
+                    name: "BAYC",
+                    floorAskPrice: {
+                      amount: { decimal: 25, usd: 65000 },
+                      currency: { symbol: "ETH" },
+                    },
+                  },
+                },
+                ownership: { tokenCount: "1" },
+              },
+            ],
+          },
+        });
+      }
+      // Arbitrum is rate-limited.
+      return fakeResponse({ status: 429, body: { message: "Rate limited" } });
+    });
+
+    const { getNftPortfolio } = await import("../src/modules/nft/index.ts");
+    const r = await getNftPortfolio({
+      wallet: WALLET,
+      chains: ["ethereum", "arbitrum"],
+    });
+
+    expect(r.rows).toHaveLength(1);
+    expect(r.coverage.find((c) => c.chain === "arbitrum")?.errored).toBe(true);
+    expect(r.coverage.find((c) => c.chain === "arbitrum")?.reason).toBe(
+      "rate_limited",
+    );
+    expect(r.notes.some((n) => n.toLowerCase().includes("rate"))).toBe(true);
+    expect(r.notes.some((n) => n.includes("RESERVOIR_API_KEY"))).toBe(true);
+  });
+
+  it("respects minFloorEth filter — drops rows below threshold", async () => {
+    fetchMock.mockImplementation(async () =>
+      fakeResponse({
+        status: 200,
+        body: {
+          tokens: [
+            {
+              token: {
+                contract: BAYC,
+                tokenId: "100",
+                collection: {
+                  id: BAYC,
+                  name: "BAYC",
+                  floorAskPrice: { amount: { decimal: 25, usd: 65000 } },
+                },
+              },
+              ownership: { tokenCount: "1" },
+            },
+            {
+              token: {
+                contract: PHISHY,
+                tokenId: "1",
+                collection: {
+                  id: PHISHY,
+                  name: "Spam",
+                  floorAskPrice: { amount: { decimal: 0.001, usd: 2.6 } },
+                },
+              },
+              ownership: { tokenCount: "1" },
+            },
+          ],
+        },
+      }),
+    );
+
+    const { getNftPortfolio } = await import("../src/modules/nft/index.ts");
+    const r = await getNftPortfolio({
+      wallet: WALLET,
+      chains: ["ethereum"],
+      minFloorEth: 1,
+    });
+
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0].collectionName).toBe("BAYC");
+  });
+
+  it("respects collections whitelist — keeps only listed contracts", async () => {
+    fetchMock.mockImplementation(async () =>
+      fakeResponse({
+        status: 200,
+        body: {
+          tokens: [
+            {
+              token: {
+                contract: BAYC,
+                tokenId: "100",
+                collection: {
+                  id: BAYC,
+                  name: "BAYC",
+                  floorAskPrice: { amount: { decimal: 25, usd: 65000 } },
+                },
+              },
+              ownership: { tokenCount: "1" },
+            },
+            {
+              token: {
+                contract: PUDGY,
+                tokenId: "1",
+                collection: {
+                  id: PUDGY,
+                  name: "Pudgy",
+                  floorAskPrice: { amount: { decimal: 8, usd: 20800 } },
+                },
+              },
+              ownership: { tokenCount: "1" },
+            },
+          ],
+        },
+      }),
+    );
+
+    const { getNftPortfolio } = await import("../src/modules/nft/index.ts");
+    const r = await getNftPortfolio({
+      wallet: WALLET,
+      chains: ["ethereum"],
+      collections: [BAYC],
+    });
+
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0].collectionName).toBe("BAYC");
+  });
+});
+
+describe("get_nft_collection", () => {
+  it("returns floor + top bid + volume + royalty for a known collection", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        status: 200,
+        body: {
+          collections: [
+            {
+              id: BAYC,
+              name: "Bored Ape Yacht Club",
+              symbol: "BAYC",
+              tokenCount: "10000",
+              ownerCount: 5500,
+              floorAsk: {
+                price: {
+                  amount: { decimal: 25, usd: 65000 },
+                  currency: { symbol: "ETH" },
+                },
+              },
+              topBid: {
+                price: {
+                  amount: { decimal: 23, usd: 59800 },
+                  currency: { symbol: "ETH" },
+                },
+              },
+              volume: {
+                "1day": 100,
+                "7day": 800,
+                "30day": 3500,
+                allTime: 950000,
+              },
+              royalties: { bps: 250, recipient: "0xCreator" },
+            },
+          ],
+        },
+      }),
+    );
+
+    const { getNftCollection } = await import("../src/modules/nft/index.ts");
+    const r = await getNftCollection({
+      contractAddress: BAYC,
+      chain: "ethereum",
+    });
+
+    expect(r.name).toBe("Bored Ape Yacht Club");
+    expect(r.floorEth).toBe(25);
+    expect(r.floorUsd).toBe(65000);
+    expect(r.topBidEth).toBe(23);
+    expect(r.volume24hEth).toBe(100);
+    expect(r.volumeAllTimeEth).toBe(950000);
+    expect(r.royaltyBps).toBe(250);
+    expect(r.notes.some((n) => n.includes("2.50%"))).toBe(true);
+  });
+
+  it("flags missing floor when the collection has no listings", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        status: 200,
+        body: {
+          collections: [
+            {
+              id: BAYC,
+              name: "Quiet Collection",
+              tokenCount: "100",
+              ownerCount: 50,
+              // No floorAsk.
+            },
+          ],
+        },
+      }),
+    );
+
+    const { getNftCollection } = await import("../src/modules/nft/index.ts");
+    const r = await getNftCollection({
+      contractAddress: BAYC,
+      chain: "ethereum",
+    });
+    expect(r.floorEth).toBeUndefined();
+    expect(r.notes.some((n) => n.toLowerCase().includes("no active listings"))).toBe(true);
+  });
+
+  it("throws when no collection found at the given address", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        status: 200,
+        body: { collections: [] },
+      }),
+    );
+    const { getNftCollection } = await import("../src/modules/nft/index.ts");
+    await expect(
+      getNftCollection({
+        contractAddress: "0x0000000000000000000000000000000000000001",
+        chain: "ethereum",
+      }),
+    ).rejects.toThrow(/No Reservoir collection found/);
+  });
+});
+
+describe("get_nft_history", () => {
+  it("merges 2-chain activity, sorts desc by timestamp, caps at limit", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("api.reservoir.tools")) {
+        return fakeResponse({
+          status: 200,
+          body: {
+            activities: [
+              {
+                type: "sale",
+                timestamp: 1_700_000_000,
+                contract: BAYC,
+                price: {
+                  amount: { decimal: 25, usd: 65000 },
+                  currency: { symbol: "ETH" },
+                },
+                token: { tokenId: "100", tokenName: "BAYC #100" },
+                collection: { collectionName: "BAYC" },
+                fromAddress: "0xseller",
+                toAddress: WALLET,
+                txHash: "0xabc",
+              },
+              {
+                type: "mint",
+                timestamp: 1_690_000_000,
+                contract: PUDGY,
+                token: { tokenId: "5" },
+                collection: { collectionName: "Pudgy Penguins" },
+                toAddress: WALLET,
+                txHash: "0xdef",
+              },
+            ],
+          },
+        });
+      }
+      if (url.includes("api-arbitrum.reservoir.tools")) {
+        return fakeResponse({
+          status: 200,
+          body: {
+            activities: [
+              {
+                type: "transfer",
+                timestamp: 1_710_000_000, // newer than ethereum's 1.7B
+                contract: PHISHY,
+                token: { tokenId: "1" },
+                collection: { collectionName: "Some L2" },
+                fromAddress: WALLET,
+                toAddress: "0xrecipient",
+                txHash: "0xfeed",
+              },
+            ],
+          },
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const { getNftHistory } = await import("../src/modules/nft/index.ts");
+    const r = await getNftHistory({
+      wallet: WALLET,
+      chains: ["ethereum", "arbitrum"],
+      limit: 25,
+    });
+
+    expect(r.items).toHaveLength(3);
+    // Sorted desc: arbitrum transfer (1.71B) > eth sale (1.70B) > eth mint (1.69B).
+    expect(r.items[0].type).toBe("transfer");
+    expect(r.items[0].chain).toBe("arbitrum");
+    expect(r.items[1].type).toBe("sale");
+    expect(r.items[1].priceEth).toBe(25);
+    expect(r.items[2].type).toBe("mint");
+  });
+
+  it("flags truncated:true when merged items exceed limit", async () => {
+    fetchMock.mockImplementation(async () =>
+      fakeResponse({
+        status: 200,
+        body: {
+          activities: Array.from({ length: 30 }, (_, i) => ({
+            type: "transfer",
+            timestamp: 1_700_000_000 + i,
+            contract: BAYC,
+            token: { tokenId: String(i) },
+            txHash: `0x${i.toString(16).padStart(64, "0")}`,
+          })),
+        },
+      }),
+    );
+    const { getNftHistory } = await import("../src/modules/nft/index.ts");
+    const r = await getNftHistory({
+      wallet: WALLET,
+      chains: ["ethereum"],
+      limit: 5,
+    });
+    expect(r.items).toHaveLength(5);
+    expect(r.truncated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Three new read-only MCP tools opening up the NFT-collector audience VaultPilot didn't reach before. All EVM-only in v1, sourced from Reservoir.

| Tool | Question it answers |
|---|---|
| `get_nft_portfolio(wallet, chains?, minFloorEth?, collections?)` | "What NFTs do I own and what are they worth at floor?" |
| `get_nft_collection(contractAddress, chain)` | "What's this collection's vitals — floor, top bid, volume, royalty?" |
| `get_nft_history(wallet, chains?, limit?)` | "What did I do with NFTs lately — mints / buys / sells / listings?" |

## Implementation

| File | Change |
|---|---|
| `src/modules/nft/reservoir.ts` (new) | HTTP client. Per-chain hosts (chain selector encoded in subdomain, not query param). Auth via `x-api-key` header when `RESERVOIR_API_KEY` is set. Structured `ReservoirRateLimitedError` + `ReservoirHttpError`; 4MB response cap. |
| `src/modules/nft/schemas.ts` (new) | Zod inputs + result types (`NftPortfolioRow`, `NftCollectionInfo`, `NftHistoryItem`). |
| `src/modules/nft/index.ts` (new) | Three handlers + per-chain projection. Multi-chain fan-out via `Promise.allSettled` so a 429 / 5xx on one chain degrades to a `coverage[].errored` flag rather than aborting. Per-collection aggregation collapses ERC-1155 + multi-token-id holdings into one row with a `tokenCount` field. |
| `src/types/index.ts` | `UserConfig.reservoirApiKey` field. |
| `src/config/user-config.ts` | `resolveReservoirApiKey` resolver, mirrors the existing API-key pattern. |
| `src/index.ts` | Three tool registrations alongside `get_token_balance` / `get_token_allowances`. |
| `test/nft.test.ts` (new) | 9 new tests. |

## Notable design choices

- **Per-collection rows, not per-token.** v1 question is "how much NFT exposure do I have?", not "list every token id." Token-id-level reporting is a follow-up if anyone needs it.
- **`Promise.allSettled` per-chain.** Reservoir rate-limits the anonymous tier at a tight ceiling that doesn't survive multi-chain fan-out. Per-chain failure → `coverage[].errored: true`, other chains still surface, plus a setup-hint note pointing at `RESERVOIR_API_KEY`.
- **`floor != liquidation` caveat always in `notes[]`.** The rolled-up `totalFloorUsd` is an upper bound based on lowest currently-listed asks; selling typically means hitting an existing bid (a few percent below floor) or accepting a sweep at a discount. The note says so explicitly so downstream consumers don't mistake the rollup for "what I'd net selling everything."
- **Filters compose.** `minFloorEth` filters out dust / spam / scam collections; `collections[]` whitelists a specific set. Both apply when both are passed.
- **Optional `RESERVOIR_API_KEY`** via env or user config, mirroring the existing pattern (etherscan / 1inch / tron / safe). Free key at https://reservoir.tools/.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/nft.test.ts` — **9/9 pass**
- [x] `npx vitest run` (full suite) — **1527/1527 pass**
- [ ] Live: call `get_nft_portfolio` against a known NFT-rich wallet and eyeball the floor + total against OpenSea / Reservoir's UI.

Test cases:
- `get_nft_portfolio` happy path: 2-chain fan-out, per-collection aggregation (2 BAYCs collapse into one row with `tokenCount: 2`), USD rollup, sort desc by `totalFloorUsd`.
- `get_nft_portfolio` rate-limit: 429 on one chain → `coverage[].errored: true, reason: "rate_limited"` for that chain, other chain still surfaces, setup hint in notes.
- `minFloorEth` drops sub-threshold rows.
- `collections[]` whitelist drops non-listed contracts.
- `get_nft_collection` happy path: floor + top bid + volume rollups + royalty (2.5% surfaced).
- `get_nft_collection` no listings: `floorEth` absent + note flag.
- `get_nft_collection` no match: throws clear error.
- `get_nft_history` 2-chain merge: sorted desc by timestamp, types projected.
- `get_nft_history` truncation: `truncated: true` when merged > limit.

## v1 out of scope (named in tool descriptions)

- **Solana NFTs** — different API surface (Helius DAS / Magic Eden); deferred to a separate plan.
- **TRON NFTs** — small market.
- **NFT signing actions** (list / sweep / buy / accept-bid / transfer) — separate plan; biggest UX risk because of approval / proxy patterns (OpenSea Seaport, Blur Pool, Reservoir router).
- **Trait-rarity ranking** beyond Reservoir's defaults — no need to compete with rarity.tools.
- **NFT-collateralized lending positions** (NFTfi / BendDAO).
- **Folding NFT total floor into headline portfolio** — deferred until liquidation-vs-floor caveat plumbing exists.

## Plan

`claude-work/plan-nft-portfolio.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)