### PR TITLE
feat(btc): watch-only multi-sig balances + UTXO reads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,8 @@ import {
   signBtcMultisigPsbt,
   combineBtcPsbts,
   finalizeBtcPsbt,
+  getBtcMultisigBalance,
+  getBtcMultisigUtxos,
   signBtcMessage,
   pairLedgerLitecoin,
   getLitecoinBalance,
@@ -238,6 +240,8 @@ import {
   signBitcoinMultisigPsbtInput,
   combineBitcoinPsbtsInput,
   finalizeBitcoinPsbtInput,
+  getBitcoinMultisigBalanceInput,
+  getBitcoinMultisigUtxosInput,
   signBtcMessageInput,
   pairLedgerLitecoinInput,
   getLitecoinBalanceInput,
@@ -2540,6 +2544,37 @@ async function main() {
       inputSchema: finalizeBitcoinPsbtInput.shape,
     },
     handler(finalizeBtcPsbt, { toolName: "finalize_btc_psbt" })
+  );
+
+  registerTool(server,
+    "get_btc_multisig_balance",
+    {
+      description:
+        "Watch-only balance read for a registered multi-sig wallet. Walks both " +
+        "BIP-32 chains (chain=0 receive, chain=1 change) up to a gap-limit window " +
+        "(default 20, BIP-44 standard), queries each derived address via the " +
+        "configured Esplora indexer, returns the aggregate balance plus per-address " +
+        "breakdown for entries with on-chain history. No device touch — addresses " +
+        "are derived locally from the stored cosigner xpubs. Phase 3 supports " +
+        "P2WSH (`wsh`) wallets only; taproot lands in a follow-up PR.",
+      inputSchema: getBitcoinMultisigBalanceInput.shape,
+    },
+    handler(getBtcMultisigBalance, { toolName: "get_btc_multisig_balance" })
+  );
+
+  registerTool(server,
+    "get_btc_multisig_utxos",
+    {
+      description:
+        "Return the UTXO set for a registered multi-sig wallet. Same gap-limit " +
+        "walk as `get_btc_multisig_balance`; each UTXO carries the witnessScript + " +
+        "cosigner pubkeys needed to build a multi-sig PSBT input. Used internally " +
+        "by `prepare_btc_multisig_send` (initiator flow); also exposed directly " +
+        "for users who want to inspect the spendable set without preparing a tx. " +
+        "No device touch.",
+      inputSchema: getBitcoinMultisigUtxosInput.shape,
+    },
+    handler(getBtcMultisigUtxos, { toolName: "get_btc_multisig_utxos" })
   );
 
   registerTool(server,

--- a/src/modules/btc/multisig-balance.ts
+++ b/src/modules/btc/multisig-balance.ts
@@ -1,0 +1,279 @@
+import { getBitcoinIndexer, type BitcoinUtxo } from "./indexer.js";
+import { deriveMultisigAddress } from "./multisig-derive.js";
+import { getPairedMultisigByName } from "./multisig.js";
+import type { PairedBitcoinMultisigWallet } from "../../types/index.js";
+
+/**
+ * Balance + UTXO reads for registered multi-sig wallets. Walks both
+ * BIP-32 chains (chain=0 receive, chain=1 change) up to a gap-limit
+ * window, queries each derived address via the existing Esplora
+ * indexer, aggregates the results.
+ *
+ * The walk follows the standard BIP-44 gap-limit semantics: scan
+ * sequential addresses on each chain, stop after `gapLimit` consecutive
+ * empty addresses (zero confirmed + mempool tx count). Default gap
+ * limit is 20, matching the BIP-44 recommendation and what wallets
+ * like Sparrow / Specter use.
+ *
+ * Used by:
+ *   - `get_btc_multisig_balance` / `get_btc_multisig_utxos` (this PR).
+ *   - PR3's initiator flow (`prepare_btc_multisig_send`) — needs the
+ *     UTXO set for coin-selection.
+ *
+ * NOTE: Each address read is one indexer call; the fan-out is bounded
+ * by `gapLimit × 2` per wallet (chains × 0/1), capped to a few dozen
+ * for sensible defaults. Mempool.space's free tier rate-limits at ~50
+ * requests / 30s; the walk fits well under that for default args.
+ */
+
+export const DEFAULT_MULTISIG_GAP_LIMIT = 20;
+export const MAX_MULTISIG_GAP_LIMIT = 100;
+
+export interface MultisigChainEntry {
+  /** Chain (0 = receive, 1 = change). */
+  chain: 0 | 1;
+  /** Address index along this chain. */
+  addressIndex: number;
+  /** Derived address. */
+  address: string;
+  /** Confirmed balance in sats. */
+  confirmedSats: bigint;
+  /** Mempool delta in sats. Can be negative (in-flight outgoing). */
+  mempoolSats: bigint;
+  /** Confirmed + mempool. */
+  totalSats: bigint;
+  /** Total tx count this address has been involved in. */
+  txCount: number;
+}
+
+export interface MultisigBalance {
+  walletName: string;
+  threshold: number;
+  totalSigners: number;
+  scriptType: PairedBitcoinMultisigWallet["scriptType"];
+  /** Aggregate confirmed balance across both chains. */
+  confirmedSats: bigint;
+  /** Aggregate mempool delta across both chains. */
+  mempoolSats: bigint;
+  /** Confirmed + mempool aggregate. */
+  totalSats: bigint;
+  /** Sum of tx counts across every walked address. */
+  txCount: number;
+  /** Per-address breakdown for the walked window (only entries with non-zero history). */
+  addresses: MultisigChainEntry[];
+  /** How far the gap-limit walk advanced on each chain. */
+  walked: { receive: number; change: number };
+}
+
+export interface MultisigUtxo extends BitcoinUtxo {
+  /** Address (bech32) the UTXO funds. */
+  address: string;
+  /** scriptPubKey bytes for this address (witness program). */
+  scriptPubKey: Buffer;
+  /** witnessScript bytes — needed to build PSBT inputs in PR3. */
+  witnessScript: Buffer;
+  /** Compressed cosigner pubkeys at this leaf, in slot order (NOT sorted). Used for PSBT bip32_derivation. */
+  cosignerPubkeys: Buffer[];
+  /** Chain (0 = receive, 1 = change). */
+  chain: 0 | 1;
+  /** Address index along this chain. */
+  addressIndex: number;
+}
+
+export interface MultisigUtxoSet {
+  walletName: string;
+  utxos: MultisigUtxo[];
+  /** Sum of utxo.value across the set, in sats. */
+  totalSats: bigint;
+  /** How far the gap-limit walk advanced on each chain. */
+  walked: { receive: number; change: number };
+}
+
+function clampGapLimit(raw: number | undefined): number {
+  if (raw === undefined) return DEFAULT_MULTISIG_GAP_LIMIT;
+  if (!Number.isInteger(raw) || raw < 1) {
+    throw new Error(
+      `gapLimit must be a positive integer (got ${raw}). Default is ${DEFAULT_MULTISIG_GAP_LIMIT}; ` +
+        `cap is ${MAX_MULTISIG_GAP_LIMIT} to bound indexer fan-out.`,
+    );
+  }
+  return Math.min(raw, MAX_MULTISIG_GAP_LIMIT);
+}
+
+/**
+ * Walk one BIP-32 chain (0 or 1) and call `visit` for each address
+ * derivation until `gapLimit` consecutive empty addresses are seen.
+ * Returns the count of addresses walked (one past the last index
+ * touched, so the walk's "end position").
+ */
+async function walkChain<T>(
+  wallet: PairedBitcoinMultisigWallet,
+  chain: 0 | 1,
+  gapLimit: number,
+  visit: (info: {
+    chain: 0 | 1;
+    addressIndex: number;
+    address: string;
+    scriptPubKey: Buffer;
+    witnessScript: Buffer;
+    cosignerPubkeys: Buffer[];
+    /** True iff the address has on-chain history (txCount > 0 or a non-zero balance). */
+    hasHistory: boolean;
+  }) => Promise<T | undefined>,
+): Promise<{ walked: number; visited: T[] }> {
+  const indexer = getBitcoinIndexer();
+  const visited: T[] = [];
+  let consecutiveEmpty = 0;
+  let i = 0;
+  while (consecutiveEmpty < gapLimit) {
+    const info = deriveMultisigAddress(wallet, chain, i);
+    const balance = await indexer.getBalance(info.address);
+    const hasHistory =
+      balance.txCount > 0 ||
+      balance.confirmedSats !== 0n ||
+      balance.mempoolSats !== 0n;
+    if (hasHistory) {
+      consecutiveEmpty = 0;
+      const ret = await visit({
+        chain,
+        addressIndex: i,
+        address: info.address,
+        scriptPubKey: info.scriptPubKey,
+        witnessScript: info.witnessScript,
+        cosignerPubkeys: info.cosignerPubkeys,
+        hasHistory: true,
+      });
+      if (ret !== undefined) visited.push(ret);
+    } else {
+      consecutiveEmpty += 1;
+      // Still call visit when the caller wants empty entries (no-op
+      // for now since our two readers only care about non-empty).
+    }
+    i += 1;
+  }
+  return { walked: i, visited };
+}
+
+export interface GetMultisigBalanceArgs {
+  walletName: string;
+  gapLimit?: number;
+}
+
+export async function getMultisigBalance(
+  args: GetMultisigBalanceArgs,
+): Promise<MultisigBalance> {
+  const wallet = getPairedMultisigByName(args.walletName);
+  if (!wallet) {
+    throw new Error(
+      `No multi-sig wallet registered under name "${args.walletName}". Call ` +
+        `\`register_btc_multisig_wallet\` first.`,
+    );
+  }
+  const gapLimit = clampGapLimit(args.gapLimit);
+  const indexer = getBitcoinIndexer();
+
+  const addresses: MultisigChainEntry[] = [];
+  let confirmedSats = 0n;
+  let mempoolSats = 0n;
+  let txCount = 0;
+
+  for (const chain of [0, 1] as const) {
+    let consecutiveEmpty = 0;
+    let i = 0;
+    while (consecutiveEmpty < gapLimit) {
+      const info = deriveMultisigAddress(wallet, chain, i);
+      const balance = await indexer.getBalance(info.address);
+      if (
+        balance.txCount > 0 ||
+        balance.confirmedSats !== 0n ||
+        balance.mempoolSats !== 0n
+      ) {
+        consecutiveEmpty = 0;
+        confirmedSats += balance.confirmedSats;
+        mempoolSats += balance.mempoolSats;
+        txCount += balance.txCount;
+        addresses.push({
+          chain,
+          addressIndex: i,
+          address: info.address,
+          confirmedSats: balance.confirmedSats,
+          mempoolSats: balance.mempoolSats,
+          totalSats: balance.totalSats,
+          txCount: balance.txCount,
+        });
+      } else {
+        consecutiveEmpty += 1;
+      }
+      i += 1;
+    }
+  }
+
+  return {
+    walletName: wallet.name,
+    threshold: wallet.threshold,
+    totalSigners: wallet.totalSigners,
+    scriptType: wallet.scriptType,
+    confirmedSats,
+    mempoolSats,
+    totalSats: confirmedSats + mempoolSats,
+    txCount,
+    addresses,
+    walked: {
+      receive:
+        addresses.filter((a) => a.chain === 0).reduce(
+          (max, a) => Math.max(max, a.addressIndex + 1),
+          0,
+        ) + gapLimit,
+      change:
+        addresses.filter((a) => a.chain === 1).reduce(
+          (max, a) => Math.max(max, a.addressIndex + 1),
+          0,
+        ) + gapLimit,
+    },
+  };
+}
+
+export interface GetMultisigUtxosArgs {
+  walletName: string;
+  gapLimit?: number;
+}
+
+export async function getMultisigUtxos(
+  args: GetMultisigUtxosArgs,
+): Promise<MultisigUtxoSet> {
+  const wallet = getPairedMultisigByName(args.walletName);
+  if (!wallet) {
+    throw new Error(
+      `No multi-sig wallet registered under name "${args.walletName}". Call ` +
+        `\`register_btc_multisig_wallet\` first.`,
+    );
+  }
+  const gapLimit = clampGapLimit(args.gapLimit);
+  const utxos: MultisigUtxo[] = [];
+  let totalSats = 0n;
+  const walked = { receive: 0, change: 0 };
+  for (const chain of [0, 1] as const) {
+    const result = await walkChain(wallet, chain, gapLimit, async (info) => {
+      const indexer = getBitcoinIndexer();
+      const addrUtxos = await indexer.getUtxos(info.address);
+      return addrUtxos.map<MultisigUtxo>((u) => ({
+        ...u,
+        address: info.address,
+        scriptPubKey: info.scriptPubKey,
+        witnessScript: info.witnessScript,
+        cosignerPubkeys: info.cosignerPubkeys,
+        chain: info.chain,
+        addressIndex: info.addressIndex,
+      }));
+    });
+    if (chain === 0) walked.receive = result.walked;
+    else walked.change = result.walked;
+    for (const batch of result.visited) {
+      for (const utxo of batch) {
+        utxos.push(utxo);
+        totalSats += BigInt(utxo.value);
+      }
+    }
+  }
+  return { walletName: wallet.name, utxos, totalSats, walked };
+}

--- a/src/modules/btc/multisig-derive.ts
+++ b/src/modules/btc/multisig-derive.ts
@@ -1,0 +1,139 @@
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+import type { PairedBitcoinMultisigWallet } from "../../types/index.js";
+
+/**
+ * Address derivation for registered multi-sig wallets. Pure crypto —
+ * no device touch, no indexer call. Used by PR2's balance/UTXO readers
+ * and (when those land) PR3's initiator flow.
+ *
+ * For a `wsh(sortedmulti(M, @0/**, @1/**, ..., @N/**))` descriptor:
+ *   1. Derive each cosigner's compressed pubkey at the (chain, index) leaf
+ *      from their stored xpub via `@scure/bip32`.
+ *   2. Sort lexicographically (sortedmulti requirement).
+ *   3. Build the witnessScript:
+ *        OP_M <pubkey1> <pubkey2> ... <pubkeyN> OP_N OP_CHECKMULTISIG
+ *   4. Wrap in P2WSH (sha256 of the script + bech32 encoding).
+ *
+ * Phase 3 PR2 supports `wsh` only. PR4 adds `tr` (taproot script-path).
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  payments: {
+    p2wsh(opts: {
+      redeem: { output: Buffer };
+      network?: unknown;
+    }): { output?: Buffer; address?: string };
+  };
+  script: { compile(chunks: Array<number | Buffer>): Buffer };
+  opcodes: Record<string, number>;
+  networks: { bitcoin: unknown };
+};
+
+const NETWORK = bitcoinjs.networks.bitcoin;
+
+/** Look up an OP_n opcode (1..16). Throws on out-of-range. */
+function opN(n: number): number {
+  if (n < 1 || n > 16 || !Number.isInteger(n)) {
+    throw new Error(`OP_n out of range: ${n} (must be integer 1..16).`);
+  }
+  // OP_1 = 0x51, OP_2 = 0x52, ..., OP_16 = 0x60.
+  return 0x50 + n;
+}
+
+/**
+ * Derive one cosigner's compressed (33-byte) pubkey at the given
+ * (chain, index) leaf from their stored xpub. Throws on derivation
+ * failure (corrupt xpub or xpub not at the expected level).
+ */
+export function deriveCosignerPubkey(
+  xpub: string,
+  change: number,
+  addressIndex: number,
+): Buffer {
+  let hd: HDKey;
+  try {
+    hd = HDKey.fromExtendedKey(xpub);
+  } catch (err) {
+    throw new Error(
+      `Cosigner xpub failed to parse: ${(err as Error).message}. The descriptor ` +
+        `may have been corrupted in storage.`,
+    );
+  }
+  const child = hd.derive(`m/${change}/${addressIndex}`);
+  if (!child.publicKey) {
+    throw new Error(
+      `Cosigner xpub derivation produced no pubkey at /${change}/${addressIndex}.`,
+    );
+  }
+  // @scure/bip32's publicKey is already the 33-byte compressed form
+  // for non-taproot keys — what bitcoinjs-lib expects.
+  return Buffer.from(child.publicKey);
+}
+
+export interface MultisigAddressInfo {
+  /** The bech32 address (e.g. `bc1q...`). */
+  address: string;
+  /** scriptPubKey bytes (witness program). */
+  scriptPubKey: Buffer;
+  /** witnessScript bytes — `OP_M <p1>...<pN> OP_N OP_CHECKMULTISIG`. Used in PSBT inputs. */
+  witnessScript: Buffer;
+  /** Compressed cosigner pubkeys at this leaf, in slot order (NOT sorted). */
+  cosignerPubkeys: Buffer[];
+}
+
+/**
+ * Derive the multi-sig address at the given (change, addressIndex) leaf
+ * for a registered wallet. Pure crypto.
+ *
+ * Phase 3 PR2 supports `scriptType === "wsh"` only. Adding `tr` is the
+ * job of PR4.
+ */
+export function deriveMultisigAddress(
+  wallet: PairedBitcoinMultisigWallet,
+  change: 0 | 1,
+  addressIndex: number,
+): MultisigAddressInfo {
+  if (wallet.scriptType !== "wsh") {
+    throw new Error(
+      `deriveMultisigAddress: scriptType "${wallet.scriptType}" not supported in this ` +
+        `module — taproot (\`tr\`) ships in a follow-up PR.`,
+    );
+  }
+  if (!Number.isInteger(addressIndex) || addressIndex < 0) {
+    throw new Error(
+      `addressIndex must be a non-negative integer, got ${addressIndex}.`,
+    );
+  }
+  // 1. Derive each cosigner's pubkey at the leaf.
+  const cosignerPubkeys = wallet.cosigners.map((c) =>
+    deriveCosignerPubkey(c.xpub, change, addressIndex),
+  );
+  // 2. sortedmulti = lexicographic sort of pubkeys.
+  const sorted = [...cosignerPubkeys].sort(Buffer.compare);
+  // 3. Build witnessScript.
+  const witnessScript = bitcoinjs.script.compile([
+    opN(wallet.threshold),
+    ...sorted,
+    opN(wallet.totalSigners),
+    bitcoinjs.opcodes.OP_CHECKMULTISIG,
+  ]);
+  // 4. Wrap in P2WSH.
+  const p2wsh = bitcoinjs.payments.p2wsh({
+    redeem: { output: witnessScript },
+    network: NETWORK,
+  });
+  if (!p2wsh.output || !p2wsh.address) {
+    throw new Error(
+      `Internal error: bitcoinjs.payments.p2wsh returned undefined output/address ` +
+        `for wallet "${wallet.name}" at leaf ${change}/${addressIndex}.`,
+    );
+  }
+  return {
+    address: p2wsh.address,
+    scriptPubKey: p2wsh.output,
+    witnessScript,
+    cosignerPubkeys,
+  };
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -162,6 +162,8 @@ import type {
   SignBitcoinMultisigPsbtArgs,
   CombineBitcoinPsbtsArgs,
   FinalizeBitcoinPsbtArgs,
+  GetBitcoinMultisigBalanceArgs,
+  GetBitcoinMultisigUtxosArgs,
   SignBtcMessageArgs,
   PairLedgerLitecoinArgs,
   GetLitecoinBalanceArgs,
@@ -1265,6 +1267,22 @@ export async function finalizeBtcPsbt(args: FinalizeBitcoinPsbtArgs) {
   return finalizePsbt({
     psbtBase64: args.psbtBase64,
     ...(args.broadcast !== undefined ? { broadcast: args.broadcast } : {}),
+  });
+}
+
+export async function getBtcMultisigBalance(args: GetBitcoinMultisigBalanceArgs) {
+  const { getMultisigBalance } = await import("../btc/multisig-balance.js");
+  return getMultisigBalance({
+    walletName: args.walletName,
+    ...(args.gapLimit !== undefined ? { gapLimit: args.gapLimit } : {}),
+  });
+}
+
+export async function getBtcMultisigUtxos(args: GetBitcoinMultisigUtxosArgs) {
+  const { getMultisigUtxos } = await import("../btc/multisig-balance.js");
+  return getMultisigUtxos({
+    walletName: args.walletName,
+    ...(args.gapLimit !== undefined ? { gapLimit: args.gapLimit } : {}),
   });
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1436,6 +1436,40 @@ export const finalizeBitcoinPsbtInput = z.object({
     ),
 });
 
+export const getBitcoinMultisigBalanceInput = z.object({
+  walletName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe(
+      "Name of a registered multi-sig wallet (matches the `name` passed to " +
+        "`register_btc_multisig_wallet`)."
+    ),
+  gapLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      "BIP-44 gap limit — stop walking each chain after N consecutive empty " +
+        "addresses. Default 20 (matches Sparrow / Specter / BIP-44 recommendation). " +
+        "Cap of 100 to bound indexer fan-out."
+    ),
+});
+
+export const getBitcoinMultisigUtxosInput = z.object({
+  walletName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe(
+      "Name of a registered multi-sig wallet. The returned UTXO set is the input " +
+        "pool PR3's `prepare_btc_multisig_send` will draw from."
+    ),
+  gapLimit: z.number().int().min(1).max(100).optional(),
+});
+
 export const getBitcoinTxHistoryInput = z.object({
   address: bitcoinAddressSchema,
   limit: z
@@ -1497,6 +1531,8 @@ export type RegisterBitcoinMultisigWalletArgs = z.infer<
 export type SignBitcoinMultisigPsbtArgs = z.infer<typeof signBitcoinMultisigPsbtInput>;
 export type CombineBitcoinPsbtsArgs = z.infer<typeof combineBitcoinPsbtsInput>;
 export type FinalizeBitcoinPsbtArgs = z.infer<typeof finalizeBitcoinPsbtInput>;
+export type GetBitcoinMultisigBalanceArgs = z.infer<typeof getBitcoinMultisigBalanceInput>;
+export type GetBitcoinMultisigUtxosArgs = z.infer<typeof getBitcoinMultisigUtxosInput>;
 export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;

--- a/test/btc-multisig-balance.test.ts
+++ b/test/btc-multisig-balance.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { HDKey } from "@scure/bip32";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+import type { PairedBitcoinMultisigWallet } from "../src/types/index.js";
+
+/**
+ * Tests for the watch-only multi-sig balance + UTXO readers (PR2).
+ * Mocks the indexer; uses real `@scure/bip32` + `bitcoinjs-lib` for
+ * address derivation so the cross-check against expected addresses is
+ * meaningful.
+ */
+
+const getBalanceMock = vi.fn();
+const getUtxosMock = vi.fn();
+
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getBalance: getBalanceMock,
+    getUtxos: getUtxosMock,
+    getFeeEstimates: vi.fn(),
+    broadcastTx: vi.fn(),
+    getTxStatus: vi.fn(),
+    getTxHex: vi.fn(),
+    getTx: vi.fn(),
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+let tmpHome: string;
+
+function deriveCosigner(seed: string) {
+  const seedBuf = Buffer.alloc(64);
+  Buffer.from(seed.padEnd(64, "x")).copy(seedBuf);
+  const master = HDKey.fromMasterSeed(seedBuf);
+  const account = master.derive("m/48'/0'/0'/2'");
+  const fp = master.fingerprint;
+  const masterFingerprint = Buffer.alloc(4);
+  masterFingerprint.writeUInt32BE(fp, 0);
+  return {
+    xpub: account.publicExtendedKey,
+    masterFingerprint: masterFingerprint.toString("hex"),
+  };
+}
+
+async function registerVault(): Promise<PairedBitcoinMultisigWallet> {
+  const a = deriveCosigner("alice");
+  const b = deriveCosigner("bob");
+  const c = deriveCosigner("carol");
+  const wallet: PairedBitcoinMultisigWallet = {
+    name: "Vault",
+    threshold: 2,
+    totalSigners: 3,
+    scriptType: "wsh",
+    descriptor: "wsh(sortedmulti(2,@0/**,@1/**,@2/**))",
+    cosigners: [
+      { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'", isOurs: true },
+      { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'", isOurs: false },
+      { xpub: c.xpub, masterFingerprint: c.masterFingerprint, derivationPath: "48'/0'/0'/2'", isOurs: false },
+    ],
+    policyHmac: "00".repeat(32),
+    appVersion: "2.4.6",
+  };
+  // Persist via the multisig store's setter — we use the direct user
+  // config path so this test doesn't depend on register's mocked Ledger
+  // flow.
+  const { patchUserConfig } = await import("../src/config/user-config.js");
+  patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+  // Force the multisig module to re-hydrate from disk.
+  const { __clearMultisigStore } = await import("../src/modules/btc/multisig.js");
+  __clearMultisigStore();
+  patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+  return wallet;
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-multisig-bal-"));
+  setConfigDirForTesting(tmpHome);
+  getBalanceMock.mockReset();
+  getUtxosMock.mockReset();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("deriveMultisigAddress", () => {
+  it("derives a stable bc1q...-prefixed P2WSH address for chain=0/index=0", async () => {
+    const wallet = await registerVault();
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const info = deriveMultisigAddress(wallet, 0, 0);
+    expect(info.address.startsWith("bc1q")).toBe(true);
+    // P2WSH bech32 addresses are 62 chars (1 hrp + 1 separator + 1 witness ver + 32 program + 6 checksum).
+    expect(info.address.length).toBe(62);
+    // Re-derivation must be deterministic.
+    const again = deriveMultisigAddress(wallet, 0, 0);
+    expect(again.address).toBe(info.address);
+    // chain=1 should produce a DIFFERENT address.
+    const change = deriveMultisigAddress(wallet, 1, 0);
+    expect(change.address).not.toBe(info.address);
+  });
+
+  it("includes every cosigner's pubkey in the witnessScript", async () => {
+    const wallet = await registerVault();
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const info = deriveMultisigAddress(wallet, 0, 0);
+    expect(info.cosignerPubkeys).toHaveLength(3);
+    for (const pk of info.cosignerPubkeys) {
+      expect(pk.length).toBe(33); // compressed
+      expect([0x02, 0x03]).toContain(pk[0]);
+    }
+    // Witness script begins with OP_2 (threshold=2 → 0x52) and ends
+    // with OP_3 (totalSigners=3 → 0x53) + OP_CHECKMULTISIG (0xae).
+    expect(info.witnessScript[0]).toBe(0x52);
+    expect(info.witnessScript[info.witnessScript.length - 2]).toBe(0x53);
+    expect(info.witnessScript[info.witnessScript.length - 1]).toBe(0xae);
+  });
+
+  it("refuses unsupported scriptType (taproot deferred to PR4)", async () => {
+    const wallet = await registerVault();
+    const taprootWallet = { ...wallet, scriptType: "tr" as never };
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    expect(() => deriveMultisigAddress(taprootWallet, 0, 0)).toThrow(
+      /not supported in this module/,
+    );
+  });
+});
+
+describe("getMultisigBalance", () => {
+  it("walks both chains and aggregates non-empty addresses", async () => {
+    await registerVault();
+    // Make chain=0 index=0 funded; everything else empty (gap limit
+    // tripped after 20 empties).
+    getBalanceMock.mockImplementation(async (address: string) => {
+      // Funded address: deterministic — first chain=0 derivation.
+      if (getBalanceMock.mock.calls.length === 1) {
+        return {
+          address,
+          confirmedSats: 50_000n,
+          mempoolSats: 0n,
+          totalSats: 50_000n,
+          txCount: 1,
+        };
+      }
+      return {
+        address,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 0,
+      };
+    });
+    const { getMultisigBalance } = await import(
+      "../src/modules/btc/multisig-balance.ts"
+    );
+    const result = await getMultisigBalance({ walletName: "Vault", gapLimit: 5 });
+    expect(result.confirmedSats).toBe(50_000n);
+    expect(result.txCount).toBe(1);
+    expect(result.addresses).toHaveLength(1);
+    expect(result.addresses[0].chain).toBe(0);
+    expect(result.addresses[0].addressIndex).toBe(0);
+    // gap-limit 5 → walks 6 receive (idx 0 funded + 5 empties), then 5 change empties.
+    expect(getBalanceMock).toHaveBeenCalledTimes(11);
+  });
+
+  it("refuses unknown wallet name", async () => {
+    const { getMultisigBalance } = await import(
+      "../src/modules/btc/multisig-balance.ts"
+    );
+    await expect(
+      getMultisigBalance({ walletName: "Nonexistent" }),
+    ).rejects.toThrow(/No multi-sig wallet registered/);
+  });
+});
+
+describe("getMultisigUtxos", () => {
+  it("returns UTXOs annotated with witnessScript + cosigner pubkeys", async () => {
+    await registerVault();
+    // First derived chain=0 address has 1 UTXO; rest empty.
+    let firstAddress: string | null = null;
+    getBalanceMock.mockImplementation(async (address: string) => {
+      const isFirst =
+        firstAddress === null || firstAddress === address;
+      if (firstAddress === null) firstAddress = address;
+      return isFirst && address === firstAddress
+        ? {
+            address,
+            confirmedSats: 100_000n,
+            mempoolSats: 0n,
+            totalSats: 100_000n,
+            txCount: 1,
+          }
+        : {
+            address,
+            confirmedSats: 0n,
+            mempoolSats: 0n,
+            totalSats: 0n,
+            txCount: 0,
+          };
+    });
+    getUtxosMock.mockImplementation(async (address: string) =>
+      address === firstAddress
+        ? [
+            {
+              txid: "ab".repeat(32),
+              vout: 0,
+              value: 100_000,
+              unconfirmed: false,
+            },
+          ]
+        : [],
+    );
+    const { getMultisigUtxos } = await import(
+      "../src/modules/btc/multisig-balance.ts"
+    );
+    const result = await getMultisigUtxos({ walletName: "Vault", gapLimit: 3 });
+    expect(result.utxos).toHaveLength(1);
+    expect(result.utxos[0].chain).toBe(0);
+    expect(result.utxos[0].addressIndex).toBe(0);
+    expect(result.utxos[0].cosignerPubkeys).toHaveLength(3);
+    expect(result.utxos[0].witnessScript[0]).toBe(0x52); // OP_2
+    expect(result.totalSats).toBe(100_000n);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 PR2 — read-only inspection of registered multi-sig wallets. No device touch; pure-crypto address derivation locally + standard Esplora reads.

Two new tools:
- `get_btc_multisig_balance({ walletName, gapLimit? })` — gap-limit walk over both chains (0 receive, 1 change), aggregate balance + per-address breakdown for entries with on-chain history.
- `get_btc_multisig_utxos({ walletName, gapLimit? })` — UTXO set annotated with `witnessScript` + cosigner pubkeys per entry. Consumed by PR3's initiator flow; also exposed directly for users who want to inspect what's spendable without preparing a tx.

New modules:
- `src/modules/btc/multisig-derive.ts` — `deriveMultisigAddress(wallet, change, addressIndex)` returns address + scriptPubKey + witnessScript + cosigner pubkeys for `wsh(sortedmulti(...))` wallets. PR3 + PR4 plug in via the same shape.
- `src/modules/btc/multisig-balance.ts` — gap-limit walk + aggregation.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-multisig-balance.test.ts` — 6/6 passing
- [x] Address derivation is deterministic, chain=0 ≠ chain=1, witness script begins with `OP_M` and ends with `OP_N OP_CHECKMULTISIG`
- [x] Full suite green except for the 2 pre-existing flaky integration-security tests (unrelated to this PR; they fail on a clean main too)
- [ ] Live smoke: register a 2-of-3 wallet that has on-chain history, confirm balance matches Sparrow / Specter

Plan: [`claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md). Independent of #329 (combine/finalize); both can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)