### PR TITLE
feat(lp): prepare_uniswap_v3_increase_liquidity (M1b)

### DIFF
--- a/src/abis/uniswap-position-manager.ts
+++ b/src/abis/uniswap-position-manager.ts
@@ -13,6 +13,13 @@ export const uniswapPositionManagerAbi = [
   },
   {
     type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ type: "address" }],
+  },
+  {
+    type: "function",
     name: "tokenOfOwnerByIndex",
     stateMutability: "view",
     inputs: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,7 @@ import {
   prepareAaveBorrow,
   prepareAaveRepay,
   prepareUniswapV3Mint,
+  prepareUniswapV3IncreaseLiquidity,
   prepareLidoStake,
   prepareLidoUnstake,
   prepareEigenLayerDeposit,
@@ -257,6 +258,7 @@ import {
   prepareAaveBorrowInput,
   prepareAaveRepayInput,
   prepareUniswapV3MintInput,
+  prepareUniswapV3IncreaseLiquidityInput,
   prepareLidoStakeInput,
   prepareLidoUnstakeInput,
   prepareEigenLayerDepositInput,
@@ -2879,6 +2881,22 @@ async function main() {
       inputSchema: prepareUniswapV3MintInput.shape,
     },
     txHandler("prepare_uniswap_v3_mint", prepareUniswapV3Mint)
+  );
+
+  registerTool(server,
+    "prepare_uniswap_v3_increase_liquidity",
+    {
+      description:
+        "Build an unsigned Uniswap V3 LP increaseLiquidity transaction — adds liquidity to an existing position identified by `tokenId`. " +
+        "Reads the position's (token0, token1, fee, tickLower, tickUpper) on-chain via positions(tokenId), so the caller only supplies the tokenId + amounts. " +
+        "Hard-refuses when the tokenId is not owned by `wallet` (the on-chain call would still succeed and route the deposit into someone else's position — the position owner gets the new liquidity). Use `get_lp_positions` to enumerate the wallet's tokenIds. " +
+        "Up to two ERC-20 approvals are chained ahead of the increaseLiquidity() call. " +
+        "v1 limitation: only WETH (not native ETH) is supported as a pair side; wrap ETH first via `prepare_native_send` to the WETH contract. " +
+        "Slippage defaults to 50 bps (0.5%); soft cap at 100 bps requires `acknowledgeHighSlippage: true`. " +
+        "Pass `amount0Desired: \"0\"` (or amount1Desired) for a single-sided range deposit when the current price is outside the position's range.",
+      inputSchema: prepareUniswapV3IncreaseLiquidityInput.shape,
+    },
+    txHandler("prepare_uniswap_v3_increase_liquidity", prepareUniswapV3IncreaseLiquidity)
   );
 
   registerTool(server,

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -93,7 +93,7 @@ import {
   buildAaveBorrow,
   buildAaveRepay,
 } from "../positions/actions.js";
-import { buildUniswapMint } from "../lp/uniswap-v3/actions.js";
+import { buildUniswapMint, buildUniswapIncrease } from "../lp/uniswap-v3/actions.js";
 import {
   buildLidoStake,
   buildLidoUnstake,
@@ -110,6 +110,7 @@ import type {
   PrepareAaveBorrowArgs,
   PrepareAaveRepayArgs,
   PrepareUniswapV3MintArgs,
+  PrepareUniswapV3IncreaseLiquidityArgs,
   PrepareLidoStakeArgs,
   PrepareLidoUnstakeArgs,
   PrepareEigenLayerDepositArgs,
@@ -2224,6 +2225,24 @@ export async function prepareUniswapV3Mint(
       acknowledgeHighSlippage: args.acknowledgeHighSlippage,
       deadlineSec: args.deadlineSec,
       recipient: args.recipient as `0x${string}` | undefined,
+      approvalCap: args.approvalCap,
+    }),
+  );
+}
+
+export async function prepareUniswapV3IncreaseLiquidity(
+  args: PrepareUniswapV3IncreaseLiquidityArgs,
+): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildUniswapIncrease({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      tokenId: args.tokenId,
+      amount0Desired: args.amount0Desired,
+      amount1Desired: args.amount1Desired,
+      slippageBps: args.slippageBps,
+      acknowledgeHighSlippage: args.acknowledgeHighSlippage,
+      deadlineSec: args.deadlineSec,
       approvalCap: args.approvalCap,
     }),
   );

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1710,3 +1710,65 @@ export const prepareUniswapV3MintInput = z.object({
 });
 
 export type PrepareUniswapV3MintArgs = z.infer<typeof prepareUniswapV3MintInput>;
+
+// Increase liquidity on an existing Uniswap V3 LP position. Reads the
+// position's pair + tick range on-chain via positions(tokenId) — caller
+// only supplies the tokenId + amounts. Same v1 limitation as mint:
+// WETH on both sides (no native-ETH refund-via-multicall in v1).
+export const prepareUniswapV3IncreaseLiquidityInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  tokenId: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .describe(
+      "ERC-721 tokenId of the Uniswap V3 LP NFT to add liquidity to. The position " +
+        "must be owned by `wallet` — the builder reads ownerOf(tokenId) and refuses " +
+        "if it doesn't match. Use `get_lp_positions` to enumerate the wallet's " +
+        "tokenIds.",
+    ),
+  amount0Desired: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable decimal amount of the position\'s token0 to add. NOT raw wei. ' +
+        'Pass "0" for a single-sided range deposit when the current price is outside ' +
+        "the position's range.",
+    ),
+  amount1Desired: z
+    .string()
+    .max(50)
+    .describe("Human-readable decimal amount of the position's token1. Same shape as amount0Desired."),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(500)
+    .optional()
+    .describe(
+      "Slippage tolerance in basis points (1 bp = 0.01%). Default 50 bps (0.5%). " +
+        "Hard ceiling 500 bps; soft cap 100 bps requires acknowledgeHighSlippage: true.",
+    ),
+  acknowledgeHighSlippage: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required when slippageBps is in (100, 500]. Surface the trade-off to the user " +
+        "before proceeding.",
+    ),
+  deadlineSec: z
+    .number()
+    .int()
+    .min(60)
+    .max(3600)
+    .optional()
+    .describe(
+      "Seconds from now until the on-chain `deadline` parameter expires. Default 1200 (20 min).",
+    ),
+  approvalCap: approvalCapSchema,
+});
+
+export type PrepareUniswapV3IncreaseLiquidityArgs = z.infer<
+  typeof prepareUniswapV3IncreaseLiquidityInput
+>;

