### PR TITLE
feat(btc): multi-sig co-signer flow (register + sign PSBT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "bitcoinjs-lib": "^6.1.7",
         "bs58check": "^3.0.1",
         "coinselect": "^3.1.13",
+        "ledger-bitcoin": "^0.3.0",
         "qrcode-terminal": "^0.12.0",
         "viem": "^2.21.0",
         "zod": "^3.23.8"
@@ -320,6 +321,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bitcoinerlab/miniscript": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-1.4.3.tgz",
+      "integrity": "sha512-gf7WK4dKJJJl+IgLGmkTOxXQLiCje9c9y4wTLC+cyt0tBDTiSXgsG0X8FFaXf4d+34b8B5p/EJGvRd7mEYB6mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bip68": "^1.0.4"
       }
     },
     "node_modules/@bitcoinerlab/secp256k1": {
@@ -5235,6 +5245,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/bip68": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip68/-/bip68-1.0.4.tgz",
+      "integrity": "sha512-O1htyufFTYy3EO0JkHg2CLykdXEtV2ssqw47Gq9A0WByp662xpJnMEB9m43LZjsSDjIAOozWRExlFQk2hlV1XQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
@@ -6034,6 +6053,20 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ecpair": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
+      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.1.0",
+        "typeforce": "^1.18.0",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ee-first": {
@@ -7492,6 +7525,78 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/ledger-bitcoin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.3.0.tgz",
+      "integrity": "sha512-gaTCdvnqFMvK6i6112MCcsNC+DDhUx1EKPDgqYoLswgwWLyb+EoZjXI0VxxkW9m7VszQdpOv210xNdohmQ6knw==",
+      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^1.1.1",
+        "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@ledgerhq/hw-transport": "^6.31.13",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.1.7"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/@bitcoinerlab/descriptors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-1.1.1.tgz",
+      "integrity": "sha512-AMFkbBBg9T1iWtEmWB23oADk7zaOQix6wUPLXalhTyFDjhkFXDd6pCRfto/HAdaPg/ccM4GMTVgYLee9WdYFyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/miniscript": "^1.2.1",
+        "@bitcoinerlab/secp256k1": "^1.0.5",
+        "bip32": "^4.0.0",
+        "bitcoinjs-lib": "^6.1.3",
+        "ecpair": "^2.1.0"
+      },
+      "peerDependencies": {
+        "ledger-bitcoin": "^0.2.2"
+      },
+      "peerDependenciesMeta": {
+        "ledger-bitcoin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/bip32": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
+      "integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "@scure/base": "^1.1.1",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/ledger-bitcoin": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
+      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
+      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^1.0.2",
+        "@bitcoinerlab/secp256k1": "^1.0.5",
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.1.3"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "bitcoinjs-lib": "^6.1.7",
     "bs58check": "^3.0.1",
     "coinselect": "^3.1.13",
+    "ledger-bitcoin": "^0.3.0",
     "qrcode-terminal": "^0.12.0",
     "viem": "^2.21.0",
     "zod": "^3.23.8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,8 @@ import {
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   prepareBitcoinRbfBump,
+  registerBtcMultisigWallet,
+  signBtcMultisigPsbt,
   signBtcMessage,
   pairLedgerLitecoin,
   getLitecoinBalance,
@@ -230,6 +232,8 @@ import {
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   prepareBitcoinRbfBumpInput,
+  registerBitcoinMultisigWalletInput,
+  signBitcoinMultisigPsbtInput,
   signBtcMessageInput,
   pairLedgerLitecoinInput,
   getLitecoinBalanceInput,
@@ -2444,6 +2448,48 @@ async function main() {
       inputSchema: prepareBitcoinRbfBumpInput.shape,
     },
     handler(prepareBitcoinRbfBump, { toolName: "prepare_btc_rbf_bump" })
+  );
+
+  registerTool(server,
+    "register_btc_multisig_wallet",
+    {
+      description:
+        "One-time registration of a multi-sig Bitcoin wallet policy with the Ledger BTC " +
+        "app (BIP-388 wallet policies). REQUIREMENTS: Ledger plugged in over USB, device " +
+        "unlocked, the 'Bitcoin' app open on-screen. Constructs a " +
+        "`wsh(sortedmulti(M,@0/**,@1/**,...))` descriptor from the supplied cosigners, " +
+        "verifies the connected Ledger's master fingerprint matches exactly one cosigner " +
+        "slot, calls Ledger's `registerWallet` (the device walks every cosigner xpub " +
+        "fingerprint on-screen for verification — the user MUST confirm each fingerprint " +
+        "matches what they expect, since this is the moment that anchors the policy), " +
+        "and persists the descriptor + 32-byte HMAC. The HMAC is reused on every " +
+        "subsequent `sign_btc_multisig_psbt` call so the user only walks the descriptor " +
+        "approval flow once per setup. Phase 2 scope: P2WSH (`wsh`) only. Hard-validates " +
+        "every cosigner xpub via @scure/bip32 round-trip — typos that would silently " +
+        "register a wallet we can never sign with are refused up-front.",
+      inputSchema: registerBitcoinMultisigWalletInput.shape,
+    },
+    handler(registerBtcMultisigWallet, { toolName: "register_btc_multisig_wallet" })
+  );
+
+  registerTool(server,
+    "sign_btc_multisig_psbt",
+    {
+      description:
+        "Co-signer flow — adds OUR Ledger signature to a multi-sig PSBT produced by an " +
+        "external initiator (Sparrow / Specter / Caravan / a peer running this server). " +
+        "Looks up the registered wallet by name, decodes the PSBT, validates every input " +
+        "carries a `bip32_derivation` entry for our master fingerprint (defense against " +
+        "being tricked into signing for a foreign tx), forwards to the Ledger device " +
+        "for the on-device output walkthrough (the user MUST verify every output " +
+        "address + amount on-device matches the chat-side verification block before " +
+        "approving), splices our partial signature(s) into the PSBT, returns the " +
+        "partial PSBT for the user to share back to the coordinator. We do NOT finalize " +
+        "or broadcast — that's the initiator's job once they have all M signatures. " +
+        "Phase 2 scope: P2WSH wallets registered via `register_btc_multisig_wallet`.",
+      inputSchema: signBitcoinMultisigPsbtInput.shape,
+    },
+    handler(signBtcMultisigPsbt, { toolName: "sign_btc_multisig_psbt" })
   );
 
   registerTool(server,

--- a/src/modules/btc/multisig.ts
+++ b/src/modules/btc/multisig.ts
@@ -1,0 +1,600 @@
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { HDKey } from "@scure/bip32";
+import {
+  patchUserConfig,
+  readUserConfig,
+  getConfigPath,
+} from "../../config/user-config.js";
+import {
+  buildWalletPolicy,
+  openLedgerMultisig,
+  type BtcMultisigAppClient,
+  type BtcMultisigPartialSignature,
+} from "../../signing/btc-multisig-usb-loader.js";
+import type {
+  PairedBitcoinMultisigCosigner,
+  PairedBitcoinMultisigWallet,
+} from "../../types/index.js";
+
+/**
+ * Bitcoin multi-sig co-signer flow. Phase 2 PR2 of the BTC Ledger
+ * roadmap. We act as ONE of N signers in a multi-sig wallet — the
+ * initiator (Sparrow / Specter / Caravan / a peer running this same
+ * server) builds the tx and produces a PSBT; the user passes the PSBT
+ * here, this module signs with the Ledger key, returns the partial PSBT
+ * for the user to share back. Combination + finalization + broadcast
+ * happens externally (deferred to a future PR — PSBT-combine is what
+ * external coordinators already do well).
+ *
+ * Two tools are exposed via this module:
+ *   - `register_btc_multisig_wallet` — one-time per setup. Builds a
+ *     `wsh(sortedmulti(M, @0/**, @1/**, ...))` descriptor, calls Ledger's
+ *     `registerWallet` (the device walks every cosigner xpub fingerprint
+ *     on-screen for verification), persists the descriptor + 32-byte
+ *     policy HMAC. The HMAC is reused on every subsequent signature
+ *     call so the user only walks the descriptor approval flow once
+ *     per setup.
+ *   - `sign_btc_multisig_psbt` — adds our signature to a multi-sig PSBT.
+ *     Looks up the registered wallet by name, decodes the PSBT,
+ *     validates inputs/outputs against the policy, calls the device
+ *     (the device walks every output address + amount on-screen),
+ *     splices our partial signature into the PSBT, returns it.
+ *
+ * Phase 2 scope: P2WSH (`wsh(sortedmulti(...))`) only. Taproot multi-sig
+ * (`tr(multi_a(...))`) and `sh(wsh(...))` wrapped multi-sig are
+ * deferred — small audience, distinct script types.
+ */
+
+// --- bitcoinjs-lib loader (CommonJS-only) ---------------------------------
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          witnessScript?: Buffer;
+          bip32Derivation?: Array<{
+            masterFingerprint: Buffer;
+            pubkey: Buffer;
+            path: string;
+          }>;
+          partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
+          witnessUtxo?: { script: Buffer; value: number };
+          nonWitnessUtxo?: Buffer;
+        }>;
+        outputs: Array<unknown>;
+      };
+      txInputs: Array<{ hash: Buffer; index: number; sequence: number }>;
+      txOutputs: Array<{ address?: string; value: number }>;
+      updateInput(
+        i: number,
+        update: { partialSig: Array<{ pubkey: Buffer; signature: Buffer }> },
+      ): unknown;
+      toBase64(): string;
+    };
+  };
+};
+
+// --- Constants ------------------------------------------------------------
+
+/** Ledger BTC app caps wallet-policy names at 16 ASCII bytes. */
+const MULTISIG_NAME_MAX_BYTES = 16;
+/** Ledger BTC app supports up to 15 cosigners in a wallet policy. */
+const MAX_COSIGNERS = 15;
+/** Sortedmulti needs at least 1-of-2 (1-of-1 is single-sig with extra steps). */
+const MIN_COSIGNERS = 2;
+
+// --- In-memory store + persistence ----------------------------------------
+
+const multisigByName = new Map<string, PairedBitcoinMultisigWallet>();
+let multisigHydrated = false;
+
+function ensureMultisigHydrated(): void {
+  if (multisigHydrated) return;
+  multisigHydrated = true;
+  const persisted = readUserConfig()?.pairings?.bitcoinMultisig ?? [];
+  for (const entry of persisted) {
+    multisigByName.set(entry.name, entry);
+  }
+}
+
+function persistMultisig(): void {
+  patchUserConfig({
+    pairings: { bitcoinMultisig: Array.from(multisigByName.values()) },
+  });
+}
+
+export function getPairedMultisigWallets(): PairedBitcoinMultisigWallet[] {
+  ensureMultisigHydrated();
+  return Array.from(multisigByName.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+export function getPairedMultisigByName(
+  name: string,
+): PairedBitcoinMultisigWallet | null {
+  ensureMultisigHydrated();
+  return multisigByName.get(name) ?? null;
+}
+
+/** Test-only — drops every cached entry. */
+export function __clearMultisigStore(): void {
+  multisigByName.clear();
+  multisigHydrated = false;
+  if (existsSync(getConfigPath())) {
+    patchUserConfig({ pairings: { bitcoinMultisig: [] } });
+  }
+}
+
+// --- Validation helpers ---------------------------------------------------
+
+/**
+ * Validate a hex-encoded master fingerprint. Ledger surfaces it as 8
+ * lowercase hex chars (4 bytes); we accept upper/lower and normalize.
+ */
+function normalizeMasterFingerprint(raw: string, ctx: string): string {
+  const trimmed = raw.trim();
+  if (!/^[0-9a-fA-F]{8}$/.test(trimmed)) {
+    throw new Error(
+      `${ctx}: masterFingerprint "${raw}" is not 8 hex characters (4 bytes).`,
+    );
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Validate a BIP-32 derivation path with no leading `m/`. Hardened
+ * markers must be `'` (apostrophe), each segment ≤ 2^31 - 1.
+ */
+function validateDerivationPath(raw: string, ctx: string): void {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error(`${ctx}: derivationPath must be a non-empty string.`);
+  }
+  if (raw.startsWith("m/") || raw.startsWith("/")) {
+    throw new Error(
+      `${ctx}: derivationPath must not start with "m/" or "/" — got "${raw}".`,
+    );
+  }
+  for (const seg of raw.split("/")) {
+    const stripped = seg.endsWith("'") ? seg.slice(0, -1) : seg;
+    if (!/^\d+$/.test(stripped)) {
+      throw new Error(
+        `${ctx}: derivationPath segment "${seg}" is not a non-negative integer.`,
+      );
+    }
+    const n = Number(stripped);
+    if (n < 0 || n >= 0x80000000) {
+      throw new Error(
+        `${ctx}: derivationPath segment ${seg} is out of range (0..2^31-1).`,
+      );
+    }
+  }
+}
+
+/**
+ * Round-trip an xpub through `@scure/bip32` to weed out checksum errors.
+ * Memory: a typo silently registers a wrong wallet that can never sign,
+ * so we want HARD validation here.
+ */
+function validateXpub(xpub: string, ctx: string): void {
+  if (typeof xpub !== "string" || xpub.length === 0) {
+    throw new Error(`${ctx}: xpub must be a non-empty string.`);
+  }
+  try {
+    HDKey.fromExtendedKey(xpub);
+  } catch (err) {
+    throw new Error(
+      `${ctx}: xpub failed checksum validation — likely a typo. ` +
+        `Original error: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Format one cosigner's key string for the Ledger BTC app's wallet
+ * policy: `[<masterFingerprint>/<derivationPath>]<xpub>`.
+ */
+function formatPolicyKey(c: PairedBitcoinMultisigCosigner): string {
+  return `[${c.masterFingerprint}/${c.derivationPath}]${c.xpub}`;
+}
+
+/**
+ * Build the descriptor template string for a P2WSH sortedmulti policy:
+ * `wsh(sortedmulti(<M>,@0/**,@1/**,...,@{N-1}/**))`.
+ */
+function buildSortedmultiDescriptor(
+  threshold: number,
+  cosignerCount: number,
+): string {
+  const slots = Array.from({ length: cosignerCount }, (_, i) => `@${i}/**`).join(",");
+  return `wsh(sortedmulti(${threshold},${slots}))`;
+}
+
+// --- register_btc_multisig_wallet ----------------------------------------
+
+export interface RegisterBitcoinMultisigWalletArgs {
+  name: string;
+  threshold: number;
+  cosigners: Array<{
+    xpub: string;
+    masterFingerprint: string;
+    derivationPath: string;
+  }>;
+  scriptType: "wsh";
+}
+
+export interface RegisterBitcoinMultisigWalletResult {
+  wallet: PairedBitcoinMultisigWallet;
+  /** Ledger app version observed at registration time. */
+  appVersion: string;
+  /** Index of the user's slot in `cosigners` (0-indexed). */
+  ourKeyIndex: number;
+}
+
+export async function registerBitcoinMultisigWallet(
+  args: RegisterBitcoinMultisigWalletArgs,
+): Promise<RegisterBitcoinMultisigWalletResult> {
+  // 1. Argument validation — every refusal here is BEFORE we touch the device.
+  if (typeof args.name !== "string" || args.name.length === 0) {
+    throw new Error("`name` must be a non-empty ASCII string.");
+  }
+  // ASCII only; the Ledger device limits the on-screen label to 16 BYTES.
+  if (!/^[\x20-\x7e]+$/.test(args.name)) {
+    throw new Error(
+      `\`name\` must be printable ASCII only (got "${args.name}").`,
+    );
+  }
+  if (Buffer.byteLength(args.name, "utf-8") > MULTISIG_NAME_MAX_BYTES) {
+    throw new Error(
+      `\`name\` is ${Buffer.byteLength(args.name, "utf-8")} bytes — Ledger BTC app caps ` +
+        `wallet-policy names at ${MULTISIG_NAME_MAX_BYTES} bytes. Shorten it.`,
+    );
+  }
+  if (args.scriptType !== "wsh") {
+    throw new Error(
+      `\`scriptType\` "${args.scriptType}" is out of scope — Phase 2 supports "wsh" only ` +
+        `(P2WSH native segwit). Taproot and P2SH-wrapped multi-sig are deferred.`,
+    );
+  }
+  if (
+    !Number.isInteger(args.threshold) ||
+    args.threshold < 1 ||
+    args.threshold > MAX_COSIGNERS
+  ) {
+    throw new Error(
+      `\`threshold\` must be an integer between 1 and ${MAX_COSIGNERS} — got ${args.threshold}.`,
+    );
+  }
+  if (!Array.isArray(args.cosigners)) {
+    throw new Error("`cosigners` must be an array.");
+  }
+  if (args.cosigners.length < MIN_COSIGNERS) {
+    throw new Error(
+      `\`cosigners\` must have at least ${MIN_COSIGNERS} entries (got ${args.cosigners.length}). ` +
+        `1-of-1 multi-sig is single-sig with extra steps; use \`prepare_btc_send\` instead.`,
+    );
+  }
+  if (args.cosigners.length > MAX_COSIGNERS) {
+    throw new Error(
+      `\`cosigners\` has ${args.cosigners.length} entries — Ledger BTC app caps wallet ` +
+        `policies at ${MAX_COSIGNERS} keys.`,
+    );
+  }
+  if (args.threshold > args.cosigners.length) {
+    throw new Error(
+      `\`threshold\` ${args.threshold} exceeds cosigner count ${args.cosigners.length}.`,
+    );
+  }
+
+  // 2. Validate every cosigner entry; weed out duplicate xpubs (the
+  //    Ledger app doesn't allow the same key twice in a policy).
+  const seenXpubs = new Set<string>();
+  const validatedCosigners: PairedBitcoinMultisigCosigner[] = args.cosigners.map(
+    (c, i) => {
+      const ctx = `cosigners[${i}]`;
+      const masterFingerprint = normalizeMasterFingerprint(c.masterFingerprint, ctx);
+      validateDerivationPath(c.derivationPath, ctx);
+      validateXpub(c.xpub, ctx);
+      if (seenXpubs.has(c.xpub)) {
+        throw new Error(
+          `${ctx}: xpub appears more than once in \`cosigners\`. Each slot must be a ` +
+            `distinct key.`,
+        );
+      }
+      seenXpubs.add(c.xpub);
+      return {
+        xpub: c.xpub,
+        masterFingerprint,
+        derivationPath: c.derivationPath,
+        isOurs: false, // patched after device probe.
+      };
+    },
+  );
+
+  // 3. Reject duplicate name (would silently overwrite the existing entry).
+  ensureMultisigHydrated();
+  if (multisigByName.has(args.name)) {
+    throw new Error(
+      `Multi-sig wallet "${args.name}" is already registered. Pick a different name, ` +
+        `or call a (future) \`unregister_btc_multisig_wallet\` first.`,
+    );
+  }
+
+  // 4. Open the device, identify which cosigner slot is ours, register
+  //    the policy. Every device touch lives inside try/finally so we
+  //    never leak the HID descriptor on error.
+  const { app, transport } = await openLedgerMultisig();
+  let result: RegisterBitcoinMultisigWalletResult;
+  try {
+    const appInfo = await app.getAppAndVersion();
+    if (appInfo.name !== "Bitcoin") {
+      throw new Error(
+        `The wrong Ledger app is open (got "${appInfo.name}"). Open the Bitcoin app ` +
+          `on the device and retry.`,
+      );
+    }
+    const ourFingerprint = (await app.getMasterFingerprint()).toLowerCase();
+    const candidates = validatedCosigners.filter(
+      (c) => c.masterFingerprint === ourFingerprint,
+    );
+    if (candidates.length === 0) {
+      throw new Error(
+        `The connected Ledger's master fingerprint ${ourFingerprint} does not appear in ` +
+          `\`cosigners\`. This Ledger is NOT a signer in the proposed wallet — refusing ` +
+          `to register a policy we can never sign with.`,
+      );
+    }
+    if (candidates.length > 1) {
+      throw new Error(
+        `Master fingerprint ${ourFingerprint} appears in multiple \`cosigners\` entries ` +
+          `— ambiguous. Each Ledger fingerprint must occupy at most one slot.`,
+      );
+    }
+    const ourEntry = candidates[0];
+    // Verify the xpub at the user-supplied derivation path matches the
+    // device-derived xpub. Catches typos in the cosigner's xpub field
+    // even when fingerprints happen to match (extremely unlikely
+    // collision, but cheap to check).
+    const deviceXpub = await app.getExtendedPubkey(ourEntry.derivationPath, false);
+    if (deviceXpub !== ourEntry.xpub) {
+      throw new Error(
+        `Cosigner xpub for fingerprint ${ourFingerprint} (path ${ourEntry.derivationPath}) ` +
+          `does not match the Ledger-derived xpub. Expected ${deviceXpub}, got ${ourEntry.xpub}. ` +
+          `Likely a copy-paste error in the cosigner's xpub field.`,
+      );
+    }
+    const ourKeyIndex = validatedCosigners.indexOf(ourEntry);
+    validatedCosigners[ourKeyIndex].isOurs = true;
+
+    // 5. Construct + register the wallet policy.
+    const descriptorTemplate = buildSortedmultiDescriptor(
+      args.threshold,
+      validatedCosigners.length,
+    );
+    const policyKeys = validatedCosigners.map(formatPolicyKey);
+    const walletPolicy = buildWalletPolicy(args.name, descriptorTemplate, policyKeys);
+    // The device walks every cosigner xpub fingerprint on-screen. The
+    // user MUST verify each fingerprint matches what they expect (this
+    // is the moment that anchors the policy — a malicious server could
+    // otherwise swap an xpub for one whose private key it controls).
+    const [, hmacBuf] = await app.registerWallet(walletPolicy);
+
+    const wallet: PairedBitcoinMultisigWallet = {
+      name: args.name,
+      threshold: args.threshold,
+      totalSigners: validatedCosigners.length,
+      scriptType: args.scriptType,
+      descriptor: descriptorTemplate,
+      cosigners: validatedCosigners,
+      policyHmac: hmacBuf.toString("hex"),
+      appVersion: appInfo.version,
+    };
+    multisigByName.set(args.name, wallet);
+    persistMultisig();
+
+    result = { wallet, appVersion: appInfo.version, ourKeyIndex };
+  } finally {
+    await transport.close().catch(() => {});
+  }
+  return result;
+}
+
+// --- sign_btc_multisig_psbt ----------------------------------------------
+
+export interface SignBitcoinMultisigPsbtArgs {
+  walletName: string;
+  psbtBase64: string;
+}
+
+export interface SignBitcoinMultisigPsbtResult {
+  partialPsbtBase64: string;
+  /** Number of signatures we added (always 1 in this flow). */
+  signaturesAdded: number;
+  /** Total signatures present after our addition. */
+  signaturesPresent: number;
+  /** Threshold M from the registered policy. */
+  signaturesNeeded: number;
+  /** True iff `signaturesPresent >= signaturesNeeded` on every input. */
+  fullySigned: boolean;
+}
+
+/**
+ * Validate that every PSBT input carries a `bip32Derivation` entry
+ * matching our master fingerprint. This is the chat-side defense against
+ * being tricked into signing for a foreign tx — the device does its own
+ * deeper validation against the registered policy, but a mismatch we
+ * catch here saves a USB round-trip.
+ *
+ * NOT a replacement for the device-side check: the user is the final
+ * authority via the on-device output walkthrough.
+ */
+function ensurePsbtMatchesOurKey(
+  psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
+  ourFingerprint: string,
+): void {
+  const ourFpBuf = Buffer.from(ourFingerprint, "hex");
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const input = psbt.data.inputs[i];
+    const derivations = input.bip32Derivation ?? [];
+    const hasOurs = derivations.some(
+      (d) => d.masterFingerprint.equals(ourFpBuf),
+    );
+    if (!hasOurs) {
+      throw new Error(
+        `PSBT input ${i} has no bip32_derivation entry for our master fingerprint ` +
+          `${ourFingerprint}. Either this PSBT belongs to a different wallet (refusing ` +
+          `to forward to the device) or the initiator built it without our xpub. ` +
+          `Verify the PSBT comes from a coordinator that knows about this Ledger.`,
+      );
+    }
+  }
+}
+
+/**
+ * Splice ledger-bitcoin's PartialSignature output into the PSBT's
+ * input-level partialSig map. P2WSH multisig uses standard ECDSA
+ * signatures (NOT taproot), so we drop `tapleafHash` and keep only
+ * `{pubkey, signature}`.
+ */
+function applyPartialSignatures(
+  psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
+  sigs: Array<[number, BtcMultisigPartialSignature]>,
+): number {
+  let added = 0;
+  for (const [inputIdx, partial] of sigs) {
+    if (partial.tapleafHash !== undefined) {
+      // Taproot script-path signatures land in `tapScriptSig`, not
+      // `partialSig`. Out of scope for Phase 2 (`wsh` only); refusing
+      // here surfaces an unexpected device-side response shape rather
+      // than silently dropping it.
+      throw new Error(
+        `Ledger returned a taproot partial signature for input ${inputIdx}, but this ` +
+          `flow is P2WSH-only. The registered policy may not match the PSBT — refusing ` +
+          `to splice.`,
+      );
+    }
+    psbt.updateInput(inputIdx, {
+      partialSig: [{ pubkey: partial.pubkey, signature: partial.signature }],
+    });
+    added += 1;
+  }
+  return added;
+}
+
+/**
+ * For each input, count how many distinct signatures are present (post-
+ * splice). Used to derive `signaturesPresent` and `fullySigned`.
+ */
+function minSignatureCount(
+  psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
+): number {
+  let min = Number.POSITIVE_INFINITY;
+  for (const input of psbt.data.inputs) {
+    const count = input.partialSig?.length ?? 0;
+    if (count < min) min = count;
+  }
+  return Number.isFinite(min) ? min : 0;
+}
+
+export async function signBitcoinMultisigPsbt(
+  args: SignBitcoinMultisigPsbtArgs,
+): Promise<SignBitcoinMultisigPsbtResult> {
+  if (typeof args.walletName !== "string" || args.walletName.length === 0) {
+    throw new Error("`walletName` must be a non-empty string.");
+  }
+  if (typeof args.psbtBase64 !== "string" || args.psbtBase64.length === 0) {
+    throw new Error("`psbtBase64` must be a non-empty base64 string.");
+  }
+
+  // 1. Look up the registered wallet.
+  ensureMultisigHydrated();
+  const wallet = multisigByName.get(args.walletName);
+  if (!wallet) {
+    const available = Array.from(multisigByName.keys());
+    throw new Error(
+      `No multi-sig wallet registered under name "${args.walletName}". ` +
+        (available.length > 0
+          ? `Registered names: ${available.join(", ")}.`
+          : `No multi-sig wallets registered yet — call \`register_btc_multisig_wallet\` first.`),
+    );
+  }
+
+  // 2. Decode the PSBT (validates structure).
+  let psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>;
+  try {
+    psbt = bitcoinjs.Psbt.fromBase64(args.psbtBase64);
+  } catch (err) {
+    throw new Error(
+      `Failed to decode PSBT: ${(err as Error).message}. The input must be a valid ` +
+        `base64-encoded PSBT v0.`,
+    );
+  }
+  if (psbt.data.inputs.length === 0) {
+    throw new Error("PSBT has no inputs — refusing to sign.");
+  }
+
+  // 3. Re-build the wallet policy from the persisted descriptor + keys.
+  const policyKeys = wallet.cosigners.map(formatPolicyKey);
+  const walletPolicy = buildWalletPolicy(
+    wallet.name,
+    wallet.descriptor,
+    policyKeys,
+  );
+  const policyHmac = Buffer.from(wallet.policyHmac, "hex");
+
+  // 4. Open device, validate PSBT shape against our key, sign.
+  const { app, transport } = await openLedgerMultisig();
+  let result: SignBitcoinMultisigPsbtResult;
+  try {
+    const appInfo = await app.getAppAndVersion();
+    if (appInfo.name !== "Bitcoin") {
+      throw new Error(
+        `The wrong Ledger app is open (got "${appInfo.name}"). Open the Bitcoin app ` +
+          `on the device and retry.`,
+      );
+    }
+    const deviceFingerprint = (await app.getMasterFingerprint()).toLowerCase();
+    const ourCosigner = wallet.cosigners.find((c) => c.isOurs);
+    if (!ourCosigner) {
+      throw new Error(
+        `Internal error: registered wallet "${wallet.name}" has no cosigner flagged ` +
+          `\`isOurs\`. Re-register via \`register_btc_multisig_wallet\`.`,
+      );
+    }
+    if (deviceFingerprint !== ourCosigner.masterFingerprint) {
+      throw new Error(
+        `Connected Ledger's master fingerprint ${deviceFingerprint} does not match the ` +
+          `fingerprint stored for "${wallet.name}" (${ourCosigner.masterFingerprint}). ` +
+          `Either the wrong Ledger is plugged in, or the registered wallet was created ` +
+          `with a different device — refusing to forward the PSBT.`,
+      );
+    }
+    ensurePsbtMatchesOurKey(psbt, deviceFingerprint);
+
+    // The device walks every output address + amount on-screen. The
+    // user MUST verify each output matches the rendered verification
+    // block before approving.
+    const partialSigs = await app.signPsbt(args.psbtBase64, walletPolicy, policyHmac);
+    if (partialSigs.length === 0) {
+      throw new Error(
+        `Ledger returned zero partial signatures for "${wallet.name}". The device may ` +
+          `have been unable to find a derivation path matching our key on any input.`,
+      );
+    }
+    const added = applyPartialSignatures(psbt, partialSigs);
+    const signaturesPresent = minSignatureCount(psbt);
+    result = {
+      partialPsbtBase64: psbt.toBase64(),
+      signaturesAdded: added,
+      signaturesPresent,
+      signaturesNeeded: wallet.threshold,
+      fullySigned: signaturesPresent >= wallet.threshold,
+    };
+  } finally {
+    await transport.close().catch(() => {});
+  }
+  return result;
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -152,6 +152,8 @@ import type {
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   PrepareBitcoinRbfBumpArgs,
+  RegisterBitcoinMultisigWalletArgs,
+  SignBitcoinMultisigPsbtArgs,
   SignBtcMessageArgs,
   PairLedgerLitecoinArgs,
   GetLitecoinBalanceArgs,
@@ -1223,6 +1225,26 @@ export async function prepareBitcoinRbfBump(args: PrepareBitcoinRbfBumpArgs) {
 export async function signBtcMessage(args: SignBtcMessageArgs) {
   const { signBitcoinMessage } = await import("../btc/actions.js");
   return signBitcoinMessage({ wallet: args.wallet, message: args.message });
+}
+
+export async function registerBtcMultisigWallet(
+  args: RegisterBitcoinMultisigWalletArgs,
+) {
+  const { registerBitcoinMultisigWallet } = await import("../btc/multisig.js");
+  return registerBitcoinMultisigWallet({
+    name: args.name,
+    threshold: args.threshold,
+    cosigners: args.cosigners,
+    scriptType: args.scriptType,
+  });
+}
+
+export async function signBtcMultisigPsbt(args: SignBitcoinMultisigPsbtArgs) {
+  const { signBitcoinMultisigPsbt } = await import("../btc/multisig.js");
+  return signBitcoinMultisigPsbt({
+    walletName: args.walletName,
+    psbtBase64: args.psbtBase64,
+  });
 }
 
 /**

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1289,6 +1289,100 @@ export const prepareBitcoinRbfBumpInput = z.object({
     ),
 });
 
+export const registerBitcoinMultisigWalletInput = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(16)
+    .regex(/^[\x20-\x7e]+$/)
+    .describe(
+      "User-chosen label for the multi-sig setup, e.g. \"Family vault\". Must be " +
+        "printable ASCII, ≤ 16 bytes (Ledger BTC app caps wallet-policy names at " +
+        "16 bytes). Surfaces on-device during the registration approval flow and " +
+        "is the lookup key for `sign_btc_multisig_psbt`. Must be unique within the " +
+        "registered wallet set."
+    ),
+  threshold: z
+    .number()
+    .int()
+    .min(1)
+    .max(15)
+    .describe(
+      "M in M-of-N. Must be ≥ 1 and ≤ cosigner count. Phase 2 hard-caps at 15 (the " +
+        "Ledger BTC app's wallet-policy limit)."
+    ),
+  cosigners: z
+    .array(
+      z.object({
+        xpub: z
+          .string()
+          .min(1)
+          .describe(
+            "BIP-32 extended public key (xpub / Ypub / Zpub form) for this signer slot. " +
+              "Round-trips through @scure/bip32 for checksum validation — a typo silently " +
+              "registers a wrong wallet that can never sign, so we hard-validate."
+          ),
+        masterFingerprint: z
+          .string()
+          .regex(/^[0-9a-fA-F]{8}$/)
+          .describe(
+            "4-byte master fingerprint as 8 hex chars (lowercase preferred but case-insensitive). " +
+              "Each cosigner gets it from `getmasterfingerprint` on their wallet (Ledger / " +
+              "Sparrow / Specter all expose it)."
+          ),
+        derivationPath: z
+          .string()
+          .min(1)
+          .describe(
+            "BIP-32 derivation path leading to `xpub`, NO leading `m/`. Standard BIP-48 " +
+              "P2WSH multisig: \"48'/0'/0'/2'\" (account 0). The wildcard suffix `/<change>/<index>` " +
+              "is appended at signing time via the descriptor template — supply only the account-level " +
+              "path here."
+          ),
+      })
+    )
+    .min(2)
+    .max(15)
+    .describe(
+      "Cosigner slots in the order they should appear in the descriptor's `@N` slots. " +
+        "Slot order is part of the descriptor identity — every cosigner must agree on " +
+        "the same ordering or they'll register different wallets. Exactly one entry's " +
+        "fingerprint+xpub must match the connected Ledger; the device flags it `isOurs` " +
+        "and uses it for signing. Phase 2 requires ≥ 2 cosigners (1-of-1 is single-sig)."
+    ),
+  scriptType: z
+    .literal("wsh")
+    .describe(
+      "Script type for the multi-sig wrapper. Phase 2 supports \"wsh\" only (P2WSH " +
+        "native segwit, `bc1q...`-style addresses). Taproot multi-sig and P2SH-wrapped " +
+        "multi-sig are deferred."
+    ),
+});
+
+export const signBitcoinMultisigPsbtInput = z.object({
+  walletName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe(
+      "Name of a previously-registered multi-sig wallet (matches the `name` passed to " +
+        "`register_btc_multisig_wallet`). Refused if no wallet is registered under " +
+        "this name."
+    ),
+  psbtBase64: z
+    .string()
+    .min(1)
+    .max(200_000)
+    .describe(
+      "Base64-encoded PSBT v0 from the initiator. Every input must carry a " +
+        "`bip32_derivation` entry for our master fingerprint, or we refuse to forward " +
+        "to the device. The Ledger app then walks every output (address + amount) " +
+        "on-device and asks for confirmation; the user MUST verify the on-device walk " +
+        "matches the chat-side verification block before approving. Cap of ~200 KB to " +
+        "bound transport buffer + on-device parsing time."
+    ),
+});
+
 export const getBitcoinTxHistoryInput = z.object({
   address: bitcoinAddressSchema,
   limit: z
@@ -1344,6 +1438,10 @@ export const signBtcMessageInput = z.object({
 
 export type GetBitcoinTxHistoryArgs = z.infer<typeof getBitcoinTxHistoryInput>;
 export type PrepareBitcoinNativeSendArgs = z.infer<typeof prepareBitcoinNativeSendInput>;
+export type RegisterBitcoinMultisigWalletArgs = z.infer<
+  typeof registerBitcoinMultisigWalletInput
+>;
+export type SignBitcoinMultisigPsbtArgs = z.infer<typeof signBitcoinMultisigPsbtInput>;
 export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;

--- a/src/signing/btc-multisig-usb-loader.ts
+++ b/src/signing/btc-multisig-usb-loader.ts
@@ -1,0 +1,134 @@
+import { createRequire } from "node:module";
+
+/**
+ * Loader for the `ledger-bitcoin` multi-sig client (BIP-388 wallet
+ * policies). This is a SEPARATE package from `@ledgerhq/hw-app-btc` —
+ * single-sig flows use the legacy SDK because that's what `pair_ledger_btc`
+ * + `prepare_btc_send` already speak; multi-sig needs the newer
+ * `AppClient` because only it exposes `registerWallet` + `signPsbt`
+ * with a `WalletPolicy` argument.
+ *
+ * Both clients share `@ledgerhq/hw-transport-node-hid`. We open a
+ * dedicated transport for each multi-sig call; HID transports are
+ * exclusive (one process can hold one device descriptor at a time), so
+ * the legacy single-sig path and this multi-sig path can't be
+ * concurrent — they're not in this server's flow anyway (each tool call
+ * opens, talks, closes).
+ *
+ * Isolating the `require()` here lets tests
+ * `vi.mock("../signing/btc-multisig-usb-loader.js")` with a fake
+ * `openLedgerMultisig()` and avoid touching the SDK entirely.
+ */
+
+export interface BtcMultisigPartialSignature {
+  pubkey: Buffer;
+  signature: Buffer;
+  tapleafHash?: Buffer;
+}
+
+export interface BtcMultisigWalletPolicy {
+  readonly name: string;
+  readonly descriptorTemplate: string;
+  readonly keys: readonly string[];
+  getId(): Buffer;
+  serialize(): Buffer;
+}
+
+export interface BtcMultisigAppClient {
+  /**
+   * Standard Ledger app-info call. Used to confirm the user has the
+   * Bitcoin app (not Ethereum / Litecoin / dashboard) open before
+   * issuing wallet-policy commands.
+   */
+  getAppAndVersion(): Promise<{ name: string; version: string; flags: number | Buffer }>;
+  /**
+   * 4-byte master fingerprint, returned as 8 lowercase hex chars.
+   * Used by registration to match the user's slot among the cosigners.
+   */
+  getMasterFingerprint(): Promise<string>;
+  /**
+   * Derive an xpub at the given BIP-32 path. `display: false` for
+   * standard paths (silent); `true` shows the path on-device for
+   * verification (we use `false` — the device already verifies the
+   * descriptor on registerWallet).
+   */
+  getExtendedPubkey(path: string, display?: boolean): Promise<string>;
+  /**
+   * Register a wallet policy with the device. The user walks every
+   * cosigner xpub fingerprint on-device. Returns `[id, hmac]`; the
+   * hmac is the per-setup token every subsequent `signPsbt` requires.
+   */
+  registerWallet(walletPolicy: BtcMultisigWalletPolicy): Promise<readonly [Buffer, Buffer]>;
+  /**
+   * Sign a PSBT with a registered wallet policy. The device walks
+   * every output (address + amount) on-screen and asks for confirmation
+   * (the policy was already approved at registration; only outputs are
+   * re-verified per signature). Returns the partial signatures keyed
+   * by input index — caller splices them into the PSBT and re-serializes.
+   */
+  signPsbt(
+    psbt: string | Buffer,
+    walletPolicy: BtcMultisigWalletPolicy,
+    walletHMAC: Buffer | null,
+    progressCallback?: () => void,
+  ): Promise<Array<[number, BtcMultisigPartialSignature]>>;
+}
+
+export interface BtcMultisigTransport {
+  close(): Promise<void>;
+}
+
+/**
+ * Construction shape from `ledger-bitcoin`. We keep this typed locally
+ * so tests don't have to model the full library surface.
+ */
+interface AppClientCtor {
+  new (transport: unknown): BtcMultisigAppClient;
+}
+interface WalletPolicyCtor {
+  new (
+    name: string,
+    descriptorTemplate: string,
+    keys: readonly string[],
+  ): BtcMultisigWalletPolicy;
+}
+
+const requireCjs = createRequire(import.meta.url);
+
+/**
+ * Construct a `WalletPolicy` for the multi-sig descriptor. Returns the
+ * `ledger-bitcoin` instance the AppClient methods accept.
+ *
+ * `keys` follow the `[<masterFingerprint>/<derivationPath>]<xpub>` shape
+ * the Ledger BTC app requires (one entry per cosigner, in slot order).
+ * `descriptorTemplate` references the keys by `@N` (0-indexed).
+ */
+export function buildWalletPolicy(
+  name: string,
+  descriptorTemplate: string,
+  keys: readonly string[],
+): BtcMultisigWalletPolicy {
+  const { WalletPolicy } = requireCjs("ledger-bitcoin") as {
+    WalletPolicy: WalletPolicyCtor;
+  };
+  return new WalletPolicy(name, descriptorTemplate, keys);
+}
+
+/**
+ * Open a USB connection to the Ledger BTC app and return an `AppClient`
+ * instance plus its underlying transport. Caller MUST close the
+ * transport in a `finally` block — HID descriptors are exclusive and
+ * leaving one open blocks every subsequent device operation.
+ */
+export async function openLedgerMultisig(): Promise<{
+  app: BtcMultisigAppClient;
+  transport: BtcMultisigTransport;
+}> {
+  const TransportNodeHid = requireCjs("@ledgerhq/hw-transport-node-hid").default;
+  const { AppClient } = requireCjs("ledger-bitcoin") as {
+    AppClient: AppClientCtor;
+  };
+  const transport = (await TransportNodeHid.open("")) as BtcMultisigTransport;
+  const app = new AppClient(transport);
+  return { app, transport };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1516,6 +1516,74 @@ export interface PairedBitcoinEntry {
 }
 
 /**
+ * Cosigner entry inside a registered multi-sig wallet policy. Carries
+ * the BIP-32 extended pubkey + master fingerprint + derivation path
+ * Ledger's wallet-policy descriptor needs to identify each signer slot.
+ *
+ * `isOurs` flags which entry corresponds to the paired Ledger device —
+ * exactly one entry has it `true` after `register_btc_multisig_wallet`
+ * verifies the user's master fingerprint + derived xpub against the
+ * cosigners list. Foreign cosigner entries (`isOurs: false`) carry only
+ * public material and are NOT touched by this server beyond shaping the
+ * descriptor; their xpubs come from out-of-band coordination (each
+ * cosigner exports their xpub independently).
+ */
+export interface PairedBitcoinMultisigCosigner {
+  /** BIP-32 extended public key (xpub/Ypub/Zpub form). */
+  xpub: string;
+  /** 4-byte master fingerprint as 8 lowercase hex chars (no `0x`). */
+  masterFingerprint: string;
+  /**
+   * Derivation path leading to `xpub`, no leading `m/`. Standard BIP-48
+   * P2WSH multisig: `48'/0'/<account>'/2'`. The `/<change>/<index>`
+   * leaves are appended at signing time via the descriptor template's
+   * `@N/**` wildcard.
+   */
+  derivationPath: string;
+  /** True for exactly one entry — the one this Ledger can sign with. */
+  isOurs: boolean;
+}
+
+/**
+ * Registered multi-sig wallet policy (BIP-388 Ledger descriptor). Persisted
+ * across server restarts; reused by every subsequent `sign_btc_multisig_psbt`
+ * call against the same setup.
+ *
+ * `policyHmac` is the 32-byte HMAC the Ledger BTC app issues during
+ * `registerWallet` and demands on every future `signPsbt(policy, hmac)`
+ * call — it cryptographically anchors the on-device policy approval to
+ * this server's stored copy. Without the HMAC the device re-prompts the
+ * full policy verification flow on every signature; storing it means the
+ * user only walks through xpub fingerprints once per setup.
+ *
+ * Phase 2 scope: `wsh(sortedmulti(M,@0/**,@1/**,...))` (P2WSH native
+ * segwit). Taproot multi-sig (`tr(multi_a(...))`) and `sh-wsh` wrapped
+ * multi-sig are deferred — small audience, distinct script types.
+ */
+export interface PairedBitcoinMultisigWallet {
+  /** User-chosen label, ASCII, ≤ 16 bytes (Ledger device limit). Unique within `bitcoinMultisig[]`. */
+  name: string;
+  /** Threshold M in M-of-N. */
+  threshold: number;
+  /** Total signers N. */
+  totalSigners: number;
+  /** Script type — Phase 2 is "wsh" only. */
+  scriptType: "wsh";
+  /**
+   * The Miniscript descriptor template registered with the device, e.g.
+   * `wsh(sortedmulti(2,@0/**,@1/**,@2/**))`. Slot indices `@N` correspond
+   * to entries in `cosigners` in registration order.
+   */
+  descriptor: string;
+  /** Cosigners in slot order. Exactly one entry has `isOurs: true`. */
+  cosigners: PairedBitcoinMultisigCosigner[];
+  /** 32-byte HMAC from `app.registerWallet`, hex-encoded (no `0x`). */
+  policyHmac: string;
+  /** Bitcoin app version at registration time, for diagnostics. */
+  appVersion: string;
+}
+
+/**
  * Litecoin pairing entry. Mirror of `PairedBitcoinEntry`. The 4
  * standard mainnet address types map to Litecoin's L/M/ltc1q/ltc1p
  * forms instead of BTC's 1/3/bc1q/bc1p.
@@ -1620,6 +1688,13 @@ export interface UserConfig {
      * write-through-to-disk semantics as the Solana / TRON slices.
      */
     bitcoin?: PairedBitcoinEntry[];
+    /**
+     * Registered Bitcoin multi-sig wallet policies. One entry per
+     * registered wallet; each carries the descriptor + cosigner xpubs +
+     * Ledger policy HMAC needed to sign subsequent PSBTs without
+     * re-walking the on-device descriptor approval flow.
+     */
+    bitcoinMultisig?: PairedBitcoinMultisigWallet[];
     /**
      * Litecoin pairings — same shape as the Bitcoin slice, BIP-44
      * coin_type 2 instead of 0.

--- a/test/btc-multisig.test.ts
+++ b/test/btc-multisig.test.ts
@@ -1,0 +1,608 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+/**
+ * Tests for the BTC multi-sig co-signer flow:
+ *   - register_btc_multisig_wallet
+ *   - sign_btc_multisig_psbt
+ *
+ * The `ledger-bitcoin` AppClient is mocked via `btc-multisig-usb-loader.js`
+ * (vi.mock at the loader level so the SDK is never loaded). PSBT
+ * construction uses real bitcoinjs-lib so the round-trip exercises the
+ * actual partialSig splicing path.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    new (opts?: { network?: unknown }): {
+      addInput(input: {
+        hash: string | Buffer;
+        index: number;
+        sequence?: number;
+        witnessUtxo?: { script: Buffer; value: number };
+        witnessScript?: Buffer;
+        bip32Derivation?: Array<{
+          masterFingerprint: Buffer;
+          pubkey: Buffer;
+          path: string;
+        }>;
+      }): unknown;
+      addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
+      toBase64(): string;
+    };
+    fromBase64(b64: string): {
+      data: { inputs: Array<{ partialSig?: Array<{ pubkey: Buffer; signature: Buffer }> }> };
+    };
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+  payments: {
+    p2wsh(opts: { redeem: { output: Buffer } }): { output?: Buffer; address?: string };
+  };
+  script: {
+    compile(chunks: Array<number | Buffer>): Buffer;
+  };
+  opcodes: { OP_2: number; OP_3: number; OP_CHECKMULTISIG: number };
+  networks: { bitcoin: unknown };
+};
+
+const NETWORK = bitcoinjs.networks.bitcoin;
+
+// --- Mocked AppClient + transport ----------------------------------------
+
+const getAppAndVersionMock = vi.fn();
+const getMasterFingerprintMock = vi.fn();
+const getExtendedPubkeyMock = vi.fn();
+const registerWalletMock = vi.fn();
+const signPsbtMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+
+vi.mock("../src/signing/btc-multisig-usb-loader.js", () => ({
+  openLedgerMultisig: async () => ({
+    app: {
+      getAppAndVersion: getAppAndVersionMock,
+      getMasterFingerprint: getMasterFingerprintMock,
+      getExtendedPubkey: getExtendedPubkeyMock,
+      registerWallet: registerWalletMock,
+      signPsbt: signPsbtMock,
+    },
+    transport: { close: transportCloseMock },
+  }),
+  buildWalletPolicy: (name: string, descriptorTemplate: string, keys: readonly string[]) => ({
+    name,
+    descriptorTemplate,
+    keys,
+    getId: () => Buffer.alloc(32),
+    serialize: () => Buffer.alloc(0),
+  }),
+}));
+
+// --- Helpers for deterministic xpubs + multisig PSBT ---------------------
+
+/**
+ * Derive a deterministic mainnet xpub from a seed string. Different
+ * seeds produce different cosigner identities. Returns the xpub string,
+ * 4-byte master fingerprint hex, and the HDKey for child derivation in
+ * sign tests.
+ */
+function makeCosigner(seed: string) {
+  const seedBuf = Buffer.alloc(64);
+  Buffer.from(seed.padEnd(64, "x")).copy(seedBuf);
+  const master = HDKey.fromMasterSeed(seedBuf);
+  // BIP-48 P2WSH multisig: m/48'/0'/0'/2'
+  const account = master.derive("m/48'/0'/0'/2'");
+  const xpub = account.publicExtendedKey;
+  // master fingerprint = first 4 bytes of HASH160(masterPubkey).
+  // @scure/bip32's HDKey exposes `fingerprint` on each derived key
+  // (=4-byte fingerprint of the PARENT). The master's own fingerprint
+  // is HDKey's `parentFingerprint` of its first child, but easier: use
+  // the library's `master.fingerprint` for the master itself.
+  const fp = master.fingerprint;
+  const masterFingerprint = Buffer.alloc(4);
+  masterFingerprint.writeUInt32BE(fp, 0);
+  return {
+    xpub,
+    masterFingerprint: masterFingerprint.toString("hex"),
+    accountKey: account,
+    masterKey: master,
+  };
+}
+
+function deriveChildPubkey(account: HDKey, change: number, index: number): Buffer {
+  const child = account.derive(`m/${change}/${index}`);
+  if (!child.publicKey) throw new Error("derive failed");
+  return Buffer.from(child.publicKey);
+}
+
+/**
+ * Build a 2-of-3 P2WSH multisig PSBT with one input (1.0 BTC) and one
+ * external output (0.5 BTC). The witnessScript + bip32Derivation are
+ * populated so `sign_btc_multisig_psbt`'s shape validation passes.
+ */
+function buildMultisigPsbt(
+  cosigners: ReturnType<typeof makeCosigner>[],
+  ourFingerprintHex: string,
+): string {
+  // Sort pubkeys lexicographically (sortedmulti requirement).
+  const change = 0;
+  const addressIndex = 0;
+  const childPubkeys = cosigners.map((c) => deriveChildPubkey(c.accountKey, change, addressIndex));
+  const sortedPubkeys = [...childPubkeys].sort(Buffer.compare);
+  const witnessScript = bitcoinjs.script.compile([
+    bitcoinjs.opcodes.OP_2,
+    ...sortedPubkeys,
+    bitcoinjs.opcodes.OP_3,
+    bitcoinjs.opcodes.OP_CHECKMULTISIG,
+  ]);
+  const p2wsh = bitcoinjs.payments.p2wsh({ redeem: { output: witnessScript } });
+  const scriptPubKey = p2wsh.output;
+  if (!scriptPubKey) throw new Error("p2wsh output missing");
+
+  const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+  // Fake prev-tx hash; only the PSBT shape matters for the unit test.
+  const prevHash = Buffer.alloc(32, 0xab);
+  const bip32Derivation = cosigners.map((c, idx) => {
+    const fp = Buffer.from(c.masterFingerprint, "hex");
+    return {
+      masterFingerprint: fp,
+      pubkey: childPubkeys[idx],
+      path: `m/48'/0'/0'/2'/${change}/${addressIndex}`,
+    };
+  });
+  psbt.addInput({
+    hash: prevHash,
+    index: 0,
+    sequence: 0xfffffffd,
+    witnessUtxo: { script: scriptPubKey, value: 100_000_000 },
+    witnessScript,
+    bip32Derivation,
+  });
+  // External recipient — real mainnet address is fine.
+  psbt.addOutput({
+    address: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+    value: 50_000_000,
+  });
+  void ourFingerprintHex; // referenced in callers for clarity
+  return psbt.toBase64();
+}
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-btc-multisig-"));
+  setConfigDirForTesting(tmpHome);
+  getAppAndVersionMock.mockReset();
+  getMasterFingerprintMock.mockReset();
+  getExtendedPubkeyMock.mockReset();
+  registerWalletMock.mockReset();
+  signPsbtMock.mockReset();
+  transportCloseMock.mockClear();
+  const { __clearMultisigStore } = await import("../src/modules/btc/multisig.js");
+  __clearMultisigStore();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("registerBitcoinMultisigWallet", () => {
+  it("registers a 2-of-3 P2WSH wallet, persists the policy + HMAC", async () => {
+    const a = makeCosigner("alice");
+    const b = makeCosigner("bob");
+    const c = makeCosigner("carol");
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    getExtendedPubkeyMock.mockResolvedValueOnce(a.xpub);
+    registerWalletMock.mockResolvedValueOnce([Buffer.alloc(32, 1), Buffer.alloc(32, 2)]);
+
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await registerBitcoinMultisigWallet({
+      name: "Family vault",
+      threshold: 2,
+      cosigners: [
+        { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: c.xpub, masterFingerprint: c.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+      ],
+      scriptType: "wsh",
+    });
+    expect(result.wallet.name).toBe("Family vault");
+    expect(result.wallet.threshold).toBe(2);
+    expect(result.wallet.totalSigners).toBe(3);
+    expect(result.wallet.descriptor).toBe("wsh(sortedmulti(2,@0/**,@1/**,@2/**))");
+    expect(result.wallet.policyHmac).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.wallet.appVersion).toBe("2.4.6");
+    expect(result.ourKeyIndex).toBe(0);
+    expect(result.wallet.cosigners[0].isOurs).toBe(true);
+    expect(result.wallet.cosigners[1].isOurs).toBe(false);
+    expect(result.wallet.cosigners[2].isOurs).toBe(false);
+    expect(transportCloseMock).toHaveBeenCalled();
+    // Persisted across module reload.
+    const { getPairedMultisigByName } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    expect(getPairedMultisigByName("Family vault")?.policyHmac).toBe(
+      result.wallet.policyHmac,
+    );
+  });
+
+  it("refuses when the connected Ledger's fingerprint is not in cosigners", async () => {
+    const a = makeCosigner("alice");
+    const b = makeCosigner("bob");
+    const stranger = makeCosigner("stranger");
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(stranger.masterFingerprint);
+
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "Foreign vault",
+        threshold: 2,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+          { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        ],
+        scriptType: "wsh",
+      }),
+    ).rejects.toThrow(/does not appear in `cosigners`/);
+    expect(registerWalletMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses duplicate wallet name", async () => {
+    const a = makeCosigner("alice");
+    const b = makeCosigner("bob");
+    getAppAndVersionMock.mockResolvedValue({ name: "Bitcoin", version: "2.4.6", flags: 0 });
+    getMasterFingerprintMock.mockResolvedValue(a.masterFingerprint);
+    getExtendedPubkeyMock.mockResolvedValue(a.xpub);
+    registerWalletMock.mockResolvedValue([Buffer.alloc(32, 1), Buffer.alloc(32, 2)]);
+
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await registerBitcoinMultisigWallet({
+      name: "Vault",
+      threshold: 2,
+      cosigners: [
+        { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+      ],
+      scriptType: "wsh",
+    });
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "Vault",
+        threshold: 2,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+          { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        ],
+        scriptType: "wsh",
+      }),
+    ).rejects.toThrow(/already registered/);
+  });
+
+  it("refuses an xpub that fails checksum validation", async () => {
+    const a = makeCosigner("alice");
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "Bad",
+        threshold: 2,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+          {
+            xpub: "xpubGARBAGE_NOT_REAL",
+            masterFingerprint: "deadbeef",
+            derivationPath: "48'/0'/0'/2'",
+          },
+        ],
+        scriptType: "wsh",
+      }),
+    ).rejects.toThrow(/checksum validation/);
+  });
+
+  it("refuses 1-of-1 (out of scope — use prepare_btc_send)", async () => {
+    const a = makeCosigner("alice");
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "Solo",
+        threshold: 1,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        ],
+        scriptType: "wsh",
+      }),
+    ).rejects.toThrow(/at least 2 entries/);
+  });
+
+  it("refuses when name exceeds 16 bytes", async () => {
+    const a = makeCosigner("alice");
+    const b = makeCosigner("bob");
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "A name that is way too long",
+        threshold: 2,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+          { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        ],
+        scriptType: "wsh",
+      }),
+    ).rejects.toThrow(/16 bytes/);
+  });
+});
+
+describe("signBitcoinMultisigPsbt", () => {
+  /** Register a 2-of-3 wallet with `alice` as our key, return cosigners. */
+  async function registerVault() {
+    const a = makeCosigner("alice");
+    const b = makeCosigner("bob");
+    const c = makeCosigner("carol");
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    getExtendedPubkeyMock.mockResolvedValueOnce(a.xpub);
+    registerWalletMock.mockResolvedValueOnce([Buffer.alloc(32, 1), Buffer.alloc(32, 2)]);
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await registerBitcoinMultisigWallet({
+      name: "Vault",
+      threshold: 2,
+      cosigners: [
+        { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: c.xpub, masterFingerprint: c.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+      ],
+      scriptType: "wsh",
+    });
+    return [a, b, c] as const;
+  }
+
+  it("signs a multi-sig PSBT and splices our partial signature", async () => {
+    const [a, b, c] = await registerVault();
+    const psbtBase64 = buildMultisigPsbt([a, b, c], a.masterFingerprint);
+
+    // Reset for the sign call.
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    // Mock signPsbt: return a partial signature for input 0.
+    const ourPubkey = deriveChildPubkey(a.accountKey, 0, 0);
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: ourPubkey,
+          // Minimal valid DER-encoded ECDSA sig with SIGHASH_ALL byte.
+          // bip174's partialSig validator runs `isDerSigWithSighash` so
+          // we can't use a placeholder here.
+          signature: Buffer.from([
+            0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01,
+          ]),
+        },
+      ],
+    ]);
+
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    const result = await signBitcoinMultisigPsbt({
+      walletName: "Vault",
+      psbtBase64,
+    });
+    expect(result.signaturesAdded).toBe(1);
+    expect(result.signaturesPresent).toBe(1);
+    expect(result.signaturesNeeded).toBe(2);
+    expect(result.fullySigned).toBe(false);
+    // The returned PSBT decodes and carries our partial signature on input 0.
+    const decoded = bitcoinjs.Psbt.fromBase64(result.partialPsbtBase64);
+    expect(decoded.data.inputs[0].partialSig?.length).toBe(1);
+    expect(decoded.data.inputs[0].partialSig?.[0].pubkey.equals(ourPubkey)).toBe(true);
+  });
+
+  it("flags fullySigned when our sig completes the threshold", async () => {
+    const [a, b, c] = await registerVault();
+    // Build PSBT with one pre-existing partial sig (from cosigner B);
+    // our signature pushes it to 2-of-3.
+    const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+    const change = 0;
+    const idx = 0;
+    const childPubkeys = [a, b, c].map((co) => deriveChildPubkey(co.accountKey, change, idx));
+    const sortedPubkeys = [...childPubkeys].sort(Buffer.compare);
+    const witnessScript = bitcoinjs.script.compile([
+      bitcoinjs.opcodes.OP_2,
+      ...sortedPubkeys,
+      bitcoinjs.opcodes.OP_3,
+      bitcoinjs.opcodes.OP_CHECKMULTISIG,
+    ]);
+    const p2wsh = bitcoinjs.payments.p2wsh({ redeem: { output: witnessScript } });
+    const scriptPubKey = p2wsh.output;
+    if (!scriptPubKey) throw new Error("scriptPubKey missing");
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xab),
+      index: 0,
+      sequence: 0xfffffffd,
+      witnessUtxo: { script: scriptPubKey, value: 100_000_000 },
+      witnessScript,
+      bip32Derivation: [a, b, c].map((co, i) => ({
+        masterFingerprint: Buffer.from(co.masterFingerprint, "hex"),
+        pubkey: childPubkeys[i],
+        path: `m/48'/0'/0'/2'/${change}/${idx}`,
+      })),
+    });
+    psbt.addOutput({
+      address: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+      value: 50_000_000,
+    });
+    // Splice cosigner B's signature in directly. We use bitcoinjs's
+    // updateInput shape via the PSBT parser path: re-load the PSBT and
+    // hand-mutate.
+    const reloaded = bitcoinjs.Psbt.fromBase64(psbt.toBase64()) as unknown as {
+      updateInput(
+        i: number,
+        update: { partialSig: Array<{ pubkey: Buffer; signature: Buffer }> },
+      ): unknown;
+      toBase64(): string;
+    };
+    reloaded.updateInput(0, {
+      partialSig: [
+        {
+          pubkey: childPubkeys[1],
+          signature: Buffer.from([
+            0x30, 0x06, 0x02, 0x01, 0x02, 0x02, 0x01, 0x02, 0x01,
+          ]),
+        },
+      ],
+    });
+    const psbtBase64 = reloaded.toBase64();
+
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: childPubkeys[0],
+          signature: Buffer.from([
+            0x30, 0x06, 0x02, 0x01, 0x03, 0x02, 0x01, 0x03, 0x01,
+          ]),
+        },
+      ],
+    ]);
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    const result = await signBitcoinMultisigPsbt({
+      walletName: "Vault",
+      psbtBase64,
+    });
+    expect(result.signaturesPresent).toBe(2);
+    expect(result.signaturesNeeded).toBe(2);
+    expect(result.fullySigned).toBe(true);
+  });
+
+  it("refuses when the PSBT has no bip32_derivation for our key", async () => {
+    const [a, b, c] = await registerVault();
+    // Build a PSBT whose bip32_derivation lists ONLY b and c — not us.
+    const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+    const childPubkeys = [a, b, c].map((co) => deriveChildPubkey(co.accountKey, 0, 0));
+    const sortedPubkeys = [...childPubkeys].sort(Buffer.compare);
+    const witnessScript = bitcoinjs.script.compile([
+      bitcoinjs.opcodes.OP_2,
+      ...sortedPubkeys,
+      bitcoinjs.opcodes.OP_3,
+      bitcoinjs.opcodes.OP_CHECKMULTISIG,
+    ]);
+    const p2wsh = bitcoinjs.payments.p2wsh({ redeem: { output: witnessScript } });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xab),
+      index: 0,
+      witnessUtxo: { script: p2wsh.output!, value: 100_000_000 },
+      witnessScript,
+      bip32Derivation: [
+        {
+          masterFingerprint: Buffer.from(b.masterFingerprint, "hex"),
+          pubkey: childPubkeys[1],
+          path: "m/48'/0'/0'/2'/0/0",
+        },
+        {
+          masterFingerprint: Buffer.from(c.masterFingerprint, "hex"),
+          pubkey: childPubkeys[2],
+          path: "m/48'/0'/0'/2'/0/0",
+        },
+      ],
+    });
+    psbt.addOutput({
+      address: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+      value: 50_000_000,
+    });
+    const psbtBase64 = psbt.toBase64();
+
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    await expect(
+      signBitcoinMultisigPsbt({ walletName: "Vault", psbtBase64 }),
+    ).rejects.toThrow(/no bip32_derivation entry for our master fingerprint/);
+    expect(signPsbtMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses when wallet name isn't registered", async () => {
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    await expect(
+      signBitcoinMultisigPsbt({
+        walletName: "Unknown",
+        psbtBase64: "cHNidP8BAFICAAAAAQ==",
+      }),
+    ).rejects.toThrow(/No multi-sig wallet registered/);
+  });
+
+  it("refuses when the device fingerprint differs from the registered one", async () => {
+    const [a, b, c] = await registerVault();
+    const psbtBase64 = buildMultisigPsbt([a, b, c], a.masterFingerprint);
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    // Different Ledger plugged in.
+    getMasterFingerprintMock.mockResolvedValueOnce("ffffffff");
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    await expect(
+      signBitcoinMultisigPsbt({ walletName: "Vault", psbtBase64 }),
+    ).rejects.toThrow(/does not match the fingerprint stored/);
+  });
+
+  it("refuses when the wrong Ledger app is open", async () => {
+    const [a, b, c] = await registerVault();
+    const psbtBase64 = buildMultisigPsbt([a, b, c], a.masterFingerprint);
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Ethereum",
+      version: "1.10.0",
+      flags: 0,
+    });
+    const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
+    await expect(
+      signBitcoinMultisigPsbt({ walletName: "Vault", psbtBase64 }),
+    ).rejects.toThrow(/wrong Ledger app/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR2 — Ledger as one of N signers in a P2WSH multi-sig wallet. We do NOT build or finalize multi-sig txs; we co-sign PSBTs from external initiators (Sparrow / Specter / Caravan / a peer running this server) and return the partial PSBT for the user to share back.

Two new tools:
- **`register_btc_multisig_wallet`** — one-time per setup. Builds a `wsh(sortedmulti(M,@0/**,@1/**,...))` descriptor, verifies the Ledger's master fingerprint matches exactly one cosigner slot, calls `registerWallet` (device walks every cosigner xpub fingerprint on-screen for verification), persists the 32-byte policy HMAC.
- **`sign_btc_multisig_psbt`** — looks up the registered wallet by name, decodes the PSBT, validates every input carries `bip32_derivation` for our master fingerprint, forwards to the device for the output walkthrough, splices our partial signature into the PSBT, returns it. We do NOT finalize or broadcast — the initiator does that once they have all M signatures.

## Implementation notes

- Adds new dependency: [`ledger-bitcoin@0.3.0`](https://github.com/LedgerHQ/app-bitcoin-new) — BIP-388 wallet policies live in this official LedgerHQ client. Our existing `@ledgerhq/hw-app-btc@10.21.1` is single-sig only and does not expose `registerWallet` / `signPsbt(psbt, policy, hmac)`. Both clients share `@ledgerhq/hw-transport-node-hid` so a single transport can drive each call (we open one per device touch).
- New `PairedBitcoinMultisigWallet` type persisted under `userConfig.pairings.bitcoinMultisig[]`. The existing per-chain merge in `patchUserConfig` handles the new slice naturally — adding a multi-sig wallet doesn't wipe single-sig pairings or vice versa.
- Hard xpub validation via `@scure/bip32` round-trip — typos that would silently register a wallet we can never sign with are refused up-front.
- HID transport always closed in `finally` — no leaked descriptors on error paths.

## Phase 2 scope

In: P2WSH (`wsh(sortedmulti(...))`) co-signer flow.

Deferred (per the plan):
- Taproot multi-sig (`tr(multi_a(...))`) — small audience, distinct script type
- P2SH-wrapped multi-sig (`sh(wsh(...))`)
- Multi-sig **initiator** flow (we build the tx, requires multi-sig UTXO enumeration + coin-selection)
- PSBT combine / finalize
- Watch-only multi-sig balance + portfolio integration

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-multisig.test.ts` — 12/12 passing
- [x] Full suite: 1569/1569 (130 files passed; no regressions in `btc-pair`, `btc-pr3-send`, `btc-rbf` etc.)
- [ ] Live smoke test: register a 2-of-3 P2WSH wallet on a real Ledger, have a coordinator (Sparrow) build a PSBT, run `sign_btc_multisig_psbt`, finalize externally, broadcast

Plan: [`claude-work/plan-bitcoin-ledger-phase2-rbf-multisig.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase2-rbf-multisig.md). Stacks on top of #322 (already merged into main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)