### PR TITLE
fix(walletconnect): multi-source nonce probe + real error messages (closes #326)

### DIFF
--- a/src/data/apis/etherscan-v2.ts
+++ b/src/data/apis/etherscan-v2.ts
@@ -96,6 +96,69 @@ export async function etherscanV2Fetch<T>(
 }
 
 /**
+ * Pending-nonce read via Etherscan V2's `module=proxy&action=eth_getTransactionCount`.
+ * Used as a SECOND nonce source by the WalletConnect late-broadcast probe:
+ * if the local RPC reports `pending <= pinned` (suggesting the tx never
+ * left Ledger Live's side) but Etherscan's mempool view disagrees, we
+ * have an ambiguous outcome and must NOT retry — exactly the failure
+ * mode that caused issue #326.
+ *
+ * Returns the nonce as a number. Throws `EtherscanApiKeyMissingError`
+ * when no API key is configured (callers swallow this and fall back to
+ * single-source behavior — having Etherscan is a defense-in-depth nice-
+ * to-have, not a hard requirement).
+ *
+ * The `proxy` module returns a JSON-RPC envelope `{ jsonrpc, id, result }`
+ * where `result` is a hex-encoded number; the V1 envelope shape that
+ * `etherscanV2Fetch` checks for (`status: "1"` etc.) does not apply, so
+ * we go through `fetchWithTimeout` directly rather than reusing the
+ * other helpers.
+ */
+export async function getEtherscanProxyPendingNonce(
+  chain: SupportedChain,
+  address: `0x${string}`,
+): Promise<number> {
+  const apiKey = resolveEtherscanApiKey(readUserConfig());
+  if (!apiKey) throw new EtherscanApiKeyMissingError();
+  const qs = new URLSearchParams({
+    chainid: String(CHAIN_IDS[chain]),
+    module: "proxy",
+    action: "eth_getTransactionCount",
+    address,
+    tag: "pending",
+    apikey: apiKey,
+  });
+  const res = await fetchWithTimeout(`${V2_BASE}?${qs.toString()}`);
+  if (!res.ok) {
+    throw new Error(
+      `Etherscan V2 ${chain} eth_getTransactionCount returned ${res.status}`,
+    );
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(
+      `Etherscan V2 ${chain} eth_getTransactionCount response exceeds ${MAX_RESPONSE_BYTES} bytes`,
+    );
+  }
+  const body = JSON.parse(text) as { result?: string; error?: { message?: string } };
+  if (body.error?.message) {
+    throw new Error(`Etherscan V2 ${chain} eth_getTransactionCount: ${body.error.message}`);
+  }
+  if (typeof body.result !== "string" || !/^0x[0-9a-fA-F]+$/.test(body.result)) {
+    throw new Error(
+      `Etherscan V2 ${chain} eth_getTransactionCount: unexpected result shape`,
+    );
+  }
+  const n = Number.parseInt(body.result, 16);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(
+      `Etherscan V2 ${chain} eth_getTransactionCount: non-finite nonce ${body.result}`,
+    );
+  }
+  return n;
+}
+
+/**
  * Lower-level variant for endpoints that return a single object, not an
  * array (e.g. some contract-level queries). Same error semantics.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -414,6 +414,7 @@ import type {
 import type { SendTransactionArgs } from "./modules/execution/schemas.js";
 
 import { readUserConfig } from "./config/user-config.js";
+import { safeErrorMessage } from "./shared/error-message.js";
 
 /**
  * URL of the agent-side preflight skill's git repo. Single source of truth
@@ -728,9 +729,13 @@ function handler<T, R>(
       }
       return { content };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Issue #326: the legacy `error instanceof Error ? error.message :
+      // String(error)` pattern produced `Error: [object Object]` when the
+      // underlying SDK (WalletConnect, viem) threw an Error whose .message
+      // was itself a structured object. Use the hardened helper instead so
+      // the agent (and the user) sees the actual failure cause.
       return {
-        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        content: [{ type: "text" as const, text: `Error: ${safeErrorMessage(error)}` }],
         isError: true,
       };
     }

--- a/src/shared/error-message.ts
+++ b/src/shared/error-message.ts
@@ -1,0 +1,99 @@
+/**
+ * Safely render an unknown thrown value as a human-readable string.
+ *
+ * The naive `error instanceof Error ? error.message : String(error)` pattern
+ * (used by the txHandler wrapper in `src/index.ts` until issue #326) breaks
+ * on errors whose `.message` is itself a structured object — common with
+ * WalletConnect SDK errors (`{ code, message }` payloads), some viem
+ * decoding errors, and a few protocol clients. Template-string
+ * interpolation calls `Object.prototype.toString` and produces the
+ * famously useless `"[object Object]"`.
+ *
+ * Live regression — issue #326, 2026-04-27 08:09 UTC: a WalletConnect
+ * `eth_sendTransaction` retry surfaced as `Error: [object Object]`,
+ * leaving the agent (and the user reading the agent's report) with no
+ * idea what actually went wrong, which compounded the panic of the
+ * adjacent retry-storm bug.
+ *
+ * Behavior:
+ *   - `Error` with a non-empty string `.message` → the message
+ *   - `Error` with an object `.message` → `<name>: <JSON-stringified>`,
+ *     so the structured fields ({code, data, …}) are visible
+ *   - Plain string → the string
+ *   - Plain object → JSON-stringified (own props + a few common Error fields)
+ *   - Anything else → `String(value)` as a last resort
+ *
+ * Stable, side-effect-free, no IO. Always returns a non-empty string.
+ */
+export function safeErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error.length > 0 ? error : "Unknown error (empty string thrown)";
+  }
+  if (error === null || error === undefined) {
+    return `Unknown error (${error === null ? "null" : "undefined"} thrown)`;
+  }
+  if (error instanceof Error) {
+    const message = error.message;
+    if (typeof message === "string" && message.length > 0 && message !== "[object Object]") {
+      return message;
+    }
+    // .message was an object, empty, or already the stringification bug —
+    // surface the structured fields. Walking own properties catches
+    // SDK-thrown errors that attach `code`, `data`, `cause`, etc.
+    const detail = stringifyOwnProps(error);
+    const name = (error.name && typeof error.name === "string") ? error.name : "Error";
+    return detail.length > 0 ? `${name}: ${detail}` : name;
+  }
+  if (typeof error === "object") {
+    const detail = stringifyOwnProps(error);
+    return detail.length > 0 ? detail : Object.prototype.toString.call(error);
+  }
+  return String(error);
+}
+
+/**
+ * Render the most useful properties of an object to JSON. Surfaces
+ * non-enumerable Error props (`name`, `message`, `code`) that
+ * `JSON.stringify` would otherwise drop, while skipping `stack`
+ * (carries V8 trace noise that often includes the literal
+ * `"[object Object]"` from the throw site and would defeat the
+ * cleanup). Returns "" when nothing useful is available.
+ *
+ * Implementation note: builds a plain enumerable copy first, THEN
+ * JSON.stringifies it. An earlier attempt used the JSON.stringify
+ * array-filter form (`JSON.stringify(value, namesArray)`) — that
+ * filters AT EVERY NESTING LEVEL, which strips nested object internals
+ * (e.g. `message.code` when `code` isn't in the outer Error's name
+ * list). The plain-copy approach lets default recursion handle nested
+ * shapes naturally.
+ */
+function stringifyOwnProps(value: unknown): string {
+  if (value === null || typeof value !== "object") return "";
+  const flat: Record<string, unknown> = {};
+  for (const name of Object.getOwnPropertyNames(value as object)) {
+    if (name === "stack") continue;
+    flat[name] = (value as Record<string, unknown>)[name];
+  }
+  for (const k of Object.keys(value as object)) {
+    if (k in flat || k === "stack") continue;
+    flat[k] = (value as Record<string, unknown>)[k];
+  }
+  if (Object.keys(flat).length === 0) return "";
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(flat, (_key, v) => {
+      if (typeof v === "function") return undefined;
+      if (typeof v === "bigint") return v.toString();
+      if (v instanceof Error) {
+        return { name: v.name, message: typeof v.message === "string" ? v.message : v.message };
+      }
+      if (v && typeof v === "object") {
+        if (seen.has(v)) return "[circular]";
+        seen.add(v);
+      }
+      return v;
+    });
+  } catch {
+    return "";
+  }
+}

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -13,6 +13,7 @@ import {
   getConfigDir,
 } from "../config/user-config.js";
 import { getClient } from "../data/rpc.js";
