### PR TITLE
feat(btc): prepare_btc_rbf_bump for stuck mempool tx replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ import {
   rescanBitcoinAccount,
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
+  prepareBitcoinRbfBump,
   signBtcMessage,
   pairLedgerLitecoin,
   getLitecoinBalance,
@@ -228,6 +229,7 @@ import {
   rescanBitcoinAccountInput,
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
+  prepareBitcoinRbfBumpInput,
   signBtcMessageInput,
   pairLedgerLitecoinInput,
   getLitecoinBalanceInput,
@@ -2420,7 +2422,31 @@ async function main() {
     handler(prepareBitcoinNativeSend, { toolName: "prepare_btc_send" })
   );
 
-  registerTool(server, 
+  registerTool(server,
+    "prepare_btc_rbf_bump",
+    {
+      description:
+        "Build a BIP-125 Replace-By-Fee replacement for a stuck mempool BTC tx. " +
+        "Reuses the original tx's exact input set, preserves every recipient " +
+        "verbatim, and shrinks the change output to absorb the fee bump. Sequence " +
+        "stays at 0xFFFFFFFD so the replacement is itself RBF-eligible (the user " +
+        "can bump again if the new rate is still too low). Returns a 15-min handle " +
+        "the agent forwards to send_transaction; the Ledger BTC app clear-signs " +
+        "every output + new fee on-screen, so there is NO blind-sign hash to " +
+        "pre-match in chat. Refusal cases: original tx already confirmed; no " +
+        "input is BIP-125-eligible; any input belongs to a wallet other than " +
+        "`wallet` (multi-source RBF out of scope); no change output (no " +
+        "headroom to absorb the bump — CPFP territory); BIP-125 rule 4 violation " +
+        "(new fee must be >= old fee + 1 sat/vB × new vsize); bumped change " +
+        "below the 546-sat dust threshold; fee exceeds the safety cap (override " +
+        "with `allowHighFee: true`). Phase 1 source-side scope: native segwit + " +
+        "taproot only.",
+      inputSchema: prepareBitcoinRbfBumpInput.shape,
+    },
+    handler(prepareBitcoinRbfBump, { toolName: "prepare_btc_rbf_bump" })
+  );
+
+  registerTool(server,
     "sign_message_btc",
     {
       description:

--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -528,6 +528,352 @@ export async function buildBitcoinNativeSend(
   return issueBitcoinHandle(tx);
 }
 
+/**
+ * Dust threshold (sats) below which an output is non-standard and won't
+ * relay. The Bitcoin Core default is `3 × output-size × min-relay-fee`,
+ * which evaluates to 294 for P2WPKH and 330 for P2TR at 1 sat/vB. We
+ * use 546 — Bitcoin Core's hardcoded floor for P2PKH and the
+ * conservative cross-type baseline every modern wallet treats as
+ * "definitely not dust." Below this the change output would either be
+ * rejected at relay time or eat the entire fee bump.
+ */
+const DUST_THRESHOLD_SATS = 546;
+
+/**
+ * Min-relay fee rate (sat/vB) used by the BIP-125 rule-4 check. Bitcoin
+ * Core's default `minRelayTxFee` is 1000 sat/kvB → 1 sat/vB; mempools
+ * with non-default `incrementalRelayFee` may require more, but 1 is the
+ * canonical floor every relay node accepts.
+ */
+const MIN_RELAY_FEE_RATE = 1;
+
+export interface BuildBitcoinRbfBumpArgs {
+  /** Paired BTC source address that signed the original tx. Segwit/taproot only (Phase 1). */
+  wallet: string;
+  /** 64-hex original tx hash. Must currently be in mempool (not yet confirmed). */
+  txid: string;
+  /** New fee rate in sat/vB. Must be high enough to satisfy BIP-125 rule 4. */
+  newFeeRate: number;
+  /** Override the fee-cap guard. Default false. */
+  allowHighFee?: boolean;
+}
+
+/**
+ * Build an RBF (BIP-125) replacement for a stuck mempool tx.
+ *
+ * The replacement reuses the original tx's exact input set and
+ * preserves every non-change output verbatim — only the change output
+ * shrinks to absorb the fee bump. Sequence is set to 0xFFFFFFFD on
+ * every input so the replacement is itself RBF-eligible (the user can
+ * bump again if the new rate is still too low).
+ *
+ * Refusal cases (every check is a hard refusal — no silent fallback):
+ *  1. `wallet` not paired or not segwit/taproot.
+ *  2. Original tx already confirmed (can't replace — `confirmed: true`).
+ *  3. No input is BIP-125-eligible (every `sequence >= 0xFFFFFFFE`).
+ *  4. Any input's prevout address differs from `wallet` (multi-source
+ *     RBF is out of scope — partial-RBF where we'd need keys we don't
+ *     have).
+ *  5. Original tx has no change output paired to the user (sweep tx
+ *     with no headroom to absorb the bump — would require adding a
+ *     fresh input, which is CPFP territory).
+ *  6. New fee fails BIP-125 rule 4: new abs fee < old abs fee +
+ *     `MIN_RELAY_FEE_RATE × new vsize`.
+ *  7. Bumped change drops below `DUST_THRESHOLD_SATS` — the bump would
+ *     consume the entire change output (relay would reject the
+ *     resulting dust output).
+ *  8. Fee exceeds the safety cap (same shape as `selectInputs`'s cap)
+ *     unless `allowHighFee: true`.
+ */
+export async function buildBitcoinRbfBump(
+  args: BuildBitcoinRbfBumpArgs,
+): Promise<UnsignedBitcoinTx> {
+  if (!/^[0-9a-fA-F]{64}$/.test(args.txid)) {
+    throw new Error(
+      `\`txid\` must be 64 hex characters, got ${args.txid.length} chars.`,
+    );
+  }
+  if (
+    !Number.isFinite(args.newFeeRate) ||
+    args.newFeeRate <= 0 ||
+    args.newFeeRate > 10_000
+  ) {
+    throw new Error(
+      `Invalid newFeeRate ${args.newFeeRate} sat/vB — expected a positive finite number ≤ 10000.`,
+    );
+  }
+
+  // 1. Validate wallet is paired and segwit/taproot.
+  assertBitcoinAddress(args.wallet);
+  const paired = getPairedBtcByAddress(args.wallet);
+  if (!paired) {
+    throw new Error(
+      `Bitcoin address ${args.wallet} is not paired. Run \`pair_ledger_btc\` first.`,
+    );
+  }
+  if (paired.addressType !== "segwit" && paired.addressType !== "taproot") {
+    throw new Error(
+      `RBF bump from ${paired.addressType} (${paired.path}) addresses is not supported ` +
+        `in Phase 1 — only native segwit (bc1q...) and taproot (bc1p...).`,
+    );
+  }
+
+  // 2. Fetch original tx.
+  const indexer = getBitcoinIndexer();
+  const orig = await indexer.getTx(args.txid);
+
+  // 3. Refuse if already confirmed.
+  if (orig.status?.confirmed === true) {
+    const blockHeight = orig.status.block_height;
+    throw new Error(
+      `Tx ${args.txid} is already confirmed${
+        blockHeight !== undefined ? ` at block ${blockHeight}` : ""
+      } — RBF only works for unconfirmed mempool txs. Nothing to bump.`,
+    );
+  }
+
+  // 4. Walk inputs: collect (txid, vout, value), check RBF eligibility,
+  //    refuse foreign inputs.
+  if (orig.vin.length === 0) {
+    throw new Error(`Tx ${args.txid} has no inputs — indexer returned malformed shape.`);
+  }
+  let anyRbfEligible = false;
+  const inputsForBuild: Array<{ txid: string; vout: number; value: number }> = [];
+  for (const v of orig.vin) {
+    const seq = typeof v.sequence === "number" ? v.sequence : 0xffffffff;
+    if (seq < 0xfffffffe) anyRbfEligible = true;
+    if (v.prevout?.scriptpubkey_address !== args.wallet) {
+      throw new Error(
+        `Tx ${args.txid} has an input from ${v.prevout?.scriptpubkey_address ?? "<unknown>"} ` +
+          `which is not the bumped wallet ${args.wallet}. Multi-source RBF is out of scope ` +
+          `for this tool — every input must belong to the address being passed as \`wallet\`.`,
+      );
+    }
+    if (typeof v.prevout.value !== "number") {
+      throw new Error(
+        `Tx ${args.txid} input ${v.txid}:${v.vout} is missing prevout.value from the indexer.`,
+      );
+    }
+    inputsForBuild.push({ txid: v.txid, vout: v.vout, value: v.prevout.value });
+  }
+  if (!anyRbfEligible) {
+    throw new Error(
+      `Tx ${args.txid} is not BIP-125 RBF-eligible (every input has sequence >= 0xFFFFFFFE). ` +
+        `The original was broadcast as final. Wait for confirmation or ask a miner-accelerator ` +
+        `service; this tool cannot replace it.`,
+    );
+  }
+
+  // 5. Walk outputs: collect, identify change.
+  if (orig.vout.length === 0) {
+    throw new Error(`Tx ${args.txid} has no outputs — indexer returned malformed shape.`);
+  }
+  // Change candidates: any output whose address is paired under the
+  // SAME (accountIndex, addressType) as `wallet`. Covers both the
+  // chain=1 default (Phase-1 native_send) and a chain=0 self-send case.
+  const allPaired = getPairedBtcAddresses();
+  const ourAddrs = new Set(
+    allPaired
+      .filter(
+        (e) =>
+          e.accountIndex === paired.accountIndex &&
+          e.addressType === paired.addressType,
+      )
+      .map((e) => e.address),
+  );
+  type OrigOutput = { address: string; value: number; isChange: boolean };
+  const origOutputs: OrigOutput[] = [];
+  for (const v of orig.vout) {
+    if (typeof v.scriptpubkey_address !== "string" || typeof v.value !== "number") {
+      throw new Error(
+        `Tx ${args.txid} has an output with missing address/value — indexer returned malformed shape.`,
+      );
+    }
+    origOutputs.push({
+      address: v.scriptpubkey_address,
+      value: v.value,
+      isChange: ourAddrs.has(v.scriptpubkey_address),
+    });
+  }
+  const changeOutputs = origOutputs.filter((o) => o.isChange);
+  if (changeOutputs.length === 0) {
+    throw new Error(
+      `Tx ${args.txid} has no change output paying back to ${args.wallet}'s account ` +
+        `(${paired.addressType}, accountIndex=${paired.accountIndex}). With no change ` +
+        `there is no headroom to absorb a fee bump — this is CPFP territory, not RBF.`,
+    );
+  }
+  if (changeOutputs.length > 1) {
+    throw new Error(
+      `Tx ${args.txid} has ${changeOutputs.length} outputs paying to this account — ` +
+        `ambiguous which is the change. Self-sends and split-change patterns are out of ` +
+        `scope for this tool.`,
+    );
+  }
+  const changeAddress = changeOutputs[0].address;
+  const changeEntryFromPairings = allPaired.find((e) => e.address === changeAddress);
+  if (!changeEntryFromPairings) {
+    throw new Error(
+      `Internal error: change address ${changeAddress} matched the paired set but ` +
+        `disappeared on lookup.`,
+    );
+  }
+
+  // 6. Recompute fee + change at the new fee rate.
+  const newVbytes = roughVbytes(inputsForBuild.length, origOutputs.length);
+  const newFee = Math.ceil(args.newFeeRate * newVbytes);
+  const totalInputValue = inputsForBuild.reduce((s, i) => s + i.value, 0);
+  const externalOutputTotal = origOutputs
+    .filter((o) => !o.isChange)
+    .reduce((s, o) => s + o.value, 0);
+  const newChangeValue = totalInputValue - externalOutputTotal - newFee;
+
+  // 7. BIP-125 rule 4: new abs fee >= old abs fee + min-relay × new vsize.
+  const oldFee = orig.fee ?? totalInputValue - origOutputs.reduce((s, o) => s + o.value, 0);
+  const minBumpAbs = oldFee + MIN_RELAY_FEE_RATE * newVbytes;
+  if (newFee < minBumpAbs) {
+    const requiredRate = Math.ceil(minBumpAbs / newVbytes);
+    throw new Error(
+      `New fee ${newFee} sats fails BIP-125 rule 4 — must be at least ${minBumpAbs} sats ` +
+        `(old fee ${oldFee} + min-relay 1 sat/vB × new vsize ${newVbytes}). ` +
+        `Retry with newFeeRate >= ${requiredRate} sat/vB.`,
+    );
+  }
+
+  // 8. Refuse if change drops below dust.
+  if (newChangeValue < DUST_THRESHOLD_SATS) {
+    throw new Error(
+      `Bumped change output would be ${newChangeValue} sats — below the ${DUST_THRESHOLD_SATS}-sat ` +
+        `dust threshold. The fee bump would consume the entire change output (or worse, ` +
+        `produce negative change). Lower newFeeRate, or use CPFP / add inputs (out of scope).`,
+    );
+  }
+
+  // 9. Fee-cap guard (mirror of `selectInputs`'s cap).
+  if (!args.allowHighFee) {
+    const vbyteCap = Math.ceil(args.newFeeRate * 10 * newVbytes);
+    const percentCap = Math.ceil(externalOutputTotal * 0.02);
+    const cap = Math.max(vbyteCap, percentCap);
+    if (newFee > cap) {
+      throw new Error(
+        `Fee ${newFee} sats exceeds safety cap ${cap} sats ` +
+          `(max of 10× feeRate-based ${vbyteCap} and 2%-of-output ${percentCap}). ` +
+          `If this is intentional (priority bump through congestion), retry with ` +
+          `\`allowHighFee: true\` after confirming with the user.`,
+      );
+    }
+  }
+
+  // 10. Fetch prev-tx hex for every UNIQUE input txid (issue #213).
+  const uniqueTxids = [...new Set(inputsForBuild.map((i) => i.txid))];
+  const prevTxHexEntries = await Promise.all(
+    uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
+  );
+  const prevTxHexByTxid = new Map(prevTxHexEntries);
+
+  // 11. Build PSBT — same shape as buildBitcoinNativeSend but with the
+  //     fixed input set and the recomputed change value spliced in.
+  const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
+  const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+  for (const input of inputsForBuild) {
+    const prevTxHex = prevTxHexByTxid.get(input.txid);
+    if (!prevTxHex) {
+      throw new Error(
+        `Internal error: prev-tx hex missing for ${input.txid} after fan-out fetch.`,
+      );
+    }
+    psbt.addInput({
+      hash: input.txid,
+      index: input.vout,
+      sequence: 0xfffffffd,
+      witnessUtxo: { script: sourceScript, value: input.value },
+      nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
+    });
+  }
+  // Output ordering preserved from the original — same indices, just
+  // change updated. Wallet fingerprinting heuristics (BIP-69, etc.) the
+  // original tx adopted carry over by construction.
+  const newOutputs = origOutputs.map((o) =>
+    o.isChange ? { ...o, value: newChangeValue } : o,
+  );
+  for (const o of newOutputs) {
+    const outScript = bitcoinjs.address.toOutputScript(o.address, NETWORK);
+    psbt.addOutput({ script: outScript, value: o.value });
+  }
+  const psbtBase64 = psbt.toBase64();
+
+  // 12. Project decoded outputs for the verification block.
+  const decodedOutputs = newOutputs.map((o) => ({
+    address: o.address,
+    amountSats: o.value.toString(),
+    amountBtc: satsToBtcString(BigInt(o.value)),
+    isChange: o.isChange,
+    ...(o.isChange ? { changePath: changeEntryFromPairings.path } : {}),
+  }));
+
+  const decodedSources = [
+    {
+      address: args.wallet,
+      pulledSats: totalInputValue.toString(),
+      pulledBtc: satsToBtcString(BigInt(totalInputValue)),
+      inputCount: inputsForBuild.length,
+    },
+  ];
+  const sources = [
+    {
+      address: args.wallet,
+      path: paired.path,
+      publicKey: paired.publicKey,
+    },
+  ];
+  const inputSources = inputsForBuild.map(() => args.wallet);
+
+  const accountPath = accountPathFromLeaf(paired.path);
+  const oldFeeRate = oldFee / Math.max(1, newVbytes); // approximate; orig vsize ≈ new vsize
+  const description =
+    `RBF bump tx ${args.txid.slice(0, 12)}…: ` +
+    `fee ${oldFee} → ${newFee} sats (${args.newFeeRate} sat/vB)`;
+
+  const tx: Omit<UnsignedBitcoinTx, "handle" | "fingerprint"> = {
+    chain: "bitcoin",
+    action: "rbf_bump",
+    from: args.wallet,
+    sources,
+    inputSources,
+    psbtBase64,
+    accountPath,
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    change: {
+      address: changeEntryFromPairings.address,
+      path: changeEntryFromPairings.path,
+      publicKey: changeEntryFromPairings.publicKey,
+    },
+    description,
+    replaces: {
+      txid: args.txid,
+      oldFeeSats: oldFee.toString(),
+      oldFeeRateSatPerVb: Math.round(oldFeeRate * 100) / 100,
+    },
+    decoded: {
+      functionName: "bitcoin.rbf_bump",
+      args: {
+        wallet: args.wallet,
+        oldTxid: args.txid,
+        oldFeeSats: oldFee.toString(),
+        newFeeRate: `${args.newFeeRate} sat/vB`,
+      },
+      outputs: decodedOutputs,
+      sources: decodedSources,
+      feeSats: newFee.toString(),
+      feeBtc: satsToBtcString(BigInt(newFee)),
+      feeRateSatPerVb: args.newFeeRate,
+      rbfEligible: true,
+    },
+    vsize: newVbytes,
+  };
+  return issueBitcoinHandle(tx);
+}
+
 /** Validate a BTC address against the four mainnet types. Re-export for tests. */
 export function _isSendableAddressType(
   type: BitcoinAddressType,

--- a/src/modules/btc/indexer.ts
+++ b/src/modules/btc/indexer.ts
@@ -106,19 +106,19 @@ export interface BitcoinTxHistoryEntry {
 /**
  * Esplora vin/vout shapes we destructure. Trimmed to fields we read.
  */
-interface EsploraVin {
+export interface EsploraVin {
   txid: string;
   vout: number;
   prevout?: { scriptpubkey_address?: string; value?: number };
   sequence?: number;
 }
 
-interface EsploraVout {
+export interface EsploraVout {
   scriptpubkey_address?: string;
   value?: number;
 }
 
-interface EsploraTx {
+export interface EsploraTx {
   txid: string;
   vin: EsploraVin[];
   vout: EsploraVout[];
@@ -210,6 +210,15 @@ export interface BitcoinIndexer {
    * sign cleanly. Issue #213.
    */
   getTxHex(txid: string): Promise<string>;
+  /**
+   * Fetch the full Esplora tx shape (vin/vout/fee/status) for a single
+   * txid. Used by the RBF fee-bump builder, which needs to: (1) confirm
+   * the tx is still in mempool (not already mined), (2) read original
+   * inputs to rebuild the same input set, (3) read original outputs to
+   * preserve recipients verbatim and identify the change output, (4)
+   * verify at least one input has BIP-125-eligible sequence.
+   */
+  getTx(txid: string): Promise<EsploraTx>;
 }
 
 /**
@@ -544,6 +553,15 @@ class EsploraIndexer implements BitcoinIndexer {
       confirmed: true,
       ...(status.block_height !== undefined ? { blockHeight: status.block_height } : {}),
     };
+  }
+
+  async getTx(txid: string): Promise<EsploraTx> {
+    if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
+      throw new Error(
+        `Bitcoin indexer getTx called with non-64-hex txid "${txid.slice(0, 80)}".`,
+      );
+    }
+    return this.getJson<EsploraTx>(`/tx/${txid}`);
   }
 
   async getTxHex(txid: string): Promise<string> {

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -151,6 +151,7 @@ import type {
   RescanBitcoinAccountArgs,
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
+  PrepareBitcoinRbfBumpArgs,
   SignBtcMessageArgs,
   PairLedgerLitecoinArgs,
   GetLitecoinBalanceArgs,
@@ -1205,6 +1206,16 @@ export async function prepareBitcoinNativeSend(
       ? { feeRateSatPerVb: args.feeRateSatPerVb }
       : {}),
     ...(args.rbf !== undefined ? { rbf: args.rbf } : {}),
+    ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
+  });
+}
+
+export async function prepareBitcoinRbfBump(args: PrepareBitcoinRbfBumpArgs) {
+  const { buildBitcoinRbfBump } = await import("../btc/actions.js");
+  return buildBitcoinRbfBump({
+    wallet: args.wallet,
+    txid: args.txid,
+    newFeeRate: args.newFeeRate,
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });
 }

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1250,6 +1250,45 @@ export const prepareBitcoinNativeSendInput = z.object({
     ),
 });
 
+export const prepareBitcoinRbfBumpInput = z.object({
+  wallet: bitcoinAddressSchema.describe(
+    "Paired Bitcoin source address that signed the original tx. Phase 1 " +
+      "scope: native segwit (`bc1q...`) and taproot (`bc1p...`) only. " +
+      "Multi-source RBF (replacing a tx whose inputs span several wallets) " +
+      "is out of scope — every input on the original tx must come from this " +
+      "single address."
+  ),
+  txid: z
+    .string()
+    .regex(/^[0-9a-fA-F]{64}$/)
+    .describe(
+      "64-hex txid of the stuck mempool tx to replace. Must currently be " +
+        "unconfirmed and BIP-125 RBF-eligible (sequence < 0xFFFFFFFE on at " +
+        "least one input — true by default for every tx `prepare_btc_send` " +
+        "produces). Already-confirmed and final-marked txs are refused."
+    ),
+  newFeeRate: z
+    .number()
+    .positive()
+    .max(10_000)
+    .describe(
+      "New fee rate in sat/vB. Must satisfy BIP-125 rule 4: the new absolute " +
+        "fee must be at least the old absolute fee plus 1 sat/vB × new vsize. " +
+        "The replacement preserves every recipient verbatim and shrinks the " +
+        "change output to absorb the bump — refused if the bump would push " +
+        "change below the dust threshold (546 sats)."
+    ),
+  allowHighFee: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override the fee-cap guard. The cap is `max(10 × newFeeRate × vbytes, " +
+        "2% of recipient output value)`. Legitimate priority bumps through " +
+        "heavy congestion can exceed it; pass true after confirming with the " +
+        "user."
+    ),
+});
+
 export const getBitcoinTxHistoryInput = z.object({
   address: bitcoinAddressSchema,
   limit: z
@@ -1305,6 +1344,7 @@ export const signBtcMessageInput = z.object({
 
 export type GetBitcoinTxHistoryArgs = z.infer<typeof getBitcoinTxHistoryInput>;
 export type PrepareBitcoinNativeSendArgs = z.infer<typeof prepareBitcoinNativeSendInput>;
+export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -1172,9 +1172,19 @@ export function renderTronAgentTaskBlock(
 export function renderBitcoinVerificationBlock(tx: UnsignedBitcoinTx): string {
   const lines: string[] = [];
   const isMultiSource = tx.decoded.sources.length > 1;
-  lines.push(
-    `VERIFY BEFORE SIGNING (Bitcoin — ${isMultiSource ? "multi-source consolidation" : "native send"})`,
-  );
+  const isRbfBump = tx.action === "rbf_bump";
+  const flowLabel = isRbfBump
+    ? "RBF fee bump"
+    : isMultiSource
+    ? "multi-source consolidation"
+    : "native send";
+  lines.push(`VERIFY BEFORE SIGNING (Bitcoin — ${flowLabel})`);
+  if (isRbfBump && tx.replaces) {
+    lines.push(
+      `Replacing mempool tx ${tx.replaces.txid} ` +
+        `(old fee ${tx.replaces.oldFeeSats} sats @ ~${tx.replaces.oldFeeRateSatPerVb} sat/vB).`,
+    );
+  }
   lines.push(
     "The Ledger Bitcoin app clear-signs every output. Confirm on-device:",
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1259,8 +1259,27 @@ export interface PairedSolanaEntry {
  */
 export interface UnsignedBitcoinTx {
   chain: "bitcoin";
-  /** Discriminator for the action — only native_send in Phase 1. */
-  action: "native_send";
+  /**
+   * Discriminator for the action.
+   *  - `native_send` — Phase 1 single-output send (also used by issue
+   *    #264 multi-source consolidation).
+   *  - `rbf_bump` — BIP-125 fee replacement of a stuck mempool tx.
+   *    Same input set as the original, recipients preserved verbatim,
+   *    the bump is absorbed by the change output.
+   */
+  action: "native_send" | "rbf_bump";
+  /**
+   * RBF replacement context — populated only on `action === "rbf_bump"`.
+   * Lets the verification block surface "replacing TX <txid>" and the
+   * old → new fee/fee-rate delta so the user reviews the bump itself,
+   * not just the new tx in isolation. The original tx is identified by
+   * `txid`; `oldFeeSats` + `oldFeeRateSatPerVb` come from the indexer.
+   */
+  replaces?: {
+    txid: string;
+    oldFeeSats: string;
+    oldFeeRateSatPerVb: number;
+  };
   /**
    * Primary source address (the first entry in `sources` for multi-source
    * sends, or the only source for single-source sends). Kept for

--- a/test/btc-rbf.test.ts
+++ b/test/btc-rbf.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjsForFixtures = requireCjs("bitcoinjs-lib") as {
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          witnessUtxo?: { script: Buffer; value: number };
+          nonWitnessUtxo?: Buffer;
+          sequence?: number;
+        }>;
+        outputs: Array<unknown>;
+      };
+      txInputs: Array<{ sequence: number }>;
+      txOutputs: Array<{ address?: string; value: number }>;
+    };
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+  networks: { bitcoin: unknown };
+};
+
+function buildPrevTxHex(value: number, address: string, vout = 0): string {
+  const tx = new bitcoinjsForFixtures.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  for (let i = 0; i <= vout; i++) {
+    const script = bitcoinjsForFixtures.address.toOutputScript(
+      address,
+      bitcoinjsForFixtures.networks.bitcoin,
+    );
+    tx.addOutput(script, i === vout ? value : 0);
+  }
+  return tx.toHex();
+}
+
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SEGWIT_PUBKEY =
+  "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+const CHANGE_ADDR = "bc1qr0p2usnskwqhupc2590l2skll0vzd84cdp3gly";
+const CHANGE_PUBKEY = SEGWIT_PUBKEY;
+const CHANGE_PATH = "84'/0'/0'/1/0";
+const RECIPIENT = "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu";
+const FOREIGN_WALLET = "bc1qpxg3y3yphn0vh4nh3rjz3p6cudn0jcvfk0nyf6";
+
+const ORIG_TXID =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+const ORIG_INPUT_TXID =
+  "2222222222222222222222222222222222222222222222222222222222222222";
+
+const getTxMock = vi.fn();
+const getTxHexMock = vi.fn();
+const getUtxosMock = vi.fn();
+const getFeeEstimatesMock = vi.fn();
+const broadcastTxMock = vi.fn();
+const getTxStatusMock = vi.fn();
+
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getUtxos: getUtxosMock,
+    getFeeEstimates: getFeeEstimatesMock,
+    broadcastTx: broadcastTxMock,
+    getTxStatus: getTxStatusMock,
+    getTxHex: getTxHexMock,
+    getTx: getTxMock,
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+let tmpHome: string;
+
+/**
+ * Build a fake Esplora tx shape for the original (pre-bump) tx. Default
+ * shape: 1 input from SEGWIT_ADDR (100k sats), 2 outputs (50k to
+ * RECIPIENT, ~49k change to CHANGE_ADDR), fee 1000 sats, mempool. Tests
+ * tweak fields via the override arg.
+ */
+function makeOrigTx(overrides: Partial<{
+  vinSequence: number;
+  vinAddress: string;
+  vinValue: number;
+  outputs: Array<{ address: string; value: number }>;
+  fee: number;
+  confirmed: boolean;
+  blockHeight: number;
+}> = {}) {
+  const vinValue = overrides.vinValue ?? 100_000;
+  const outputs =
+    overrides.outputs ??
+    [
+      { address: RECIPIENT, value: 50_000 },
+      { address: CHANGE_ADDR, value: 49_000 },
+    ];
+  const fee = overrides.fee ?? vinValue - outputs.reduce((s, o) => s + o.value, 0);
+  return {
+    txid: ORIG_TXID,
+    vin: [
+      {
+        txid: ORIG_INPUT_TXID,
+        vout: 0,
+        prevout: {
+          scriptpubkey_address: overrides.vinAddress ?? SEGWIT_ADDR,
+          value: vinValue,
+        },
+        sequence: overrides.vinSequence ?? 0xfffffffd,
+      },
+    ],
+    vout: outputs.map((o) => ({
+      scriptpubkey_address: o.address,
+      value: o.value,
+    })),
+    fee,
+    status: overrides.confirmed
+      ? { confirmed: true, block_height: overrides.blockHeight ?? 900_000 }
+      : { confirmed: false },
+  };
+}
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-btc-rbf-"));
+  setConfigDirForTesting(tmpHome);
+  getTxMock.mockReset();
+  getTxHexMock.mockReset();
+  getUtxosMock.mockReset();
+  getFeeEstimatesMock.mockReset();
+  broadcastTxMock.mockReset();
+  getTxStatusMock.mockReset();
+  // Default: derive prev-tx hex from the input value the most-recent
+  // getTxMock returned. Tests can override per-call.
+  getTxHexMock.mockImplementation(async (txid: string) => {
+    const lastResult = getTxMock.mock.results[getTxMock.mock.results.length - 1];
+    if (!lastResult || lastResult.type !== "return") {
+      throw new Error(`getTxHex(${txid}) called but no getTx mock has run.`);
+    }
+    const tx = (await lastResult.value) as ReturnType<typeof makeOrigTx>;
+    const matchingVin = tx.vin.find((v) => v.txid === txid);
+    if (!matchingVin) {
+      throw new Error(`No vin matches txid ${txid}.`);
+    }
+    return buildPrevTxHex(matchingVin.prevout.value, SEGWIT_ADDR, matchingVin.vout);
+  });
+  const { clearPairedBtcAddresses, setPairedBtcAddress } = await import(
+    "../src/signing/btc-usb-signer.js"
+  );
+  const { __clearBitcoinTxStore } = await import(
+    "../src/signing/btc-tx-store.js"
+  );
+  clearPairedBtcAddresses();
+  __clearBitcoinTxStore();
+  setPairedBtcAddress({
+    address: SEGWIT_ADDR,
+    publicKey: SEGWIT_PUBKEY,
+    path: "84'/0'/0'/0/0",
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 0,
+    addressIndex: 0,
+  });
+  setPairedBtcAddress({
+    address: CHANGE_ADDR,
+    publicKey: CHANGE_PUBKEY,
+    path: CHANGE_PATH,
+    appVersion: "2.2.0",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 1,
+    addressIndex: 0,
+  });
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("buildBitcoinRbfBump", () => {
+  it("happy path: bumps fee, shrinks change, preserves recipient", async () => {
+    getTxMock.mockResolvedValueOnce(makeOrigTx({ fee: 1_000 }));
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinRbfBump({
+      wallet: SEGWIT_ADDR,
+      txid: ORIG_TXID,
+      newFeeRate: 25,
+    });
+    expect(tx.chain).toBe("bitcoin");
+    expect(tx.action).toBe("rbf_bump");
+    expect(tx.from).toBe(SEGWIT_ADDR);
+    expect(tx.handle).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(tx.replaces?.txid).toBe(ORIG_TXID);
+    expect(tx.replaces?.oldFeeSats).toBe("1000");
+    expect(tx.decoded.feeRateSatPerVb).toBe(25);
+    expect(tx.decoded.rbfEligible).toBe(true);
+    // Recipient preserved verbatim.
+    const recipient = tx.decoded.outputs.find((o) => o.address === RECIPIENT);
+    expect(recipient?.amountSats).toBe("50000");
+    // Change shrunk: input 100k - recipient 50k - newFee = newChange.
+    const change = tx.decoded.outputs.find((o) => o.address === CHANGE_ADDR);
+    expect(change?.isChange).toBe(true);
+    const newFee = Number(tx.decoded.feeSats);
+    expect(newFee).toBeGreaterThan(1_000);
+    expect(Number(change?.amountSats)).toBe(100_000 - 50_000 - newFee);
+    // PSBT carries every input with sequence 0xFFFFFFFD + nonWitnessUtxo.
+    const psbt = bitcoinjsForFixtures.Psbt.fromBase64(tx.psbtBase64);
+    expect(psbt.txInputs.length).toBe(1);
+    expect(psbt.txInputs[0].sequence).toBe(0xfffffffd);
+    expect(psbt.data.inputs[0].witnessUtxo).toBeDefined();
+    expect(psbt.data.inputs[0].nonWitnessUtxo).toBeDefined();
+  });
+
+  it("refuses when the original tx is already confirmed", async () => {
+    getTxMock.mockResolvedValueOnce(
+      makeOrigTx({ confirmed: true, blockHeight: 900_001 }),
+    );
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/already confirmed/);
+  });
+
+  it("refuses when no input is BIP-125-eligible", async () => {
+    getTxMock.mockResolvedValueOnce(makeOrigTx({ vinSequence: 0xffffffff }));
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/not BIP-125 RBF-eligible/);
+  });
+
+  it("refuses when an input belongs to a foreign wallet", async () => {
+    getTxMock.mockResolvedValueOnce(
+      makeOrigTx({ vinAddress: FOREIGN_WALLET }),
+    );
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/Multi-source RBF is out of scope/);
+  });
+
+  it("refuses when the original tx has no change output (sweep)", async () => {
+    getTxMock.mockResolvedValueOnce(
+      makeOrigTx({
+        outputs: [{ address: RECIPIENT, value: 99_000 }],
+        fee: 1_000,
+      }),
+    );
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/no change output/);
+  });
+
+  it("refuses when newFeeRate fails BIP-125 rule 4", async () => {
+    // Old fee 5000 sats; newFeeRate 30 sat/vB × ~141 vbytes ≈ 4230 sats —
+    // strictly less than the 5141-sats minimum required by rule 4.
+    getTxMock.mockResolvedValueOnce(makeOrigTx({ fee: 5_000 }));
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 30,
+      }),
+    ).rejects.toThrow(/BIP-125 rule 4/);
+  });
+
+  it("refuses when bumped change drops below dust", async () => {
+    // Input 100k - recipient 99k = 1k available. Any fee bump ≥ 455 sats
+    // pushes change below the 546-sat dust threshold.
+    getTxMock.mockResolvedValueOnce(
+      makeOrigTx({
+        outputs: [
+          { address: RECIPIENT, value: 99_000 },
+          { address: CHANGE_ADDR, value: 900 },
+        ],
+        fee: 100,
+      }),
+    );
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/dust threshold/);
+  });
+
+  it("refuses unpaired wallet", async () => {
+    const { clearPairedBtcAddresses } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    clearPairedBtcAddresses();
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: ORIG_TXID,
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/not paired/);
+  });
+
+  it("allowHighFee threads through to the build path", async () => {
+    getTxMock.mockResolvedValueOnce(makeOrigTx({ fee: 500 }));
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinRbfBump({
+      wallet: SEGWIT_ADDR,
+      txid: ORIG_TXID,
+      newFeeRate: 50,
+      allowHighFee: true,
+    });
+    expect(tx.action).toBe("rbf_bump");
+    expect(Number(tx.decoded.feeSats)).toBeGreaterThan(500);
+  });
+
+  it("rejects malformed txid up-front (no indexer call)", async () => {
+    const { buildBitcoinRbfBump } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinRbfBump({
+        wallet: SEGWIT_ADDR,
+        txid: "not-a-real-txid",
+        newFeeRate: 25,
+      }),
+    ).rejects.toThrow(/64 hex characters/);
+    expect(getTxMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR1 — BIP-125 Replace-By-Fee bump tool for unconfirmed BTC txs. Lets the user replace a stuck mempool tx with a higher-fee version using the same Ledger pipeline as the existing send.

- New tool `prepare_btc_rbf_bump({ wallet, txid, newFeeRate, allowHighFee? })`. Reuses original input set, preserves every recipient verbatim, shrinks change to absorb the bump.
- New `BitcoinIndexer.getTx(txid)` returning the full Esplora tx shape (vin/vout/fee/status).
- `UnsignedBitcoinTx.action` extended to `"native_send" | "rbf_bump"` + optional `replaces` field carrying the original-tx context for the verification block.
- Refusal coverage: already-confirmed, non-RBF, foreign-input, no-change, BIP-125 rule 4 violation, dust-threshold breach, fee-cap (override via `allowHighFee`).

Phase 1 source-side scope kept: native segwit + taproot only. Plan: [`claude-work/plan-bitcoin-ledger-phase2-rbf-multisig.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase2-rbf-multisig.md) (PR1 of 2; PR2 = multi-sig co-signer flow, separate PR).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-rbf.test.ts` — 10/10 passing (happy path, already-confirmed, non-RBF, foreign-input, no-change, BIP-125 rule 4, dust, unpaired, allowHighFee, malformed-txid)
- [x] No regressions in adjacent BTC suites (`btc-pr3-send`, `btc-multi-source-send`, `btc-pair`, `btc-indexer-retry`, `btc-bip32-derive`, `btc-pr1`, `btc-pr4-portfolio-message-sign`, `btc-rescan-throttle-tristate`)
- [ ] Live-broadcast smoke test: prepare a stuck send, run `prepare_btc_rbf_bump`, sign on Ledger, broadcast — replaces the original in the mempool

🤖 Generated with [Claude Code](https://claude.com/claude-code)