### PR TITLE
feat(btc): combine_btc_psbts + finalize_btc_psbt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,8 @@ import {
   prepareBitcoinRbfBump,
   registerBtcMultisigWallet,
   signBtcMultisigPsbt,
+  combineBtcPsbts,
+  finalizeBtcPsbt,
   signBtcMessage,
   pairLedgerLitecoin,
   getLitecoinBalance,
@@ -234,6 +236,8 @@ import {
   prepareBitcoinRbfBumpInput,
   registerBitcoinMultisigWalletInput,
   signBitcoinMultisigPsbtInput,
+  combineBitcoinPsbtsInput,
+  finalizeBitcoinPsbtInput,
   signBtcMessageInput,
   pairLedgerLitecoinInput,
   getLitecoinBalanceInput,
@@ -2490,6 +2494,40 @@ async function main() {
       inputSchema: signBitcoinMultisigPsbtInput.shape,
     },
     handler(signBtcMultisigPsbt, { toolName: "sign_btc_multisig_psbt" })
+  );
+
+  registerTool(server,
+    "combine_btc_psbts",
+    {
+      description:
+        "Merge 2-15 partial PSBTs from multi-sig cosigners into one whose inputs " +
+        "carry every cosigner's signature. Each entry must be a base64-encoded PSBT " +
+        "v0 sharing the same unsigned tx body (same inputs/outputs/sequences/locktime); " +
+        "only per-cosigner witness data may differ. Refuses with a clear error when " +
+        "bodies disagree — combining across distinct unsigned txs would silently merge " +
+        "signatures across different transactions. Returns the merged PSBT plus a " +
+        "per-input signature count so the caller can tell whether the threshold has " +
+        "been reached. No device touch.",
+      inputSchema: combineBitcoinPsbtsInput.shape,
+    },
+    handler(combineBtcPsbts, { toolName: "combine_btc_psbts" })
+  );
+
+  registerTool(server,
+    "finalize_btc_psbt",
+    {
+      description:
+        "Finalize a fully-signed multi-sig PSBT (typically the output of " +
+        "`combine_btc_psbts` once the threshold is met) and extract the " +
+        "broadcast-ready tx hex. Refuses with a per-input breakdown when any input " +
+        "is below its threshold (e.g. \"input 0: 1/2 signatures\"). Pass " +
+        "`broadcast: true` to send via the configured indexer in the same call — " +
+        "returns `broadcastedTxid` on success. Pass `broadcast: false` (default) " +
+        "when the caller wants to inspect the hex first or broadcast through a " +
+        "different relay. No device touch.",
+      inputSchema: finalizeBitcoinPsbtInput.shape,
+    },
+    handler(finalizeBtcPsbt, { toolName: "finalize_btc_psbt" })
   );
 
   registerTool(server,

--- a/src/modules/btc/psbt-combine.ts
+++ b/src/modules/btc/psbt-combine.ts
@@ -1,0 +1,258 @@
+import { createRequire } from "node:module";
+import { getBitcoinIndexer } from "./indexer.js";
+
+/**
+ * PSBT combine + finalize for the multi-sig flows. Phase 3 PR1 of the
+ * BTC Ledger roadmap.
+ *
+ * `combinePsbts` merges partial PSBTs from M cosigners into one whose
+ * inputs carry every cosigner's signature. `finalizePsbt` consumes a
+ * combined PSBT, validates every input has reached its threshold,
+ * extracts the broadcast-ready tx hex, and optionally broadcasts via
+ * the indexer.
+ *
+ * Both tools are bitcoinjs-lib wrappers — the heavy lifting is in
+ * `Psbt.combine(...)` and `Psbt.finalizeAllInputs()`. We add three
+ * things:
+ *   1. Defense against being tricked into combining PSBTs with
+ *      different unsigned-tx bodies (an honest mistake or an attack
+ *      that swaps the recipient).
+ *   2. A clear per-input breakdown when finalize fails because the
+ *      threshold isn't met.
+ *   3. Optional indexer broadcast routing — finalize-and-broadcast in
+ *      one call when the user is the M-th signer.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
+          tapScriptSig?: Array<{ pubkey: Buffer; signature: Buffer; leafHash: Buffer }>;
+          tapKeySig?: Buffer;
+          witnessScript?: Buffer;
+          finalScriptSig?: Buffer;
+          finalScriptWitness?: Buffer;
+        }>;
+      };
+      txInputs: Array<{ hash: Buffer; index: number; sequence: number }>;
+      txOutputs: Array<{ address?: string; value: number; script: Buffer }>;
+      combine(...others: Array<unknown>): unknown;
+      finalizeAllInputs(): unknown;
+      extractTransaction(disableFeeCheck?: boolean): {
+        toHex(): string;
+        getId(): string;
+        virtualSize(): number;
+      };
+      toBase64(): string;
+    };
+  };
+};
+
+// --- Helpers -------------------------------------------------------------
+
+/**
+ * The "unsigned tx body" that two PSBTs must agree on to be combinable:
+ * inputs (txid + vout + sequence) and outputs (script + value). Witness
+ * data is per-cosigner and explicitly differs across PSBTs — that's the
+ * whole point of combining.
+ */
+function unsignedBodyFingerprint(
+  psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
+): string {
+  const inputs = psbt.txInputs
+    .map(
+      (i) =>
+        `${Buffer.from(i.hash).reverse().toString("hex")}:${i.index}:${i.sequence}`,
+    )
+    .join(",");
+  const outputs = psbt.txOutputs
+    .map((o) => `${o.script.toString("hex")}:${o.value}`)
+    .join(",");
+  return `${inputs}|${outputs}`;
+}
+
+/** Count signatures present on an input (post-combine, pre-finalize). */
+function countSignatures(input: {
+  partialSig?: Array<unknown>;
+  tapScriptSig?: Array<unknown>;
+  tapKeySig?: Buffer;
+}): number {
+  let n = 0;
+  if (input.partialSig) n += input.partialSig.length;
+  if (input.tapScriptSig) n += input.tapScriptSig.length;
+  if (input.tapKeySig) n += 1;
+  return n;
+}
+
+/**
+ * Best-effort threshold extraction from a witnessScript (P2WSH
+ * sortedmulti). The script's first byte is `OP_M` where M = byte - 80,
+ * for OP_1..OP_16 (0x51..0x60). Returns `null` for taproot inputs (the
+ * threshold lives in the leaf script — taproot finalization is bitcoinjs's
+ * job, not ours; we surface present-count only).
+ */
+function inferP2wshThreshold(witnessScript: Buffer | undefined): number | null {
+  if (!witnessScript || witnessScript.length === 0) return null;
+  const opcode = witnessScript[0];
+  if (opcode >= 0x51 && opcode <= 0x60) return opcode - 0x50;
+  return null;
+}
+
+// --- combine_btc_psbts ---------------------------------------------------
+
+export interface CombineBtcPsbtsArgs {
+  psbts: string[];
+}
+
+export interface CombineBtcPsbtsResult {
+  combinedPsbtBase64: string;
+  /** Number of input PSBTs combined. */
+  psbtCount: number;
+  /** Per-input signature count after the combine. */
+  signaturesPerInput: number[];
+}
+
+export function combinePsbts(args: CombineBtcPsbtsArgs): CombineBtcPsbtsResult {
+  if (!Array.isArray(args.psbts) || args.psbts.length < 2) {
+    throw new Error(
+      `\`psbts\` must be an array of at least 2 PSBTs (got ${args.psbts?.length ?? 0}).`,
+    );
+  }
+  const decoded = args.psbts.map((b64, idx) => {
+    try {
+      return bitcoinjs.Psbt.fromBase64(b64);
+    } catch (err) {
+      throw new Error(
+        `psbts[${idx}] failed to decode: ${(err as Error).message}. Each entry must ` +
+          `be a valid base64-encoded PSBT v0.`,
+      );
+    }
+  });
+  const baseline = unsignedBodyFingerprint(decoded[0]);
+  for (let i = 1; i < decoded.length; i++) {
+    const fp = unsignedBodyFingerprint(decoded[i]);
+    if (fp !== baseline) {
+      throw new Error(
+        `psbts[${i}] has a different unsigned tx body than psbts[0]. Combining PSBTs ` +
+          `from different unsigned txs would silently merge signatures across distinct ` +
+          `transactions — refusing. Confirm every cosigner started from the same ` +
+          `coordinator-issued PSBT.`,
+      );
+    }
+  }
+  // bitcoinjs-lib's combine mutates the receiver in-place; the order
+  // matters when there are conflicts (the receiver wins). Use a fresh
+  // copy of psbt[0] as the receiver so we don't mutate the caller's
+  // input. fromBase64 already gave us a fresh object — combine the rest in.
+  const combined = decoded[0];
+  for (let i = 1; i < decoded.length; i++) {
+    combined.combine(decoded[i]);
+  }
+  const signaturesPerInput = combined.data.inputs.map((input) =>
+    countSignatures(input),
+  );
+  return {
+    combinedPsbtBase64: combined.toBase64(),
+    psbtCount: args.psbts.length,
+    signaturesPerInput,
+  };
+}
+
+// --- finalize_btc_psbt ---------------------------------------------------
+
+export interface FinalizeBtcPsbtArgs {
+  psbtBase64: string;
+  /** Optional: broadcast via the configured indexer after finalization. */
+  broadcast?: boolean;
+}
+
+export interface FinalizeBtcPsbtResult {
+  /** Hex-encoded fully-signed tx, ready to broadcast. */
+  txHex: string;
+  /** 64-hex transaction id (sha256d(tx) reversed). */
+  txid: string;
+  /** Tx vsize (vbytes), useful for fee-rate post-checks. */
+  vsize: number;
+  /**
+   * Set when `broadcast: true` and the indexer accepted the tx —
+   * matches `txid` on success. Undefined when `broadcast` was false or
+   * when the broadcast call itself threw (the throw propagates; we
+   * don't swallow).
+   */
+  broadcastedTxid?: string;
+}
+
+export async function finalizePsbt(
+  args: FinalizeBtcPsbtArgs,
+): Promise<FinalizeBtcPsbtResult> {
+  if (typeof args.psbtBase64 !== "string" || args.psbtBase64.length === 0) {
+    throw new Error("`psbtBase64` must be a non-empty base64 string.");
+  }
+  let psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>;
+  try {
+    psbt = bitcoinjs.Psbt.fromBase64(args.psbtBase64);
+  } catch (err) {
+    throw new Error(`Failed to decode PSBT: ${(err as Error).message}`);
+  }
+  // Per-input pre-flight: surface a useful error BEFORE bitcoinjs's
+  // generic "Cannot finalize input X" exception.
+  const underSigned: Array<{ index: number; have: number; need: number | null }> = [];
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const input = psbt.data.inputs[i];
+    if (input.finalScriptSig || input.finalScriptWitness) continue; // already finalized
+    const have = countSignatures(input);
+    const need = inferP2wshThreshold(input.witnessScript);
+    if (need !== null && have < need) {
+      underSigned.push({ index: i, have, need });
+    }
+  }
+  if (underSigned.length > 0) {
+    const lines = underSigned.map(
+      (u) => `  • input ${u.index}: ${u.have}/${u.need ?? "?"} signatures`,
+    );
+    throw new Error(
+      `Cannot finalize — some inputs are below their threshold:\n${lines.join("\n")}\n\n` +
+        `Gather the remaining signatures (combine via \`combine_btc_psbts\`) before ` +
+        `retrying \`finalize_btc_psbt\`.`,
+    );
+  }
+
+  // Finalize only inputs that aren't already finalized — calling
+  // `finalizeAllInputs()` blanket on a PSBT whose inputs already carry
+  // `finalScriptWitness` re-runs the finalizer and crashes (bitcoinjs
+  // doesn't have an idempotent guard there).
+  const needsFinalize = psbt.data.inputs.some(
+    (input) => !input.finalScriptSig && !input.finalScriptWitness,
+  );
+  if (needsFinalize) {
+    try {
+      psbt.finalizeAllInputs();
+    } catch (err) {
+      throw new Error(
+        `bitcoinjs-lib refused to finalize: ${(err as Error).message}. The signatures ` +
+          `present may not satisfy the script (wrong pubkeys, malformed sigs, or a ` +
+          `script type bitcoinjs does not auto-finalize).`,
+      );
+    }
+  }
+  const tx = psbt.extractTransaction();
+  const txHex = tx.toHex();
+  const txid = tx.getId();
+  const vsize = tx.virtualSize();
+
+  let broadcastedTxid: string | undefined;
+  if (args.broadcast === true) {
+    const indexer = getBitcoinIndexer();
+    broadcastedTxid = await indexer.broadcastTx(txHex);
+  }
+
+  return {
+    txHex,
+    txid,
+    vsize,
+    ...(broadcastedTxid !== undefined ? { broadcastedTxid } : {}),
+  };
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -154,6 +154,8 @@ import type {
   PrepareBitcoinRbfBumpArgs,
   RegisterBitcoinMultisigWalletArgs,
   SignBitcoinMultisigPsbtArgs,
+  CombineBitcoinPsbtsArgs,
+  FinalizeBitcoinPsbtArgs,
   SignBtcMessageArgs,
   PairLedgerLitecoinArgs,
   GetLitecoinBalanceArgs,
@@ -1244,6 +1246,19 @@ export async function signBtcMultisigPsbt(args: SignBitcoinMultisigPsbtArgs) {
   return signBitcoinMultisigPsbt({
     walletName: args.walletName,
     psbtBase64: args.psbtBase64,
+  });
+}
+
+export async function combineBtcPsbts(args: CombineBitcoinPsbtsArgs) {
+  const { combinePsbts } = await import("../btc/psbt-combine.js");
+  return combinePsbts({ psbts: args.psbts });
+}
+
+export async function finalizeBtcPsbt(args: FinalizeBitcoinPsbtArgs) {
+  const { finalizePsbt } = await import("../btc/psbt-combine.js");
+  return finalizePsbt({
+    psbtBase64: args.psbtBase64,
+    ...(args.broadcast !== undefined ? { broadcast: args.broadcast } : {}),
   });
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1383,6 +1383,41 @@ export const signBitcoinMultisigPsbtInput = z.object({
     ),
 });
 
+export const combineBitcoinPsbtsInput = z.object({
+  psbts: z
+    .array(z.string().min(1).max(200_000))
+    .min(2)
+    .max(15)
+    .describe(
+      "Array of 2-15 base64-encoded PSBT v0 strings to merge. Every entry must " +
+        "share the same unsigned tx body (same inputs in the same order, same " +
+        "outputs in the same order, same sequence numbers, same locktime); only " +
+        "the per-cosigner witness data may differ. Refused if any pair has a " +
+        "mismatched body — combining PSBTs across distinct unsigned txs would " +
+        "silently merge signatures across different transactions."
+    ),
+});
+
+export const finalizeBitcoinPsbtInput = z.object({
+  psbtBase64: z
+    .string()
+    .min(1)
+    .max(200_000)
+    .describe(
+      "Base64-encoded PSBT v0 with all required signatures spliced in (typically " +
+        "via `combine_btc_psbts`). Refused with a per-input breakdown when any " +
+        "input is below its threshold (e.g. 1/2 sigs)."
+    ),
+  broadcast: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, broadcasts the finalized tx via the configured indexer and " +
+        "returns `broadcastedTxid` alongside `txid`. When false (default), only " +
+        "returns the tx hex — the caller decides when/where to broadcast."
+    ),
+});
+
 export const getBitcoinTxHistoryInput = z.object({
   address: bitcoinAddressSchema,
   limit: z
@@ -1442,6 +1477,8 @@ export type RegisterBitcoinMultisigWalletArgs = z.infer<
   typeof registerBitcoinMultisigWalletInput
 >;
 export type SignBitcoinMultisigPsbtArgs = z.infer<typeof signBitcoinMultisigPsbtInput>;
+export type CombineBitcoinPsbtsArgs = z.infer<typeof combineBitcoinPsbtsInput>;
+export type FinalizeBitcoinPsbtArgs = z.infer<typeof finalizeBitcoinPsbtInput>;
 export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;

--- a/test/btc-psbt-combine.test.ts
+++ b/test/btc-psbt-combine.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+
+/**
+ * PR1 — combine_btc_psbts + finalize_btc_psbt. No device touch; pure
+ * bitcoinjs-lib wrapper tests with a mocked indexer for the broadcast
+ * path.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    new (opts?: { network?: unknown }): {
+      addInput(input: {
+        hash: string | Buffer;
+        index: number;
+        sequence?: number;
+        witnessUtxo?: { script: Buffer; value: number };
+        witnessScript?: Buffer;
+        bip32Derivation?: Array<{
+          masterFingerprint: Buffer;
+          pubkey: Buffer;
+          path: string;
+        }>;
+      }): unknown;
+      addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
+      updateInput(
+        i: number,
+        update: {
+          partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
+        },
+      ): unknown;
+      toBase64(): string;
+    };
+    fromBase64(b64: string): {
+      data: { inputs: Array<{ partialSig?: Array<unknown> }> };
+      txOutputs: Array<{ address?: string; value: number }>;
+    };
+  };
+  payments: {
+    p2wsh(opts: { redeem: { output: Buffer } }): { output?: Buffer };
+  };
+  script: { compile(chunks: Array<number | Buffer>): Buffer };
+  opcodes: { OP_2: number; OP_3: number; OP_CHECKMULTISIG: number };
+  networks: { bitcoin: unknown };
+};
+
+const NETWORK = bitcoinjs.networks.bitcoin;
+
+const broadcastTxMock = vi.fn();
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    broadcastTx: broadcastTxMock,
+    getUtxos: vi.fn(),
+    getFeeEstimates: vi.fn(),
+    getTxStatus: vi.fn(),
+    getTxHex: vi.fn(),
+    getTx: vi.fn(),
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+beforeEach(() => {
+  broadcastTxMock.mockReset();
+});
+
+// --- PSBT fixture builders ----------------------------------------------
+
+function deriveCosigner(seed: string) {
+  const seedBuf = Buffer.alloc(64);
+  Buffer.from(seed.padEnd(64, "x")).copy(seedBuf);
+  const master = HDKey.fromMasterSeed(seedBuf);
+  const account = master.derive("m/48'/0'/0'/2'");
+  const child = account.derive("m/0/0");
+  if (!child.publicKey) throw new Error("derive failed");
+  const fp = master.fingerprint;
+  const masterFingerprint = Buffer.alloc(4);
+  masterFingerprint.writeUInt32BE(fp, 0);
+  return {
+    masterFingerprint,
+    pubkey: Buffer.from(child.publicKey),
+  };
+}
+
+/**
+ * Build a 2-of-3 P2WSH PSBT skeleton (no signatures yet). Returns the
+ * base64 plus the cosigner pubkeys in sorted order so tests can splice
+ * partial sigs.
+ */
+function buildSkeletonPsbt(): {
+  psbtBase64: string;
+  sortedPubkeys: Buffer[];
+  witnessScript: Buffer;
+} {
+  const cosignerA = deriveCosigner("alice");
+  const cosignerB = deriveCosigner("bob");
+  const cosignerC = deriveCosigner("carol");
+  const pubs = [cosignerA.pubkey, cosignerB.pubkey, cosignerC.pubkey];
+  const sortedPubkeys = [...pubs].sort(Buffer.compare);
+  const witnessScript = bitcoinjs.script.compile([
+    bitcoinjs.opcodes.OP_2,
+    ...sortedPubkeys,
+    bitcoinjs.opcodes.OP_3,
+    bitcoinjs.opcodes.OP_CHECKMULTISIG,
+  ]);
+  const p2wsh = bitcoinjs.payments.p2wsh({ redeem: { output: witnessScript } });
+  if (!p2wsh.output) throw new Error("p2wsh output missing");
+  const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+  psbt.addInput({
+    hash: Buffer.alloc(32, 0xab),
+    index: 0,
+    sequence: 0xfffffffd,
+    witnessUtxo: { script: p2wsh.output, value: 100_000_000 },
+    witnessScript,
+  });
+  psbt.addOutput({
+    address: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+    value: 50_000_000,
+  });
+  return { psbtBase64: psbt.toBase64(), sortedPubkeys, witnessScript };
+}
+
+/**
+ * Minimal valid DER-encoded ECDSA signature with SIGHASH_ALL byte.
+ * bitcoinjs-lib's PSBT validator runs `isDerSigWithSighash`, so we
+ * construct one with rLen=1, sLen=1.
+ */
+function fakeDerSig(rByte: number, sByte: number): Buffer {
+  return Buffer.from([0x30, 0x06, 0x02, 0x01, rByte, 0x02, 0x01, sByte, 0x01]);
+}
+
+/**
+ * Take a skeleton PSBT and splice in ONE partial sig at the given pubkey.
+ */
+function withPartialSig(
+  psbtBase64: string,
+  pubkey: Buffer,
+  sig: Buffer,
+): string {
+  const psbt = bitcoinjs.Psbt.fromBase64(psbtBase64) as unknown as {
+    updateInput(
+      i: number,
+      update: { partialSig: Array<{ pubkey: Buffer; signature: Buffer }> },
+    ): unknown;
+    toBase64(): string;
+  };
+  psbt.updateInput(0, { partialSig: [{ pubkey, signature: sig }] });
+  return psbt.toBase64();
+}
+
+// --- combinePsbts --------------------------------------------------------
+
+describe("combinePsbts", () => {
+  it("merges two partial PSBTs into one carrying both signatures", async () => {
+    const skel = buildSkeletonPsbt();
+    const psbtA = withPartialSig(skel.psbtBase64, skel.sortedPubkeys[0], fakeDerSig(1, 1));
+    const psbtB = withPartialSig(skel.psbtBase64, skel.sortedPubkeys[1], fakeDerSig(2, 2));
+    const { combinePsbts } = await import("../src/modules/btc/psbt-combine.ts");
+    const result = combinePsbts({ psbts: [psbtA, psbtB] });
+    expect(result.psbtCount).toBe(2);
+    expect(result.signaturesPerInput).toEqual([2]);
+    const decoded = bitcoinjs.Psbt.fromBase64(result.combinedPsbtBase64);
+    expect(decoded.data.inputs[0].partialSig?.length).toBe(2);
+  });
+
+  it("refuses when PSBTs have different unsigned tx bodies", async () => {
+    const skelA = buildSkeletonPsbt();
+    // Build a second skeleton with a DIFFERENT recipient (different output script).
+    const cosignerA = deriveCosigner("alice");
+    const cosignerB = deriveCosigner("bob");
+    const cosignerC = deriveCosigner("carol");
+    const sortedPubkeys = [cosignerA.pubkey, cosignerB.pubkey, cosignerC.pubkey].sort(Buffer.compare);
+    const witnessScript = bitcoinjs.script.compile([
+      bitcoinjs.opcodes.OP_2,
+      ...sortedPubkeys,
+      bitcoinjs.opcodes.OP_3,
+      bitcoinjs.opcodes.OP_CHECKMULTISIG,
+    ]);
+    const p2wsh = bitcoinjs.payments.p2wsh({ redeem: { output: witnessScript } });
+    if (!p2wsh.output) throw new Error("p2wsh output missing");
+    const evil = new bitcoinjs.Psbt({ network: NETWORK });
+    evil.addInput({
+      hash: Buffer.alloc(32, 0xab),
+      index: 0,
+      sequence: 0xfffffffd,
+      witnessUtxo: { script: p2wsh.output, value: 100_000_000 },
+      witnessScript,
+    });
+    // Different recipient address → different output script.
+    evil.addOutput({
+      address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+      value: 50_000_000,
+    });
+    const psbtA = withPartialSig(skelA.psbtBase64, skelA.sortedPubkeys[0], fakeDerSig(1, 1));
+    const psbtEvil = withPartialSig(evil.toBase64(), sortedPubkeys[1], fakeDerSig(2, 2));
+    const { combinePsbts } = await import("../src/modules/btc/psbt-combine.ts");
+    expect(() => combinePsbts({ psbts: [psbtA, psbtEvil] })).toThrow(
+      /different unsigned tx body/,
+    );
+  });
+
+  it("refuses on fewer than 2 PSBTs", async () => {
+    const { combinePsbts } = await import("../src/modules/btc/psbt-combine.ts");
+    expect(() => combinePsbts({ psbts: ["only-one"] })).toThrow(/at least 2 PSBTs/);
+  });
+
+  it("refuses on a malformed PSBT entry", async () => {
+    const skel = buildSkeletonPsbt();
+    const { combinePsbts } = await import("../src/modules/btc/psbt-combine.ts");
+    expect(() =>
+      combinePsbts({ psbts: [skel.psbtBase64, "totally-not-a-psbt"] }),
+    ).toThrow(/failed to decode/);
+  });
+});
+
+// --- finalizePsbt --------------------------------------------------------
+
+describe("finalizePsbt", () => {
+  it("refuses with per-input breakdown when threshold not met", async () => {
+    const skel = buildSkeletonPsbt();
+    // Only one signature on a 2-of-3 wallet — under-signed.
+    const psbtA = withPartialSig(skel.psbtBase64, skel.sortedPubkeys[0], fakeDerSig(1, 1));
+    const { finalizePsbt } = await import("../src/modules/btc/psbt-combine.ts");
+    await expect(finalizePsbt({ psbtBase64: psbtA })).rejects.toThrow(
+      /input 0: 1\/2 signatures/,
+    );
+  });
+
+  it("rejects malformed PSBT", async () => {
+    const { finalizePsbt } = await import("../src/modules/btc/psbt-combine.ts");
+    await expect(finalizePsbt({ psbtBase64: "not-base64" })).rejects.toThrow(
+      /Failed to decode/,
+    );
+  });
+
+  /**
+   * Build a P2WPKH PSBT and pre-finalize input 0 by injecting
+   * `finalScriptWitness` directly. Lets us exercise `extractTransaction`
+   * + the broadcast path without producing a real ECDSA sig (the local
+   * tiny-secp256k1 / ecpair version skew makes ECPair signing unusable
+   * in tests).
+   */
+  function buildPreFinalizedPsbt(): string {
+    const dummyPubkey = Buffer.alloc(33, 0x02);
+    const pay = (
+      bitcoinjs as unknown as {
+        payments: {
+          p2wpkh(opts: { pubkey: Buffer; network: unknown }): { output?: Buffer; address?: string };
+        };
+      }
+    ).payments.p2wpkh({ pubkey: dummyPubkey, network: NETWORK });
+    if (!pay.output || !pay.address) throw new Error("p2wpkh build failed");
+    const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xcd),
+      index: 0,
+      witnessUtxo: { script: pay.output, value: 100_000 },
+    });
+    psbt.addOutput({ address: pay.address, value: 50_000 });
+    // Inject finalScriptWitness directly: a fake DER sig + dummy pubkey
+    // is enough for `extractTransaction` to assemble the witness stack.
+    // bitcoinjs's `extractTransaction` doesn't re-validate.
+    const fakeSigDer = Buffer.from([
+      0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01,
+    ]);
+    // BIP-141 witness encoding: count(2) || len-prefixed item || len-prefixed item.
+    const witness = Buffer.concat([
+      Buffer.from([0x02]),
+      Buffer.from([fakeSigDer.length]),
+      fakeSigDer,
+      Buffer.from([dummyPubkey.length]),
+      dummyPubkey,
+    ]);
+    (psbt as unknown as {
+      data: { inputs: Array<{ finalScriptWitness?: Buffer }> };
+    }).data.inputs[0].finalScriptWitness = witness;
+    return psbt.toBase64();
+  }
+
+  it("forwards to indexer when broadcast: true", async () => {
+    const psbtBase64 = buildPreFinalizedPsbt();
+    broadcastTxMock.mockResolvedValueOnce("abcdef".repeat(10) + "1234");
+    const { finalizePsbt } = await import("../src/modules/btc/psbt-combine.ts");
+    const result = await finalizePsbt({ psbtBase64, broadcast: true });
+    expect(result.txid).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.vsize).toBeGreaterThan(0);
+    expect(result.broadcastedTxid).toBe("abcdef".repeat(10) + "1234");
+    expect(broadcastTxMock).toHaveBeenCalledWith(result.txHex);
+  });
+
+  it("does not broadcast when broadcast: false (default)", async () => {
+    const psbtBase64 = buildPreFinalizedPsbt();
+    const { finalizePsbt } = await import("../src/modules/btc/psbt-combine.ts");
+    const result = await finalizePsbt({ psbtBase64 });
+    expect(result.txHex.length).toBeGreaterThan(0);
+    expect(result.broadcastedTxid).toBeUndefined();
+    expect(broadcastTxMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 PR1 — multi-sig PSBT plumbing for the co-signer / initiator flows. No device touch; pure bitcoinjs-lib wrappers with three additions:
1. **Body-mismatch defense** — refuses combining PSBTs with different unsigned tx bodies (an honest mistake or an attack swapping the recipient mid-flow).
2. **Per-input threshold breakdown** — finalize errors call out exactly which inputs are under-signed.
3. **Optional in-call broadcast** — finalize-and-broadcast in one shot when the user is the M-th signer.

Two new tools:
- `combine_btc_psbts({ psbts: string[] })` — 2-15 base64 PSBTs in, merged PSBT + per-input sig count out.
- `finalize_btc_psbt({ psbtBase64, broadcast? })` — finalizes, returns `{ txHex, txid, vsize, broadcastedTxid? }`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-psbt-combine.test.ts` — 8/8 passing
- [x] Full suite: 1595/1595 passing
- [ ] Live smoke: combine real partial PSBTs from a 2-of-3 P2WSH wallet, finalize, broadcast

Plan: [`claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md). Independent of PR2 (watch-only balances); both can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)