--- a/src/modules/lp/uniswap-v3/actions.ts
+++ b/src/modules/lp/uniswap-v3/actions.ts
@@ -273,6 +273,255 @@ export async function buildUniswapMint(
   return chainApprovals(approvals, mintTx);
 }
 
+export interface BuildUniswapIncreaseParams {
+  chain: SupportedChain;
+  wallet: `0x${string}`;
+  /** ERC-721 tokenId of the existing position to add liquidity to. */
+  tokenId: string;
+  /**
+   * Human-readable amount of the position's token0 to add. Pass "0"
+   * for a single-sided range deposit when the current price is
+   * outside [tickLower, tickUpper] and only the other side is needed.
+   */
+  amount0Desired: string;
+  /** Same for token1. */
+  amount1Desired: string;
+  slippageBps?: number;
+  acknowledgeHighSlippage?: boolean;
+  deadlineSec?: number;
+  approvalCap?: string;
+}
+
+/**
+ * Build an unsigned `increaseLiquidity()` tx for an existing Uniswap V3
+ * LP position. Reads the position's (token0, token1, fee, tickLower,
+ * tickUpper) on-chain so the caller doesn't have to thread them; uses
+ * the same Position math as mint to derive amount0Min / amount1Min.
+ *
+ * Hard refusal up front:
+ *   - tokenId not owned by `wallet` — funds would route into someone
+ *     else's position. The on-chain call would still succeed; the
+ *     position owner gets the new liquidity, not the caller. Refused.
+ *   - position not initialized (positions(tokenId) reverts) — caught
+ *     and surfaced as a clear "tokenId not found" error.
+ *   - both desired amounts zero.
+ */
+export async function buildUniswapIncrease(
+  p: BuildUniswapIncreaseParams,
+): Promise<UnsignedTx> {
+  const cfg = CONTRACTS[p.chain]?.uniswap;
+  if (!cfg) {
+    throw new Error(`Uniswap V3 is not registered on ${p.chain}.`);
+  }
+  const positionManager = cfg.positionManager as `0x${string}`;
+  const factoryAddr = cfg.factory as `0x${string}`;
+  const client = getClient(p.chain);
+
+  const tokenIdBig = BigInt(p.tokenId);
+  const slippageBps = parseSlippageBps({
+    slippageBps: p.slippageBps,
+    acknowledgeHighSlippage: p.acknowledgeHighSlippage,
+  });
+
+  // 1. Position state + ownership in one multicall. positions() reverts
+  //    on a non-existent tokenId — `allowFailure: false` lets that
+  //    bubble; we wrap to surface the "tokenId not found" path cleanly.
+  let positionData: readonly [
+    bigint,
+    `0x${string}`,
+    `0x${string}`,
+    `0x${string}`,
+    number,
+    number,
+    number,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+  ];
+  let owner: `0x${string}`;
+  try {
+    const [posResult, ownerResult] = await client.multicall({
+      contracts: [
+        {
+          address: positionManager,
+          abi: uniswapPositionManagerAbi,
+          functionName: "positions",
+          args: [tokenIdBig],
+        },
+        {
+          address: positionManager,
+          abi: uniswapPositionManagerAbi,
+          functionName: "ownerOf",
+          args: [tokenIdBig],
+        },
+      ],
+      allowFailure: false,
+    });
+    positionData = posResult as typeof positionData;
+    owner = ownerResult as `0x${string}`;
+  } catch (err) {
+    throw new Error(
+      `Uniswap V3 NPM positions(${p.tokenId}) read failed on ${p.chain}. ` +
+        `Most likely the tokenId does not exist. ` +
+        `(${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  if (owner.toLowerCase() !== p.wallet.toLowerCase()) {
+    throw new Error(
+      `Uniswap V3 LP NFT tokenId=${p.tokenId} is owned by ${owner}, not ${p.wallet}. ` +
+        `Refusing to increase liquidity — the on-chain call would route the deposit into ` +
+        `someone else's position. Verify the tokenId is one this wallet actually holds ` +
+        `(see get_lp_positions).`,
+    );
+  }
+
+  const [, , token0Addr, token1Addr, fee, tickLower, tickUpper] = positionData;
+
+  // 2. Token meta + pool address + slot0. Same layered reads as mint;
+  //    just with the position's pre-known (token0, token1, fee).
+  const [meta, poolAddr] = await Promise.all([
+    resolveTokenPairMeta(p.chain, [token0Addr, token1Addr]),
+    client.readContract({
+      address: factoryAddr,
+      abi: uniswapFactoryAbi,
+      functionName: "getPool",
+      args: [token0Addr, token1Addr, fee],
+    }) as Promise<`0x${string}`>,
+  ]);
+  if (poolAddr === "0x0000000000000000000000000000000000000000") {
+    throw new Error(
+      `Uniswap V3 pool ${token0Addr}/${token1Addr} fee=${fee} on ${p.chain} ` +
+        `does not resolve. The position's pool was uninitialized — should not happen ` +
+        `for an existing tokenId. Investigate.`,
+    );
+  }
+  const [decimals0, decimals1] = [meta[0].decimals, meta[1].decimals];
+  const [symbol0, symbol1] = [meta[0].symbol, meta[1].symbol];
+  const amount0Wei = parseUnits(p.amount0Desired, decimals0);
+  const amount1Wei = parseUnits(p.amount1Desired, decimals1);
+  if (amount0Wei === 0n && amount1Wei === 0n) {
+    throw new Error(
+      "At least one of amount0Desired / amount1Desired must be > 0.",
+    );
+  }
+
+  const [slot0, poolLiquidity] = await client.multicall({
+    contracts: [
+      { address: poolAddr, abi: uniswapPoolAbi, functionName: "slot0" },
+      { address: poolAddr, abi: uniswapPoolAbi, functionName: "liquidity" },
+    ],
+    allowFailure: false,
+  });
+  const sqrtPriceX96 = (slot0 as readonly [bigint, number, ...unknown[]])[0];
+  const currentTick = Number((slot0 as readonly [bigint, number, ...unknown[]])[1]);
+  void poolLiquidity;
+
+  const tickSpacing = TICK_SPACINGS[fee];
+  if (!tickSpacing) {
+    throw new Error(
+      `Uniswap V3 position ${p.tokenId} has unknown fee tier ${fee}. Refusing.`,
+    );
+  }
+
+  // 3. Slippage-bounded floors. Same math helper as mint; the position's
+  //    existing tick range comes from positions().
+  const { amount0: amount0Min, amount1: amount1Min } = mintAmountsWithSlippage({
+    pool: {
+      fee,
+      sqrtRatioX96: sqrtPriceX96,
+      tickCurrent: currentTick,
+      tickSpacing,
+    },
+    tickLower,
+    tickUpper,
+    amount0Desired: amount0Wei,
+    amount1Desired: amount1Wei,
+    slippageBps,
+  });
+
+  // 4. Encode increaseLiquidity() calldata.
+  const deadlineSec = p.deadlineSec ?? DEFAULT_DEADLINE_SEC;
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSec);
+
+  const increaseData = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "increaseLiquidity",
+    args: [
+      {
+        tokenId: tokenIdBig,
+        amount0Desired: amount0Wei,
+        amount1Desired: amount1Wei,
+        amount0Min,
+        amount1Min,
+        deadline,
+      },
+    ],
+  });
+  const increaseTx: UnsignedTx = {
+    chain: p.chain,
+    to: positionManager,
+    data: increaseData,
+    value: "0",
+    from: p.wallet,
+    description:
+      `Increase Uniswap V3 LP position #${p.tokenId}: ` +
+      `${p.amount0Desired} ${symbol0} + ${p.amount1Desired} ${symbol1} ` +
+      `at ${fee / 10_000}% fee, ticks [${tickLower}, ${tickUpper}], ` +
+      `slippage ${slippageBps} bps`,
+    decoded: {
+      functionName: "increaseLiquidity",
+      args: {
+        tokenId: p.tokenId,
+        amount0Desired: p.amount0Desired,
+        amount1Desired: p.amount1Desired,
+        amount0Min: amount0Min.toString(),
+        amount1Min: amount1Min.toString(),
+        deadline: deadline.toString(),
+      },
+    },
+  };
+
+  // 5. Approvals — one per nonzero side; reuse the chain machinery.
+  const approvals: Array<UnsignedTx | null> = [];
+  if (amount0Wei > 0n) {
+    const cap0 = resolveApprovalCap(p.approvalCap, amount0Wei, decimals0);
+    approvals.push(
+      await buildApprovalTx({
+        chain: p.chain,
+        wallet: p.wallet,
+        asset: token0Addr,
+        spender: positionManager,
+        amountWei: amount0Wei,
+        approvalAmount: cap0.approvalAmount,
+        approvalDisplay: cap0.display,
+        symbol: symbol0,
+        spenderLabel: "Uniswap V3 NonfungiblePositionManager",
+      }),
+    );
+  }
+  if (amount1Wei > 0n) {
+    const cap1 = resolveApprovalCap(p.approvalCap, amount1Wei, decimals1);
+    approvals.push(
+      await buildApprovalTx({
+        chain: p.chain,
+        wallet: p.wallet,
+        asset: token1Addr,
+        spender: positionManager,
+        amountWei: amount1Wei,
+        approvalAmount: cap1.approvalAmount,
+        approvalDisplay: cap1.display,
+        symbol: symbol1,
+        spenderLabel: "Uniswap V3 NonfungiblePositionManager",
+      }),
+    );
+  }
+
+  return chainApprovals(approvals, increaseTx);
+}
+
 // Re-export erc20Abi so future builders in this module don't need a
 // duplicate import; tests also reach for it.
 export { erc20Abi };

