### PR TITLE
feat(btc): multi-sig initiator flow + unregister

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,9 +155,11 @@ import {
   prepareBitcoinNativeSend,
   prepareBitcoinRbfBump,
   registerBtcMultisigWallet,
+  unregisterBtcMultisigWallet,
   signBtcMultisigPsbt,
   combineBtcPsbts,
   finalizeBtcPsbt,
+  prepareBtcMultisigSend,
   getBtcMultisigBalance,
   getBtcMultisigUtxos,
   signBtcMessage,
@@ -244,9 +246,11 @@ import {
   prepareBitcoinNativeSendInput,
   prepareBitcoinRbfBumpInput,
   registerBitcoinMultisigWalletInput,
+  unregisterBitcoinMultisigWalletInput,
   signBitcoinMultisigPsbtInput,
   combineBitcoinPsbtsInput,
   finalizeBitcoinPsbtInput,
+  prepareBitcoinMultisigSendInput,
   getBitcoinMultisigBalanceInput,
   getBitcoinMultisigUtxosInput,
   signBtcMessageInput,
@@ -2589,6 +2593,51 @@ async function main() {
       inputSchema: getBitcoinMultisigUtxosInput.shape,
     },
     handler(getBtcMultisigUtxos, { toolName: "get_btc_multisig_utxos" })
+  );
+
+  registerTool(server,
+    "prepare_btc_multisig_send",
+    {
+      description:
+        "Initiator flow — build a tx FROM a registered multi-sig wallet, sign it " +
+        "with our Ledger key in the same call, return the partial PSBT for " +
+        "cosigners to sign. Pipeline: " +
+        "(1) fetch UTXOs across the wallet's gap-limit window, " +
+        "(2) coin-select with a multi-sig-aware vbyte estimator (P2WSH " +
+        "`sortedmulti(M,...,N)` inputs are ~2-4× P2WPKH), " +
+        "(3) resolve a fresh chain=1 change address (lowest unused index), " +
+        "(4) build PSBT v0 with witnessUtxo + nonWitnessUtxo (Ledger app 2.x " +
+        "requirement) + witnessScript + bip32_derivation for ALL cosigners, " +
+        "(5) sign with our Ledger via the existing co-signer flow (the device " +
+        "walks every output address + amount on-screen), " +
+        "(6) splice our signature into the PSBT, return the partial PSBT. " +
+        "We do NOT finalize or broadcast — the caller gathers remaining " +
+        "signatures externally, then runs `combine_btc_psbts` + " +
+        "`finalize_btc_psbt`. The fee-cap guard scales to multi-sig sizes " +
+        "automatically. Phase 3 supports `wsh` (P2WSH) wallets only; taproot " +
+        "lands in a follow-up PR.",
+      inputSchema: prepareBitcoinMultisigSendInput.shape,
+    },
+    handler(prepareBtcMultisigSend, { toolName: "prepare_btc_multisig_send" })
+  );
+
+  registerTool(server,
+    "unregister_btc_multisig_wallet",
+    {
+      description:
+        "Drop a registered multi-sig wallet from the local cache. The Ledger " +
+        "device retains the policy HMAC indefinitely (no on-device unregister " +
+        "API), so re-registering with the SAME descriptor + cosigners returns " +
+        "the same HMAC the device already has. This tool only forgets the " +
+        "local-disk entry — call it before re-registering with different " +
+        "cosigners under the same name, or to clean up wallets you no longer " +
+        "use. Idempotent: returns `removed: false` when the name isn't " +
+        "registered. No device touch.",
+      inputSchema: unregisterBitcoinMultisigWalletInput.shape,
+    },
+    handler(unregisterBtcMultisigWallet, {
+      toolName: "unregister_btc_multisig_wallet",
+    })
   );
 
   registerTool(server,

--- a/src/modules/btc/multisig.ts
+++ b/src/modules/btc/multisig.ts
@@ -11,12 +11,20 @@ import {
   openLedgerMultisig,
   type BtcMultisigAppClient,
   type BtcMultisigPartialSignature,
+  type BtcMultisigWalletPolicy,
 } from "../../signing/btc-multisig-usb-loader.js";
 import type {
   PairedBitcoinMultisigCosigner,
   PairedBitcoinMultisigWallet,
 } from "../../types/index.js";
 import { assertCanonicalLedgerApp } from "../../signing/canonical-apps.js";
+import { BTC_DECIMALS, SATS_PER_BTC } from "../../config/btc.js";
+import { getBitcoinIndexer, type BitcoinUtxo } from "./indexer.js";
+import { deriveMultisigAddress } from "./multisig-derive.js";
+import {
+  getMultisigUtxos,
+  type MultisigUtxo,
+} from "./multisig-balance.js";
 
 /**
  * Bitcoin multi-sig co-signer flow. Phase 2 PR2 of the BTC Ledger
@@ -50,33 +58,53 @@ import { assertCanonicalLedgerApp } from "../../signing/canonical-apps.js";
 // --- bitcoinjs-lib loader (CommonJS-only) ---------------------------------
 
 const requireCjs = createRequire(import.meta.url);
+interface PsbtInputDataShape {
+  witnessScript?: Buffer;
+  bip32Derivation?: Array<{
+    masterFingerprint: Buffer;
+    pubkey: Buffer;
+    path: string;
+  }>;
+  partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
+  witnessUtxo?: { script: Buffer; value: number };
+  nonWitnessUtxo?: Buffer;
+}
+
+interface PsbtInstance {
+  data: { inputs: PsbtInputDataShape[]; outputs: Array<unknown> };
+  txInputs: Array<{ hash: Buffer; index: number; sequence: number }>;
+  txOutputs: Array<{ address?: string; value: number }>;
+  addInput(input: {
+    hash: string | Buffer;
+    index: number;
+    sequence?: number;
+    witnessUtxo?: { script: Buffer; value: number };
+    witnessScript?: Buffer;
+    nonWitnessUtxo?: Buffer;
+    bip32Derivation?: Array<{
+      masterFingerprint: Buffer;
+      pubkey: Buffer;
+      path: string;
+    }>;
+  }): unknown;
+  addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
+  updateInput(
+    i: number,
+    update: { partialSig: Array<{ pubkey: Buffer; signature: Buffer }> },
+  ): unknown;
+  toBase64(): string;
+}
+
 const bitcoinjs = requireCjs("bitcoinjs-lib") as {
   Psbt: {
-    fromBase64(b64: string): {
-      data: {
-        inputs: Array<{
-          witnessScript?: Buffer;
-          bip32Derivation?: Array<{
-            masterFingerprint: Buffer;
-            pubkey: Buffer;
-            path: string;
-          }>;
-          partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
-          witnessUtxo?: { script: Buffer; value: number };
-          nonWitnessUtxo?: Buffer;
-        }>;
-        outputs: Array<unknown>;
-      };
-      txInputs: Array<{ hash: Buffer; index: number; sequence: number }>;
-      txOutputs: Array<{ address?: string; value: number }>;
-      updateInput(
-        i: number,
-        update: { partialSig: Array<{ pubkey: Buffer; signature: Buffer }> },
-      ): unknown;
-      toBase64(): string;
-    };
+    new (opts?: { network?: unknown }): PsbtInstance;
+    fromBase64(b64: string): PsbtInstance;
   };
+  address: { toOutputScript(addr: string, network?: unknown): Buffer };
+  networks: { bitcoin: unknown };
 };
+
+const NETWORK = bitcoinjs.networks.bitcoin;
 
 // --- Constants ------------------------------------------------------------
 
@@ -596,4 +624,440 @@ export async function signBitcoinMultisigPsbt(
     await transport.close().catch(() => {});
   }
   return result;
+}
+
+// --- unregister_btc_multisig_wallet --------------------------------------
+
+export interface UnregisterBitcoinMultisigWalletArgs {
+  walletName: string;
+}
+
+export interface UnregisterBitcoinMultisigWalletResult {
+  removed: boolean;
+  walletName: string;
+}
+
+/**
+ * Drop a registered wallet from the local cache. The Ledger device
+ * retains the policy HMAC indefinitely (no on-device unregister API),
+ * so re-registering with the same descriptor + cosigners returns the
+ * same HMAC the device already has — `register_btc_multisig_wallet` is
+ * idempotent for the device but re-creates the local cache entry.
+ */
+export function unregisterBitcoinMultisigWallet(
+  args: UnregisterBitcoinMultisigWalletArgs,
+): UnregisterBitcoinMultisigWalletResult {
+  ensureMultisigHydrated();
+  const removed = multisigByName.delete(args.walletName);
+  if (removed) persistMultisig();
+  return { removed, walletName: args.walletName };
+}
+
+// --- prepare_btc_multisig_send (initiator flow) --------------------------
+
+/**
+ * Helpers borrowed from src/modules/btc/actions.ts. Duplicated here
+ * rather than re-exported to avoid creating a dependency on the
+ * single-sig action module.
+ */
+function satsToBtcString(sats: bigint): string {
+  const negative = sats < 0n;
+  const abs = negative ? -sats : sats;
+  const whole = abs / SATS_PER_BTC;
+  const frac = abs - whole * SATS_PER_BTC;
+  const fracStr = frac.toString().padStart(8, "0").replace(/0+$/, "") || "0";
+  const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+  return negative ? `-${body}` : body;
+}
+
+function parseBtcAmountToSats(amount: string): bigint | null {
+  if (amount === "max") return null;
+  if (!/^\d+(\.\d{1,8})?$/.test(amount)) {
+    throw new Error(
+      `Invalid BTC amount "${amount}" — expected a decimal with up to 8 fractional ` +
+        `digits (e.g. "0.001", "0.5") or "max" for the full balance minus fees.`,
+    );
+  }
+  const [whole, frac = ""] = amount.split(".");
+  const padded = frac.padEnd(BTC_DECIMALS, "0");
+  return BigInt(whole) * SATS_PER_BTC + BigInt(padded);
+}
+
+/** Dust threshold (sats) — same constant as the RBF builder. */
+const DUST_THRESHOLD_SATS = 546;
+
+/**
+ * Per-input vbyte estimate for a P2WSH `sortedmulti(M, ..., N)` spend.
+ *
+ * Witness stack: empty (CHECKMULTISIG off-by-one) + M sigs (~73B each)
+ * + the witness script (3 + 34*N bytes for sortedmulti). Witness data
+ * counts at 1/4 weight; non-witness is the standard 41 bytes (outpoint
+ * + sequence + empty scriptSig).
+ *
+ * vsize ≈ ceil((4 * 41 + (1 + 1 + M*(73+1) + 1 + (3 + 34*N)) ) / 4)
+ *      ≈ 41 + ceil((6 + 74*M + 34*N) / 4)
+ *
+ * Conservative-tight: rounds slightly up so the fee-cap stays
+ * conservative even when actual sigs are 71-72 bytes (typical) instead
+ * of 73 (worst case).
+ */
+function p2wshMultisigInputVbytes(threshold: number, totalSigners: number): number {
+  return 41 + Math.ceil((6 + 74 * threshold + 34 * totalSigners) / 4);
+}
+
+/** P2WSH output vbytes: 8 value + 1 len + 34 script = 43 bytes. */
+const P2WSH_OUTPUT_VBYTES = 43;
+
+/** Mainnet recipient output: covers P2WPKH (31) / P2WSH (43) / P2TR (43). Conservative pick. */
+const STANDARD_OUTPUT_VBYTES = 43;
+
+/** Tx overhead: 4 version + 4 locktime + 1 input-count + 1 output-count + 2 segwit marker/flag (×0.25 weight). */
+const TX_OVERHEAD_VBYTES = 11;
+
+function estimateMultisigTxVbytes(
+  inputCount: number,
+  outputCount: number,
+  wallet: PairedBitcoinMultisigWallet,
+): number {
+  return (
+    TX_OVERHEAD_VBYTES +
+    inputCount * p2wshMultisigInputVbytes(wallet.threshold, wallet.totalSigners) +
+    outputCount * STANDARD_OUTPUT_VBYTES
+  );
+}
+
+/**
+ * Greedy largest-first coin selection over multi-sig UTXOs. Returns
+ * the selected inputs + computed fee + change value. Refuses with a
+ * clear "insufficient funds" error when no subset covers
+ * `amountSats + fee`.
+ *
+ * We do NOT use the `coinselect` library here because its vbyte
+ * estimator is hardcoded for P2WPKH (~68 vbytes per input) and
+ * underestimates multi-sig by 2-3×. A custom estimator is small enough
+ * that re-implementing accumulative selection is simpler than trying
+ * to convince `coinselect` of the right per-input weight.
+ */
+function selectMultisigInputs(
+  utxos: MultisigUtxo[],
+  wallet: PairedBitcoinMultisigWallet,
+  recipientAmountSats: bigint,
+  feeRateSatPerVb: number,
+  hasChange: boolean,
+): {
+  selected: MultisigUtxo[];
+  feeSats: bigint;
+  changeSats: bigint;
+  vsize: number;
+} {
+  // Largest-first to minimize input count.
+  const sorted = [...utxos].sort((a, b) => b.value - a.value);
+  let totalIn = 0n;
+  const selected: MultisigUtxo[] = [];
+  for (const u of sorted) {
+    selected.push(u);
+    totalIn += BigInt(u.value);
+    const outputCount = hasChange ? 2 : 1;
+    const vsize = estimateMultisigTxVbytes(
+      selected.length,
+      outputCount,
+      wallet,
+    );
+    const feeSats = BigInt(Math.ceil(feeRateSatPerVb * vsize));
+    const need = recipientAmountSats + feeSats;
+    if (totalIn >= need) {
+      const changeSats = totalIn - need;
+      // If we asked for change but it would be dust, retry without change
+      // (the dust value is then added to the fee).
+      if (hasChange && changeSats < BigInt(DUST_THRESHOLD_SATS)) {
+        const noChangeVsize = estimateMultisigTxVbytes(
+          selected.length,
+          1,
+          wallet,
+        );
+        const noChangeFee = BigInt(Math.ceil(feeRateSatPerVb * noChangeVsize));
+        if (totalIn >= recipientAmountSats + noChangeFee) {
+          return {
+            selected,
+            feeSats: totalIn - recipientAmountSats,
+            changeSats: 0n,
+            vsize: noChangeVsize,
+          };
+        }
+        // Couldn't even afford no-change layout — keep accumulating.
+        continue;
+      }
+      return {
+        selected,
+        feeSats,
+        changeSats: hasChange ? changeSats : 0n,
+        vsize,
+      };
+    }
+  }
+  throw new Error(
+    `Insufficient funds: total UTXO value across all walked addresses cannot cover ` +
+      `${recipientAmountSats} sats + estimated fee at ${feeRateSatPerVb} sat/vB. ` +
+      `Add funds to the wallet or wait for more confirmations.`,
+  );
+}
+
+/**
+ * Find the lowest chain=1 (change) addressIndex that has NO on-chain
+ * history. Used as the change destination for a new send. We re-derive
+ * locally and call `getBalance` for each — same gap-limit walk as the
+ * balance reader, just stopping at the first empty.
+ */
+async function findUnusedChangeIndex(
+  wallet: PairedBitcoinMultisigWallet,
+): Promise<{ address: string; addressIndex: number }> {
+  const indexer = getBitcoinIndexer();
+  // Hard cap: don't walk past 1000 indices. If you have 1000 used
+  // change addresses on a multi-sig wallet, something pathological is
+  // going on.
+  for (let i = 0; i < 1000; i++) {
+    const info = deriveMultisigAddress(wallet, 1, i);
+    const bal = await indexer.getBalance(info.address);
+    if (
+      bal.txCount === 0 &&
+      bal.confirmedSats === 0n &&
+      bal.mempoolSats === 0n
+    ) {
+      return { address: info.address, addressIndex: i };
+    }
+  }
+  throw new Error(
+    `Could not find an unused chain=1 (change) address within the first 1000 indices ` +
+      `of "${wallet.name}". The wallet's change-chain history is implausibly long.`,
+  );
+}
+
+export interface PrepareBitcoinMultisigSendArgs {
+  walletName: string;
+  to: string;
+  amount: string; // decimal-BTC string ("0.001") or "max"
+  feeRateSatPerVb?: number;
+  allowHighFee?: boolean;
+}
+
+export interface PrepareBitcoinMultisigSendResult {
+  /** PSBT carrying our Ledger signature on every input. Share with cosigners → combine → finalize. */
+  partialPsbtBase64: string;
+  /** Number of signatures we just added (typically `inputCount × 1`). */
+  signaturesAdded: number;
+  /** Min signatures present across inputs after our addition. */
+  signaturesPresent: number;
+  /** Threshold M from the policy. */
+  signaturesNeeded: number;
+  /** True iff our sig completed the threshold on every input. */
+  fullySigned: boolean;
+  walletName: string;
+  /** Resolved recipient address (post address-book / ENS). */
+  to: string;
+  /** Total recipient value, sats. */
+  recipientSats: string;
+  /** Total recipient value, decimal-BTC string for display. */
+  recipientBtc: string;
+  /** Computed absolute fee, sats. */
+  feeSats: string;
+  /** Same fee as decimal-BTC string. */
+  feeBtc: string;
+  /** Fee rate used (sat/vB). */
+  feeRateSatPerVb: number;
+  /** Estimated tx vsize (vbytes). */
+  vsize: number;
+  /** Change address selected (chain=1, unused). Undefined when there's no change output. */
+  changeAddress?: string;
+  /** Change value (sats). 0 when there's no change output (dust-absorbed by fee). */
+  changeSats: string;
+  /** Rendered description for the verification block. */
+  description: string;
+}
+
+export async function prepareBitcoinMultisigSend(
+  args: PrepareBitcoinMultisigSendArgs,
+): Promise<PrepareBitcoinMultisigSendResult> {
+  // 1. Look up registered wallet.
+  const wallet = getPairedMultisigByName(args.walletName);
+  if (!wallet) {
+    const available = Array.from(multisigByName.keys());
+    throw new Error(
+      `No multi-sig wallet registered under name "${args.walletName}". ` +
+        (available.length > 0
+          ? `Registered: ${available.join(", ")}.`
+          : `Call \`register_btc_multisig_wallet\` first.`),
+    );
+  }
+  if (wallet.scriptType !== "wsh") {
+    throw new Error(
+      `prepare_btc_multisig_send: scriptType "${wallet.scriptType}" not supported in this ` +
+        `release — taproot lands in a follow-up PR.`,
+    );
+  }
+
+  // 2. Resolve recipient (address-book + ENS shim).
+  const { resolveRecipient } = await import("../../contacts/resolver.js");
+  const resolved = await resolveRecipient(args.to, "bitcoin");
+  const resolvedTo = resolved.address;
+
+  // 3. Resolve fee rate (default to indexer's halfHourFee, ~3-block target).
+  const indexer = getBitcoinIndexer();
+  let feeRate: number;
+  if (args.feeRateSatPerVb !== undefined) {
+    feeRate = args.feeRateSatPerVb;
+  } else {
+    const fees = await indexer.getFeeEstimates();
+    feeRate = fees.halfHourFee;
+  }
+  if (!Number.isFinite(feeRate) || feeRate <= 0 || feeRate > 10_000) {
+    throw new Error(
+      `Resolved fee rate ${feeRate} sat/vB is invalid (expected positive ≤ 10000).`,
+    );
+  }
+
+  // 4. Fetch UTXOs across the multi-sig wallet's gap-limit window.
+  const { utxos } = await getMultisigUtxos({ walletName: args.walletName });
+  if (utxos.length === 0) {
+    throw new Error(
+      `No UTXOs found in "${args.walletName}". Verify with \`get_btc_multisig_balance\` ` +
+        `and confirm at least one tx has confirmed.`,
+    );
+  }
+
+  // 5. Resolve "max" → fee-aware amount, else parse decimal-BTC → sats.
+  let amountSats: bigint;
+  if (args.amount === "max") {
+    const totalUtxoValue = utxos.reduce((sum, u) => sum + BigInt(u.value), 0n);
+    const maxVsize = estimateMultisigTxVbytes(utxos.length, 1, wallet);
+    const maxFee = BigInt(Math.ceil(feeRate * maxVsize));
+    if (totalUtxoValue <= maxFee) {
+      throw new Error(
+        `Cannot "max": total UTXO value ${satsToBtcString(totalUtxoValue)} BTC is at or ` +
+          `below the estimated fee ${satsToBtcString(maxFee)} BTC at ${feeRate} sat/vB. ` +
+          `Lower the feeRate or wait for more confirmations.`,
+      );
+    }
+    amountSats = totalUtxoValue - maxFee;
+  } else {
+    const parsed = parseBtcAmountToSats(args.amount);
+    if (parsed === null) {
+      throw new Error(`Internal: parseBtcAmountToSats null for ${args.amount}`);
+    }
+    amountSats = parsed;
+  }
+  if (amountSats <= 0n) {
+    throw new Error(`Resolved amount ${amountSats} sats is not positive.`);
+  }
+
+  // 6. Resolve unused change address (chain=1).
+  const change = await findUnusedChangeIndex(wallet);
+
+  // 7. Coin-select.
+  const isMax = args.amount === "max";
+  const selection = selectMultisigInputs(
+    utxos,
+    wallet,
+    amountSats,
+    feeRate,
+    !isMax, // "max" sweeps everything → no change.
+  );
+
+  // 8. Fee-cap guard — same shape as `selectInputs`'s cap.
+  if (!args.allowHighFee) {
+    const vbyteCap = Math.ceil(feeRate * 10 * selection.vsize);
+    const percentCap = Math.ceil(Number(amountSats) * 0.02);
+    const cap = Math.max(vbyteCap, percentCap);
+    if (selection.feeSats > BigInt(cap)) {
+      throw new Error(
+        `Fee ${selection.feeSats} sats exceeds safety cap ${cap} sats ` +
+          `(max of 10× feeRate-based ${vbyteCap} and 2%-of-output ${percentCap}). ` +
+          `If intentional (priority send through congestion), retry with allowHighFee: true.`,
+      );
+    }
+  }
+
+  // 9. Fetch prev-tx hex for every UNIQUE input txid (Ledger app 2.x
+  //    requirement — issue #213).
+  const uniqueTxids = [...new Set(selection.selected.map((u) => u.txid))];
+  const prevTxHexEntries = await Promise.all(
+    uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
+  );
+  const prevTxHexByTxid = new Map(prevTxHexEntries);
+
+  // 10. Build PSBT. Each input carries witnessUtxo + nonWitnessUtxo +
+  //     witnessScript + bip32_derivation for ALL cosigners (so each
+  //     cosigner's wallet can find its own derivation path on signing).
+  const psbt = new bitcoinjs.Psbt({ network: NETWORK });
+  for (const utxo of selection.selected) {
+    const prevTxHex = prevTxHexByTxid.get(utxo.txid);
+    if (!prevTxHex) {
+      throw new Error(
+        `Internal: prev-tx hex missing for ${utxo.txid} after fan-out fetch.`,
+      );
+    }
+    const bip32Derivation = wallet.cosigners.map((c, idx) => ({
+      masterFingerprint: Buffer.from(c.masterFingerprint, "hex"),
+      pubkey: utxo.cosignerPubkeys[idx],
+      // Full path including the leaf — the Ledger app requires the
+      // leading `m/` and the per-cosigner derivationPath, then the
+      // /<chain>/<index> tail at this UTXO's leaf.
+      path: `m/${c.derivationPath}/${utxo.chain}/${utxo.addressIndex}`,
+    }));
+    psbt.addInput({
+      hash: utxo.txid,
+      index: utxo.vout,
+      sequence: 0xfffffffd, // RBF-eligible.
+      witnessUtxo: { script: utxo.scriptPubKey, value: utxo.value },
+      nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
+      witnessScript: utxo.witnessScript,
+      bip32Derivation,
+    });
+  }
+  // Recipient output.
+  psbt.addOutput({
+    script: bitcoinjs.address.toOutputScript(resolvedTo, NETWORK),
+    value: Number(amountSats),
+  });
+  // Change output (when present).
+  if (selection.changeSats > 0n) {
+    psbt.addOutput({
+      script: bitcoinjs.address.toOutputScript(change.address, NETWORK),
+      value: Number(selection.changeSats),
+    });
+  }
+  const psbtBase64 = psbt.toBase64();
+
+  // 11. Sign with our Ledger via the existing co-signer flow. This
+  //     does the device touch + splice in one place.
+  const signed = await signBitcoinMultisigPsbt({
+    walletName: args.walletName,
+    psbtBase64,
+  });
+
+  const recipientDisplay = resolved.label
+    ? `${resolved.label} (${resolvedTo})`
+    : resolvedTo;
+  const description =
+    `Multi-sig send from "${args.walletName}" (${wallet.threshold}-of-${wallet.totalSigners} ` +
+    `${wallet.scriptType}): ${satsToBtcString(amountSats)} BTC → ${recipientDisplay}. ` +
+    `Our signature added: ${signed.signaturesPresent}/${signed.signaturesNeeded} present.`;
+
+  return {
+    partialPsbtBase64: signed.partialPsbtBase64,
+    signaturesAdded: signed.signaturesAdded,
+    signaturesPresent: signed.signaturesPresent,
+    signaturesNeeded: signed.signaturesNeeded,
+    fullySigned: signed.fullySigned,
+    walletName: args.walletName,
+    to: resolvedTo,
+    recipientSats: amountSats.toString(),
+    recipientBtc: satsToBtcString(amountSats),
+    feeSats: selection.feeSats.toString(),
+    feeBtc: satsToBtcString(selection.feeSats),
+    feeRateSatPerVb: feeRate,
+    vsize: selection.vsize,
+    ...(selection.changeSats > 0n ? { changeAddress: change.address } : {}),
+    changeSats: selection.changeSats.toString(),
+    description,
+  };
 }

--- a/src/modules/btc/multisig.ts
+++ b/src/modules/btc/multisig.ts
@@ -53,6 +53,7 @@ import {
  * Phase 2 scope: P2WSH (`wsh(sortedmulti(...))`) only. Taproot multi-sig
  * (`tr(multi_a(...))`) and `sh(wsh(...))` wrapped multi-sig are
  * deferred — small audience, distinct script types.
+ * bump
  */
 
 // --- bitcoinjs-lib loader (CommonJS-only) ---------------------------------

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -178,6 +178,8 @@ import type {
   FinalizeBitcoinPsbtArgs,
   GetBitcoinMultisigBalanceArgs,
   GetBitcoinMultisigUtxosArgs,
+  PrepareBitcoinMultisigSendArgs,
+  UnregisterBitcoinMultisigWalletArgs,
   SignBtcMessageArgs,
   PairLedgerLitecoinArgs,
   GetLitecoinBalanceArgs,
@@ -1298,6 +1300,32 @@ export async function getBtcMultisigUtxos(args: GetBitcoinMultisigUtxosArgs) {
     walletName: args.walletName,
     ...(args.gapLimit !== undefined ? { gapLimit: args.gapLimit } : {}),
   });
+}
+
+export async function prepareBtcMultisigSend(
+  args: PrepareBitcoinMultisigSendArgs,
+) {
+  const { prepareBitcoinMultisigSend } = await import("../btc/multisig.js");
+  return prepareBitcoinMultisigSend({
+    walletName: args.walletName,
+    to: args.to,
+    amount: args.amount,
+    ...(args.feeRateSatPerVb !== undefined
+      ? { feeRateSatPerVb: args.feeRateSatPerVb }
+      : {}),
+    ...(args.allowHighFee !== undefined
+      ? { allowHighFee: args.allowHighFee }
+      : {}),
+  });
+}
+
+export async function unregisterBtcMultisigWallet(
+  args: UnregisterBitcoinMultisigWalletArgs,
+) {
+  const { unregisterBitcoinMultisigWallet } = await import(
+    "../btc/multisig.js"
+  );
+  return unregisterBitcoinMultisigWallet({ walletName: args.walletName });
 }
 
 /**

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1454,6 +1454,60 @@ export const finalizeBitcoinPsbtInput = z.object({
     ),
 });
 
+export const prepareBitcoinMultisigSendInput = z.object({
+  walletName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe(
+      "Name of a registered multi-sig wallet (matches `register_btc_multisig_wallet`)."
+    ),
+  to: bitcoinAddressSchema.describe(
+    "Recipient address. Any of the four mainnet types is accepted as a destination."
+  ),
+  amount: z
+    .string()
+    .max(50)
+    .regex(/^(max|\d+(\.\d{1,8})?)$/)
+    .describe(
+      'Decimal BTC string (up to 8 fractional digits, e.g. "0.001") or "max" to ' +
+        "sweep every UTXO across the wallet's gap-limit window. \"max\" picks the " +
+        "fee-aware amount after coin-selection so the user doesn't have to subtract " +
+        "fees by hand."
+    ),
+  feeRateSatPerVb: z
+    .number()
+    .positive()
+    .max(10000)
+    .optional()
+    .describe(
+      "Fee rate in sat/vB. Optional — defaults to mempool.space's `halfHourFee` " +
+        "(~3-block target). Multi-sig txs are inherently larger than P2WPKH, so the " +
+        "absolute fee at the same sat/vB will be ~2-4× a single-sig send."
+    ),
+  allowHighFee: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override the fee-cap guard. The cap is `max(10 × feeRate × vbytes, 2% of " +
+        "recipient value)` and uses the multi-sig vsize estimator."
+    ),
+});
+
+export const unregisterBitcoinMultisigWalletInput = z.object({
+  walletName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe(
+      "Name of the wallet to drop from the local cache. Idempotent — succeeds with " +
+        "`removed: false` when the name isn't registered. The Ledger device retains " +
+        "the policy HMAC indefinitely (no on-device unregister API), so re-registering " +
+        "the same descriptor returns the same HMAC; this tool only forgets the local " +
+        "entry."
+    ),
+});
+
 export const getBitcoinMultisigBalanceInput = z.object({
   walletName: z
     .string()
@@ -1551,6 +1605,10 @@ export type CombineBitcoinPsbtsArgs = z.infer<typeof combineBitcoinPsbtsInput>;
 export type FinalizeBitcoinPsbtArgs = z.infer<typeof finalizeBitcoinPsbtInput>;
 export type GetBitcoinMultisigBalanceArgs = z.infer<typeof getBitcoinMultisigBalanceInput>;
 export type GetBitcoinMultisigUtxosArgs = z.infer<typeof getBitcoinMultisigUtxosInput>;
+export type PrepareBitcoinMultisigSendArgs = z.infer<typeof prepareBitcoinMultisigSendInput>;
+export type UnregisterBitcoinMultisigWalletArgs = z.infer<
+  typeof unregisterBitcoinMultisigWalletInput
+>;
 export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;

--- a/test/btc-multisig-initiator.test.ts
+++ b/test/btc-multisig-initiator.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+import type { PairedBitcoinMultisigWallet } from "../src/types/index.js";
+
+/**
+ * PR3 — `prepare_btc_multisig_send` (initiator flow) +
+ * `unregister_btc_multisig_wallet`. Mocks the indexer + multi-sig USB
+ * loader; uses real bitcoinjs-lib + @scure/bip32 for crypto.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          witnessScript?: Buffer;
+          witnessUtxo?: { script: Buffer; value: number };
+          nonWitnessUtxo?: Buffer;
+          bip32Derivation?: Array<unknown>;
+          partialSig?: Array<unknown>;
+        }>;
+      };
+      txInputs: Array<{ sequence: number }>;
+      txOutputs: Array<{ address?: string; value: number }>;
+    };
+  };
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  address: { toOutputScript(addr: string, network?: unknown): Buffer };
+  networks: { bitcoin: unknown };
+};
+
+// --- Mocks --------------------------------------------------------------
+
+const getBalanceMock = vi.fn();
+const getUtxosMock = vi.fn();
+const getFeeEstimatesMock = vi.fn();
+const getTxHexMock = vi.fn();
+const getTxMock = vi.fn();
+const getTxStatusMock = vi.fn();
+const broadcastTxMock = vi.fn();
+
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getBalance: getBalanceMock,
+    getUtxos: getUtxosMock,
+    getFeeEstimates: getFeeEstimatesMock,
+    getTxHex: getTxHexMock,
+    getTx: getTxMock,
+    getTxStatus: getTxStatusMock,
+    broadcastTx: broadcastTxMock,
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+const getAppAndVersionMock = vi.fn();
+const getMasterFingerprintMock = vi.fn();
+const getExtendedPubkeyMock = vi.fn();
+const registerWalletMock = vi.fn();
+const signPsbtMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+
+vi.mock("../src/signing/btc-multisig-usb-loader.js", () => ({
+  openLedgerMultisig: async () => ({
+    app: {
+      getAppAndVersion: getAppAndVersionMock,
+      getMasterFingerprint: getMasterFingerprintMock,
+      getExtendedPubkey: getExtendedPubkeyMock,
+      registerWallet: registerWalletMock,
+      signPsbt: signPsbtMock,
+    },
+    transport: { close: transportCloseMock },
+  }),
+  buildWalletPolicy: (name: string, descriptorTemplate: string, keys: readonly string[]) => ({
+    name,
+    descriptorTemplate,
+    keys,
+    getId: () => Buffer.alloc(32),
+    serialize: () => Buffer.alloc(0),
+  }),
+}));
+
+// --- Helpers ------------------------------------------------------------
+
+function deriveCosigner(seed: string) {
+  const seedBuf = Buffer.alloc(64);
+  Buffer.from(seed.padEnd(64, "x")).copy(seedBuf);
+  const master = HDKey.fromMasterSeed(seedBuf);
+  const account = master.derive("m/48'/0'/0'/2'");
+  const fp = master.fingerprint;
+  const masterFingerprint = Buffer.alloc(4);
+  masterFingerprint.writeUInt32BE(fp, 0);
+  return {
+    xpub: account.publicExtendedKey,
+    masterFingerprint: masterFingerprint.toString("hex"),
+    accountKey: account,
+  };
+}
+
+function makeWallet(
+  cosigners: Array<ReturnType<typeof deriveCosigner>>,
+): PairedBitcoinMultisigWallet {
+  return {
+    name: "Vault",
+    threshold: 2,
+    totalSigners: cosigners.length,
+    scriptType: "wsh",
+    descriptor: `wsh(sortedmulti(2,${cosigners.map((_, i) => `@${i}/**`).join(",")}))`,
+    cosigners: cosigners.map((c, i) => ({
+      xpub: c.xpub,
+      masterFingerprint: c.masterFingerprint,
+      derivationPath: "48'/0'/0'/2'",
+      isOurs: i === 0,
+    })),
+    policyHmac: "00".repeat(32),
+    appVersion: "2.4.6",
+  };
+}
+
+/**
+ * Build a minimal mainnet prev-tx hex that pays `value` sats to an
+ * arbitrary scriptPubKey at vout 0. Same shape the Phase 1 send tests
+ * use — we don't validate this prev-tx anywhere; it just needs to be
+ * parseable by bitcoinjs.
+ */
+function buildPrevTxHex(value: number, scriptPubKey: Buffer): string {
+  const tx = new bitcoinjs.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  tx.addOutput(scriptPubKey, value);
+  return tx.toHex();
+}
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-multisig-init-"));
+  setConfigDirForTesting(tmpHome);
+  getBalanceMock.mockReset();
+  getUtxosMock.mockReset();
+  getFeeEstimatesMock.mockReset();
+  getTxHexMock.mockReset();
+  getTxMock.mockReset();
+  getTxStatusMock.mockReset();
+  broadcastTxMock.mockReset();
+  getAppAndVersionMock.mockReset();
+  getMasterFingerprintMock.mockReset();
+  getExtendedPubkeyMock.mockReset();
+  registerWalletMock.mockReset();
+  signPsbtMock.mockReset();
+  transportCloseMock.mockClear();
+  const { __clearMultisigStore } = await import("../src/modules/btc/multisig.js");
+  __clearMultisigStore();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("unregisterBitcoinMultisigWallet", () => {
+  it("removes a registered wallet from the cache", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+    const { unregisterBitcoinMultisigWallet, getPairedMultisigByName } =
+      await import("../src/modules/btc/multisig.js");
+    expect(getPairedMultisigByName("Vault")).not.toBeNull();
+    const result = unregisterBitcoinMultisigWallet({ walletName: "Vault" });
+    expect(result.removed).toBe(true);
+    expect(getPairedMultisigByName("Vault")).toBeNull();
+  });
+
+  it("idempotent: returns removed: false on unknown name", async () => {
+    const { unregisterBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = unregisterBitcoinMultisigWallet({ walletName: "Nonexistent" });
+    expect(result.removed).toBe(false);
+  });
+});
+
+describe("prepareBitcoinMultisigSend", () => {
+  async function setupVaultWithUtxo(amountSats: number) {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+
+    // Derive the chain=0 / index=0 multi-sig address so we know what
+    // to fund.
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const fundedAddr = deriveMultisigAddress(wallet, 0, 0);
+    // chain=0/index=0 has UTXOs; everything else empty.
+    getBalanceMock.mockImplementation(async (addr: string) => {
+      if (addr === fundedAddr.address) {
+        return {
+          address: addr,
+          confirmedSats: BigInt(amountSats),
+          mempoolSats: 0n,
+          totalSats: BigInt(amountSats),
+          txCount: 1,
+        };
+      }
+      return {
+        address: addr,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 0,
+      };
+    });
+    getUtxosMock.mockImplementation(async (addr: string) =>
+      addr === fundedAddr.address
+        ? [
+            {
+              txid: "ab".repeat(32),
+              vout: 0,
+              value: amountSats,
+              unconfirmed: false,
+            },
+          ]
+        : [],
+    );
+    getFeeEstimatesMock.mockResolvedValue({
+      fastestFee: 20,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+    getTxHexMock.mockImplementation(async (txid: string) => {
+      if (txid === "ab".repeat(32)) {
+        return buildPrevTxHex(amountSats, fundedAddr.scriptPubKey);
+      }
+      throw new Error(`unexpected getTxHex(${txid})`);
+    });
+    return { wallet, cosigners: [a, b, c], fundedAddr };
+  }
+
+  it("builds + signs a multi-sig send, returns partial PSBT with our sig", async () => {
+    const { wallet, cosigners } = await setupVaultWithUtxo(100_000_000); // 1 BTC
+    const a = cosigners[0];
+
+    // sign_btc_multisig_psbt path: device confirms app, fingerprint,
+    // returns one partial sig.
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    // Derive the per-input child pubkey we'd produce at chain=0/idx=0.
+    const childA = a.accountKey.derive("m/0/0");
+    const ourPubkey = Buffer.from(childA.publicKey!);
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: ourPubkey,
+          signature: Buffer.from([
+            0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01,
+          ]),
+        },
+      ],
+    ]);
+
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await prepareBitcoinMultisigSend({
+      walletName: "Vault",
+      to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+      amount: "0.001",
+      feeRateSatPerVb: 10,
+    });
+    expect(result.signaturesAdded).toBe(1);
+    expect(result.signaturesPresent).toBe(1);
+    expect(result.signaturesNeeded).toBe(2);
+    expect(result.fullySigned).toBe(false);
+    expect(result.walletName).toBe("Vault");
+    expect(result.feeRateSatPerVb).toBe(10);
+    expect(Number(result.feeSats)).toBeGreaterThan(0);
+    expect(result.changeAddress).toBeDefined();
+
+    // The returned PSBT carries our partial sig + bip32_derivation
+    // for ALL cosigners on every input.
+    const psbt = bitcoinjs.Psbt.fromBase64(result.partialPsbtBase64);
+    expect(psbt.data.inputs[0].witnessScript).toBeDefined();
+    expect(psbt.data.inputs[0].nonWitnessUtxo).toBeDefined();
+    expect(psbt.data.inputs[0].bip32Derivation?.length).toBe(3);
+    expect(psbt.data.inputs[0].partialSig?.length).toBe(1);
+    // Sequence is RBF-eligible.
+    expect(psbt.txInputs[0].sequence).toBe(0xfffffffd);
+    // Two outputs: recipient + change (~1 BTC - 0.001 BTC - fee).
+    expect(psbt.txOutputs.length).toBe(2);
+    expect(psbt.txOutputs[0].value).toBe(100_000); // 0.001 BTC
+  });
+
+  it("refuses unknown wallet name", async () => {
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      prepareBitcoinMultisigSend({
+        walletName: "Nonexistent",
+        to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+        amount: "0.001",
+      }),
+    ).rejects.toThrow(/No multi-sig wallet registered/);
+  });
+
+  it("refuses when the wallet has zero UTXOs", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+    getBalanceMock.mockResolvedValue({
+      address: "",
+      confirmedSats: 0n,
+      mempoolSats: 0n,
+      totalSats: 0n,
+      txCount: 0,
+    });
+    getUtxosMock.mockResolvedValue([]);
+    getFeeEstimatesMock.mockResolvedValue({
+      fastestFee: 20,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      prepareBitcoinMultisigSend({
+        walletName: "Vault",
+        to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+        amount: "0.001",
+      }),
+    ).rejects.toThrow(/No UTXOs found/);
+  });
+
+  it("refuses insufficient funds", async () => {
+    await setupVaultWithUtxo(1_000); // 1000 sats — way too small for any reasonable send
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      prepareBitcoinMultisigSend({
+        walletName: "Vault",
+        to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+        amount: "0.01", // 1M sats > 1k
+        feeRateSatPerVb: 10,
+      }),
+    ).rejects.toThrow(/Insufficient funds/);
+  });
+
+  it("supports 'max' to sweep every UTXO without change", async () => {
+    const { wallet, cosigners } = await setupVaultWithUtxo(100_000_000);
+    const a = cosigners[0];
+
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    const childA = a.accountKey.derive("m/0/0");
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: Buffer.from(childA.publicKey!),
+          signature: Buffer.from([
+            0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01,
+          ]),
+        },
+      ],
+    ]);
+
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await prepareBitcoinMultisigSend({
+      walletName: "Vault",
+      to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+      amount: "max",
+      feeRateSatPerVb: 10,
+    });
+    // No change → only one output.
+    const psbt = bitcoinjs.Psbt.fromBase64(result.partialPsbtBase64);
+    expect(psbt.txOutputs.length).toBe(1);
+    expect(result.changeAddress).toBeUndefined();
+    expect(result.changeSats).toBe("0");
+    // Recipient gets balance - fee.
+    expect(Number(psbt.txOutputs[0].value)).toBe(100_000_000 - Number(result.feeSats));
+    void wallet;
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 PR3 — **stacked on #331 (PR2 — watch-only balances)**. Initiator flow for spending FROM a registered multi-sig wallet, plus a local-cache `unregister_btc_multisig_wallet` tool.

