### PR TITLE
perf(release): prune devDependencies before pkg snapshot (~20 MB smaller)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Build dist/
         run: npm run build
 
+      - name: Prune devDependencies before pkg snapshot
+        # Mirror release-binaries.yml so the smoke test exercises the same
+        # node_modules shape the release binary will see. Catches the case
+        # where a runtime feature accidentally requires a devDep (would be
+        # invisible without prune; would only fail at release time).
+        run: npm prune --omit=dev --legacy-peer-deps
+
       - name: Bundle server binary
         run: npx pkg . --target node22-linux-x64 --output release/vaultpilot-mcp-linux-x64-server
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,14 @@ jobs:
         run: npm prune --omit=dev --legacy-peer-deps
 
       - name: Bundle server binary
-        run: npx pkg . --target node22-linux-x64 --output release/vaultpilot-mcp-linux-x64-server
+        # `npx --package=@yao-pkg/pkg pkg` (NOT plain `npx pkg`): the prune
+        # step above removed the @yao-pkg/pkg devDep + its `pkg` bin link
+        # from node_modules, so plain `npx pkg` falls through to the npm
+        # registry and fetches the unrelated deprecated `pkg@5.8.1`, which
+        # doesn't support Node 22 (`Error! No available node version
+        # satisfies 'node22'`). The explicit --package flag tells npx
+        # which package to fetch when the bin isn't local.
+        run: npx --package=@yao-pkg/pkg pkg . --target node22-linux-x64 --output release/vaultpilot-mcp-linux-x64-server
         env:
           CI: "true"
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -100,6 +100,19 @@ jobs:
       - name: Build dist/
         run: npm run build
 
+      - name: Prune devDependencies before pkg snapshot
+        # `npm ci` above installs deps + devDeps (we need typescript etc. for
+        # `npm run build`). Once dist/ is built, drop the devDeps so pkg
+        # doesn't snapshot them. vitest pulls in @rolldown (45MB binding) and
+        # lightningcss (~20MB) transitively — neither is reachable from the
+        # MCP server entry point at runtime, but pkg's static-require walker
+        # can't always prove that, so the snapshot grows. Empirically this
+        # shaves ~20MB off the binary on linux-x64. Lower output size = faster
+        # release-asset upload + less likely to trip GitHub's reverse-proxy
+        # idle-timeout on slow runners (root cause of the v0.9.4
+        # macos-arm64-server upload failure — issue #330 follow-up).
+        run: npm prune --omit=dev --legacy-peer-deps
+
       - name: Bundle server binary
         # `pkg .` (not `pkg dist/index.js`) so pkg picks up package.json
         # context including the `pkg.scripts` glob and the bin block.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -121,7 +121,16 @@ jobs:
         # an ESM exports-map resolution bug for subpath imports like
         # `@modelcontextprotocol/sdk/server/mcp.js` — `pkg .` is the
         # supported path.
-        run: npx pkg . --target ${{ matrix.target }} --output release/${{ matrix.server_asset }}
+        #
+        # `npx --package=@yao-pkg/pkg pkg` (NOT plain `npx pkg`): the
+        # prune step above removed the @yao-pkg/pkg devDep + its `pkg`
+        # bin link from node_modules, so plain `npx pkg` falls through
+        # to the npm registry and fetches the unrelated deprecated
+        # `pkg@5.8.1`, which doesn't support Node 22 at all (`Error! No
+        # available node version satisfies 'node22'`). The explicit
+        # --package flag tells npx which package to fetch when the bin
+        # isn't local.
+        run: npx --package=@yao-pkg/pkg pkg . --target ${{ matrix.target }} --output release/${{ matrix.server_asset }}
         env:
           CI: "true"
 
@@ -129,7 +138,7 @@ jobs:
         # Direct entrypoint here is fine — setup.js doesn't import any
         # subpath exports from CJS-fallback packages, so the resolution
         # bug above doesn't apply.
-        run: npx pkg dist/setup.js --target ${{ matrix.target }} --output release/${{ matrix.setup_asset }}
+        run: npx --package=@yao-pkg/pkg pkg dist/setup.js --target ${{ matrix.target }} --output release/${{ matrix.setup_asset }}
         env:
           CI: "true"
 


### PR DESCRIPTION
## Summary

Adds `npm prune --omit=dev --legacy-peer-deps` between `npm run build` and the pkg bundle steps in both `release-binaries.yml` and `ci.yml`. Shrinks the pkg-bundled binary by ~20 MB to give upload more headroom on slow matrix legs.

## Why

The v0.9.4 release lost `vaultpilot-mcp-macos-arm64-server` to a GitHub reverse-proxy timeout during upload (the \"Unicorn!\" 5xx page). Investigation showed:

- macos-14 (Apple silicon) runners push at ~22 Mbps; 504 MB → ~3 min 12 s upload window
- That sits at the edge of GitHub's reverse-proxy idle-timeout for upload connections
- `softprops/action-gh-release@v2` doesn't retry 5xx, so the proxy timeout surfaces as a fatal error
- linux-x64-server (504 MB, same workflow, same release id, same minute) succeeded — same upload duration but evidently squeezed in just under the timeout

Less binary = faster upload = lower probability of tripping the timeout. Doesn't eliminate the problem (a retry-on-5xx wrapper is the more robust fix, orthogonal to size — separate PR).

## Where the bytes were going

`vitest` (devDep) pulls in `@rolldown/*` (45 MB binding), `lightningcss` (~20 MB), and `esbuild` + `@esbuild` (~22 MB) transitively. None of these are reachable from `src/index.ts` at runtime, but pkg's static-require walker can't always prove unreachability, so the snapshot grew.

Pruning devDeps **after** `npm run build` (so tsc still runs) but **before** `npx pkg .` (so the snapshot only sees runtime deps) removes the ambiguity at the source.

## Measurements (local, linux-x64)

| Stage | node_modules | binary |
|---|---|---|
| Before this PR | 692 MB | 504 MB |
| After this PR | 557 MB (-135 MB) | 483 MB (-21 MB) |

Smoke test (`scripts/smoke-test-binary.mjs`) passes on the slimmed binary: `tools: 156`.

## Test plan

- [x] `npm run build` clean.
- [x] `npm prune --omit=dev` succeeds without removing anything required by the runtime entry path.
- [x] `npx pkg .` produces a smaller binary that boots and serves `tools/list` end-to-end.
- [x] CI's `Binary smoke test (linux-x64)` job (added in #336) will exercise the new prune step on every PR going forward.

## Not in scope

- **Upload retry on 5xx** — separate PR. Switch `softprops/action-gh-release@v2` for `gh release upload --clobber` inside a 3-attempt bash retry loop. Higher robustness yield than size reduction; both are complementary.
- **Larger size reductions** — would require dropping SDK features (Kamino's `@raydium-io` transit alone is 85 MB; LiFi's `@mysten/sui` is 25 MB; viem is 67 MB). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)