### PR TITLE
chore(release): bump to 0.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Patch release. Headlines:

- **Fixes the broken v0.9.3 binary release** — `release-binaries.yml`'s smoke test refused to upload binaries on v0.9.3 because the bundled binary failed to boot (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`, [#330](https://github.com/szhygulin/vaultpilot-mcp/issues/330)). [PR #336](https://github.com/szhygulin/vaultpilot-mcp/pull/336) static-imported the oracle poller and added a binary smoke test on PRs so this class of regression cannot recur.
- **Curve v0.1**, **BTC multi-sig**, **BTC RBF bump**, **LP shared infra** — additive new tool surface.
- **WalletConnect retry hardening** + **send_transaction ambiguous-retry ack gate** — pickup safer behavior when a broadcast result is indeterminate.
- **Compact cross-check pasteableBlock** + SHA-pinned `docs/cross-check-v1.md` — second-LLM verification block shrinks from ~80 lines to ~28 lines.

Full changelog in the commit body.

## Patch vs minor

Patch bump. New tool surface is strictly additive; no breaking changes to existing tool inputs or response shapes. Consumers on `^0.9.0` ranges pick this up automatically — the desired UX for tooling that doesn't change signing semantics.

## Operator checklist (post-merge)

- [ ] Tag the merge commit `v0.9.4` and create a GitHub Release (this triggers `release-binaries.yml` + `publish.yml`).
- [ ] Watch the binary build matrix — with #336 merged, all four platforms (linux-x64 / macos-arm64 / macos-x64 / win-x64) should pass smoke-test and upload.
- [ ] Verify `https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh` resolves to the new release and `curl … | bash` completes end-to-end on at least one platform.
- [ ] Close [#330](https://github.com/szhygulin/vaultpilot-mcp/issues/330) once the release page shows the full asset set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)