### PR TITLE
feat(send_transaction): ambiguous-retry ack gate for EVM (closes #326 P3)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -7,12 +7,17 @@ import {
   initiatePairing,
   requestSendTransaction,
   getConnectedAccounts,
+  WalletConnectRequestTimeoutError,
 } from "../../signing/walletconnect.js";
 import {
   consumeHandle,
   retireHandle,
   attachPinnedGas,
   getPinnedGas,
+  markAmbiguousAttempt,
+  getAmbiguousAttempt,
+  clearAmbiguousAttempt,
+  type AmbiguousAttempt,
   type StashedPin,
 } from "../../signing/tx-store.js";
 import { consumeTronHandle, retireTronHandle } from "../../signing/tron-tx-store.js";
@@ -2814,6 +2819,79 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
  * failure (no WC relay roundtrip, no eth_call, no chain-id check that would
  * meaninglessly fire before we even know what chain we're on).
  */
+/**
+ * Build the user-facing refusal text when an EVM `send_transaction` is
+ * called on a handle that has a previous ambiguous-attempt mark and
+ * the agent did not pass `acknowledgeRetryRiskAfterAmbiguousFailure:
+ * true`. Issue #326 P3 — the previous attempt's recovery guidance is
+ * re-stated so the agent surfaces it to the user before retrying.
+ *
+ * Per-kind copy: `consumed_unmatched` and `ambiguous_disagreement`
+ * lean stronger on "DO NOT retry without verifying on a block
+ * explorer first"; `no_broadcast` is permissive but still requires
+ * the user to know about the duplicate-prompt risk.
+ */
+function buildAmbiguousRetryRefusalMessage(
+  prev: AmbiguousAttempt,
+  handle: string,
+): string {
+  const ageMs = Date.now() - prev.at;
+  const ageSec = Math.round(ageMs / 1000);
+  const common =
+    `This send_transaction call is a retry on a handle whose previous attempt (${ageSec}s ago) ` +
+    `returned a WalletConnect timeout with probe outcome \`${prev.kind}\`. Issue #326 — a blind retry ` +
+    `at this point CAN queue a duplicate signing prompt to Ledger Live (the WC subapp may have ` +
+    `silently completed signing in the background). The duplicate-prompt scenario looks identical ` +
+    `to a key-leak attack pattern (two prompts for the same nonce) even though it's mathematically ` +
+    `benign — the user's first reaction will be alarm.\n\n` +
+    `Before passing \`acknowledgeRetryRiskAfterAmbiguousFailure: true\` to retry, do this with the user:\n`;
+  const perKind = (() => {
+    if (prev.kind === "no_broadcast") {
+      return (
+        `  1. Tell the user that the previous attempt timed out but the on-chain probe (local RPC + ` +
+        `Etherscan cross-check, where available) confirmed nothing landed at the pinned nonce.\n` +
+        `  2. Tell them that retrying CAN STILL queue a duplicate prompt; if a duplicate prompt ` +
+        `appears on their Ledger, the right action is **REJECT** — the original tx will land normally ` +
+        `(retrying after a successful background sign double-counts the slot otherwise).\n` +
+        `  3. Get explicit user acknowledgement, then re-call send_transaction with the same ` +
+        `\`previewToken\`, \`userDecision: "send"\`, AND \`acknowledgeRetryRiskAfterAmbiguousFailure: true\`.`
+      );
+    }
+    if (prev.kind === "consumed_unmatched") {
+      return (
+        `  1. Tell the user that the pinned nonce was consumed in the last 16 blocks but no tx in ` +
+        `that window had a matching pre-sign hash. Most likely the original tx mined further back ` +
+        `than the probe window, or a parallel tool / RBF replacement used the same slot.\n` +
+        `  2. Have them check on a block explorer (Etherscan / Ledger Live tx history) for any tx ` +
+        `with the pinned nonce on this wallet — if found, the original send already succeeded.\n` +
+        `  3. If genuinely no tx with the pinned nonce is found AND the user wants to try again, ` +
+        `they should re-prepare from scratch (new handle, fresh nonce/gas pin) — a same-pin retry ` +
+        `would fail at the chain level with "nonce too low". Acknowledging the risk on THIS handle ` +
+        `is unlikely to be useful; mostly this kind exists so the agent stops to verify rather than ` +
+        `silently retrying.`
+      );
+    }
+    // ambiguous_disagreement
+    return (
+      `  1. Tell the user that local RPC and Etherscan disagree on whether the pinned nonce was ` +
+      `consumed: most likely Ledger Live finished signing + relayed the tx through ITS own RPC ` +
+      `after our 120s timer fired and the propagation hasn't reached our local node yet.\n` +
+      `  2. Have them check on a block explorer (etherscan.io / Ledger Live tx history) for a tx ` +
+      `with the pinned nonce on this wallet within the last ~5 minutes — if found, the original ` +
+      `send already succeeded and NO retry is needed.\n` +
+      `  3. If after ~5 minutes no tx with the pinned nonce appears on chain, the slot is genuinely ` +
+      `free and they should re-prepare from scratch (NEW handle, fresh nonce/gas pin). Retrying ` +
+      `THIS handle with the ack flag is allowed but discouraged — re-prepare is the safer path.`
+    );
+  })();
+  return (
+    common +
+    perKind +
+    `\n\nHandle: \`${handle}\` (still valid; 15-min TTL from prepare). Previous outcome kind: ` +
+    `\`${prev.kind}\`. Issue #326 P3.`
+  );
+}
+
 export async function sendTransaction(args: SendTransactionArgs): Promise<{
   txHash: `0x${string}` | string;
   chain: SupportedChain | "tron" | "solana" | "bitcoin" | "litecoin";
@@ -2903,6 +2981,24 @@ export async function sendTransaction(args: SendTransactionArgs): Promise<{
         "token drift without a user-initiated refresh is not expected.",
     );
   }
+  // Issue #326 P3 — gate retries behind an explicit ack flag when the
+  // previous attempt on this handle returned a timeout-with-probe
+  // outcome. The mark survives until the agent re-calls with the ack,
+  // a successful submission retires the handle, or the 15-minute TTL
+  // prunes the entry. Without this guard, an agent that sees the
+  // probe's "safe to retry" message can pile retries on top of each
+  // other and queue duplicate device prompts that look like a
+  // key-leak attack pattern.
+  const previousAmbiguous = getAmbiguousAttempt(args.handle);
+  if (previousAmbiguous && args.acknowledgeRetryRiskAfterAmbiguousFailure !== true) {
+    throw new Error(buildAmbiguousRetryRefusalMessage(previousAmbiguous, args.handle));
+  }
+  if (previousAmbiguous && args.acknowledgeRetryRiskAfterAmbiguousFailure === true) {
+    // The user has acknowledged the risk; clear the mark so the next
+    // attempt is a fresh slate. A SECOND ambiguous outcome on this
+    // retry will set the mark again and require ANOTHER explicit ack.
+    clearAmbiguousAttempt(args.handle);
+  }
   const tx = consumeHandle(args.handle);
   const pinned = {
     nonce: stashed.nonce,
@@ -2913,7 +3009,28 @@ export async function sendTransaction(args: SendTransactionArgs): Promise<{
   // Issue #232: thread the pinned pre-sign hash so a WC timeout can
   // run a late-broadcast probe (find a tx that mined after our 120s
   // timer fired) instead of surfacing a false-alarm timeout.
-  const hash = await requestSendTransaction(tx, pinned, stashed.preSignHash);
+  let hash: `0x${string}`;
+  try {
+    hash = await requestSendTransaction(tx, pinned, stashed.preSignHash);
+  } catch (e) {
+    // Issue #326 P3 — mark the handle as ambiguous when the timeout
+    // path produced a structured probe outcome. The next
+    // send_transaction call on this handle will require the explicit
+    // ack flag. Mark fires regardless of the WC error wording so
+    // future probe-result variants slot in cleanly.
+    if (e instanceof WalletConnectRequestTimeoutError && e.kind !== "unknown") {
+      const kindMap: Record<
+        Exclude<typeof e.kind, "unknown">,
+        "no_broadcast" | "consumed_unmatched" | "ambiguous_disagreement"
+      > = {
+        no_broadcast: "no_broadcast",
+        consumed_unmatched: "consumed_unmatched",
+        ambiguous_disagreement: "ambiguous_disagreement",
+      };
+      markAmbiguousAttempt(args.handle, kindMap[e.kind]);
+    }
+    throw e;
+  }
   // Only retire the handle after successful submission. If requestSendTransaction
   // throws (device disconnect, user rejection, relay timeout), the handle stays
   // valid and the caller can retry until the 15-minute TTL expires. The pin

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -780,6 +780,24 @@ export const sendTransactionInput = z.object({
         "Schema-enforced contract that the preview-time / prepare-time summary was surfaced to " +
         "the user, not skipped. Missing value → send_transaction refuses with a clear error."
     ),
+  acknowledgeRetryRiskAfterAmbiguousFailure: z
+    .literal(true)
+    .optional()
+    .describe(
+      "Required ONLY when re-calling send_transaction on an EVM handle whose previous attempt " +
+        "returned a `WalletConnectRequestTimeoutError` (no_broadcast / consumed_unmatched / " +
+        "ambiguous_disagreement). Issue #326 P3: a previous timeout-with-probe outcome leaves " +
+        "the device in an uncertain state — Ledger Live may have silently completed signing in " +
+        "the background, and a blind retry queues a duplicate signing prompt that LOOKS exactly " +
+        "like a key-leak attack pattern (two prompts for the same nonce). The flag is the agent's " +
+        "schema-level confirmation that the user has been told about the duplicate-prompt risk " +
+        "(reject any duplicate prompt; the original tx will land normally) AND has verified via " +
+        "a block explorer that no tx with the pinned nonce has landed in the last ~5 minutes. " +
+        "Without this flag on a marked handle, send_transaction refuses and surfaces the " +
+        "previous outcome's recovery guidance. Cleared by the ack itself — a SECOND ambiguous " +
+        "outcome on the retry requires another explicit ack. EVM-only; ignored on TRON / Solana / " +
+        "BTC / LTC handles since their signing paths don't go through WalletConnect."
+    ),
 });
 
 export const previewSendInput = z.object({

--- a/src/signing/tx-store.ts
+++ b/src/signing/tx-store.ts
@@ -50,10 +50,49 @@ export interface StashedPin {
   previewToken: string;
 }
 
+/**
+ * Discriminator for the three timeout-path outcomes that produce an
+ * ambiguous send_transaction result. Issue #326 P3 — when any of these
+ * fires, the handle is marked so a subsequent `send_transaction` call
+ * on the same handle refuses unless the agent passes
+ * `acknowledgeRetryRiskAfterAmbiguousFailure: true`. Different kinds
+ * carry different recovery guidance:
+ *
+ *   - `no_broadcast` → cross-checked safe to retry, but retry CAN
+ *     queue a duplicate device prompt if WC silently completed signing
+ *     in the background. User must understand the duplicate-prompt
+ *     risk before retrying.
+ *   - `consumed_unmatched` → the slot was consumed by SOME tx in the
+ *     last 16 blocks but its pre-sign hash didn't match ours. Retrying
+ *     with the same pin will fail at the chain level (nonce too low);
+ *     the user must investigate via block explorer.
+ *   - `ambiguous_disagreement` → local RPC and Etherscan disagree on
+ *     the pending nonce. The tx may have broadcast through Ledger
+ *     Live's RPC. User must verify on a block explorer before any
+ *     retry.
+ */
+export type AmbiguousAttemptKind =
+  | "no_broadcast"
+  | "consumed_unmatched"
+  | "ambiguous_disagreement";
+
+export interface AmbiguousAttempt {
+  kind: AmbiguousAttemptKind;
+  /** Date.now() at which the ambiguous outcome was recorded. */
+  at: number;
+}
+
 interface StoredTx {
   tx: UnsignedTx;
   expiresAt: number;
   pin?: StashedPin;
+  /**
+   * Set when a previous `send_transaction` on this handle returned a
+   * timeout-with-probe-result. Cleared on `retireHandle` (successful
+   * submission) or when the agent retries with the explicit ack flag.
+   * Issue #326 P3.
+   */
+  ambiguousAttempt?: AmbiguousAttempt;
 }
 
 const store = new Map<string, StoredTx>();
@@ -170,4 +209,44 @@ export function getPinnedGas(handle: string): StashedPin | undefined {
 export function hasHandle(handle: string): boolean {
   prune();
   return store.has(handle);
+}
+
+/**
+ * Mark `handle` as having had an ambiguous-outcome send attempt. Called
+ * from `sendTransaction`'s catch block when `requestSendTransaction`
+ * raises a `WalletConnectRequestTimeoutError` whose `kind` is one of
+ * the post-probe outcomes. The mark survives until `retireHandle`
+ * (successful submission) or `clearAmbiguousAttempt` (explicit
+ * acknowledged retry). Issue #326 P3.
+ */
+export function markAmbiguousAttempt(handle: string, kind: AmbiguousAttemptKind): void {
+  prune();
+  const entry = store.get(handle);
+  if (!entry) return;
+  entry.ambiguousAttempt = { kind, at: Date.now() };
+}
+
+/**
+ * Read the ambiguous-attempt mark on `handle`, or undefined if none.
+ * Called at the top of `sendTransaction` to gate retries behind the
+ * `acknowledgeRetryRiskAfterAmbiguousFailure` flag. Does NOT clear
+ * the mark — clearing is the caller's choice (only after a fresh
+ * acknowledged attempt completes or starts).
+ */
+export function getAmbiguousAttempt(handle: string): AmbiguousAttempt | undefined {
+  prune();
+  return store.get(handle)?.ambiguousAttempt;
+}
+
+/**
+ * Clear the ambiguous-attempt mark. Called when the agent retries with
+ * the ack flag — the next attempt is a fresh slate (one ack per
+ * ambiguity); a SECOND ambiguous outcome on the retry will set the
+ * mark again and require ANOTHER explicit ack.
+ */
+export function clearAmbiguousAttempt(handle: string): void {
+  prune();
+  const entry = store.get(handle);
+  if (!entry) return;
+  delete entry.ambiguousAttempt;
 }

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -292,6 +292,32 @@ export class WalletConnectSessionUnavailableError extends Error {
 }
 
 /**
+ * Discriminator for `WalletConnectRequestTimeoutError`. Surfaces which
+ * post-timeout probe outcome produced the error so callers (today:
+ * `sendTransaction` in `modules/execution/index.ts`) can route their
+ * follow-up logic without parsing message text. Issue #326 P3 reads
+ * this field to mark the handle's ambiguous-attempt state.
+ *
+ *   - `unknown` — pre-probe code path (no pin / no preSignHash). Only
+ *     reachable via test/legacy callers that don't supply both.
+ *   - `no_broadcast` — local RPC + Etherscan agree the pinned nonce
+ *     is still pending; safe to retry but the duplicate-prompt risk
+ *     warning still applies.
+ *   - `consumed_unmatched` — pinned nonce was consumed but no tx in
+ *     the recent block window matches our pre-sign hash; investigate
+ *     before any retry (a same-pin retry would fail with "nonce too
+ *     low").
+ *   - `ambiguous_disagreement` — local RPC says no broadcast, Etherscan
+ *     says the wallet has advanced past the pinned nonce. Strong DO
+ *     NOT retry signal.
+ */
+export type WcTimeoutKind =
+  | "unknown"
+  | "no_broadcast"
+  | "consumed_unmatched"
+  | "ambiguous_disagreement";
+
+/**
  * Error thrown when the WC request itself exceeds the hard wall-clock
  * timeout. Complements the pre-publish probe: even if the session is alive
  * at probe time, the peer can go away between probe and `c.request`
@@ -300,9 +326,11 @@ export class WalletConnectSessionUnavailableError extends Error {
  * send_transaction eventually returns control to the agent.
  */
 export class WalletConnectRequestTimeoutError extends Error {
-  constructor(message: string) {
+  readonly kind: WcTimeoutKind;
+  constructor(message: string, kind: WcTimeoutKind = "unknown") {
     super(message);
     this.name = "WalletConnectRequestTimeoutError";
+    this.kind = kind;
   }
 }
 
@@ -964,6 +992,7 @@ export async function requestSendTransaction(
           chainId,
           probeWindowBlocks: LATE_BROADCAST_PROBE_BLOCKS,
         }),
+        "consumed_unmatched",
       );
     }
     if (probe.status === "ambiguous_nonce_disagreement") {
@@ -980,6 +1009,7 @@ export async function requestSendTransaction(
           chainId,
           timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
         }),
+        "ambiguous_disagreement",
       );
     }
     // probe.status === "no_broadcast" → safe to retry, surface the
@@ -993,6 +1023,7 @@ export async function requestSendTransaction(
         timeoutSeconds: WC_SEND_REQUEST_TIMEOUT_MS / 1000,
         etherscanPendingNonce: probe.etherscanPendingNonce,
       }),