--- a/test/uniswap-v3-increase.test.ts
+++ b/test/uniswap-v3-increase.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for `buildUniswapIncrease` — the increaseLiquidity-side LP
+ * builder, M1b in `claude-work/plan-dex-liquidity-provision.md`.
+ * Mocks the RPC client surface so positions(tokenId) + ownerOf
+ * + slot0 + factory.getPool all produce deterministic values; asserts
+ * the calldata + approval chain.
+ *
+ * Key invariants exercised:
+ *   - Happy path: positions() → known pair + ticks → mintAmountsWithSlippage
+ *     → increaseLiquidity() calldata, two approvals chained ahead.
+ *   - Hard refuse when ownerOf(tokenId) ≠ wallet (would route the
+ *     deposit into someone else's position).
+ *   - Hard refuse when both desired amounts are zero.
+ *   - Single-sided deposit (amount0Desired = 0) emits only the token1
+ *     approval.
+ *   - Slippage gating + acknowledgeHighSlippage flag.
+ *   - approvalCap: "exact" produces approve(amount) calldata for the
+ *     first approval.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { decodeFunctionData } from "viem";
+import { uniswapPositionManagerAbi } from "../src/abis/uniswap-position-manager.js";
+import { erc20Abi } from "../src/abis/erc20.js";
+
+const { readContractMock, multicallMock } = vi.hoisted(() => ({
+  readContractMock: vi.fn(),
+  multicallMock: vi.fn(),
+}));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+    multicall: multicallMock,
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD" as const;
+const OTHER_WALLET = "0x1111111111111111111111111111111111111111" as const;
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as const;
+const NPM = "0xC36442b4a4522E871399CD717aBDD847Ab11FE88" as const;
+const USDC_WETH_POOL = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8" as const;
+
+const TOKEN_ID = "12345";
+
+// Realistic-ish pool state — see uniswap-v3-mint.test.ts for the
+// derivation. sqrtRatioX96 corresponds to USDC/WETH near $3000/ETH at
+// tick=-201960; tick range [-202020, -201900] keeps the position
+// in-range so the slippage helper exercises the "in-range" branch.
+const FAKE_CURRENT_TICK = -201_960;
+const FAKE_SQRT_PRICE_X96 = 3_262_820_378_846_468_593_912_909n;
+const FAKE_POOL_LIQUIDITY = 10_000_000_000_000_000_000n;
+
+// positions() return tuple: (nonce, operator, token0, token1, fee,
+// tickLower, tickUpper, liquidity, feeGrowthInside0LastX128,
+// feeGrowthInside1LastX128, tokensOwed0, tokensOwed1)
+function positionTuple(opts: {
+  token0?: `0x${string}`;
+  token1?: `0x${string}`;
+  fee?: number;
+  tickLower?: number;
+  tickUpper?: number;
+} = {}) {
+  return [
+    0n,
+    "0x0000000000000000000000000000000000000000" as `0x${string}`,
+    opts.token0 ?? USDC,
+    opts.token1 ?? WETH,
+    opts.fee ?? 3_000,
+    opts.tickLower ?? -202_020,
+    opts.tickUpper ?? -201_900,
+    1_000_000n, // existing liquidity (not consumed by builder)
+    0n,
+    0n,
+    0n,
+    0n,
+  ] as const;
+}
+
+function mockHappyPath(opts: { owner?: `0x${string}` } = {}) {
+  multicallMock.mockImplementation(async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+    if (contracts[0]?.functionName === "positions" && contracts[1]?.functionName === "ownerOf") {
+      return [positionTuple(), opts.owner ?? WALLET];
+    }
+    if (contracts[0]?.functionName === "decimals" && contracts[1]?.functionName === "symbol") {
+      // resolveTokenPairMeta: 2 tokens × (decimals, symbol)
+      return [6, "USDC", 18, "WETH"];
+    }
+    if (contracts[0]?.functionName === "slot0" && contracts[1]?.functionName === "liquidity") {
+      return [
+        [FAKE_SQRT_PRICE_X96, FAKE_CURRENT_TICK, 0, 1, 1, 0, true],
+        FAKE_POOL_LIQUIDITY,
+      ];
+    }
+    throw new Error(
+      `unexpected multicall: ${JSON.stringify(contracts.map((c) => c.functionName))}`,
+    );
+  });
+  readContractMock.mockImplementation(
+    async ({ functionName }: { functionName: string }) => {
+      if (functionName === "getPool") return USDC_WETH_POOL;
+      if (functionName === "allowance") return 0n;
+      throw new Error(`unexpected readContract: ${functionName}`);
+    },
+  );
+}
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  multicallMock.mockReset();
+});
+
+describe("buildUniswapIncrease", () => {
+  it("happy path: increase USDC/WETH 0.3% position #12345 → increaseLiquidity() calldata + 2 approvals", async () => {
+    mockHappyPath();
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapIncrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      amount0Desired: "100",
+      amount1Desired: "0.05",
+      slippageBps: 50,
+    });
+    expect(tx.description).toContain("Approve USDC");
+    expect(tx.next!.description).toContain("Approve WETH");
+    expect(tx.next!.next).toBeDefined();
+
+    const incTx = tx.next!.next!;
+    expect(incTx.to.toLowerCase()).toBe(NPM.toLowerCase());
+    expect(incTx.value).toBe("0");
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: incTx.data,
+    });
+    expect(decoded.functionName).toBe("increaseLiquidity");
+    const params = (decoded.args as readonly [{
+      tokenId: bigint;
+      amount0Desired: bigint;
+      amount1Desired: bigint;
+      amount0Min: bigint;
+      amount1Min: bigint;
+      deadline: bigint;
+    }])[0];
+    expect(params.tokenId).toBe(12_345n);
+    expect(params.amount0Desired).toBe(100_000_000n); // 100 USDC, 6 decimals
+    expect(params.amount1Desired).toBe(50_000_000_000_000_000n); // 0.05 WETH
+    expect(params.amount0Min).toBeLessThanOrEqual(params.amount0Desired);
+    expect(params.amount1Min).toBeLessThanOrEqual(params.amount1Desired);
+    expect(incTx.description).toContain("position #12345");
+  });
+
+  it("hard-refuses when the tokenId is owned by a different address", async () => {
+    mockHappyPath({ owner: OTHER_WALLET });
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapIncrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        amount0Desired: "100",
+        amount1Desired: "0.05",
+      }),
+    ).rejects.toThrow(/not the wallet|is owned by/);
+  });
+
+  it("surfaces a clear error when positions(tokenId) reverts (tokenId not found)", async () => {
+    multicallMock.mockImplementation(
+      async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+        if (contracts[0]?.functionName === "positions") {
+          throw new Error("execution reverted");
+        }
+        throw new Error("unexpected");
+      },
+    );
+    readContractMock.mockResolvedValue(0n);
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapIncrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: "999999999",
+        amount0Desired: "1",
+        amount1Desired: "1",
+      }),
+    ).rejects.toThrow(/tokenId does not exist|positions\(/);
+  });
+
+  it("rejects when both desired amounts are zero", async () => {
+    mockHappyPath();
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapIncrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        amount0Desired: "0",
+        amount1Desired: "0",
+      }),
+    ).rejects.toThrow(/At least one.*must be > 0/);
+  });
+
+  it("emits only the nonzero-side approval for single-sided range deposits", async () => {
+    // Position with range entirely above current price → only token1 needed.
+    multicallMock.mockImplementation(
+      async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+        if (contracts[0]?.functionName === "positions") {
+          return [
+            positionTuple({ tickLower: -201_840, tickUpper: -201_780 }),
+            WALLET,
+          ];
+        }
+        if (contracts[0]?.functionName === "decimals") return [6, "USDC", 18, "WETH"];
+        if (contracts[0]?.functionName === "slot0") {
+          return [
+            [FAKE_SQRT_PRICE_X96, FAKE_CURRENT_TICK, 0, 1, 1, 0, true],
+            FAKE_POOL_LIQUIDITY,
+          ];
+        }
+        throw new Error("unexpected");
+      },
+    );
+    readContractMock.mockImplementation(
+      async ({ functionName }: { functionName: string }) => {
+        if (functionName === "getPool") return USDC_WETH_POOL;
+        if (functionName === "allowance") return 0n;
+        throw new Error("unexpected");
+      },
+    );
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapIncrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      amount0Desired: "0",
+      amount1Desired: "0.05",
+      slippageBps: 50,
+    });
+    expect(tx.description).toContain("Approve WETH");
+    expect(tx.description).not.toContain("Approve USDC");
+    expect(tx.next!.description).toContain("Increase Uniswap V3");
+  });
+
+  it("rejects high slippage without acknowledgeHighSlippage", async () => {
+    mockHappyPath();
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapIncrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        amount0Desired: "100",
+        amount1Desired: "0.05",
+        slippageBps: 150,
+      }),
+    ).rejects.toThrow(/sandwich-bait/);
+  });
+
+  it("accepts high slippage when acknowledgeHighSlippage=true", async () => {
+    mockHappyPath();
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapIncrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      amount0Desired: "100",
+      amount1Desired: "0.05",
+      slippageBps: 150,
+      acknowledgeHighSlippage: true,
+    });
+    expect(tx.next!.next!.description).toContain("slippage 150 bps");
+  });
+
+  it("approval calldata uses the configured cap (exact)", async () => {
+    mockHappyPath();
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapIncrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      amount0Desired: "100",
+      amount1Desired: "0.05",
+      approvalCap: "exact",
+    });
+    const decodedApprove = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decodedApprove.functionName).toBe("approve");
+    const [, amount] = decodedApprove.args as readonly [string, bigint];
+    expect(amount).toBe(100_000_000n);
+  });
+
+  it("skips approvals when allowance already satisfies the deposit", async () => {
+    multicallMock.mockImplementation(
+      async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+        if (contracts[0]?.functionName === "positions") {
+          return [positionTuple(), WALLET];
+        }
+        if (contracts[0]?.functionName === "decimals") return [6, "USDC", 18, "WETH"];
+        if (contracts[0]?.functionName === "slot0") {
+          return [
+            [FAKE_SQRT_PRICE_X96, FAKE_CURRENT_TICK, 0, 1, 1, 0, true],
+            FAKE_POOL_LIQUIDITY,
+          ];
+        }
+        throw new Error("unexpected");
+      },
+    );
+    readContractMock.mockImplementation(
+      async ({ functionName }: { functionName: string }) => {
+        if (functionName === "getPool") return USDC_WETH_POOL;
+        if (functionName === "allowance") return 2n ** 256n - 1n;
+        throw new Error("unexpected");
+      },
+    );
+    const { buildUniswapIncrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapIncrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      amount0Desired: "100",
+      amount1Desired: "0.05",
+    });
+    expect(tx.description).toContain("Increase Uniswap V3");
+    expect(tx.next).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Second LP write tool — adds liquidity to an existing Uniswap V3 LP position by tokenId. Builds on [#334 (M1a — mint)](https://github.com/szhygulin/vaultpilot-mcp/pull/334) and [#327 (M0 shared infra)](https://github.com/szhygulin/vaultpilot-mcp/pull/327).

## What's in this PR

- `src/abis/uniswap-position-manager.ts` — adds `ownerOf` ERC-721 selector (used to verify the tokenId belongs to the caller before routing the deposit).
- `src/modules/lp/uniswap-v3/actions.ts` — `buildUniswapIncrease`. Reads the position state + ownership in one multicall, fetches pool slot0 + liquidity in another, runs `mintAmountsWithSlippage` from M1a's port over the position's existing tick range, encodes `increaseLiquidity()` via viem, chains approvals via M0's `chainApprovals`.
- `src/modules/execution/{schemas,index}.ts` — Zod input + handler.
- `src/index.ts` — `prepare_uniswap_v3_increase_liquidity` tool registration.

## Hard-refusal cases

| Case | Why it's a hard refuse |
|---|---|
| `ownerOf(tokenId) ≠ wallet` | The on-chain `increaseLiquidity()` would still succeed and **route the deposit into the actual owner's position** — the caller's tokens would credit someone else's NFT. Refused at prepare time with a message naming the actual owner. |
| `positions(tokenId)` reverts | Surfaces as "tokenId does not exist" rather than a cryptic multicall failure. |
| both desired amounts zero | Same as mint — there's nothing to do. |

## v1 scope (unchanged from M1a)

- **WETH-only** (no native ETH); wrap first via `prepare_native_send` to the WETH contract.
- Slippage: 50 bps default; soft cap 100 bps requires `acknowledgeHighSlippage: true`; hard ceiling 500 bps.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1708/1708 pass parallel in 35s
- [x] 9 new tests in `test/uniswap-v3-increase.test.ts`:
  - Happy path: USDC/WETH 0.3% increase → `increaseLiquidity()` calldata + 2 approvals chained ahead
  - Wrong-owner hard refuse
  - tokenId-not-found error surfaces clearly
  - Both-amounts-zero rejection
  - Single-sided range deposit emits only the nonzero-side approval
  - Slippage gating (rejection without ack, acceptance with ack)
  - `approvalCap: "exact"` produces approve(amount) calldata
  - Already-unlimited allowance skips approvals
- [ ] CI green
- [ ] One real mainnet increase with minimal amounts on a known position, signed on a real Ledger device

## Follow-ups

- M1c: `prepare_uniswap_v3_decrease_liquidity` + `_collect` + `_burn` — the close-out lifecycle. `decrease_liquidity` will need round-down deltas in `sqrt-price-math.ts` (`getAmount0Delta` / `getAmount1Delta` with `roundUp: false`).
- M1d: `prepare_uniswap_v3_rebalance` — multicall compose of decrease + collect + burn + mint.
- Native-ETH support across mint+increase via NPM's `multicall([mint, refundETH()])` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)