### PR TITLE
fix(risk-score): handle DefiLlama time-series tvl + map versioned slugs to bounty programs (closes #309)

### DIFF
--- a/src/modules/security/risk-score.ts
+++ b/src/modules/security/risk-score.ts
@@ -5,8 +5,13 @@ import { fetchWithTimeout } from "../../data/http.js";
 
 interface LlamaProtocol {
   name: string;
-  tvl?: number;
+  // DefiLlama's `/protocol/<slug>` endpoint returns `tvl` as a time-series
+  // array of `{ date, totalLiquidityUSD }` snapshots. Older docs / legacy
+  // protocols sometimes returned a scalar — accept both.
+  tvl?: number | Array<{ date: number; totalLiquidityUSD: number }>;
   chainTvls?: Record<string, number>;
+  // Legacy field — no longer present on current responses; kept optional for
+  // backwards compat in case it returns for some protocols.
   tvlHistory?: Array<[number, number]>;
   audits?: string;
   audit_links?: string[];
@@ -18,10 +23,65 @@ interface LlamaProtocol {
 // Source: Immunefi program pages (https://immunefi.com/explore/).
 const IMMUNEFI_BOUNTIES: Record<string, { program: string; maxBountyUsd: number }> = {
   aave: { program: "Aave", maxBountyUsd: 1_000_000 },
+  compound: { program: "Compound", maxBountyUsd: 500_000 },
   uniswap: { program: "Uniswap", maxBountyUsd: 15_500_000 }, // Uniswap has a leading program
   lido: { program: "Lido", maxBountyUsd: 2_000_000 },
   eigenlayer: { program: "EigenLayer", maxBountyUsd: 2_000_000 },
 };
+
+// DefiLlama protocol slugs are versioned (`aave-v3`, `compound-v3`) but
+// Immunefi bounties are program-level — one program covers all versions.
+// Map versioned slugs to the canonical bounty key.
+const BOUNTY_ALIASES: Record<string, string> = {
+  "aave-v2": "aave",
+  "aave-v3": "aave",
+  "compound-v2": "compound",
+  "compound-v3": "compound",
+  "uniswap-v2": "uniswap",
+  "uniswap-v3": "uniswap",
+  "uniswap-v4": "uniswap",
+};
+
+/**
+ * DefiLlama's `/protocol/<slug>` returns `tvl` as a time-series array of
+ * `{ date, totalLiquidityUSD }` for current responses. Older / cached shapes
+ * may return a scalar. Pull the latest snapshot when array-shaped.
+ */
+function extractCurrentTvl(
+  tvl: number | Array<{ date: number; totalLiquidityUSD: number }> | undefined,
+): number | undefined {
+  if (typeof tvl === "number" && Number.isFinite(tvl)) return tvl;
+  if (Array.isArray(tvl) && tvl.length > 0) {
+    const last = tvl[tvl.length - 1];
+    if (last && typeof last.totalLiquidityUSD === "number") {
+      return last.totalLiquidityUSD;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 30-day TVL trend as a fractional change. Reads from the `tvl` time-series
+ * (current API) and falls back to the legacy `tvlHistory` field if `tvl` is
+ * scalar. Returns undefined when there isn't enough history.
+ */
+function compute30dTrend(data: LlamaProtocol): number | undefined {
+  if (Array.isArray(data.tvl) && data.tvl.length > 30) {
+    const now = data.tvl[data.tvl.length - 1]?.totalLiquidityUSD;
+    const then = data.tvl[data.tvl.length - 31]?.totalLiquidityUSD;
+    if (typeof now === "number" && typeof then === "number" && then !== 0) {
+      return round((now - then) / then, 4);
+    }
+  }
+  if (data.tvlHistory && data.tvlHistory.length > 30) {
+    const now = data.tvlHistory[data.tvlHistory.length - 1]?.[1];
+    const then = data.tvlHistory[data.tvlHistory.length - 31]?.[1];
+    if (typeof now === "number" && typeof then === "number" && then !== 0) {
+      return round((now - then) / then, 4);
+    }
+  }
+  return undefined;
+}
 
 async function fetchLlamaProtocol(slug: string): Promise<LlamaProtocol | null> {
   const key = `risk:llama:${slug.toLowerCase()}`;
@@ -63,19 +123,16 @@ export async function getProtocolRiskScore(protocol: string): Promise<{
   } = { hasBugBounty: false };
 
   if (data) {
-    raw.tvlUsd = data.tvl ?? undefined;
-    if (data.tvlHistory && data.tvlHistory.length > 30) {
-      const now = data.tvlHistory[data.tvlHistory.length - 1]?.[1];
-      const then = data.tvlHistory[data.tvlHistory.length - 31]?.[1];
-      if (now && then) raw.tvlTrend30d = round((now - then) / then, 4);
-    }
+    raw.tvlUsd = extractCurrentTvl(data.tvl);
+    raw.tvlTrend30d = compute30dTrend(data);
     if (data.listedAt) {
       raw.contractAgeDays = Math.floor((Date.now() / 1000 - data.listedAt) / 86400);
     }
     if (data.audit_links) raw.auditsReported = data.audit_links.length;
   }
 
-  const bounty = IMMUNEFI_BOUNTIES[slug];
+  const bountyKey = BOUNTY_ALIASES[slug] ?? slug;
+  const bounty = IMMUNEFI_BOUNTIES[bountyKey];
   if (bounty) {
     raw.hasBugBounty = true;
     raw.bountyMaxUsd = bounty.maxBountyUsd;

--- a/test/risk-score.test.ts
+++ b/test/risk-score.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression tests for #309 — get_protocol_risk_score returns score:null
+ * for major protocols.
+ *
+ * Two underlying bugs covered:
+ *   - Bug 1: DefiLlama's `/protocol/<slug>` endpoint returns `tvl` as a
+ *     time-series array of `{ date, totalLiquidityUSD }` snapshots, not a
+ *     scalar. The old extractor read `data.tvl` as a number, computed
+ *     `array / 1e6`, got NaN, and propagated null through the score.
+ *   - Bug 2: `IMMUNEFI_BOUNTIES` keys are program-level (`aave`,
+ *     `compound`) but DefiLlama slugs are versioned (`aave-v3`,
+ *     `compound-v3`), so the bounty lookup missed.
+ *
+ * Both bugs make the headline `score` field of the tool's output null for
+ * the two largest non-Maker EVM lending protocols. These tests pin the
+ * fixed behavior so a future refactor that re-introduces either bug fails
+ * loud.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchWithTimeoutMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/data/http.js", () => ({
+  fetchWithTimeout: fetchWithTimeoutMock,
+}));
+
+// Disable cache so fixture changes between tests aren't masked.
+vi.mock("../src/data/cache.js", () => ({
+  cache: {
+    remember: async (_key: string, _ttl: number, factory: () => Promise<unknown>) => factory(),
+  },
+}));
+
+import { getProtocolRiskScore } from "../src/modules/security/risk-score.js";
+
+function fakeOk(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+function tvlSeries(latest: number, length: number, days30Ago: number) {
+  // Build a series whose tail looks like
+  //   ... [length-31] = days30Ago   ...  [length-1] = latest
+  const out: Array<{ date: number; totalLiquidityUSD: number }> = [];
+  for (let i = 0; i < length; i++) {
+    let v: number;
+    if (i === length - 1) v = latest;
+    else if (i === length - 31) v = days30Ago;
+    else v = Math.round((latest + days30Ago) / 2);
+    out.push({ date: 1_700_000_000 + i * 86400, totalLiquidityUSD: v });
+  }
+  return out;
+}
+
+beforeEach(() => {
+  fetchWithTimeoutMock.mockReset();
+});
+
+describe("getProtocolRiskScore — #309 regressions", () => {
+  it("Bug 1: extracts current TVL from the time-series array shape (latest snapshot)", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Compound V3",
+        // Current API shape: array of { date, totalLiquidityUSD }
+        tvl: tvlSeries(1_350_000_000, 60, 1_300_000_000),
+        listedAt: 1_640_000_000,
+        audit_links: ["https://x.com/audit1", "https://x.com/audit2"],
+      }),
+    );
+
+    const result = await getProtocolRiskScore("compound-v3");
+
+    // Headline: score must be a real number, not null.
+    expect(result.score).toBeDefined();
+    expect(Number.isFinite(result.score)).toBe(true);
+
+    // raw.tvlUsd resolves to the latest snapshot's totalLiquidityUSD.
+    expect(result.raw.tvlUsd).toBe(1_350_000_000);
+
+    // No more "TVL $NaNM" — the note string must contain a real number.
+    expect(result.breakdown.tvl.note).toMatch(/TVL \$[\d.]+M/);
+    expect(result.breakdown.tvl.note).not.toMatch(/NaN/);
+
+    // Trend computed from the same series (latest vs 30 days ago).
+    expect(result.raw.tvlTrend30d).toBeDefined();
+  });
+
+  it("Bug 1: still works when tvl is the legacy scalar shape", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Some Old Protocol",
+        tvl: 12_500_000, // legacy scalar form
+        listedAt: 1_640_000_000,
+        audit_links: ["https://x.com/audit1"],
+      }),
+    );
+    const result = await getProtocolRiskScore("some-old-protocol");
+    expect(result.score).toBeDefined();
+    expect(result.raw.tvlUsd).toBe(12_500_000);
+  });
+
+  it("Bug 1: missing tvl field doesn't crash; surfaces as 'no TVL data'", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Something",
+        listedAt: 1_640_000_000,
+      }),
+    );
+    const result = await getProtocolRiskScore("something");
+    expect(result.raw.tvlUsd).toBeUndefined();
+    expect(result.breakdown.tvl.note).toBe("no TVL data");
+    // Score still computed — TVL just contributes 0.
+    expect(result.score).toBeDefined();
+  });
+
+  it("Bug 2: aave-v3 resolves to the Aave Immunefi bounty via alias map", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Aave V3",
+        tvl: tvlSeries(8_000_000_000, 60, 7_500_000_000),
+        listedAt: 1_600_000_000,
+        audit_links: Array.from({ length: 8 }, (_, i) => `https://x.com/audit${i}`),
+      }),
+    );
+
+    const result = await getProtocolRiskScore("aave-v3");
+
+    expect(result.raw.hasBugBounty).toBe(true);
+    expect(result.raw.bountyMaxUsd).toBe(1_000_000); // matches IMMUNEFI_BOUNTIES.aave
+    expect(result.breakdown.bounty.value).toBe(20);
+    expect(result.breakdown.bounty.note).toMatch(/Immunefi bounty up to \$1,000,000/);
+  });
+
+  it("Bug 2: compound-v3 resolves to the Compound Immunefi bounty via alias map", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Compound V3",
+        tvl: tvlSeries(1_350_000_000, 60, 1_300_000_000),
+        listedAt: 1_640_000_000,
+        audit_links: ["https://x.com/audit1", "https://x.com/audit2"],
+      }),
+    );
+
+    const result = await getProtocolRiskScore("compound-v3");
+
+    expect(result.raw.hasBugBounty).toBe(true);
+    expect(result.raw.bountyMaxUsd).toBe(500_000);
+    expect(result.breakdown.bounty.value).toBe(20);
+  });
+
+  it("Bug 2: unaliased + unbounty-listed slug correctly reports no bounty", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({ name: "Random Protocol", tvl: 100_000_000 }),
+    );
+    const result = await getProtocolRiskScore("random-rugpull");
+    expect(result.raw.hasBugBounty).toBe(false);
+    expect(result.breakdown.bounty.value).toBe(0);
+    expect(result.breakdown.bounty.note).toBe("no Immunefi bounty registered");
+  });
+
+  it("End-to-end: compound-v3 with the realistic API shape produces a meaningful score (the issue repro)", async () => {
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      fakeOk({
+        name: "Compound V3",
+        tvl: tvlSeries(1_350_000_000, 100, 1_200_000_000),
+        listedAt: Math.floor(Date.now() / 1000) - 1320 * 86400, // ~1320 days
+        audit_links: ["https://x.com/audit1"],
+      }),
+    );
+
+    const result = await getProtocolRiskScore("compound-v3");
+
+    // Pre-fix behavior: score === undefined (rendered as null).
+    // Post-fix: should be a meaningful positive number — TVL + age + bounty + audits all contribute.
+    expect(result.score).toBeDefined();
+    expect(result.score!).toBeGreaterThan(50);
+    expect(result.raw.hasBugBounty).toBe(true);
+    expect(result.raw.tvlUsd).toBe(1_350_000_000);
+  });
+});