+import { getEtherscanProxyPendingNonce } from "../data/apis/etherscan-v2.js";
 import { eip1559PreSignHash } from "./verification.js";
 
 /**
@@ -568,14 +569,66 @@ export function noBroadcastConfirmedMessage(args: {
   pinnedNonce: number;
   chainId: number | string;
   timeoutSeconds: number;
+  /**
+   * When the cross-check ran and agreed, surface the second-source
+   * value too — it's the strongest "safe to retry" signal we can give.
+   * Issue #326.
+   */
+  etherscanPendingNonce?: number;
 }): string {
+  const xchk =
+    args.etherscanPendingNonce !== undefined
+      ? `Etherscan's mempool view independently confirms pending=\`${args.etherscanPendingNonce}\`, so the two sources agree. `
+      : "";
   return (
     `WalletConnect signing request did not complete within ${args.timeoutSeconds}s — and an automatic ` +
     `on-chain probe confirmed that the pending nonce for \`${args.from}\` on chain id \`${args.chainId}\` ` +
-    `is still \`${args.pinnedNonce}\` (pinned), so no late broadcast is in flight. ` +
+    `is still \`${args.pinnedNonce}\` (pinned), so no late broadcast is in flight. ${xchk}` +
     `Safe to retry: call \`send_transaction\` on the SAME handle within its 15-min TTL. ` +
     `The user is most likely still reviewing the tx on the Ledger device — closing the WalletConnect ` +
-    `subapp on Ledger Live and reopening it before the retry can help if the device prompt got stale. Issue #232.`
+    `subapp on Ledger Live and reopening it before the retry can help if the device prompt got stale. ` +
+    `When relaying this to the user, include a one-line nudge that the previous attempt's outcome was ` +
+    `uncertain enough to time out — if the WC subapp HAD silently completed signing in the background, ` +
+    `the retry can queue a duplicate prompt to their Ledger; in that case the right action is to ` +
+    `**REJECT the duplicate prompt** (the original tx will land normally) rather than approve it. ` +
+    `Issues #232, #326.`
+  );
+}
+
+/**
+ * Surfaced when the local RPC reports the pinned nonce is still pending
+ * (which would historically have green-lit a retry as `no_broadcast`)
+ * but the Etherscan mempool view reports the wallet has advanced past
+ * it. Issue #326 — a divergence here is the canonical signal that the
+ * tx broadcast through Ledger Live's RPC and our local node hasn't
+ * caught up yet. Retrying in this state is exactly what queued the
+ * phantom duplicate prompt that triggered the live incident.
+ */
+export function ambiguousNonceDisagreementMessage(args: {
+  from: `0x${string}` | string;
+  pinnedNonce: number;
+  localPendingNonce: number;
+  etherscanPendingNonce: number;
+  chainId: number | string;
+  timeoutSeconds: number;
+}): string {
+  return (
+    `WalletConnect signing request did not complete within ${args.timeoutSeconds}s. ` +
+    `The on-chain probe found AMBIGUOUS state for \`${args.from}\` on chain id \`${args.chainId}\`: ` +
+    `the configured RPC says pending nonce is \`${args.localPendingNonce}\` (= pinned ${args.pinnedNonce}, ` +
+    `would mean nothing broadcast), but Etherscan's mempool view reports the wallet's pending nonce is ` +
+    `already \`${args.etherscanPendingNonce}\` (> pinned, would mean SOMETHING broadcast). ` +
+    `Most likely cause: Ledger Live finished signing + relayed the tx through its own RPC after our ` +
+    `${args.timeoutSeconds}s timer fired, and Etherscan's mempool indexer has seen it but our local node ` +
+    `hasn't caught up yet. ` +
+    `**DO NOT retry \`send_transaction\` on this handle** — if the tx did broadcast, retrying queues a ` +
+    `duplicate signing prompt to Ledger Live that looks exactly like a key-leak attack pattern (issue ` +
+    `#326). Tell the user to: ` +
+    `(1) check their wallet on a block explorer (etherscan.io / Ledger Live's tx history) for a recently ` +
+    `broadcast tx with nonce ${args.pinnedNonce} — if found, the original send succeeded; ` +
+    `(2) if no tx with nonce ${args.pinnedNonce} appears within ~5 minutes, the slot is genuinely free ` +
+    `and they can re-prepare from scratch (NEW handle, fresh nonce/gas pin) and try again. ` +
+    `Issue #326.`
   );
 }
 
