### PR TITLE
feat(risk-score): canonicalize 'curve' → 'curve-dex' DefiLlama slug

### DIFF
--- a/src/modules/security/risk-score.ts
+++ b/src/modules/security/risk-score.ts
@@ -42,6 +42,16 @@ const BOUNTY_ALIASES: Record<string, string> = {
   "uniswap-v4": "uniswap",
 };
 
+// User-friendly protocol names that don't match DefiLlama's actual slug.
+// `aave` / `compound` happen to be valid DefiLlama slugs so they don't need
+// an entry. `curve` is NOT — DefiLlama returns 400 "Protocol not found";
+// the canonical slug is `curve-dex`. Without this alias, every Curve
+// position consumer that asks for "curve" gets `score: undefined` despite
+// real TVL + audits being available on DefiLlama under `curve-dex`.
+const LLAMA_SLUG_ALIASES: Record<string, string> = {
+  curve: "curve-dex",
+};
+
 /**
  * DefiLlama's `/protocol/<slug>` returns `tvl` as a time-series array of
  * `{ date, totalLiquidityUSD }` for current responses. Older / cached shapes
@@ -111,7 +121,8 @@ export async function getProtocolRiskScore(protocol: string): Promise<{
   };
 }> {
   const slug = protocol.toLowerCase();
-  const data = await fetchLlamaProtocol(slug);
+  const llamaSlug = LLAMA_SLUG_ALIASES[slug] ?? slug;
+  const data = await fetchLlamaProtocol(llamaSlug);
 
   const raw: {
     tvlUsd?: number;

--- a/test/risk-score.test.ts
+++ b/test/risk-score.test.ts
@@ -157,6 +157,35 @@ describe("getProtocolRiskScore — #309 regressions", () => {
     expect(result.breakdown.bounty.note).toBe("no Immunefi bounty registered");
   });
 
+  it("Llama-slug alias: 'curve' canonicalizes to 'curve-dex' so DefiLlama returns data instead of 400", async () => {
+    // DefiLlama 400s on `/protocol/curve` (verified via curl, 2026-04-27);
+    // the canonical slug is `curve-dex`. We assert the alias map redirects
+    // the input so Curve consumers don't silently get score: undefined.
+    fetchWithTimeoutMock.mockImplementationOnce(async (url: string) => {
+      // The function under test must call DefiLlama with the canonical
+      // slug, not the bare "curve". If this expectation fails, the alias
+      // map regressed.
+      expect(url).toContain("/protocol/curve-dex");
+      return fakeOk({
+        name: "Curve DEX",
+        tvl: tvlSeries(1_730_000_000, 60, 1_650_000_000),
+        listedAt: 1_600_000_000,
+        audit_links: ["https://x.com/audit1", "https://x.com/audit2"],
+      });
+    });
+
+    const result = await getProtocolRiskScore("curve");
+
+    expect(result.protocol).toBe("curve");
+    expect(result.score).toBeDefined();
+    expect(Number.isFinite(result.score)).toBe(true);
+    expect(result.raw.tvlUsd).toBe(1_730_000_000);
+    // Curve is NOT on Immunefi (verified 2026-04-27); bounty must remain
+    // honest about that rather than synthesizing a fake entry.
+    expect(result.raw.hasBugBounty).toBe(false);
+    expect(result.breakdown.bounty.note).toBe("no Immunefi bounty registered");
+  });
+
   it("End-to-end: compound-v3 with the realistic API shape produces a meaningful score (the issue repro)", async () => {
     fetchWithTimeoutMock.mockResolvedValueOnce(
       fakeOk({


### PR DESCRIPTION
## Summary

Item 1 from the Curve v0.2 backlog ([#321](https://github.com/szhygulin/vaultpilot-mcp/issues/321)) — the cheapest one. Adds a `LLAMA_SLUG_ALIASES` map so user-friendly protocol names are canonicalized to DefiLlama's actual slugs before the API call.

The concrete bug: `get_protocol_risk_score(\"curve\")` hits DefiLlama's `/protocol/curve` which returns 400 \"Protocol not found\" — Curve's canonical DefiLlama slug is `curve-dex`. Without this alias every Curve consumer gets `score: undefined` despite real TVL ($1.73B), audit count (2), and listing date being available under `curve-dex`. Verified by `curl https://api.llama.fi/protocol/curve-dex` (200 OK, real data) vs `curl https://api.llama.fi/protocol/curve` (400 Protocol not found).

`aave` and `compound` happen to be valid DefiLlama slugs on their own, so they don't need an entry — only `curve` does today. The map is here so future protocols where the common name diverges from the DefiLlama slug can be added in one line.

## Why no Immunefi entry?

[#321](https://github.com/szhygulin/vaultpilot-mcp/issues/321) suggested adding Curve to `IMMUNEFI_BOUNTIES`, but Curve is **not** on Immunefi — verified at [immunefi.com/explore](https://immunefi.com/explore/) on 2026-04-27, Curve does not appear in the 231-program list. Curve runs its own self-hosted bounty program at [resources.curve.fi](https://resources.curve.fi/). The response correctly reports \"no Immunefi bounty registered\" rather than synthesizing a fake entry — bounty: 0/20, but TVL + audits + age still contribute, so the overall score is meaningful.

## Test plan

- [x] New regression test (`test/risk-score.test.ts:160`) — mocks DefiLlama, asserts the function calls `/protocol/curve-dex` (not `/protocol/curve`) when invoked with `\"curve\"`, verifies `score` is defined and `hasBugBounty: false`.
- [x] All 8 risk-score tests pass.
- [x] `npm run build` clean.

## What's still in #321 (deferred)

- get_curve_pool_info (read tool)
- prepare_curve_remove_liquidity + remove_liquidity_one_coin
- gauge_deposit / gauge_withdraw / gauge_claim
- meta-pool dispatch
- factory variants (stable v1/v2, twocrypto, crypto, tricrypto)
- chain expansion (Arbitrum / Polygon / Base)
- legacy pre-factory pools

🤖 Generated with [Claude Code](https://claude.com/claude-code)