### PR TITLE
feat(btc): taproot multi-sig (tr/sortedmulti_a)

### DIFF
--- a/src/modules/btc/multisig-balance.ts
+++ b/src/modules/btc/multisig-balance.ts
@@ -66,18 +66,27 @@ export interface MultisigBalance {
 }
 
 export interface MultisigUtxo extends BitcoinUtxo {
-  /** Address (bech32) the UTXO funds. */
+  /** Address (bech32 / bech32m) the UTXO funds. */
   address: string;
   /** scriptPubKey bytes for this address (witness program). */
   scriptPubKey: Buffer;
-  /** witnessScript bytes — needed to build PSBT inputs in PR3. */
+  /** witnessScript bytes — needed to build PSBT inputs (P2WSH or taproot leaf). */
   witnessScript: Buffer;
-  /** Compressed cosigner pubkeys at this leaf, in slot order (NOT sorted). Used for PSBT bip32_derivation. */
+  /**
+   * Cosigner pubkeys at this leaf, slot order. P2WSH: 33-byte
+   * compressed. Taproot: 32-byte x-only.
+   */
   cosignerPubkeys: Buffer[];
   /** Chain (0 = receive, 1 = change). */
   chain: 0 | 1;
   /** Address index along this chain. */
   addressIndex: number;
+  /** Taproot-only: tapleaf hash for the script-path branch. */
+  tapLeafHash?: Buffer;
+  /** Taproot-only: x-only NUMS internal key. */
+  internalPubkey?: Buffer;
+  /** Taproot-only: control block witness for the script-path spend. */
+  controlBlock?: Buffer;
 }
 
 export interface MultisigUtxoSet {
@@ -117,6 +126,9 @@ async function walkChain<T>(
     scriptPubKey: Buffer;
     witnessScript: Buffer;
     cosignerPubkeys: Buffer[];
+    tapLeafHash?: Buffer;
+    internalPubkey?: Buffer;
+    controlBlock?: Buffer;
     /** True iff the address has on-chain history (txCount > 0 or a non-zero balance). */
     hasHistory: boolean;
   }) => Promise<T | undefined>,
@@ -141,6 +153,11 @@ async function walkChain<T>(
         scriptPubKey: info.scriptPubKey,
         witnessScript: info.witnessScript,
         cosignerPubkeys: info.cosignerPubkeys,
+        ...(info.tapLeafHash !== undefined ? { tapLeafHash: info.tapLeafHash } : {}),
+        ...(info.internalPubkey !== undefined
+          ? { internalPubkey: info.internalPubkey }
+          : {}),
+        ...(info.controlBlock !== undefined ? { controlBlock: info.controlBlock } : {}),
         hasHistory: true,
       });
       if (ret !== undefined) visited.push(ret);
@@ -260,6 +277,11 @@ export async function getMultisigUtxos(
         ...u,
         address: info.address,
         scriptPubKey: info.scriptPubKey,
+        ...(info.tapLeafHash !== undefined ? { tapLeafHash: info.tapLeafHash } : {}),
+        ...(info.internalPubkey !== undefined
+          ? { internalPubkey: info.internalPubkey }
+          : {}),
+        ...(info.controlBlock !== undefined ? { controlBlock: info.controlBlock } : {}),
         witnessScript: info.witnessScript,
         cosignerPubkeys: info.cosignerPubkeys,
         chain: info.chain,

--- a/src/modules/btc/multisig-derive.ts
+++ b/src/modules/btc/multisig-derive.ts
@@ -25,11 +25,43 @@ const bitcoinjs = requireCjs("bitcoinjs-lib") as {
       redeem: { output: Buffer };
       network?: unknown;
     }): { output?: Buffer; address?: string };
+    p2tr(opts: {
+      internalPubkey?: Buffer;
+      scriptTree?: { output: Buffer };
+      redeem?: { output: Buffer; redeemVersion?: number };
+      network?: unknown;
+    }): {
+      output?: Buffer;
+      address?: string;
+      witness?: Buffer[];
+      hash?: Buffer;
+    };
   };
+  initEccLib(eccLib: unknown): void;
   script: { compile(chunks: Array<number | Buffer>): Buffer };
   opcodes: Record<string, number>;
   networks: { bitcoin: unknown };
 };
+
+/**
+ * Initialize bitcoinjs-lib's ECC library so taproot constructions
+ * (`p2tr`, BIP-341 tweak math) work. Without this, the `p2tr` payment
+ * builder throws "No ECC Library provided" — taproot needs a
+ * `xOnlyPointAddTweak` implementation that's not bundled with
+ * bitcoinjs-lib by default.
+ *
+ * `@bitcoinerlab/secp256k1` is a pure-JS, tiny-secp256k1-compatible
+ * ECC backend already present in the dep tree (transitive via
+ * `ledger-bitcoin`). One-time init at module load is the standard
+ * pattern.
+ */
+let eccInitialized = false;
+function ensureEccInitialized(): void {
+  if (eccInitialized) return;
+  const ecc = requireCjs("@bitcoinerlab/secp256k1");
+  bitcoinjs.initEccLib(ecc);
+  eccInitialized = true;
+}
 
 const NETWORK = bitcoinjs.networks.bitcoin;
 