@@ -593,23 +646,37 @@ export function noBroadcastConfirmedMessage(args: {
 const LATE_BROADCAST_PROBE_BLOCKS = 16;
 
 /**
- * Outcome of `probeForLateBroadcast`. Three branches:
+ * Outcome of `probeForLateBroadcast`. Four branches:
  *   - `matched` → found an on-chain tx whose pre-sign hash equals the
  *     server's pinned hash; the WC timeout was a false alarm and we can
  *     return the tx hash to the caller.
  *   - `no_broadcast` → the pending nonce on chain is still ≤ the pinned
- *     nonce; the tx never left Ledger Live's side. Safe to retry.
+ *     nonce on BOTH the configured RPC and (when available) Etherscan's
+ *     mempool view. The tx never left Ledger Live's side. Safe to retry.
  *   - `consumed_unmatched` → the pinned nonce was consumed but no tx in
  *     the recent block window had a matching pre-sign hash. Could be a
  *     different tx (RBF replacement, parallel tooling) using the same
  *     slot, or our tx mined further back than the probe window. Don't
  *     retry; surface the pending nonce so the agent can guide the user
  *     to a block explorer.
+ *   - `ambiguous_nonce_disagreement` → the configured RPC reports the
+ *     pinned nonce is still pending (would be `no_broadcast`) but the
+ *     Etherscan mempool view reports the wallet has already advanced
+ *     past it. Indicates a propagation/visibility gap between the two
+ *     sources — the tx may have broadcast through Ledger Live's RPC
+ *     and not yet reached ours. DO NOT retry: the canonical issue #326
+ *     scenario is that retry queues a duplicate signing prompt that
+ *     looks exactly like a key-leak attack to the user.
  */
 export type LateBroadcastProbeResult =
   | { status: "matched"; txHash: `0x${string}` }
-  | { status: "no_broadcast"; pendingNonce: number }
-  | { status: "consumed_unmatched"; pendingNonce: number };
+  | { status: "no_broadcast"; pendingNonce: number; etherscanPendingNonce?: number }
+  | { status: "consumed_unmatched"; pendingNonce: number }
+  | {
+      status: "ambiguous_nonce_disagreement";
+      localPendingNonce: number;
+      etherscanPendingNonce: number;
+    };
 
 /**
  * After a WC `eth_sendTransaction` times out, find out whether the tx
@@ -643,12 +710,44 @@ export async function probeForLateBroadcast(args: {
   chainId: number;
   /** Override the default block window (for tests). */
   blockWindow?: number;
+  /**
+   * Issue #326 — second nonce source. When provided AND the local RPC
+   * reports `pending <= pinned` (would otherwise be `no_broadcast`), this
+   * is queried as a defense-in-depth cross-check. If it returns
+   * `> pinned`, the two sources disagree and we surface
+   * `ambiguous_nonce_disagreement` so the caller refuses to retry —
+   * preventing the duplicate-prompt scenario from issue #326.
+   *
+   * Errors thrown by this probe are swallowed (no API key, rate limit,
+   * network failure): the caller falls back to the legacy single-source
+   * `no_broadcast` outcome. Etherscan is a defense-in-depth nice-to-have,
+   * not a hard dependency — users without an `ETHERSCAN_API_KEY` get
+   * the pre-issue-326 behavior without regression.
+   */
+  etherscanPendingNonceProbe?: () => Promise<number>;
 }): Promise<LateBroadcastProbeResult> {
   const pendingNonce = await args.client.getTransactionCount({
     address: args.from,
     blockTag: "pending",
   });
   if (pendingNonce <= args.pinnedNonce) {
+    if (args.etherscanPendingNonceProbe) {
+      let etherscanPendingNonce: number | undefined;
+      try {
+        etherscanPendingNonce = await args.etherscanPendingNonceProbe();
+      } catch {
+        // Fall back to local-only result; cross-check unavailable.
+        return { status: "no_broadcast", pendingNonce };
+      }
+      if (etherscanPendingNonce > args.pinnedNonce) {
+        return {
+          status: "ambiguous_nonce_disagreement",
+          localPendingNonce: pendingNonce,
+          etherscanPendingNonce,
+        };
+      }
+      return { status: "no_broadcast", pendingNonce, etherscanPendingNonce };
+    }
     return { status: "no_broadcast", pendingNonce };
   }
   const head = await args.client.getBlockNumber();
@@ -835,6 +934,14 @@ export async function requestSendTransaction(
         pinnedNonce: pinned.nonce,
         expectedPreSignHash,
         chainId,
+        // Issue #326 — Etherscan-side cross-check on the pending nonce.
+        // Errors are swallowed inside the probe (no API key, rate
+        // limit, network failure) so users without ETHERSCAN_API_KEY
+        // get the pre-issue-326 single-source behavior; only when the
+        // probe runs AND the two sources DISAGREE do we surface the
+        // ambiguous-state error.
+        etherscanPendingNonceProbe: async () =>
+          getEtherscanProxyPendingNonce(tx.chain, from as `0x${string}`),
       });
     } catch {
       // Probe-internal failure (RPC down, decoder threw) → fall back
@@ -859,6 +966,22 @@ export async function requestSendTransaction(
         }),
       );
     }