+      "no_broadcast",
     );
   });
   return hash;

--- a/test/wc-ambiguous-retry-ack.test.ts
+++ b/test/wc-ambiguous-retry-ack.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Issue #326 P3 — handle-state ambiguous-attempt mark + the
+ * `acknowledgeRetryRiskAfterAmbiguousFailure` ack gate on
+ * `send_transaction`. Unit tests for the tx-store helpers and the
+ * end-to-end gate behavior in the EVM `sendTransaction` handler.
+ *
+ * The full WalletConnect SDK isn't stubbed here — `requestSendTransaction`
+ * is mocked at the module boundary so each test exercises the gate
+ * logic in isolation, the way `walletconnect-send-liveness.test.ts`
+ * does for the pre-publish liveness probe.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
+import { erc20Abi } from "../src/abis/erc20.js";
+import { CONTRACTS } from "../src/config/contracts.js";
+
+const USDC = getAddress(CONTRACTS.ethereum.tokens.USDC);
+const RECIPIENT = getAddress("0x2222222222222222222222222222222222222222");
+const SENDER = getAddress("0x1111111111111111111111111111111111111111");
+
+const PIN_FIELDS = {
+  nonce: 7,
+  maxFeePerGas: 30_000_000_000n,
+  maxPriorityFeePerGas: 1_000_000_000n,
+  gas: 100_000n,
+  preSignHash: ("0x" + "ab".repeat(32)) as `0x${string}`,
+  pinnedAt: Date.now(),
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+function buildTx() {
+  return {
+    chain: "ethereum" as const,
+    to: USDC,
+    data: encodeFunctionData({ abi: erc20Abi, functionName: "transfer", args: [RECIPIENT, 100n] }),
+    value: "0",
+    from: SENDER,
+    description: "Send 100 USDC",
+  };
+}
+
+describe("tx-store ambiguous-attempt helpers (P3)", () => {
+  it("markAmbiguousAttempt + getAmbiguousAttempt round-trip on an issued handle", async () => {
+    const { issueHandles } = await import("../src/signing/tx-store.js");
+    const { markAmbiguousAttempt, getAmbiguousAttempt } = await import(
+      "../src/signing/tx-store.js"
+    );
+    const stamped = issueHandles(buildTx());
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeUndefined();
+    markAmbiguousAttempt(stamped.handle!, "no_broadcast");
+    const out = getAmbiguousAttempt(stamped.handle!);
+    expect(out?.kind).toBe("no_broadcast");
+    expect(out?.at).toBeGreaterThan(0);
+  });
+
+  it("clearAmbiguousAttempt drops the mark", async () => {
+    const { issueHandles, markAmbiguousAttempt, clearAmbiguousAttempt, getAmbiguousAttempt } =
+      await import("../src/signing/tx-store.js");
+    const stamped = issueHandles(buildTx());
+    markAmbiguousAttempt(stamped.handle!, "ambiguous_disagreement");
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeDefined();
+    clearAmbiguousAttempt(stamped.handle!);
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeUndefined();
+  });
+
+  it("getAmbiguousAttempt on an unknown handle returns undefined (no throw)", async () => {
+    const { getAmbiguousAttempt } = await import("../src/signing/tx-store.js");
+    expect(getAmbiguousAttempt("00000000-0000-0000-0000-000000000000")).toBeUndefined();
+  });
+
+  it("retireHandle clears the mark transitively (the entry is gone)", async () => {
+    const { issueHandles, markAmbiguousAttempt, retireHandle, getAmbiguousAttempt } =
+      await import("../src/signing/tx-store.js");
+    const stamped = issueHandles(buildTx());
+    markAmbiguousAttempt(stamped.handle!, "no_broadcast");
+    retireHandle(stamped.handle!);
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeUndefined();
+  });
+});
+
+describe("WalletConnectRequestTimeoutError carries a `kind` discriminator (P3)", () => {
+  it("default kind is `unknown` for back-compat with legacy callers", async () => {
+    const { WalletConnectRequestTimeoutError } = await import(
+      "../src/signing/walletconnect.js"
+    );
+    const e = new WalletConnectRequestTimeoutError("legacy");
+    expect(e.kind).toBe("unknown");
+  });
+
+  it("kind round-trips for each post-probe outcome", async () => {
+    const { WalletConnectRequestTimeoutError } = await import(
+      "../src/signing/walletconnect.js"
+    );
+    const kinds = ["no_broadcast", "consumed_unmatched", "ambiguous_disagreement"] as const;
+    for (const k of kinds) {
+      const e = new WalletConnectRequestTimeoutError("msg", k);
+      expect(e.kind).toBe(k);
+      expect(e.name).toBe("WalletConnectRequestTimeoutError");
+    }
+  });
+});
+
+describe("sendTransaction (EVM) — ambiguous-retry ack gate (P3)", () => {
+  /**
+   * Mock the WC layer at the module boundary. The first call rejects
+   * with a tagged timeout error (simulating the live #326 incident);
+   * the second call resolves with a hash. The gate logic is what we're
+   * testing — the WC mock just lets the gate run.
+   */
+  function stubWalletConnect(opts: {
+    firstError?: { message: string; kind: "no_broadcast" | "consumed_unmatched" | "ambiguous_disagreement" } | null;
+    secondHash?: `0x${string}`;
+  }) {
+    const requestSendTransaction = vi.fn();
+    if (opts.firstError) {
+      requestSendTransaction.mockImplementationOnce(async () => {
+        const wc = await import("../src/signing/walletconnect.js");
+        throw new wc.WalletConnectRequestTimeoutError(
+          opts.firstError!.message,
+          opts.firstError!.kind,
+        );
+      });
+    }
+    if (opts.secondHash) {
+      requestSendTransaction.mockResolvedValueOnce(opts.secondHash);
+    }
+    vi.doMock("../src/signing/walletconnect.js", async () => {
+      const actual = await vi.importActual<typeof import("../src/signing/walletconnect.js")>(
+        "../src/signing/walletconnect.js",
+      );
+      return {
+        ...actual,
+        requestSendTransaction,
+      };
+    });
+    return { requestSendTransaction };
+  }
+
+  it("first attempt that times out with `no_broadcast` marks the handle and the second attempt without ack is refused", async () => {
+    stubWalletConnect({
+      firstError: { message: "no_broadcast — safe to retry but ambiguous", kind: "no_broadcast" },
+    });
+    const { issueHandles, attachPinnedGas, getAmbiguousAttempt } = await import(
+      "../src/signing/tx-store.js"
+    );
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const stamped = issueHandles(buildTx());
+    attachPinnedGas(stamped.handle!, { ...PIN_FIELDS, previewToken: "tok-1" });
+
+    // First attempt — WC timeout error propagates, handle gets marked.
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow(/no_broadcast/i);
+    expect(getAmbiguousAttempt(stamped.handle!)?.kind).toBe("no_broadcast");
+
+    // Second attempt without ack — refused with the recovery guidance,
+    // WC layer NOT called again (the gate fires before
+    // requestSendTransaction).
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow(/acknowledgeRetryRiskAfterAmbiguousFailure/);
+    // Mark survives (still not retired) — the gate refused without
+    // clearing.
+    expect(getAmbiguousAttempt(stamped.handle!)?.kind).toBe("no_broadcast");
+  });
+
+  it("second attempt WITH the ack flag clears the mark and proceeds; success retires the handle", async () => {
+    const successHash = ("0x" + "ee".repeat(32)) as `0x${string}`;
+    stubWalletConnect({
+      firstError: { message: "no_broadcast", kind: "no_broadcast" },
+      secondHash: successHash,
+    });
+    const { issueHandles, attachPinnedGas, getAmbiguousAttempt, hasHandle } = await import(
+      "../src/signing/tx-store.js"
+    );
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const stamped = issueHandles(buildTx());
+    attachPinnedGas(stamped.handle!, { ...PIN_FIELDS, previewToken: "tok-1" });
+
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow();
+    expect(getAmbiguousAttempt(stamped.handle!)?.kind).toBe("no_broadcast");
+
+    // Acknowledged retry succeeds.
+    const result = await sendTransaction({
+      handle: stamped.handle!,
+      confirmed: true,
+      previewToken: "tok-1",
+      userDecision: "send",
+      acknowledgeRetryRiskAfterAmbiguousFailure: true,
+    });
+    expect(result.txHash).toBe(successHash);
+    expect(hasHandle(stamped.handle!)).toBe(false);
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeUndefined();
+  });
+
+  it("ambiguous_disagreement on attempt 1 → refusal copy mentions block explorer + 5-min wait + re-prepare path", async () => {
+    stubWalletConnect({
+      firstError: { message: "sources disagree", kind: "ambiguous_disagreement" },
+    });
+    const { issueHandles, attachPinnedGas } = await import("../src/signing/tx-store.js");
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const stamped = issueHandles(buildTx());
+    attachPinnedGas(stamped.handle!, { ...PIN_FIELDS, previewToken: "tok-1" });
+
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow();
+
+    // Second attempt without ack — refused; verify the per-kind copy.
+    let captured: Error | null = null;
+    try {
+      await sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      });
+    } catch (e) {
+      captured = e as Error;
+    }
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured!.message).toMatch(/block explorer/i);
+    expect(captured!.message).toMatch(/re-prepare/i);
+    expect(captured!.message).toMatch(/ambiguous_disagreement/);
+    expect(captured!.message).toMatch(/#326/);
+  });
+
+  it("consumed_unmatched on attempt 1 → refusal copy says re-prepare, same-pin retry would fail at chain level", async () => {
+    stubWalletConnect({
+      firstError: { message: "slot consumed by another tx", kind: "consumed_unmatched" },
+    });
+    const { issueHandles, attachPinnedGas } = await import("../src/signing/tx-store.js");
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const stamped = issueHandles(buildTx());
+    attachPinnedGas(stamped.handle!, { ...PIN_FIELDS, previewToken: "tok-1" });
+
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow();
+
+    let captured: Error | null = null;
+    try {
+      await sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      });
+    } catch (e) {
+      captured = e as Error;
+    }
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured!.message).toMatch(/nonce too low/i);
+    expect(captured!.message).toMatch(/re-prepare/i);
+    expect(captured!.message).toMatch(/consumed_unmatched/);
+  });
+
+  it("legacy `unknown` kind (pre-probe path) does NOT set the mark (only structured probe outcomes do)", async () => {
+    stubWalletConnect({
+      firstError: { message: "raw timeout", kind: "no_broadcast" }, // placeholder
+    });
+    // Re-stub with `unknown`-kind error specifically.
+    vi.resetModules();
+    const wc = await import("../src/signing/walletconnect.js");
+    vi.doMock("../src/signing/walletconnect.js", async () => {
+      const actual = await vi.importActual<typeof import("../src/signing/walletconnect.js")>(
+        "../src/signing/walletconnect.js",
+      );
+      return {
+        ...actual,
+        requestSendTransaction: vi.fn(async () => {
+          throw new wc.WalletConnectRequestTimeoutError("legacy timeout, no probe ran");
+          // default kind = "unknown"
+        }),
+      };
+    });
+    const { issueHandles, attachPinnedGas, getAmbiguousAttempt } = await import(
+      "../src/signing/tx-store.js"
+    );
+    const { sendTransaction } = await import("../src/modules/execution/index.js");
+    const stamped = issueHandles(buildTx());
+    attachPinnedGas(stamped.handle!, { ...PIN_FIELDS, previewToken: "tok-1" });
+
+    await expect(
+      sendTransaction({
+        handle: stamped.handle!,
+        confirmed: true,
+        previewToken: "tok-1",
+        userDecision: "send",
+      }),
+    ).rejects.toThrow(/legacy timeout/);
+    // Unknown-kind timeouts are NOT marked — they pre-date the probe
+    // and only surface in test/legacy callers without pin or hash.
+    expect(getAmbiguousAttempt(stamped.handle!)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #332 (P1+P2+P4 from issue #326). Adds the third defense layer: when a previous send_transaction on a handle returned a WalletConnect timeout with a structured probe outcome (\`no_broadcast\` / \`consumed_unmatched\` / \`ambiguous_disagreement\`), the next call on that handle **refuses** unless the agent passes \`acknowledgeRetryRiskAfterAmbiguousFailure: true\`.

## Why

P1 prevents retry when sources disagree. P3 catches the adjacent case: agent gets a \"safe to retry\" / \"consumed\" / \"disagreement\" outcome and *silently retries* before the user has even finished reading the previous error message. The ack flag forces the agent to surface the duplicate-prompt risk to the user and get explicit confirmation before piling on another WC request — the canonical issue-326 incident shape.

## Implementation

| Layer | Change |
|---|---|
| \`WalletConnectRequestTimeoutError\` | New \`kind\` discriminator (\`unknown\` / \`no_broadcast\` / \`consumed_unmatched\` / \`ambiguous_disagreement\`). All construction sites updated. Catches route by \`kind\`, not message text. |
| \`signing/tx-store.ts\` | New \`ambiguousAttempt?: { kind, at }\` on \`StoredTx\` + \`markAmbiguousAttempt\` / \`getAmbiguousAttempt\` / \`clearAmbiguousAttempt\` helpers. Mark survives until retire (success), clear (acked retry), or TTL prune. |
| \`modules/execution/schemas.ts\` | New \`acknowledgeRetryRiskAfterAmbiguousFailure: z.literal(true).optional()\` on \`sendTransactionInput\`. EVM-only. |
| \`modules/execution/index.ts\` | Top-of-handler gate (refuse without ack); try/catch around \`requestSendTransaction\` (mark on tagged WC timeout); per-kind refusal copy. |

## Per-kind refusal copy

- **\`no_broadcast\`** — tell user about duplicate-prompt risk; if a duplicate prompt appears on Ledger, **REJECT** it (the original tx will land normally); after explicit acknowledgement, retry with the ack flag.
- **\`consumed_unmatched\`** — block-explorer check; same-pin retry would fail with \"nonce too low\" anyway, so re-prepare from scratch rather than acking this handle.
- **\`ambiguous_disagreement\`** — block-explorer check; if no tx with the pinned nonce appears within ~5 minutes the slot is genuinely free and re-prepare is the safer path.

## Test plan

11 new cases in \`test/wc-ambiguous-retry-ack.test.ts\`:
- [x] tx-store helpers (mark, clear, unknown-handle, retire-clears-mark)
- [x] \`WalletConnectRequestTimeoutError\` discriminator round-trip across all 4 kinds
- [x] sendTransaction marks the handle on tagged timeout + refuses second attempt without ack
- [x] Ack flag clears the mark + proceeds + retires on success
- [x] Per-kind refusal copy: ambiguous_disagreement (block explorer + 5 min + re-prepare)
- [x] Per-kind refusal copy: consumed_unmatched (re-prepare; same-pin retry fails)
- [x] Legacy \`unknown\` kind does NOT mark (only structured probe outcomes do)

All **82 WC-adjacent tests pass cleanly** in isolation. Full-suite flakes in unrelated areas (integration-security, send-hash-pin's preview_send happy-path, solana-setup-status — same pre-existing test-ordering / mock-contamination flagged on #332; different files fail each run).

## Out of scope

- TRON / Solana / BTC / LTC retries. Their signing paths use different error shapes (USB transport, nonce-account drift) and the duplicate-prompt mechanic doesn't apply the same way (TRON Ledger app clear-signs every action; Solana ATA prompts behave differently). If we hit a same-shape incident on those chains, the discriminator + tx-store mark pattern ports naturally — kept chain-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)