@@ -73,14 +105,55 @@ export function deriveCosignerPubkey(
 }
 
 export interface MultisigAddressInfo {
-  /** The bech32 address (e.g. `bc1q...`). */
+  /** The bech32(m) address (`bc1q...` for P2WSH, `bc1p...` for taproot). */
   address: string;
   /** scriptPubKey bytes (witness program). */
   scriptPubKey: Buffer;
-  /** witnessScript bytes — `OP_M <p1>...<pN> OP_N OP_CHECKMULTISIG`. Used in PSBT inputs. */
+  /** Script bytes — `OP_M <p1>...<pN> OP_N OP_CHECKMULTISIG` (P2WSH) or
+   * the leaf script `<p1> CHECKSIG <p2> CHECKSIGADD ... <M> EQUAL` (P2TR). */
   witnessScript: Buffer;
-  /** Compressed cosigner pubkeys at this leaf, in slot order (NOT sorted). */
+  /** Compressed (P2WSH) or x-only (P2TR) cosigner pubkeys at this leaf, in slot order (NOT sorted). */
   cosignerPubkeys: Buffer[];
+  /** Taproot-only: tapleaf hash for the script-path branch. Undefined for P2WSH. */
+  tapLeafHash?: Buffer;
+  /** Taproot-only: x-only NUMS internal key. Undefined for P2WSH. */
+  internalPubkey?: Buffer;
+  /** Taproot-only: control block witness for spending the script-path. Undefined for P2WSH. */
+  controlBlock?: Buffer;
+}
+
+/** BIP-341 NUMS x-only public key (lift_x(SHA256(G))). */
+const NUMS_XONLY = Buffer.from(
+  "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+  "hex",
+);
+
+/** Convert a 33-byte compressed pubkey to its 32-byte x-only form. */
+function toXOnly(pubkey: Buffer): Buffer {
+  if (pubkey.length === 33) return pubkey.subarray(1);
+  if (pubkey.length === 32) return pubkey;
+  throw new Error(`Unexpected pubkey length ${pubkey.length} (want 32 or 33).`);
+}
+
+/**
+ * Build the BIP-342 leaf script for a taproot `sortedmulti_a` policy:
+ *   <p1_xonly> OP_CHECKSIG <p2_xonly> OP_CHECKSIGADD ... <pN_xonly> OP_CHECKSIGADD <M> OP_NUMEQUAL
+ *
+ * Pubkeys must be supplied lex-sorted (the `sortedmulti_a` invariant).
+ */
+function buildSortedmultiALeafScript(
+  threshold: number,
+  sortedXOnlyPubkeys: Buffer[],
+): Buffer {
+  const chunks: Array<number | Buffer> = [];
+  for (let i = 0; i < sortedXOnlyPubkeys.length; i++) {
+    chunks.push(sortedXOnlyPubkeys[i]);
+    chunks.push(i === 0 ? bitcoinjs.opcodes.OP_CHECKSIG : bitcoinjs.opcodes.OP_CHECKSIGADD);
+  }
+  // OP_M for threshold (1..16 → 0x51..0x60).
+  chunks.push(opN(threshold));
+  chunks.push(bitcoinjs.opcodes.OP_NUMEQUAL);
+  return bitcoinjs.script.compile(chunks);
 }
 
 /**
@@ -95,16 +168,13 @@ export function deriveMultisigAddress(
   change: 0 | 1,
   addressIndex: number,
 ): MultisigAddressInfo {
-  if (wallet.scriptType !== "wsh") {
-    throw new Error(
-      `deriveMultisigAddress: scriptType "${wallet.scriptType}" not supported in this ` +
-        `module — taproot (\`tr\`) ships in a follow-up PR.`,
-    );
-  }
   if (!Number.isInteger(addressIndex) || addressIndex < 0) {
     throw new Error(
       `addressIndex must be a non-negative integer, got ${addressIndex}.`,
     );
+  }
+  if (wallet.scriptType === "tr") {
+    return deriveTaprootMultisigAddress(wallet, change, addressIndex);
   }
   // 1. Derive each cosigner's pubkey at the leaf.
   const cosignerPubkeys = wallet.cosigners.map((c) =>
@@ -135,5 +205,66 @@ export function deriveMultisigAddress(
     scriptPubKey: p2wsh.output,
     witnessScript,
     cosignerPubkeys,
+  };
+}
+
+/**
+ * Taproot script-path multisig address derivation:
+ *   `tr(<NUMS>, sortedmulti_a(M, @1/**, ..., @N/**))`.
+ *
+ * NUMS internal key has no known private key, so the only spend path
+ * is via the leaf script (M-of-N CHECKSIGADD). The leaf script uses
+ * x-only pubkeys (32 bytes), sorted lexicographically.
+ *
+ * Returns the bech32m address (`bc1p...`), the leaf script bytes,
+ * x-only cosigner pubkeys (slot order), the tapleaf hash, the
+ * internal pubkey (NUMS), and the control block needed to spend.
+ */
+function deriveTaprootMultisigAddress(
+  wallet: PairedBitcoinMultisigWallet,
+  change: 0 | 1,
+  addressIndex: number,
+): MultisigAddressInfo {
+  ensureEccInitialized();
+  // 1. Derive cosigner compressed pubkeys, then convert to x-only.
+  const compressedPubkeys = wallet.cosigners.map((c) =>
+    deriveCosignerPubkey(c.xpub, change, addressIndex),
+  );
+  const xOnlyPubkeys = compressedPubkeys.map(toXOnly);
+  // 2. sortedmulti_a = lex sort of x-only pubkeys.
+  const sorted = [...xOnlyPubkeys].sort(Buffer.compare);
+  // 3. Build the leaf script.
+  const leafScript = buildSortedmultiALeafScript(wallet.threshold, sorted);
+  // 4. Construct P2TR with NUMS internal key + script tree.
+  const p2tr = bitcoinjs.payments.p2tr({
+    internalPubkey: NUMS_XONLY,
+    scriptTree: { output: leafScript },
+    redeem: { output: leafScript, redeemVersion: 0xc0 },
+    network: NETWORK,
+  });
+  if (!p2tr.output || !p2tr.address) {
+    throw new Error(
+      `Internal error: bitcoinjs.payments.p2tr returned undefined output/address ` +
+        `for wallet "${wallet.name}" at leaf ${change}/${addressIndex}.`,
+    );
+  }
+  // The control block is the last witness element bitcoinjs assembled
+  // for the script-path spend (witness = [...script_args, leafScript, controlBlock]).
+  // Tests + finalize don't strictly need it on the address itself, but
+  // we surface it for the initiator flow's PSBT field population.
+  const controlBlock =
+    p2tr.witness && p2tr.witness.length > 0
+      ? p2tr.witness[p2tr.witness.length - 1]
+      : undefined;
+  return {
+    address: p2tr.address,
+    scriptPubKey: p2tr.output,
+    witnessScript: leafScript,
+    // For taproot, surface the x-only forms (matches what
+    // sortedmulti_a uses on-chain). Keep slot order, not sorted.
+    cosignerPubkeys: xOnlyPubkeys,
+    tapLeafHash: p2tr.hash,
+    internalPubkey: NUMS_XONLY,
+    ...(controlBlock !== undefined ? { controlBlock } : {}),
   };
 }

--- a/src/modules/btc/multisig.ts
+++ b/src/modules/btc/multisig.ts
@@ -67,6 +67,24 @@ interface PsbtInputDataShape {
   partialSig?: Array<{ pubkey: Buffer; signature: Buffer }>;
   witnessUtxo?: { script: Buffer; value: number };
   nonWitnessUtxo?: Buffer;
+  tapInternalKey?: Buffer;
+  tapMerkleRoot?: Buffer;
+  tapLeafScript?: Array<{
+    leafVersion: number;
+    script: Buffer;
+    controlBlock: Buffer;
+  }>;
+  tapBip32Derivation?: Array<{
+    masterFingerprint: Buffer;
+    pubkey: Buffer;
+    path: string;
+    leafHashes: Buffer[];
+  }>;
+  tapScriptSig?: Array<{
+    pubkey: Buffer;
+    signature: Buffer;
+    leafHash: Buffer;
+  }>;
 }
 
 interface PsbtInstance {
@@ -84,6 +102,19 @@ interface PsbtInstance {
       masterFingerprint: Buffer;
       pubkey: Buffer;
       path: string;
+    }>;
+    tapInternalKey?: Buffer;
+    tapMerkleRoot?: Buffer;
+    tapLeafScript?: Array<{
+      leafVersion: number;
+      script: Buffer;
+      controlBlock: Buffer;
+    }>;
+    tapBip32Derivation?: Array<{
+      masterFingerprint: Buffer;
+      pubkey: Buffer;
+      path: string;
+      leafHashes: Buffer[];
     }>;
   }): unknown;
   addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
