### PR TITLE
chore(release): bump to 0.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.9.1",
+      "version": "0.9.3",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.9.1",
+      "version": "0.9.3",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Patch bump capturing everything merged since v0.9.1. New tool surface from #317 is strictly additive; `^0.9.0` consumers pick this up automatically. 0.9.2 was skipped at the maintainer's request.

## What's in this release

- #285 `feat(tron)`: TRON CHECKS PERFORMED template (EVM-mirror)
- #300 `feat(tron)`: widen tx expiration to 24h max (closes #280)
- #307 `fix(allowances)`: preview_send accepts `approve(spender, 0)` revokes (closes #305)
- #313 `refactor`: per-chain second-LLM prompt split (~50% shorter for EVM)
- #314 `ux(explain_tx)`: "post-mortem" → "analysis" rename
- #317 `feat(share)`: read-only advisor — 4 new tools (`generate_readonly_link`, `import_readonly_token`, `list_readonly_invites`, `revoke_readonly_invite`)
- Plus parallel work merged this window: #306 (Permit2 sub-allowances), #315 (NFT portfolio), #316 (preflight v4 pin), #318 (risk_score TVL fix)

## Verification

- [x] `npm run build` — clean
- [x] `npm test` — 1547/1547 pass
- [x] `git grep 0.9.1` — no stale refs
- [x] `package.json` + `server.json` (top-level + `packages[0]`) all at 0.9.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)