+    if (probe.status === "ambiguous_nonce_disagreement") {
+      // Issue #326 — local RPC and Etherscan disagree on whether the
+      // pinned nonce was consumed. The tx may have broadcast through
+      // Ledger Live's RPC and not yet reached our local node. Refuse
+      // to retry; tell the user to verify via block explorer.
+      throw new WalletConnectRequestTimeoutError(
+        ambiguousNonceDisagreementMessage({
+          from,
+          pinnedNonce: pinned.nonce,
+          localPendingNonce: probe.localPendingNonce,
+          etherscanPendingNonce: probe.etherscanPendingNonce,
+          chainId,
+          timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
+        }),
+      );
+    }
     // probe.status === "no_broadcast" → safe to retry, surface the
     // confirmed-no-broadcast variant so the agent doesn't fall back to
     // the conservative original message.
@@ -868,6 +991,7 @@ export async function requestSendTransaction(
         pinnedNonce: pinned.nonce,
         chainId,
         timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
+        etherscanPendingNonce: probe.etherscanPendingNonce,
       }),
     );
   });

--- a/test/safe-error-message.test.ts
+++ b/test/safe-error-message.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { safeErrorMessage } from "../src/shared/error-message.js";
+
+describe("safeErrorMessage — issue #326 stringification fix", () => {
+  it("standard Error with string message → returns the message", () => {
+    expect(safeErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("Error with object message → unwraps structured fields, never returns '[object Object]'", () => {
+    // The exact failure mode that surfaced as "Error: [object Object]"
+    // in the live incident — some SDKs (WalletConnect) throw Errors
+    // whose `.message` is itself a structured object, and the legacy
+    // pattern `${error.message}` toString'd it to literal garbage.
+    const err = new Error();
+    Object.defineProperty(err, "message", {
+      value: { code: 4001, reason: "user_rejected" },
+      enumerable: true,
+    });
+    const out = safeErrorMessage(err);
+    expect(out).not.toBe("[object Object]");
+    expect(out).not.toContain("[object Object]");
+    expect(out).toContain("user_rejected");
+    expect(out).toContain("4001");
+  });
+
+  it("Error with empty string message → falls back to name + own props", () => {
+    class CustomError extends Error {
+      code = "ERR_CUSTOM";
+      constructor() {
+        super("");
+        this.name = "CustomError";
+      }
+    }
+    const out = safeErrorMessage(new CustomError());
+    expect(out).toContain("CustomError");
+    expect(out).toContain("ERR_CUSTOM");
+  });
+
+  it("plain string thrown → returns the string verbatim", () => {
+    expect(safeErrorMessage("just a string")).toBe("just a string");
+  });
+
+  it("plain object thrown → JSON-stringified, structured fields visible", () => {
+    const out = safeErrorMessage({ kind: "wc-relay-error", code: 4100, message: "Unauthorized method" });
+    expect(out).toContain("wc-relay-error");
+    expect(out).toContain("4100");
+    expect(out).toContain("Unauthorized method");
+  });
+
+  it("null / undefined → labels them explicitly rather than returning empty", () => {
+    expect(safeErrorMessage(null)).toMatch(/null/);
+    expect(safeErrorMessage(undefined)).toMatch(/undefined/);
+  });
+
+  it("circular object → does not throw; surfaces what it can", () => {
+    const o: Record<string, unknown> = { kind: "loop" };
+    o.self = o;
+    expect(() => safeErrorMessage(o)).not.toThrow();
+    const out = safeErrorMessage(o);
+    expect(out).toContain("loop");
+    // Either `[circular]` is surfaced or the toString fallback fires —
+    // the assertion is just "no throw, no garbage".
+    expect(out).not.toBe("");
+  });
+
+  it("Error with literal '[object Object]' message (the live bug) → still recovers structured fields", () => {
+    // Defensive: if the bug ever resurfaces upstream, we must still
+    // surface SOMETHING useful rather than parroting the literal back.
+    const err = new Error("[object Object]");
+    Object.defineProperty(err, "code", { value: 4001, enumerable: true });
+    const out = safeErrorMessage(err);
+    expect(out).not.toBe("[object Object]");
+    // The own-property unwrap should pick up `code`.
+    expect(out).toMatch(/4001/);
+  });
+
+  it("BigInt fields in structured object don't crash JSON.stringify", () => {
+    // viem-side errors often carry BigInt gas/nonce fields, which
+    // JSON.stringify rejects by default. Our helper must coerce.
+    const out = safeErrorMessage({ kind: "viem-error", gas: 1234567890123n });
+    expect(out).toContain("viem-error");
+    expect(out).toContain("1234567890123");
+  });
+});

--- a/test/wc-late-broadcast-probe.test.ts
+++ b/test/wc-late-broadcast-probe.test.ts
@@ -15,6 +15,7 @@ import {
   probeForLateBroadcast,
   consumedUnmatchedMessage,
   noBroadcastConfirmedMessage,
+  ambiguousNonceDisagreementMessage,
 } from "../src/signing/walletconnect.js";
 
 const FROM = "0x1111111111111111111111111111111111111111" as const;
@@ -229,8 +230,125 @@ describe("probeForLateBroadcast", () => {
   });
 });
 
-describe("noBroadcastConfirmedMessage — issue #232 wording lock", () => {
-  it("tells the agent it's safe to retry the same handle", async () => {
+describe("probeForLateBroadcast — issue #326 multi-source nonce cross-check", () => {
+  it("when local says no_broadcast AND etherscan agrees → no_broadcast (with cross-check value surfaced)", async () => {
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce,
+      getBlockNumber: async () => {
+        throw new Error("must not be called when pending=pinned");
+      },
+      getBlock: async () => {
+        throw new Error("must not be called when pending=pinned");
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      etherscanPendingNonceProbe: async () => SAMPLE_TX_FIELDS.nonce,
+    });
+    expect(result.status).toBe("no_broadcast");
+    if (result.status === "no_broadcast") {
+      expect(result.pendingNonce).toBe(SAMPLE_TX_FIELDS.nonce);
+      expect(result.etherscanPendingNonce).toBe(SAMPLE_TX_FIELDS.nonce);
+    }
+  });
+
+  it("when local says no_broadcast BUT etherscan reports pending > pinned → ambiguous_nonce_disagreement", async () => {
+    // Canonical issue #326 scenario: Ledger Live broadcast through its
+    // own RPC, Etherscan's mempool indexer saw it, our local node
+    // hasn't caught up yet. Retrying queues the duplicate-prompt.
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce,
+      getBlockNumber: async () => {
+        throw new Error("must not be called on disagreement (no walk needed)");
+      },
+      getBlock: async () => {
+        throw new Error("must not be called on disagreement");
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      etherscanPendingNonceProbe: async () => SAMPLE_TX_FIELDS.nonce + 1,
+    });
+    expect(result.status).toBe("ambiguous_nonce_disagreement");
+    if (result.status === "ambiguous_nonce_disagreement") {
+      expect(result.localPendingNonce).toBe(SAMPLE_TX_FIELDS.nonce);
+      expect(result.etherscanPendingNonce).toBe(SAMPLE_TX_FIELDS.nonce + 1);
+    }
+  });
+
+  it("when local says no_broadcast and etherscan probe THROWS → falls back to no_broadcast (no regression for users without API key)", async () => {
+    // Defense in depth — a failed cross-check (no API key, rate limit,
+    // network blip) must not turn a benign no_broadcast into a scary
+    // ambiguous error. Users without an Etherscan key get the
+    // pre-issue-326 single-source behavior unchanged.
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce,
+      getBlockNumber: async () => {
+        throw new Error("must not be called");
+      },
+      getBlock: async () => {
+        throw new Error("must not be called");
+      },
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      etherscanPendingNonceProbe: async () => {
+        throw new Error("ETHERSCAN_API_KEY is not set");
+      },
+    });
+    expect(result.status).toBe("no_broadcast");
+    if (result.status === "no_broadcast") {
+      expect(result.pendingNonce).toBe(SAMPLE_TX_FIELDS.nonce);
+      expect(result.etherscanPendingNonce).toBeUndefined();
+    }
+  });
+
+  it("when local says pending > pinned, the etherscan probe is NOT called (slot already consumed locally)", async () => {
+    // Optimization regression guard: when the local RPC already saw
+    // the slot consumed, the cross-check has no value — we proceed
+    // straight to the matched/consumed_unmatched walk.
+    const expectedHash = ("0xcee2a965b8e35a85dbce7b7389bc5ea2ffb1846c8abdaea676ee709d9d0f0165" as const);
+    const tx = eip1559TxOnBlock(SAMPLE_TX_FIELDS, { hash: expectedHash });
+    let etherscanCalls = 0;
+    const client = {
+      getTransactionCount: async () => SAMPLE_TX_FIELDS.nonce + 1,
+      getBlockNumber: async () => 24_961_480n,
+      getBlock: async () => ({ number: 24_961_480n, transactions: [tx] }),
+    };
+    const result = await probeForLateBroadcast({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      from: FROM,
+      pinnedNonce: SAMPLE_TX_FIELDS.nonce,
+      expectedPreSignHash: preSignHashOf(SAMPLE_TX_FIELDS),
+      chainId: CHAIN_ID,
+      etherscanPendingNonceProbe: async () => {
+        etherscanCalls++;
+        return SAMPLE_TX_FIELDS.nonce + 1;
+      },
+    });
+    expect(result.status).toBe("matched");
+    expect(etherscanCalls).toBe(0);
+  });
+});
+
+describe("noBroadcastConfirmedMessage — wording lock", () => {
+  it("tells the agent it's safe to retry the same handle (issue #232 baseline)", async () => {
     const msg = noBroadcastConfirmedMessage({
       from: FROM,
       pinnedNonce: 273,
@@ -242,7 +360,60 @@ describe("noBroadcastConfirmedMessage — issue #232 wording lock", () => {
     expect(msg).toContain("SAME handle");
     expect(msg).toContain(FROM);
     expect(msg).toContain("273");
-    expect(msg).toContain("Issue #232");
+    expect(msg).toContain("Issue");
+  });
+
+  it("issue #326: includes the duplicate-prompt warning the agent must relay to the user on retry", async () => {
+    // Even when retry IS safe (per the cross-check), the user should
+    // know that if the WC subapp had silently completed signing in
+    // the background, retrying CAN still queue a duplicate prompt.
+    // Reject the duplicate; original tx lands normally.
+    const msg = noBroadcastConfirmedMessage({
+      from: FROM,
+      pinnedNonce: 273,
+      chainId: 1,
+      timeoutSeconds: 120,
+    });
+    expect(msg).toMatch(/REJECT the duplicate prompt/i);
+    expect(msg).toMatch(/original tx will land normally/i);
+    expect(msg).toContain("#326");
+  });
+
+  it("when etherscan cross-check ran and agreed, surfaces the second-source value", async () => {
+    const msg = noBroadcastConfirmedMessage({
+      from: FROM,
+      pinnedNonce: 273,
+      chainId: 1,
+      timeoutSeconds: 120,
+      etherscanPendingNonce: 273,
+    });
+    expect(msg).toMatch(/Etherscan/);
+    expect(msg).toMatch(/two sources agree/i);
+  });
+});
+
+describe("ambiguousNonceDisagreementMessage — issue #326 wording lock", () => {
+  it("tells the agent NOT to retry and explains the duplicate-prompt risk", async () => {
+    const msg = ambiguousNonceDisagreementMessage({
+      from: FROM,
+      pinnedNonce: 278,
+      localPendingNonce: 278,
+      etherscanPendingNonce: 279,
+      chainId: 1,
+      timeoutSeconds: 120,
+    });
+    expect(msg).toMatch(/DO NOT retry/i);
+    expect(msg).toMatch(/duplicate signing prompt/i);
+    expect(msg).toMatch(/key-leak attack pattern/i);
+    expect(msg).toContain("278");
+    expect(msg).toContain("279");
+    expect(msg).toContain(FROM);
+    expect(msg).toContain("#326");
+    // The recovery guidance — block-explorer check + "if no tx with the
+    // pinned nonce, it's safe to re-prepare from scratch" — gives the
+    // user a concrete way out instead of leaving them stuck.
+    expect(msg).toMatch(/block explorer/i);
+    expect(msg).toMatch(/re-prepare/i);
   });
 });
 


### PR DESCRIPTION
Closes #326. Implements **P1, P2, P4** from the issue. P3 (handle \"ambiguous failure\" state + ack flag) intentionally deferred to a follow-up — it touches the EVM tx-store + send_transaction schema and is worth its own focused PR after P1 has been live for a release to confirm we got the prevention angle right.

## The incident this prevents

Live 2026-04-27 08:09–08:17 UTC. WalletConnect signing request timed out at 120s, our local-RPC nonce probe correctly reported \"no broadcast\" from its perspective, the agent retried — but Ledger Live HAD silently completed signing + relayed the tx through its own RPC. The retry queued a duplicate signing prompt to the device. **The user's first thought was \"is this a key-leak attack pattern?\"** The wallet UI behaved exactly like one (two prompts, same nonce). The mathematical reality (RFC-6979 deterministic k = no real attack surface) is correct but unhelpful in the moment.

## P1 — multi-source nonce cross-check before declaring \"no broadcast\"

\`probeForLateBroadcast\` now takes an optional \`etherscanPendingNonceProbe\`. When the local RPC reports \`pending <= pinned\` (would historically green-light a retry as \`no_broadcast\`), we ALSO ask Etherscan's mempool view via \`module=proxy&action=eth_getTransactionCount&tag=pending\`.

| Local | Etherscan | Outcome |
|---|---|---|
| pending ≤ pinned | pending ≤ pinned | \`no_broadcast\` (high-confidence safe to retry) |
| pending ≤ pinned | pending > pinned | **\`ambiguous_nonce_disagreement\`** — refuse retry, guide user to block explorer |
| pending ≤ pinned | probe threw (no API key, rate limit) | \`no_broadcast\` (legacy fallback, no regression for users without ETHERSCAN_API_KEY) |
| pending > pinned | (not called) | \`matched\` or \`consumed_unmatched\` (existing block walk) |

Users without an Etherscan key get pre-issue-326 behavior unchanged.

## P2 — \`safeErrorMessage\` helper

The legacy \`error instanceof Error ? error.message : String(error)\` pattern in src/index.ts's txHandler produced literal \`Error: [object Object]\` when the underlying SDK (WalletConnect, viem) threw an Error whose \`.message\` was itself a structured object — exactly what the agent reported on retry attempt #2 in the live incident.

New \`src/shared/error-message.ts\` walks the value, surfaces structured fields, skips \`stack\` (V8 trace noise often contains the literal \`[object Object]\` from the throw site), handles BigInt + circular refs.

## P4 — duplicate-prompt warning on retry guidance

Even the \"safe to retry\" path now includes a user-facing nudge: if WC silently completed signing in the background, retrying CAN queue a duplicate device prompt; the right action on that prompt is **REJECT** (not approve) — the original tx will land normally. The \`ambiguous_nonce_disagreement\` message is stronger still: explicit \"DO NOT retry\", the key-leak-pattern warning, and a concrete recovery path.

## Test plan

- [x] **4 new probe-cross-check cases** — no_broadcast with agreement; ambiguous on disagreement; fallback when probe throws; etherscan probe NOT called when local already saw consumption (optimization regression guard)
- [x] **2 new wording-lock cases** — duplicate-prompt warning in \`noBroadcastConfirmedMessage\`; \`ambiguousNonceDisagreementMessage\` contents (REJECT, key-leak pattern, block-explorer guidance, recovery path)
- [x] **8 new \`safeErrorMessage\` cases** — Error w/ string, Error w/ object, empty message, plain string, plain object, null/undefined, circular ref, BigInt fields, literal \`[object Object]\` recovery
- [x] **57 WC-adjacent tests pass cleanly in isolation** — \`safe-error-message.test.ts\`, \`wc-late-broadcast-probe.test.ts\`, \`walletconnect-send-liveness.test.ts\`, \`send-hash-pin.test.ts\`
- [x] Full-suite runs show flakes in unrelated areas (BTC gap-limit, integration-security, solana-setup-status — different files fail each run; test-ordering / mock-contamination, not us)

## Out of scope (deferred)

- **P3** — handle \"ambiguous failure\" state machine + \`acknowledgeRetryRiskAfterAmbiguousFailure\` flag on send_transaction. Worth its own focused PR after P1 has been live to confirm the prevention angle is sufficient.
- **Ledger Live de-duplication** — the duplicate \`wc_sessionRequest\` Ledger Live processes from its relay queue is upstream; file separately if it persists in next LL release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)