@@ -233,12 +264,161 @@ function formatPolicyKey(c: PairedBitcoinMultisigCosigner): string {
  * Build the descriptor template string for a P2WSH sortedmulti policy:
  * `wsh(sortedmulti(<M>,@0/**,@1/**,...,@{N-1}/**))`.
  */
-function buildSortedmultiDescriptor(
+function buildWshSortedmultiDescriptor(
   threshold: number,
   cosignerCount: number,
 ): string {
   const slots = Array.from({ length: cosignerCount }, (_, i) => `@${i}/**`).join(",");
   return `wsh(sortedmulti(${threshold},${slots}))`;
+}
+
+/**
+ * BIP-341 NUMS x-only public key. Defined as `lift_x(SHA256(G))` where
+ * G is the secp256k1 generator. Provably has no known private key —
+ * used as the taproot internal key when the wallet is script-path-only
+ * (no key-path spend allowed).
+ *
+ * Hex from BIP-341 specification; same point Sparrow / Specter /
+ * miniscript.fyi all use for "no key-path" taproot multi-sig.
+ */
+const NUMS_XONLY_HEX =
+  "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+
+/**
+ * Construct a BIP-32 xpub-form serialization of the NUMS point. The
+ * Ledger wallet-policy parser only accepts xpubs in key info (raw
+ * x-only points are not in the documented grammar), so we wrap NUMS
+ * as a depth-0 xpub with a deterministic chaincode (all zeros) and
+ * even-Y compressed form (0x02 prefix).
+ *
+ * NOTE: this NUMS encoding is NOT verified against a live Ledger BTC
+ * app at the time of this PR — the documentation is silent on the
+ * precise NUMS form expected. Live testing is required before merging.
+ * If this encoding is rejected, the fix is local (rebuild the xpub
+ * with a different chaincode / parent fingerprint convention) and
+ * doesn't ripple through the rest of the multi-sig code.
+ */
+function buildNumsXpub(): string {
+  const xonly = Buffer.from(NUMS_XONLY_HEX, "hex");
+  // BIP-340 x-only points are conventionally even-Y; prefix with 0x02.
+  const compressedPubkey = Buffer.concat([Buffer.from([0x02]), xonly]);
+  // BIP-32 serialized public key: 78 bytes.
+  const buf = Buffer.alloc(78);
+  // Mainnet xpub version (0x0488B21E).
+  buf.writeUInt32BE(0x0488b21e, 0);
+  // Depth = 0 (master).
+  buf.writeUInt8(0, 4);
+  // Parent fingerprint = 0x00000000 (master has no parent).
+  buf.writeUInt32BE(0, 5);
+  // Child number = 0.
+  buf.writeUInt32BE(0, 9);
+  // Chain code: all zeros (no known precedent for non-zero NUMS chaincode).
+  // (offsets 13..44 already zeroed by Buffer.alloc)
+  // Public key at offset 45 (33 bytes).
+  compressedPubkey.copy(buf, 45);
+  // base58check encode.
+  return base58CheckEncode(buf);
+}
+
+const NUMS_XPUB = buildNumsXpub();
+
+/**
+ * Build the descriptor template string for a taproot sortedmulti_a
+ * policy: `tr(@0/**, sortedmulti_a(<M>, @1/**, @2/**, ..., @N/**))`.
+ *
+ * Slot @0 is the NUMS internal key (provably unspendable key-path).
+ * Slots @1..@N are the user cosigners. The Ledger BTC app's wallet
+ * policy parser accepts `tr(KP, TREE)` with `multi_a` / `sortedmulti_a`
+ * fragments inside `TREE` (verified against app-bitcoin-new/doc/wallet.md).
+ */
+function buildTrSortedmultiADescriptor(
+  threshold: number,
+  cosignerCount: number,
+): string {
+  const slots = Array.from(
+    { length: cosignerCount },
+    (_, i) => `@${i + 1}/**`,
+  ).join(",");
+  return `tr(@0/**,sortedmulti_a(${threshold},${slots}))`;
+}
+
+/** Build the per-cosigner key info string for the wallet policy. */
+function buildPolicyKeysForWallet(
+  scriptType: "wsh" | "tr",
+  cosigners: PairedBitcoinMultisigCosigner[],
+): string[] {
+  const cosignerKeys = cosigners.map(formatPolicyKey);
+  if (scriptType === "wsh") return cosignerKeys;
+  // tr: prepend NUMS as slot @0, cosigners shift to @1..@N.
+  return [`[00000000]${NUMS_XPUB}`, ...cosignerKeys];
+}
+
+/** Pick the descriptor builder for a given script type. */
+function buildDescriptorTemplate(
+  scriptType: "wsh" | "tr",
+  threshold: number,
+  cosignerCount: number,
+): string {
+  if (scriptType === "wsh") {
+    return buildWshSortedmultiDescriptor(threshold, cosignerCount);
+  }
+  return buildTrSortedmultiADescriptor(threshold, cosignerCount);
+}
+
+/** base58check encoder (BIP-32 xpub serialization). */
+function base58CheckEncode(payload: Buffer): string {
+  const crypto = requireCjs("node:crypto") as {
+    createHash(alg: string): { update(b: Buffer): { digest(): Buffer } };
+  };
+  const sha256 = (b: Buffer) => crypto.createHash("sha256").update(b).digest();
+  const checksum = sha256(sha256(payload)).subarray(0, 4);
+  const full = Buffer.concat([payload, checksum]);
+  return base58Encode(full);
+}
+
+/** Minimal base58 encoder (avoids pulling in another dep). */
+function base58Encode(buffer: Buffer): string {
+  const ALPHABET =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let intVal = 0n;
+  for (const byte of buffer) intVal = (intVal << 8n) + BigInt(byte);
+  let out = "";
+  while (intVal > 0n) {
+    const rem = intVal % 58n;
+    intVal /= 58n;
+    out = ALPHABET[Number(rem)] + out;
+  }
+  // Leading zero bytes → leading '1's.
+  for (const byte of buffer) {
+    if (byte === 0) out = "1" + out;
+    else break;
+  }
+  return out;
+}
+
+/**
+ * Min Ledger BTC app version that supports `sortedmulti_a` in wallet
+ * policies. Per LedgerHQ release notes, taproot policies landed in
+ * v2.1.0 and `sortedmulti_a` shortly after; v2.2.0 is the safe lower
+ * bound for the taproot multi-sig flows in this PR.
+ *
+ * NOT verified against a live device at this PR's time of writing —
+ * if the live app rejects on a 2.2.x version, raise this constant
+ * accordingly.
+ */
+const MIN_TR_APP_VERSION = "2.2.0";
+
+/** Compare app versions as `major.minor.patch` triples. Returns -1/0/1. */
+function compareSemver(a: string, b: string): number {
+  const parse = (s: string) => s.split(".").map((n) => parseInt(n, 10) || 0);
+  const av = parse(a);
+  const bv = parse(b);
+  for (let i = 0; i < 3; i++) {
+    const x = av[i] ?? 0;
+    const y = bv[i] ?? 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
 }
 
 // --- register_btc_multisig_wallet ----------------------------------------
@@ -251,7 +431,7 @@ export interface RegisterBitcoinMultisigWalletArgs {
     masterFingerprint: string;
     derivationPath: string;
   }>;
-  scriptType: "wsh";
+  scriptType: "wsh" | "tr";
 }
 
 export interface RegisterBitcoinMultisigWalletResult {
@@ -281,10 +461,11 @@ export async function registerBitcoinMultisigWallet(
         `wallet-policy names at ${MULTISIG_NAME_MAX_BYTES} bytes. Shorten it.`,
     );
   }
-  if (args.scriptType !== "wsh") {
+  if (args.scriptType !== "wsh" && args.scriptType !== "tr") {
     throw new Error(
-      `\`scriptType\` "${args.scriptType}" is out of scope — Phase 2 supports "wsh" only ` +
-        `(P2WSH native segwit). Taproot and P2SH-wrapped multi-sig are deferred.`,
+      `\`scriptType\` "${args.scriptType}" is not supported — accepted: "wsh" (P2WSH) ` +
+        `or "tr" (taproot script-path with NUMS internal key). P2SH-wrapped multi-sig ` +
+        `is out of scope.`,
     );
   }
   if (
@@ -364,6 +545,16 @@ export async function registerBitcoinMultisigWallet(
           `on the device and retry.`,
       );
     }
+    if (
+      args.scriptType === "tr" &&
+      compareSemver(appInfo.version, MIN_TR_APP_VERSION) < 0
+    ) {
+      throw new Error(
+        `Taproot multi-sig (\`scriptType: "tr"\`) requires Ledger BTC app ` +
+          `≥ ${MIN_TR_APP_VERSION}; the connected device has ${appInfo.version}. ` +
+          `Update the BTC app via Ledger Live before retrying.`,
+      );
+    }
     const ourFingerprint = (await app.getMasterFingerprint()).toLowerCase();
     const candidates = validatedCosigners.filter(
       (c) => c.masterFingerprint === ourFingerprint,
@@ -398,11 +589,12 @@ export async function registerBitcoinMultisigWallet(
     validatedCosigners[ourKeyIndex].isOurs = true;
 
     // 5. Construct + register the wallet policy.
-    const descriptorTemplate = buildSortedmultiDescriptor(
+    const descriptorTemplate = buildDescriptorTemplate(
+      args.scriptType,
       args.threshold,
       validatedCosigners.length,
     );
-    const policyKeys = validatedCosigners.map(formatPolicyKey);
+    const policyKeys = buildPolicyKeysForWallet(args.scriptType, validatedCosigners);
     const walletPolicy = buildWalletPolicy(args.name, descriptorTemplate, policyKeys);
     // The device walks every cosigner xpub fingerprint on-screen. The
     // user MUST verify each fingerprint matches what they expect (this
@@ -466,26 +658,38 @@ function ensurePsbtMatchesOurKey(
   const ourFpBuf = Buffer.from(ourFingerprint, "hex");
   for (let i = 0; i < psbt.data.inputs.length; i++) {
     const input = psbt.data.inputs[i];
-    const derivations = input.bip32Derivation ?? [];
-    const hasOurs = derivations.some(
-      (d) => d.masterFingerprint.equals(ourFpBuf),
-    );
+    // P2WSH inputs carry derivations in `bip32Derivation`; taproot
+    // script-path inputs carry them in `tapBip32Derivation`. Either is
+    // sufficient evidence that our key is among the signers.
+    const ecdsaDerivations = input.bip32Derivation ?? [];
+    const tapDerivations = input.tapBip32Derivation ?? [];
+    const hasOurs =
+      ecdsaDerivations.some((d) => d.masterFingerprint.equals(ourFpBuf)) ||
+      tapDerivations.some((d) => d.masterFingerprint.equals(ourFpBuf));
     if (!hasOurs) {
       throw new Error(
-        `PSBT input ${i} has no bip32_derivation entry for our master fingerprint ` +
-          `${ourFingerprint}. Either this PSBT belongs to a different wallet (refusing ` +
-          `to forward to the device) or the initiator built it without our xpub. ` +
-          `Verify the PSBT comes from a coordinator that knows about this Ledger.`,
+        `PSBT input ${i} has no bip32_derivation (ECDSA or taproot) entry for our ` +
+          `master fingerprint ${ourFingerprint}. Either this PSBT belongs to a ` +
+          `different wallet (refusing to forward to the device) or the initiator ` +
+          `built it without our xpub. Verify the PSBT comes from a coordinator ` +
+          `that knows about this Ledger.`,
       );
     }
   }
 }
 
 /**
- * Splice ledger-bitcoin's PartialSignature output into the PSBT's
- * input-level partialSig map. P2WSH multisig uses standard ECDSA
- * signatures (NOT taproot), so we drop `tapleafHash` and keep only
- * `{pubkey, signature}`.
+ * Splice ledger-bitcoin's PartialSignature output into the PSBT.
+ *
+ * Two paths:
+ *  - **P2WSH multi-sig** (no tapleafHash): standard ECDSA signature →
+ *    PSBT input's `partialSig` field.
+ *  - **Taproot script-path multi-sig** (tapleafHash present): Schnorr
+ *    signature → PSBT input's `tapScriptSig` field (BIP-371).
+ *
+ * Both update via bitcoinjs-lib's `psbt.updateInput`. The tap path
+ * uses the field name `tapScriptSig`, which bip174's converter accepts
+ * as `{pubkey, signature, leafHash}` triples.
  */
 function applyPartialSignatures(
   psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
@@ -494,19 +698,33 @@ function applyPartialSignatures(
   let added = 0;
   for (const [inputIdx, partial] of sigs) {
     if (partial.tapleafHash !== undefined) {
-      // Taproot script-path signatures land in `tapScriptSig`, not
-      // `partialSig`. Out of scope for Phase 2 (`wsh` only); refusing
-      // here surfaces an unexpected device-side response shape rather
-      // than silently dropping it.
-      throw new Error(
-        `Ledger returned a taproot partial signature for input ${inputIdx}, but this ` +
-          `flow is P2WSH-only. The registered policy may not match the PSBT — refusing ` +
-          `to splice.`,
-      );
+      // Taproot script-path: splice into tapScriptSig.
+      (psbt as unknown as {
+        updateInput(
+          i: number,
+          update: {
+            tapScriptSig: Array<{
+              pubkey: Buffer;
+              signature: Buffer;
+              leafHash: Buffer;
+            }>;
+          },
+        ): unknown;
+      }).updateInput(inputIdx, {
+        tapScriptSig: [
+          {
+            pubkey: partial.pubkey,
+            signature: partial.signature,
+            leafHash: partial.tapleafHash,
+          },
+        ],
+      });
+    } else {
+      // P2WSH: standard ECDSA partialSig.
+      psbt.updateInput(inputIdx, {
+        partialSig: [{ pubkey: partial.pubkey, signature: partial.signature }],
+      });
     }
-    psbt.updateInput(inputIdx, {
-      partialSig: [{ pubkey: partial.pubkey, signature: partial.signature }],
-    });
     added += 1;
   }
   return added;
@@ -515,13 +733,21 @@ function applyPartialSignatures(
 /**
  * For each input, count how many distinct signatures are present (post-
  * splice). Used to derive `signaturesPresent` and `fullySigned`.
+ * Counts both ECDSA `partialSig` (P2WSH path) and Schnorr `tapScriptSig`
+ * (taproot script-path) entries.
  */
 function minSignatureCount(
   psbt: ReturnType<typeof bitcoinjs.Psbt.fromBase64>,
 ): number {
   let min = Number.POSITIVE_INFINITY;
   for (const input of psbt.data.inputs) {
-    const count = input.partialSig?.length ?? 0;
+    const inputWithTap = input as {
+      partialSig?: Array<unknown>;
+      tapScriptSig?: Array<unknown>;
+    };
+    const ecdsaCount = inputWithTap.partialSig?.length ?? 0;
+    const schnorrCount = inputWithTap.tapScriptSig?.length ?? 0;
+    const count = ecdsaCount + schnorrCount;
     if (count < min) min = count;
   }
   return Number.isFinite(min) ? min : 0;
@@ -565,7 +791,10 @@ export async function signBitcoinMultisigPsbt(
   }
 
   // 3. Re-build the wallet policy from the persisted descriptor + keys.
-  const policyKeys = wallet.cosigners.map(formatPolicyKey);
+  //    For taproot wallets, the policy keys array prepends the NUMS
+  //    internal key — must match what was passed to registerWallet so
+  //    the device's HMAC verifies.
+  const policyKeys = buildPolicyKeysForWallet(wallet.scriptType, wallet.cosigners);
   const walletPolicy = buildWalletPolicy(
     wallet.name,
     wallet.descriptor,
@@ -706,8 +935,32 @@ function p2wshMultisigInputVbytes(threshold: number, totalSigners: number): numb
   return 41 + Math.ceil((6 + 74 * threshold + 34 * totalSigners) / 4);
 }
 
-/** P2WSH output vbytes: 8 value + 1 len + 34 script = 43 bytes. */
-const P2WSH_OUTPUT_VBYTES = 43;
+/**
+ * Taproot script-path multisig (`tr(<NUMS>, sortedmulti_a(M, ..., N))`)
+ * input vbytes:
+ *   non-witness: 41 (outpoint + sequence + empty scriptSig)
+ *   witness:
+ *     - count byte (1)
+ *     - M Schnorr sigs (65 bytes each: 1 length + 64 sig)
+ *       (assumes all M signers signed; non-signers contribute 0x00 byte
+ *        empty placeholder — bitcoinjs-lib's finalizer fills both)
+ *     - N - M empty placeholders × ~1 byte each (CHECKSIGADD requires
+ *       a stack item per pubkey; non-signers push empty)
+ *     - script: 1 + 1 + N × (32 + 1) + 1 + 1 + 1 = 4 + 33*N bytes
+ *     - control block: 1 + (1 + 32 + 32 × tree_depth) — single-leaf, depth=0,
+ *       so 1 + 33 = 34 bytes
+ * vsize ≈ 41 + ceil((1 + 65*M + (N - M) + 4 + 33*N + 34) / 4)
+ *      = 41 + ceil((40 + 64*M + 34*N) / 4)
+ */
+function trMultisigInputVbytes(threshold: number, totalSigners: number): number {
+  return 41 + Math.ceil((40 + 64 * threshold + 34 * totalSigners) / 4);
+}
+
+function multisigInputVbytes(wallet: PairedBitcoinMultisigWallet): number {
+  return wallet.scriptType === "tr"
+    ? trMultisigInputVbytes(wallet.threshold, wallet.totalSigners)
+    : p2wshMultisigInputVbytes(wallet.threshold, wallet.totalSigners);
+}
 
 /** Mainnet recipient output: covers P2WPKH (31) / P2WSH (43) / P2TR (43). Conservative pick. */
 const STANDARD_OUTPUT_VBYTES = 43;
@@ -722,7 +975,7 @@ function estimateMultisigTxVbytes(
 ): number {
   return (
     TX_OVERHEAD_VBYTES +
-    inputCount * p2wshMultisigInputVbytes(wallet.threshold, wallet.totalSigners) +
+    inputCount * multisigInputVbytes(wallet) +
     outputCount * STANDARD_OUTPUT_VBYTES
   );
 }
@@ -889,10 +1142,9 @@ export async function prepareBitcoinMultisigSend(
           : `Call \`register_btc_multisig_wallet\` first.`),
     );
   }
-  if (wallet.scriptType !== "wsh") {
+  if (wallet.scriptType !== "wsh" && wallet.scriptType !== "tr") {
     throw new Error(
-      `prepare_btc_multisig_send: scriptType "${wallet.scriptType}" not supported in this ` +
-        `release — taproot lands in a follow-up PR.`,
+      `prepare_btc_multisig_send: scriptType "${wallet.scriptType}" not supported.`,
     );
   }
 
@@ -996,23 +1248,65 @@ export async function prepareBitcoinMultisigSend(
         `Internal: prev-tx hex missing for ${utxo.txid} after fan-out fetch.`,
       );
     }
-    const bip32Derivation = wallet.cosigners.map((c, idx) => ({
-      masterFingerprint: Buffer.from(c.masterFingerprint, "hex"),
-      pubkey: utxo.cosignerPubkeys[idx],
-      // Full path including the leaf — the Ledger app requires the
-      // leading `m/` and the per-cosigner derivationPath, then the
-      // /<chain>/<index> tail at this UTXO's leaf.
-      path: `m/${c.derivationPath}/${utxo.chain}/${utxo.addressIndex}`,
-    }));
-    psbt.addInput({
-      hash: utxo.txid,
-      index: utxo.vout,
-      sequence: 0xfffffffd, // RBF-eligible.
-      witnessUtxo: { script: utxo.scriptPubKey, value: utxo.value },
-      nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
-      witnessScript: utxo.witnessScript,
-      bip32Derivation,
-    });
+    if (wallet.scriptType === "tr") {
+      // Taproot script-path input: tap_bip32_derivation (with leaf
+      // hashes), tap_internal_key, tap_merkle_root, tap_leaf_script.
+      // No `bip32Derivation` / `witnessScript` (those are P2WSH-side).
+      // No `nonWitnessUtxo` — taproot sighashes commit to input amount,
+      // so the device verifies amounts from `witnessUtxo` directly.
+      if (
+        !utxo.tapLeafHash ||
+        !utxo.internalPubkey ||
+        !utxo.controlBlock
+      ) {
+        throw new Error(
+          `Internal: taproot UTXO at ${utxo.txid}:${utxo.vout} is missing tapLeafHash / ` +
+            `internalPubkey / controlBlock. The derivation path may not have populated them.`,
+        );
+      }
+      const leafHash = utxo.tapLeafHash;
+      const tapBip32Derivation = wallet.cosigners.map((c, idx) => ({
+        masterFingerprint: Buffer.from(c.masterFingerprint, "hex"),
+        pubkey: utxo.cosignerPubkeys[idx], // x-only (32 bytes) for taproot
+        path: `m/${c.derivationPath}/${utxo.chain}/${utxo.addressIndex}`,
+        leafHashes: [leafHash],
+      }));
+      psbt.addInput({
+        hash: utxo.txid,
+        index: utxo.vout,
+        sequence: 0xfffffffd,
+        witnessUtxo: { script: utxo.scriptPubKey, value: utxo.value },
+        tapInternalKey: utxo.internalPubkey,
+        tapMerkleRoot: utxo.tapLeafHash,
+        tapLeafScript: [
+          {
+            leafVersion: 0xc0, // BIP-342 leaf version.
+            script: utxo.witnessScript,
+            controlBlock: utxo.controlBlock,
+          },
+        ],
+        tapBip32Derivation,
+      });
+    } else {
+      // P2WSH multi-sig input.
+      const bip32Derivation = wallet.cosigners.map((c, idx) => ({
+        masterFingerprint: Buffer.from(c.masterFingerprint, "hex"),
+        pubkey: utxo.cosignerPubkeys[idx],
+        // Full path including the leaf — the Ledger app requires the
+        // leading `m/` and the per-cosigner derivationPath, then the
+        // /<chain>/<index> tail at this UTXO's leaf.
+        path: `m/${c.derivationPath}/${utxo.chain}/${utxo.addressIndex}`,
+      }));
+      psbt.addInput({
+        hash: utxo.txid,
+        index: utxo.vout,
+        sequence: 0xfffffffd, // RBF-eligible.
+        witnessUtxo: { script: utxo.scriptPubKey, value: utxo.value },
+        nonWitnessUtxo: Buffer.from(prevTxHex, "hex"),
+        witnessScript: utxo.witnessScript,
+        bip32Derivation,
+      });
+    }
   }
   // Recipient output.
   psbt.addOutput({

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1351,11 +1351,15 @@ export const registerBitcoinMultisigWalletInput = z.object({
         "and uses it for signing. Phase 2 requires ≥ 2 cosigners (1-of-1 is single-sig)."
     ),
   scriptType: z
-    .literal("wsh")
+    .enum(["wsh", "tr"])
     .describe(
-      "Script type for the multi-sig wrapper. Phase 2 supports \"wsh\" only (P2WSH " +
-        "native segwit, `bc1q...`-style addresses). Taproot multi-sig and P2SH-wrapped " +
-        "multi-sig are deferred."
+      'Script type for the multi-sig wrapper:\n' +
+        '  - "wsh" — P2WSH `sortedmulti(M, ...)`. Standard ECDSA signatures, ' +
+        "`bc1q...`-style addresses. Phase 2 default.\n" +
+        '  - "tr" — Taproot script-path `tr(<NUMS>, sortedmulti_a(M, ...))`. ' +
+        "Schnorr signatures, `bc1p...`-style addresses. Internal key is a NUMS " +
+        "point with no known private key, so the only spend path is the M-of-N " +
+        "leaf script. Requires Ledger BTC app ≥ 2.2.0. Phase 3 PR4."
     ),
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1567,8 +1567,16 @@ export interface PairedBitcoinMultisigWallet {
   threshold: number;
   /** Total signers N. */
   totalSigners: number;
-  /** Script type — Phase 2 is "wsh" only. */
-  scriptType: "wsh";
+  /**
+   * Script type:
+   *  - `wsh` — P2WSH `sortedmulti(M, ...)`. Standard ECDSA signatures
+   *    splice into PSBT `partialSig`. Phase 2 default.
+   *  - `tr` — Taproot script-path `tr(<NUMS>, sortedmulti_a(M, ...))`.
+   *    Schnorr signatures splice into PSBT `tap_script_sig`. Internal
+   *    key is a NUMS point with no known private key (provably
+   *    unspendable key-path). Phase 3 PR4.
+   */
+  scriptType: "wsh" | "tr";
   /**
    * The Miniscript descriptor template registered with the device, e.g.
    * `wsh(sortedmulti(2,@0/**,@1/**,@2/**))`. Slot indices `@N` correspond

--- a/test/btc-multisig-balance.test.ts
+++ b/test/btc-multisig-balance.test.ts
@@ -123,16 +123,8 @@ describe("deriveMultisigAddress", () => {
     expect(info.witnessScript[info.witnessScript.length - 1]).toBe(0xae);
   });
 
-  it("refuses unsupported scriptType (taproot deferred to PR4)", async () => {
-    const wallet = await registerVault();
-    const taprootWallet = { ...wallet, scriptType: "tr" as never };
-    const { deriveMultisigAddress } = await import(
-      "../src/modules/btc/multisig-derive.ts"
-    );
-    expect(() => deriveMultisigAddress(taprootWallet, 0, 0)).toThrow(
-      /not supported in this module/,
-    );
-  });
+  // (Phase 3 PR4 added "tr" support via deriveTaprootMultisigAddress;
+  // dedicated taproot tests live in test/btc-multisig-taproot.test.ts.)
 });
 
 describe("getMultisigBalance", () => {

--- a/test/btc-multisig-taproot.test.ts
+++ b/test/btc-multisig-taproot.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { HDKey } from "@scure/bip32";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+import type { PairedBitcoinMultisigWallet } from "../src/types/index.js";
+
+/**
+ * PR4 — Taproot multi-sig (`tr(<NUMS>, sortedmulti_a(M, ...))`).
+ *
+ * Tests cover the parts that don't require a live Ledger:
+ *   - NUMS xpub construction is deterministic + valid base58check
+ *   - `tr` descriptor template construction
+ *   - Address derivation produces a well-formed `bc1p...` address
+ *     populated with tapLeafHash / internalPubkey / controlBlock
+ *   - register flow accepts `scriptType: "tr"` and rejects on stale
+ *     app version
+ *   - sign flow splices Schnorr partial sigs into `tap_script_sig`
+ *     (NOT `partial_sig`)
+ *   - initiator flow builds a PSBT with `tap_internal_key`,
+ *     `tap_merkle_root`, `tap_leaf_script`, `tap_bip32_derivation`
+ *
+ * What this PR's tests do NOT cover (live-test required pre-merge):
+ *   - The exact NUMS xpub encoding the Ledger BTC app accepts in
+ *     wallet policies. The wallet.md spec is silent on the precise
+ *     form; we use the most-documented convention (depth-0 xpub,
+ *     all-zero chaincode, all-zero parent fingerprint, even-Y NUMS).
+ *     If the device rejects on registerWallet, the fix is local
+ *     (rebuild the xpub) and doesn't ripple.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    fromBase64(b64: string): {
+      data: {
+        inputs: Array<{
+          tapInternalKey?: Buffer;
+          tapMerkleRoot?: Buffer;
+          tapLeafScript?: Array<unknown>;
+          tapBip32Derivation?: Array<unknown>;
+          tapScriptSig?: Array<unknown>;
+          partialSig?: Array<unknown>;
+        }>;
+      };
+      txInputs: Array<{ sequence: number }>;
+      txOutputs: Array<{ value: number }>;
+    };
+  };
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  address: { toOutputScript(addr: string, network?: unknown): Buffer };
+  networks: { bitcoin: unknown };
+};
+
+// --- Mocks --------------------------------------------------------------
+
+const getBalanceMock = vi.fn();
+const getUtxosMock = vi.fn();
+const getFeeEstimatesMock = vi.fn();
+const getTxHexMock = vi.fn();
+const getTxMock = vi.fn();
+const getTxStatusMock = vi.fn();
+const broadcastTxMock = vi.fn();
+
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({
+    getBalance: getBalanceMock,
+    getUtxos: getUtxosMock,
+    getFeeEstimates: getFeeEstimatesMock,
+    getTxHex: getTxHexMock,
+    getTx: getTxMock,
+    getTxStatus: getTxStatusMock,
+    broadcastTx: broadcastTxMock,
+  }),
+  resetBitcoinIndexer: () => {},
+}));
+
+const getAppAndVersionMock = vi.fn();
+const getMasterFingerprintMock = vi.fn();
+const getExtendedPubkeyMock = vi.fn();
+const registerWalletMock = vi.fn();
+const signPsbtMock = vi.fn();
+const transportCloseMock = vi.fn(async () => {});
+
+vi.mock("../src/signing/btc-multisig-usb-loader.js", () => ({
+  openLedgerMultisig: async () => ({
+    app: {
+      getAppAndVersion: getAppAndVersionMock,
+      getMasterFingerprint: getMasterFingerprintMock,
+      getExtendedPubkey: getExtendedPubkeyMock,
+      registerWallet: registerWalletMock,
+      signPsbt: signPsbtMock,
+    },
+    transport: { close: transportCloseMock },
+  }),
+  buildWalletPolicy: (
+    name: string,
+    descriptorTemplate: string,
+    keys: readonly string[],
+  ) => ({
+    name,
+    descriptorTemplate,
+    keys,
+    getId: () => Buffer.alloc(32),
+    serialize: () => Buffer.alloc(0),
+  }),
+}));
+
+// --- Helpers ------------------------------------------------------------
+
+function deriveCosigner(seed: string) {
+  const seedBuf = Buffer.alloc(64);
+  Buffer.from(seed.padEnd(64, "x")).copy(seedBuf);
+  const master = HDKey.fromMasterSeed(seedBuf);
+  const account = master.derive("m/48'/0'/0'/2'");
+  const fp = master.fingerprint;
+  const masterFingerprint = Buffer.alloc(4);
+  masterFingerprint.writeUInt32BE(fp, 0);
+  return {
+    xpub: account.publicExtendedKey,
+    masterFingerprint: masterFingerprint.toString("hex"),
+    accountKey: account,
+  };
+}
+
+function makeTrWallet(
+  cosigners: Array<ReturnType<typeof deriveCosigner>>,
+): PairedBitcoinMultisigWallet {
+  return {
+    name: "TrVault",
+    threshold: 2,
+    totalSigners: cosigners.length,
+    scriptType: "tr",
+    descriptor: `tr(@0/**,sortedmulti_a(2,${cosigners.map((_, i) => `@${i + 1}/**`).join(",")}))`,
+    cosigners: cosigners.map((c, i) => ({
+      xpub: c.xpub,
+      masterFingerprint: c.masterFingerprint,
+      derivationPath: "48'/0'/0'/2'",
+      isOurs: i === 0,
+    })),
+    policyHmac: "00".repeat(32),
+    appVersion: "2.4.6",
+  };
+}
+
+function buildPrevTxHex(value: number, scriptPubKey: Buffer): string {
+  const tx = new bitcoinjs.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  tx.addOutput(scriptPubKey, value);
+  return tx.toHex();
+}
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-multisig-tr-"));
+  setConfigDirForTesting(tmpHome);
+  getBalanceMock.mockReset();
+  getUtxosMock.mockReset();
+  getFeeEstimatesMock.mockReset();
+  getTxHexMock.mockReset();
+  getTxMock.mockReset();
+  getTxStatusMock.mockReset();
+  broadcastTxMock.mockReset();
+  getAppAndVersionMock.mockReset();
+  getMasterFingerprintMock.mockReset();
+  getExtendedPubkeyMock.mockReset();
+  registerWalletMock.mockReset();
+  signPsbtMock.mockReset();
+  transportCloseMock.mockClear();
+  const { __clearMultisigStore } = await import(
+    "../src/modules/btc/multisig.js"
+  );
+  __clearMultisigStore();
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// --- Address derivation -------------------------------------------------
+
+describe("deriveMultisigAddress (tr)", () => {
+  it("produces a bc1p... address with tapLeafHash + internalPubkey + controlBlock", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeTrWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const info = deriveMultisigAddress(wallet, 0, 0);
+    expect(info.address.startsWith("bc1p")).toBe(true);
+    expect(info.tapLeafHash).toBeInstanceOf(Buffer);
+    expect(info.tapLeafHash?.length).toBe(32);
+    expect(info.internalPubkey).toBeInstanceOf(Buffer);
+    expect(info.internalPubkey?.length).toBe(32);
+    expect(info.controlBlock).toBeInstanceOf(Buffer);
+    // The derived cosigner pubkeys should be x-only (32 bytes), not
+    // compressed (33).
+    expect(info.cosignerPubkeys).toHaveLength(3);
+    for (const pk of info.cosignerPubkeys) {
+      expect(pk.length).toBe(32);
+    }
+    // Re-derivation is deterministic.
+    const again = deriveMultisigAddress(wallet, 0, 0);
+    expect(again.address).toBe(info.address);
+    expect(again.tapLeafHash?.equals(info.tapLeafHash!)).toBe(true);
+  });
+});
+
+// --- Register flow ------------------------------------------------------
+
+describe("registerBitcoinMultisigWallet (tr)", () => {
+  it("builds tr(<NUMS>, sortedmulti_a(...)) descriptor and accepts scriptType: tr", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    getExtendedPubkeyMock.mockResolvedValueOnce(a.xpub);
+    registerWalletMock.mockResolvedValueOnce([Buffer.alloc(32, 1), Buffer.alloc(32, 2)]);
+
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await registerBitcoinMultisigWallet({
+      name: "TrVault",
+      threshold: 2,
+      cosigners: [
+        { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        { xpub: c.xpub, masterFingerprint: c.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+      ],
+      scriptType: "tr",
+    });
+    expect(result.wallet.scriptType).toBe("tr");
+    expect(result.wallet.descriptor).toBe(
+      "tr(@0/**,sortedmulti_a(2,@1/**,@2/**,@3/**))",
+    );
+    // Descriptor template registered with @1..@3 for cosigners and
+    // @0 for NUMS internal key. Verify the keys array passed to
+    // registerWallet has 4 entries (NUMS prepended).
+    expect(registerWalletMock).toHaveBeenCalledTimes(1);
+    const [policyArg] = registerWalletMock.mock.calls[0];
+    expect((policyArg as { keys: string[] }).keys).toHaveLength(4);
+    // Slot 0 is the NUMS xpub.
+    expect((policyArg as { keys: string[] }).keys[0]).toMatch(/^\[00000000\]xpub/);
+  });
+
+  it("refuses scriptType: tr on Ledger BTC app < 2.2.0", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.0.5",
+      flags: 0,
+    });
+
+    const { registerBitcoinMultisigWallet } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    await expect(
+      registerBitcoinMultisigWallet({
+        name: "TrVault",
+        threshold: 2,
+        cosigners: [
+          { xpub: a.xpub, masterFingerprint: a.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+          { xpub: b.xpub, masterFingerprint: b.masterFingerprint, derivationPath: "48'/0'/0'/2'" },
+        ],
+        scriptType: "tr",
+      }),
+    ).rejects.toThrow(/requires Ledger BTC app/);
+    expect(registerWalletMock).not.toHaveBeenCalled();
+  });
+});
+
+// --- Sign flow ----------------------------------------------------------
+
+describe("signBitcoinMultisigPsbt (tr)", () => {
+  it("splices Schnorr partial sig into tap_script_sig (NOT partial_sig)", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeTrWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+
+    // Build a minimal taproot PSBT with our tapBip32Derivation entry.
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const info = deriveMultisigAddress(wallet, 0, 0);
+
+    const requireFresh = createRequire(import.meta.url);
+    const bj = requireFresh("bitcoinjs-lib") as {
+      Psbt: new (opts?: { network?: unknown }) => {
+        addInput(input: Record<string, unknown>): unknown;
+        addOutput(out: Record<string, unknown>): unknown;
+        toBase64(): string;
+      };
+      address: { toOutputScript(a: string, n: unknown): Buffer };
+      networks: { bitcoin: unknown };
+    };
+    const NETWORK = bj.networks.bitcoin;
+    const psbt = new bj.Psbt({ network: NETWORK });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xab),
+      index: 0,
+      sequence: 0xfffffffd,
+      witnessUtxo: { script: info.scriptPubKey, value: 100_000_000 },
+      tapInternalKey: info.internalPubkey,
+      tapMerkleRoot: info.tapLeafHash,
+      tapLeafScript: [
+        {
+          leafVersion: 0xc0,
+          script: info.witnessScript,
+          controlBlock: info.controlBlock,
+        },
+      ],
+      tapBip32Derivation: wallet.cosigners.map((cosigner, idx) => ({
+        masterFingerprint: Buffer.from(cosigner.masterFingerprint, "hex"),
+        pubkey: info.cosignerPubkeys[idx],
+        path: `m/${cosigner.derivationPath}/0/0`,
+        leafHashes: [info.tapLeafHash],
+      })),
+    });
+    psbt.addOutput({
+      script: bj.address.toOutputScript(
+        "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+        NETWORK,
+      ),
+      value: 50_000_000,
+    });
+    const psbtBase64 = psbt.toBase64();
+
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    // Schnorr signature: 64 bytes (no DER encoding, no sighash byte for default).
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: info.cosignerPubkeys[0],
+          signature: Buffer.alloc(64, 0x77),
+          tapleafHash: info.tapLeafHash,
+        },
+      ],
+    ]);
+
+    const { signBitcoinMultisigPsbt } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await signBitcoinMultisigPsbt({
+      walletName: "TrVault",
+      psbtBase64,
+    });
+    expect(result.signaturesAdded).toBe(1);
+
+    const decoded = bitcoinjs.Psbt.fromBase64(result.partialPsbtBase64);
+    // Schnorr sig lands in tap_script_sig, NOT partial_sig.
+    expect(decoded.data.inputs[0].tapScriptSig?.length).toBe(1);
+    expect(decoded.data.inputs[0].partialSig).toBeUndefined();
+  });
+});
+
+// --- Initiator flow -----------------------------------------------------
+
+describe("prepareBitcoinMultisigSend (tr)", () => {
+  it("builds a taproot PSBT with tap_internal_key + tap_leaf_script + tap_bip32_derivation", async () => {
+    const a = deriveCosigner("alice");
+    const b = deriveCosigner("bob");
+    const c = deriveCosigner("carol");
+    const wallet = makeTrWallet([a, b, c]);
+    const { patchUserConfig } = await import("../src/config/user-config.js");
+    patchUserConfig({ pairings: { bitcoinMultisig: [wallet] } });
+
+    const { deriveMultisigAddress } = await import(
+      "../src/modules/btc/multisig-derive.ts"
+    );
+    const fundedAddr = deriveMultisigAddress(wallet, 0, 0);
+
+    getBalanceMock.mockImplementation(async (addr: string) => {
+      if (addr === fundedAddr.address) {
+        return {
+          address: addr,
+          confirmedSats: 100_000_000n,
+          mempoolSats: 0n,
+          totalSats: 100_000_000n,
+          txCount: 1,
+        };
+      }
+      return {
+        address: addr,
+        confirmedSats: 0n,
+        mempoolSats: 0n,
+        totalSats: 0n,
+        txCount: 0,
+      };
+    });
+    getUtxosMock.mockImplementation(async (addr: string) =>
+      addr === fundedAddr.address
+        ? [
+            {
+              txid: "ab".repeat(32),
+              vout: 0,
+              value: 100_000_000,
+              unconfirmed: false,
+            },
+          ]
+        : [],
+    );
+    getFeeEstimatesMock.mockResolvedValue({
+      fastestFee: 20,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+    getTxHexMock.mockResolvedValue(
+      buildPrevTxHex(100_000_000, fundedAddr.scriptPubKey),
+    );
+
+    getAppAndVersionMock.mockResolvedValueOnce({
+      name: "Bitcoin",
+      version: "2.4.6",
+      flags: 0,
+    });
+    getMasterFingerprintMock.mockResolvedValueOnce(a.masterFingerprint);
+    signPsbtMock.mockResolvedValueOnce([
+      [
+        0,
+        {
+          pubkey: fundedAddr.cosignerPubkeys[0],
+          signature: Buffer.alloc(64, 0x77),
+          tapleafHash: fundedAddr.tapLeafHash,
+        },
+      ],
+    ]);
+
+    const { prepareBitcoinMultisigSend } = await import(
+      "../src/modules/btc/multisig.js"
+    );
+    const result = await prepareBitcoinMultisigSend({
+      walletName: "TrVault",
+      to: "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu",
+      amount: "0.001",
+      feeRateSatPerVb: 10,
+    });
+    expect(result.signaturesAdded).toBe(1);
+
+    const psbt = bitcoinjs.Psbt.fromBase64(result.partialPsbtBase64);
+    const input = psbt.data.inputs[0];
+    expect(input.tapInternalKey).toBeDefined();
+    expect(input.tapInternalKey?.length).toBe(32);
+    expect(input.tapMerkleRoot).toBeDefined();
+    expect(input.tapLeafScript?.length).toBe(1);
+    expect(input.tapBip32Derivation?.length).toBe(3);
+    expect(input.tapScriptSig?.length).toBe(1);
+    expect(input.partialSig).toBeUndefined();
+  });
+});

--- a/test/btc-multisig.test.ts
+++ b/test/btc-multisig.test.ts
@@ -562,7 +562,7 @@ describe("signBitcoinMultisigPsbt", () => {
     const { signBitcoinMultisigPsbt } = await import("../src/modules/btc/multisig.js");
     await expect(
       signBitcoinMultisigPsbt({ walletName: "Vault", psbtBase64 }),
-    ).rejects.toThrow(/no bip32_derivation entry for our master fingerprint/);
+    ).rejects.toThrow(/no bip32_derivation .*for our/);
     expect(signPsbtMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Phase 3 PR4 — taproot script-path multi-sig (`tr(<NUMS>, sortedmulti_a(M, ...))`). **Stacked on #335 (PR3 — initiator flow + unregister)**.

The Ledger BTC app's wallet-policy parser accepts `tr(KP, TREE)` with `multi_a` / `sortedmulti_a` fragments inside `TREE` (verified pre-planning against [app-bitcoin-new/doc/wallet.md](https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md)). MuSig2 key-path aggregation is NOT supported by the app, so we use a NUMS internal key (provably no spend path) and spend exclusively through the script-path leaf.

## What's added

- `PairedBitcoinMultisigWallet.scriptType` widened to `"wsh" | "tr"`.
- Descriptor builder: `tr(@0/**, sortedmulti_a(M, @1/**, @2/**, ..., @N/**))` with NUMS as slot @0.
- Address derivation (`deriveTaprootMultisigAddress`) — `bitcoinjs.payments.p2tr` with internalPubkey=NUMS + scriptTree=leafScript. ECC lib initialized once via `@bitcoinerlab/secp256k1` (already transitive via ledger-bitcoin).
- Leaf script: BIP-342 `<p1> CHECKSIG <p2> CHECKSIGADD ... <pN> CHECKSIGADD <M> NUMEQUAL` over x-only sorted pubkeys.
- PSBT input fields: `tap_internal_key`, `tap_merkle_root`, `tap_leaf_script` (leafVersion=0xc0), `tap_bip32_derivation` (with leafHashes per cosigner). No `nonWitnessUtxo` (taproot sighashes commit to input amount).
- Sign-flow splice: `applyPartialSignatures` dispatches on `tapleafHash` and routes Schnorr sigs to `tap_script_sig` (BIP-371) instead of `partial_sig`.
- Vbyte estimator: separate formula for tr inputs accounting for Schnorr 64-byte sigs + control block + leaf script (cheaper than P2WSH ECDSA-DER).
- Min app version check: `tr` requires Ledger BTC app ≥ 2.2.0; register refuses on stale devices with a clear message.

## ⚠ Live-test required pre-merge

The exact NUMS xpub encoding the Ledger BTC app accepts in wallet policies is NOT documented in [`wallet.md`](https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md) — the spec is silent on the precise form. This PR uses the most-documented convention:
- BIP-341 NUMS x-only point (`lift_x(SHA256(G))`) prefixed with `0x02` for even-Y compressed form
- Depth-0 BIP-32 xpub serialization with all-zero chaincode + all-zero parent fingerprint
- Key info entry: `[00000000]<NUMS_XPUB>` (no derivation path)

If the live device rejects on `registerWallet`, the fix is local to `buildNumsXpub()` in `src/modules/btc/multisig.ts` and doesn't ripple. Same risk profile as the rest of the multi-sig flow's live-testing — expected before any of these PRs are exercised against real funds.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/btc-multisig-taproot.test.ts` — 5/5 passing (address derivation, register on supported / stale-app versions, sign splices into tap_script_sig, initiator builds tap field set)
- [x] All 4 multi-sig suites green: 29/29 (taproot + balance + initiator + co-signer)
- [ ] Live smoke: register a 2-of-3 P2TR wallet on Ledger app v2.2+, verify on-device descriptor approval flow
- [ ] Live smoke: prepare + sign a tr send, share PSBT with cosigner-2 (Sparrow), combine + finalize + broadcast

Plan: [`claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md`](../blob/main/claude-work/plan-bitcoin-ledger-phase3-multisig-followups.md). **Stacked on #335** — review #335 first; this PR's diff is taproot-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)