### PR TITLE
fix(release): static-import oracle-poller so pkg binary boots (closes #330)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,42 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  binary-smoke-test:
+    # Build the linux-x64 binary the same way `release-binaries.yml` does
+    # and run the cross-OS smoke test against it. Catches startup-time
+    # regressions that only surface inside a pkg-bundled snapshot — e.g.
+    # `await import()` calls in the boot path tripping
+    # ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING (issue #330). Linux only on
+    # PRs; the macOS / Windows targets keep building on the release event,
+    # where pkg cross-compile cost is acceptable. Linux catches the common
+    # class because pkg's snapshot host is the same across targets — the
+    # dynamic-import bug shows up identically on every OS.
+    name: Binary smoke test (linux-x64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build dist/
+        run: npm run build
+
+      - name: Bundle server binary
+        run: npx pkg . --target node22-linux-x64 --output release/vaultpilot-mcp-linux-x64-server
+        env:
+          CI: "true"
+
+      - name: Mark server binary executable
+        run: chmod +x ./release/vaultpilot-mcp-linux-x64-server
+
+      - name: Smoke-test server binary
+        run: node scripts/smoke-test-binary.mjs ./release/vaultpilot-mcp-linux-x64-server

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,6 +339,7 @@ import {
 import { getCompoundMarketInfo } from "./modules/compound/market-info.js";
 import { getMarketIncidentStatus } from "./modules/incidents/index.js";
 import { getMarketIncidentStatusInput } from "./modules/incidents/schemas.js";
+import { startOraclePoller } from "./modules/incidents/oracle-poller.js";
 import {
   buildCompoundSupply,
   buildCompoundWithdraw,
@@ -3471,9 +3472,12 @@ async function main() {
   // call here even if a future code path also invokes it. The
   // setInterval is unref'd so it doesn't keep the process alive
   // beyond the stdio transport's lifecycle.
-  const { startOraclePoller } = await import(
-    "./modules/incidents/oracle-poller.js"
-  );
+  //
+  // Imported statically (not via `await import()`) because @yao-pkg/pkg
+  // bundles the binary into a single snapshot whose host VM does not wire
+  // a dynamic-import callback — any `import()` at startup throws
+  // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING and the binary exits before
+  // serving its first JSON-RPC. See issue #330.
   startOraclePoller();
 
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- The v0.9.3 bundled binaries fail at startup with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` because `src/index.ts:main()` used `await import("./modules/incidents/oracle-poller.js")`. @yao-pkg/pkg's single-file snapshot does not wire a dynamic-import callback, so any `import()` at module-load time throws synchronously and the process exits before MCP can serve its first request.
- The smoke test in `release-binaries.yml` correctly refused to upload the broken binaries, but `install.sh` (uploaded by an independent job with no `needs:`) still landed in the release. Result: the latest-release URL points at install scripts that 404 on every platform.
- This PR converts the dynamic import to a static one and adds a `binary-smoke-test` CI job that catches this class of regression at PR time rather than release time.

## Root cause

From the v0.9.3 release-binaries job log (linux):

```
[vaultpilot-mcp] fatal: TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.
    at importModuleDynamicallyCallback (node:internal/modules/esm/utils:273:9)
    at main (/snapshot/vaultpilot-mcp/dist/index.js)
binary exited before tools/list response (code=1 signal=null)
```

Introduced by [PR #270](https://github.com/szhygulin/vaultpilot-mcp/pull/270) (oracle-price-anomaly poller, 2026-04-26). Affects v0.9.1 and v0.9.3 — all platforms.

## Test plan

- [x] `npm run build` clean.
- [x] `npx pkg . --target node22-linux-x64 --output release/test-server` builds without warnings.
- [x] `node scripts/smoke-test-binary.mjs ./release/test-server` against the locally-built binary returns `tools: 153` (was failing with `binary exited before tools/list response (code=1 signal=null)` on v0.9.3).
- [x] `npm test` passes (1630/1630).
- [ ] After merge: re-run `release-binaries` for v0.9.3 (or cut v0.9.4) so the latest-release install URLs resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)