Two new tools:
- **`prepare_btc_multisig_send({ walletName, to, amount, feeRateSatPerVb?, allowHighFee? })`** — fetches UTXOs (via PR2's `getMultisigUtxos`), runs multi-sig coin-selection with a script-type-aware vbyte estimator, resolves a fresh chain=1 change address, builds a PSBT v0 with `witnessUtxo` + `nonWitnessUtxo` + `witnessScript` + `bip32_derivation` for ALL cosigners, signs with our Ledger via the existing co-signer flow, returns the partial PSBT for the user to share with cosigners.
- **`unregister_btc_multisig_wallet({ walletName })`** — drops the local-cache entry. Idempotent. The Ledger device retains the policy HMAC indefinitely (no on-device unregister API), so re-registering with the same descriptor returns the same HMAC; this tool only forgets the local entry.

## Notable implementation choices

- **Custom coin-selection over `coinselect` library**: P2WSH `sortedmulti(M, ..., N)` inputs are ~2-4× P2WPKH in vbytes. The bundled `coinselect` lib has a hardcoded P2WPKH estimator and would underestimate fees by 2-3×. A 30-line greedy largest-first accumulator + a multi-sig-aware vbyte formula is simpler than wedging the right per-input weight into `coinselect`.
- **No `UnsignedBitcoinTx` envelope / no `send_transaction` dispatch**: this flow returns the partial PSBT directly. The user's next step is `combine_btc_psbts` + `finalize_btc_psbt` (PR1 tools, #329) once the remaining cosigners sign — we don't need the existing send_transaction broadcast path.
- **Vbyte estimator** lives in `multisig.ts` (a few small helpers); takes `(threshold, totalSigners)` so PR4 can reuse the same shape for taproot script-path inputs (Schnorr sigs are 64 bytes vs 73 for ECDSA-DER, slightly cheaper).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-multisig-initiator.test.ts` — 7/7 passing (build + sign happy path, unknown wallet refusal, zero-UTXO refusal, insufficient funds, "max" sweep, unregister happy path, unregister idempotent)
- [x] Full suite: 1600/1600 passing
- [ ] Live smoke: 2-of-3 P2WSH wallet with on-chain history, prepare a send, sign on Ledger, share PSBT with cosigner-2 (Sparrow), combine + finalize + broadcast

Plan: [`claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md). **Stacked on #331** — review #331 first; this PR's diff is only the initiator flow + unregister.

🤖 Generated with [Claude Code](https://claude.com/claude-code)