### PR DESCRIPTION
## Summary

- `extractCurrentTvl()` + `compute30dTrend()` handle both the new time-series `tvl` array (current DefiLlama API) and the legacy scalar/`tvlHistory` shapes — empirically confirmed `tvl` is now an array of `{ date, totalLiquidityUSD }` and `tvlHistory` is gone (`null`).
- `BOUNTY_ALIASES` maps versioned DefiLlama slugs (`aave-v3`, `compound-v3`, `uniswap-v3`, etc.) to the program-level keys in `IMMUNEFI_BOUNTIES`. Added a `compound` entry while there.

## Why score was null

Both bugs hit the same `score` aggregation. Bug 1 alone is sufficient to nuke it: TVL field parsed as scalar → divided by 1e6 → `NaN` → null score. Bug 2 separately just produced wrong-but-non-null bounty contribution. Combined effect documented in the issue.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/risk-score.test.ts` — 7/7 pass
  - new shape (time-series array) extracts latest `totalLiquidityUSD` ✓
  - legacy shape (scalar) still works ✓
  - missing `tvl` field surfaces as "no TVL data" without crashing ✓
  - `aave-v3` resolves to Aave program ($1M) via alias ✓
  - `compound-v3` resolves to Compound program ($500K) via alias ✓
  - unaliased + unbountied slug correctly reports no bounty ✓
  - end-to-end `compound-v3` repro — score is now a meaningful number > 50 ✓
- [x] `npx vitest run` (full suite) — **1525/1525 pass**
- [ ] Live sanity: call `get_protocol_risk_score({ protocol: "compound-v3" })` post-merge, expect non-null score with `hasBugBounty: true` and a finite TVL number.

## Notes

Compound's Immunefi bounty max ($500K) is from publicly-listed amounts; verify against current Immunefi listing if precision matters — alias-map fix doesn't depend on the exact figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)