### PR TITLE
feat(lp): Uniswap V3 close-out lifecycle (M1c — decrease + collect + burn)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,9 @@ import {
   prepareAaveRepay,
   prepareUniswapV3Mint,
   prepareUniswapV3IncreaseLiquidity,
+  prepareUniswapV3DecreaseLiquidity,
+  prepareUniswapV3Collect,
+  prepareUniswapV3Burn,
   prepareLidoStake,
   prepareLidoUnstake,
   prepareEigenLayerDeposit,
@@ -259,6 +262,9 @@ import {
   prepareAaveRepayInput,
   prepareUniswapV3MintInput,
   prepareUniswapV3IncreaseLiquidityInput,
+  prepareUniswapV3DecreaseLiquidityInput,
+  prepareUniswapV3CollectInput,
+  prepareUniswapV3BurnInput,
   prepareLidoStakeInput,
   prepareLidoUnstakeInput,
   prepareEigenLayerDepositInput,
@@ -2897,6 +2903,44 @@ async function main() {
       inputSchema: prepareUniswapV3IncreaseLiquidityInput.shape,
     },
     txHandler("prepare_uniswap_v3_increase_liquidity", prepareUniswapV3IncreaseLiquidity)
+  );
+
+  registerTool(server,
+    "prepare_uniswap_v3_decrease_liquidity",
+    {
+      description:
+        "Build an unsigned Uniswap V3 LP decreaseLiquidity transaction — removes liquidity from an existing position by tokenId. " +
+        "Pass `liquidityPct: 100` for a full close-out (typical follow-up: `prepare_uniswap_v3_collect`, then optionally `prepare_uniswap_v3_burn`). " +
+        "Pass `liquidity: \"<raw>\"` for exact-amount accounting; the two args are mutually exclusive. " +
+        "Hard-refuses when the tokenId is not owned by `wallet` (would credit the actual owner) and when the position has zero liquidity (nothing to decrease). " +
+        "**Withdrawn tokens become `tokensOwed` on the position — they do NOT move to the wallet until you call `prepare_uniswap_v3_collect` afterwards.** This separation matches the on-chain protocol shape and lets the agent batch decrease+collect via rebalance.",
+      inputSchema: prepareUniswapV3DecreaseLiquidityInput.shape,
+    },
+    txHandler("prepare_uniswap_v3_decrease_liquidity", prepareUniswapV3DecreaseLiquidity)
+  );
+
+  registerTool(server,
+    "prepare_uniswap_v3_collect",
+    {
+      description:
+        "Build an unsigned Uniswap V3 LP collect transaction — harvests every token the position is owed (decreased liquidity from prior `prepare_uniswap_v3_decrease_liquidity` calls + accrued swap fees) up to uint128.max per side. " +
+        "Hard-refuses when the tokenId is not owned by `wallet`. The protocol auto-settles uncollected fee growth into `tokensOwed` inside the call, so even a position with `tokensOwed{0,1}=0` may receive tokens. " +
+        "`recipient` defaults to the wallet; pass an address to send the harvest elsewhere.",
+      inputSchema: prepareUniswapV3CollectInput.shape,
+    },
+    txHandler("prepare_uniswap_v3_collect", prepareUniswapV3Collect)
+  );
+
+  registerTool(server,
+    "prepare_uniswap_v3_burn",
+    {
+      description:
+        "Build an unsigned Uniswap V3 LP burn transaction — destroys the position NFT (irreversible). " +
+        "Hard-refuses unless the position is fully drained: `liquidity == 0` AND `tokensOwed{0,1} == 0`. " +
+        "Standard close-out sequence: `prepare_uniswap_v3_decrease_liquidity({ liquidityPct: 100 })` → `prepare_uniswap_v3_collect` → `prepare_uniswap_v3_burn`. The error message names the right next step on each refusal.",
+      inputSchema: prepareUniswapV3BurnInput.shape,
+    },
+    txHandler("prepare_uniswap_v3_burn", prepareUniswapV3Burn)
   );
 
   registerTool(server,

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -93,7 +93,13 @@ import {
   buildAaveBorrow,
   buildAaveRepay,
 } from "../positions/actions.js";
-import { buildUniswapMint, buildUniswapIncrease } from "../lp/uniswap-v3/actions.js";
+import {
+  buildUniswapMint,
+  buildUniswapIncrease,
+  buildUniswapDecrease,
+  buildUniswapCollect,
+  buildUniswapBurn,
+} from "../lp/uniswap-v3/actions.js";
 import {
   buildLidoStake,
   buildLidoUnstake,
@@ -111,6 +117,9 @@ import type {
   PrepareAaveRepayArgs,
   PrepareUniswapV3MintArgs,
   PrepareUniswapV3IncreaseLiquidityArgs,
+  PrepareUniswapV3DecreaseLiquidityArgs,
+  PrepareUniswapV3CollectArgs,
+  PrepareUniswapV3BurnArgs,
   PrepareLidoStakeArgs,
   PrepareLidoUnstakeArgs,
   PrepareEigenLayerDepositArgs,
@@ -2244,6 +2253,48 @@ export async function prepareUniswapV3IncreaseLiquidity(
       acknowledgeHighSlippage: args.acknowledgeHighSlippage,
       deadlineSec: args.deadlineSec,
       approvalCap: args.approvalCap,
+    }),
+  );
+}
+
+export async function prepareUniswapV3DecreaseLiquidity(
+  args: PrepareUniswapV3DecreaseLiquidityArgs,
+): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildUniswapDecrease({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      tokenId: args.tokenId,
+      liquidityPct: args.liquidityPct,
+      liquidity: args.liquidity,
+      slippageBps: args.slippageBps,
+      acknowledgeHighSlippage: args.acknowledgeHighSlippage,
+      deadlineSec: args.deadlineSec,
+    }),
+  );
+}
+
+export async function prepareUniswapV3Collect(
+  args: PrepareUniswapV3CollectArgs,
+): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildUniswapCollect({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      tokenId: args.tokenId,
+      recipient: args.recipient as `0x${string}` | undefined,
+    }),
+  );
+}
+
+export async function prepareUniswapV3Burn(
+  args: PrepareUniswapV3BurnArgs,
+): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildUniswapBurn({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      tokenId: args.tokenId,
     }),
   );
 }

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1772,3 +1772,84 @@ export const prepareUniswapV3IncreaseLiquidityInput = z.object({
 export type PrepareUniswapV3IncreaseLiquidityArgs = z.infer<
   typeof prepareUniswapV3IncreaseLiquidityInput
 >;
+
+// M1c — close-out lifecycle. The decrease + collect + burn trio.
+export const prepareUniswapV3DecreaseLiquidityInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  tokenId: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .describe(
+      "ERC-721 tokenId of the LP NFT to decrease liquidity from. Must be owned by `wallet`.",
+    ),
+  liquidityPct: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      "Percentage of position liquidity to withdraw (1-100). Pass 100 for full close-out " +
+        "(typical follow-up: prepare_uniswap_v3_collect, then optionally burn). " +
+        "Mutually exclusive with `liquidity` — pass exactly one.",
+    ),
+  liquidity: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .optional()
+    .describe(
+      "Raw liquidity to withdraw (decimal-string bigint). Use when you need exact " +
+        "accounting; otherwise prefer liquidityPct. Mutually exclusive with `liquidityPct`.",
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(500)
+    .optional()
+    .describe("Slippage tolerance in bps. Default 50; soft cap 100."),
+  acknowledgeHighSlippage: z.boolean().optional(),
+  deadlineSec: z.number().int().min(60).max(3600).optional(),
+});
+
+export const prepareUniswapV3CollectInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  tokenId: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .describe(
+      "ERC-721 tokenId of the LP NFT to harvest fees + tokensOwed from. Must be owned by `wallet`.",
+    ),
+  recipient: addressSchema
+    .optional()
+    .describe(
+      "Address to receive the harvested tokens. Default: wallet (the position owner).",
+    ),
+});
+
+export const prepareUniswapV3BurnInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  tokenId: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .describe(
+      "ERC-721 tokenId of the LP NFT to destroy. Must be owned by `wallet`. The position " +
+        "must be fully drained: liquidity = 0 AND tokensOwed{0,1} = 0. Refused otherwise " +
+        "with the right sequence (decrease → collect → burn) named in the error.",
+    ),
+});
+
+export type PrepareUniswapV3DecreaseLiquidityArgs = z.infer<
+  typeof prepareUniswapV3DecreaseLiquidityInput
+>;
+export type PrepareUniswapV3CollectArgs = z.infer<
+  typeof prepareUniswapV3CollectInput
+>;
+export type PrepareUniswapV3BurnArgs = z.infer<typeof prepareUniswapV3BurnInput>;

--- a/src/modules/lp/uniswap-v3/actions.ts
+++ b/src/modules/lp/uniswap-v3/actions.ts
@@ -28,7 +28,11 @@ import {
 import { resolveTokenPairMeta } from "../../shared/token-meta.js";
 import { parseSlippageBps } from "../preflight.js";
 import { TICK_SPACINGS, nearestUsableTick } from "./tick-math.js";
-import { mintAmountsWithSlippage, type PoolState } from "./position-math.js";
+import {
+  burnAmountsWithSlippage,
+  mintAmountsWithSlippage,
+  type PoolState,
+} from "./position-math.js";
 import type { SupportedChain, UnsignedTx } from "../../../types/index.js";
 
 const SUPPORTED_FEE_TIERS = [100, 500, 3000, 10000] as const;
@@ -520,6 +524,404 @@ export async function buildUniswapIncrease(
   }
 
   return chainApprovals(approvals, increaseTx);
+}
+
+// uint128 max — used by `collect()` to harvest everything the position
+// is owed without a 256-bit cap argument.
+const U128_MAX = (1n << 128n) - 1n;
+
+/**
+ * Read positions(tokenId) + ownerOf(tokenId) for a Uniswap V3 LP NFT;
+ * assert ownership matches `wallet`. Returns the parsed tuple. Used by
+ * decrease / collect / burn — all three need the same preflight.
+ */
+async function readOwnedPosition(
+  chain: SupportedChain,
+  positionManager: `0x${string}`,
+  wallet: `0x${string}`,
+  tokenId: bigint,
+): Promise<{
+  nonce: bigint;
+  operator: `0x${string}`;
+  token0: `0x${string}`;
+  token1: `0x${string}`;
+  fee: number;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+  feeGrowthInside0LastX128: bigint;
+  feeGrowthInside1LastX128: bigint;
+  tokensOwed0: bigint;
+  tokensOwed1: bigint;
+}> {
+  const client = getClient(chain);
+  let posResult: readonly unknown[];
+  let owner: `0x${string}`;
+  try {
+    const [pos, ownerRes] = await client.multicall({
+      contracts: [
+        {
+          address: positionManager,
+          abi: uniswapPositionManagerAbi,
+          functionName: "positions",
+          args: [tokenId],
+        },
+        {
+          address: positionManager,
+          abi: uniswapPositionManagerAbi,
+          functionName: "ownerOf",
+          args: [tokenId],
+        },
+      ],
+      allowFailure: false,
+    });
+    posResult = pos as readonly unknown[];
+    owner = ownerRes as `0x${string}`;
+  } catch (err) {
+    throw new Error(
+      `Uniswap V3 NPM positions(${tokenId}) read failed on ${chain}. ` +
+        `Most likely the tokenId does not exist. ` +
+        `(${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  if (owner.toLowerCase() !== wallet.toLowerCase()) {
+    throw new Error(
+      `Uniswap V3 LP NFT tokenId=${tokenId} is owned by ${owner}, not ${wallet}. ` +
+        `Refusing — the on-chain call would credit the actual position owner, ` +
+        `not the caller. Verify the tokenId via get_lp_positions.`,
+    );
+  }
+  return {
+    nonce: posResult[0] as bigint,
+    operator: posResult[1] as `0x${string}`,
+    token0: posResult[2] as `0x${string}`,
+    token1: posResult[3] as `0x${string}`,
+    fee: posResult[4] as number,
+    tickLower: posResult[5] as number,
+    tickUpper: posResult[6] as number,
+    liquidity: posResult[7] as bigint,
+    feeGrowthInside0LastX128: posResult[8] as bigint,
+    feeGrowthInside1LastX128: posResult[9] as bigint,
+    tokensOwed0: posResult[10] as bigint,
+    tokensOwed1: posResult[11] as bigint,
+  };
+}
+
+export interface BuildUniswapDecreaseParams {
+  chain: SupportedChain;
+  wallet: `0x${string}`;
+  tokenId: string;
+  /**
+   * Percentage of the position's liquidity to withdraw, 1-100. Pass
+   * `100` to fully drain (typical close-out path is then collect+burn).
+   * Mutually exclusive with `liquidity`.
+   */
+  liquidityPct?: number;
+  /**
+   * Raw liquidity amount to withdraw. Use this when you need exact
+   * accounting; otherwise prefer `liquidityPct`. Mutually exclusive
+   * with `liquidityPct`.
+   */
+  liquidity?: string;
+  slippageBps?: number;
+  acknowledgeHighSlippage?: boolean;
+  deadlineSec?: number;
+}
+
+/**
+ * Build an unsigned `decreaseLiquidity()` tx for an existing Uniswap V3
+ * LP position. The decrease ALONE does not transfer tokens to the
+ * caller — it credits `tokensOwed{0,1}` on the position. The agent
+ * follows up with `prepare_uniswap_v3_collect` (or, for full close-out,
+ * with rebalance / burn) to actually move the tokens.
+ *
+ * The `liquidity` arg the on-chain call needs is computed from
+ * `liquidityPct` × `position.liquidity`. amount0Min/amount1Min come
+ * from `burnAmountsWithSlippage`.
+ */
+export async function buildUniswapDecrease(
+  p: BuildUniswapDecreaseParams,
+): Promise<UnsignedTx> {
+  const cfg = CONTRACTS[p.chain]?.uniswap;
+  if (!cfg) {
+    throw new Error(`Uniswap V3 is not registered on ${p.chain}.`);
+  }
+  if (
+    (p.liquidityPct === undefined && p.liquidity === undefined) ||
+    (p.liquidityPct !== undefined && p.liquidity !== undefined)
+  ) {
+    throw new Error(
+      "Pass exactly one of `liquidityPct` (1-100) or `liquidity` (raw bigint string).",
+    );
+  }
+  if (p.liquidityPct !== undefined) {
+    if (
+      !Number.isInteger(p.liquidityPct) ||
+      p.liquidityPct < 1 ||
+      p.liquidityPct > 100
+    ) {
+      throw new Error(
+        `liquidityPct must be an integer in [1, 100] (got ${p.liquidityPct}).`,
+      );
+    }
+  }
+  const positionManager = cfg.positionManager as `0x${string}`;
+  const factoryAddr = cfg.factory as `0x${string}`;
+  const tokenIdBig = BigInt(p.tokenId);
+  const slippageBps = parseSlippageBps({
+    slippageBps: p.slippageBps,
+    acknowledgeHighSlippage: p.acknowledgeHighSlippage,
+  });
+
+  const pos = await readOwnedPosition(p.chain, positionManager, p.wallet, tokenIdBig);
+
+  if (pos.liquidity === 0n) {
+    throw new Error(
+      `Position #${p.tokenId} has zero liquidity already — nothing to decrease. ` +
+        `If you want to harvest fees only, use \`prepare_uniswap_v3_collect\`. ` +
+        `If you want to remove the NFT entirely, use \`prepare_uniswap_v3_burn\`.`,
+    );
+  }
+
+  const liquidityToBurn =
+    p.liquidity !== undefined
+      ? BigInt(p.liquidity)
+      : (pos.liquidity * BigInt(p.liquidityPct!)) / 100n;
+  if (liquidityToBurn === 0n) {
+    throw new Error(
+      `liquidityPct=${p.liquidityPct} on position #${p.tokenId} resolved to 0. ` +
+        `Pass a higher percentage or use raw \`liquidity\`.`,
+    );
+  }
+  if (liquidityToBurn > pos.liquidity) {
+    throw new Error(
+      `liquidity=${liquidityToBurn} exceeds position liquidity ${pos.liquidity}.`,
+    );
+  }
+
+  const client = getClient(p.chain);
+  const [meta, poolAddr] = await Promise.all([
+    resolveTokenPairMeta(p.chain, [pos.token0, pos.token1]),
+    client.readContract({
+      address: factoryAddr,
+      abi: uniswapFactoryAbi,
+      functionName: "getPool",
+      args: [pos.token0, pos.token1, pos.fee],
+    }) as Promise<`0x${string}`>,
+  ]);
+  if (poolAddr === "0x0000000000000000000000000000000000000000") {
+    throw new Error(
+      `Uniswap V3 pool ${pos.token0}/${pos.token1} fee=${pos.fee} on ${p.chain} ` +
+        `does not resolve. Investigate.`,
+    );
+  }
+  const [symbol0, symbol1] = [meta[0].symbol, meta[1].symbol];
+
+  const [slot0] = await client.multicall({
+    contracts: [
+      { address: poolAddr, abi: uniswapPoolAbi, functionName: "slot0" },
+    ],
+    allowFailure: false,
+  });
+  const sqrtPriceX96 = (slot0 as readonly [bigint, number, ...unknown[]])[0];
+  const currentTick = Number((slot0 as readonly [bigint, number, ...unknown[]])[1]);
+
+  const tickSpacing = TICK_SPACINGS[pos.fee];
+  if (!tickSpacing) {
+    throw new Error(
+      `Uniswap V3 position ${p.tokenId} has unknown fee tier ${pos.fee}.`,
+    );
+  }
+
+  const { amount0: amount0Min, amount1: amount1Min } = burnAmountsWithSlippage({
+    pool: {
+      fee: pos.fee,
+      sqrtRatioX96: sqrtPriceX96,
+      tickCurrent: currentTick,
+      tickSpacing,
+    },
+    tickLower: pos.tickLower,
+    tickUpper: pos.tickUpper,
+    liquidity: liquidityToBurn,
+    slippageBps,
+  });
+
+  const deadlineSec = p.deadlineSec ?? DEFAULT_DEADLINE_SEC;
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSec);
+
+  const data = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "decreaseLiquidity",
+    args: [
+      {
+        tokenId: tokenIdBig,
+        liquidity: liquidityToBurn,
+        amount0Min,
+        amount1Min,
+        deadline,
+      },
+    ],
+  });
+  const pctLabel =
+    p.liquidityPct !== undefined ? `${p.liquidityPct}%` : `${liquidityToBurn} raw`;
+  return {
+    chain: p.chain,
+    to: positionManager,
+    data,
+    value: "0",
+    from: p.wallet,
+    description:
+      `Decrease Uniswap V3 LP position #${p.tokenId} by ${pctLabel} ` +
+      `(${symbol0}/${symbol1} at ${pos.fee / 10_000}% fee, slippage ${slippageBps} bps). ` +
+      `Withdrawn tokens become tokensOwed on the position — follow up with ` +
+      `prepare_uniswap_v3_collect to actually move them to the wallet.`,
+    decoded: {
+      functionName: "decreaseLiquidity",
+      args: {
+        tokenId: p.tokenId,
+        liquidity: liquidityToBurn.toString(),
+        amount0Min: amount0Min.toString(),
+        amount1Min: amount1Min.toString(),
+        deadline: deadline.toString(),
+      },
+    },
+  };
+}
+
+export interface BuildUniswapCollectParams {
+  chain: SupportedChain;
+  wallet: `0x${string}`;
+  tokenId: string;
+  /** Recipient of the harvested tokens. Default: wallet. */
+  recipient?: `0x${string}`;
+}
+
+/**
+ * Build an unsigned `collect()` tx that harvests every token the
+ * position is owed (decreased liquidity + accrued fees) up to
+ * `uint128.max` per side. The on-chain implementation pays out the
+ * lesser of `tokensOwed` and the provided cap, so passing the max
+ * is the standard way to drain everything in one call.
+ */
+export async function buildUniswapCollect(
+  p: BuildUniswapCollectParams,
+): Promise<UnsignedTx> {
+  const cfg = CONTRACTS[p.chain]?.uniswap;
+  if (!cfg) {
+    throw new Error(`Uniswap V3 is not registered on ${p.chain}.`);
+  }
+  const positionManager = cfg.positionManager as `0x${string}`;
+  const tokenIdBig = BigInt(p.tokenId);
+  const pos = await readOwnedPosition(p.chain, positionManager, p.wallet, tokenIdBig);
+
+  // tokensOwed* on the position struct is the *settled* fee + decreased-
+  // liquidity buffer. Uncollected fees that haven't been settled to the
+  // position struct yet (the fee-growth tracker delta) ALSO get
+  // harvested by collect() — the protocol updates owed first inside the
+  // call. So a position with tokensOwed0 = 0 may still receive tokens,
+  // and we should not refuse on that basis.
+  const recipient = p.recipient ?? p.wallet;
+
+  const client = getClient(p.chain);
+  const meta = await resolveTokenPairMeta(p.chain, [pos.token0, pos.token1]);
+  const [symbol0, symbol1] = [meta[0].symbol, meta[1].symbol];
+  void client;
+
+  const data = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "collect",
+    args: [
+      {
+        tokenId: tokenIdBig,
+        recipient,
+        amount0Max: U128_MAX,
+        amount1Max: U128_MAX,
+      },
+    ],
+  });
+  return {
+    chain: p.chain,
+    to: positionManager,
+    data,
+    value: "0",
+    from: p.wallet,
+    description:
+      `Collect Uniswap V3 LP position #${p.tokenId} fees + tokensOwed (${symbol0}/${symbol1}) ` +
+      `to ${recipient.toLowerCase() === p.wallet.toLowerCase() ? "wallet" : recipient}. ` +
+      `Harvests everything (amount0Max=amount1Max=uint128.max).`,
+    decoded: {
+      functionName: "collect",
+      args: {
+        tokenId: p.tokenId,
+        recipient,
+        amount0Max: "uint128.max",
+        amount1Max: "uint128.max",
+      },
+    },
+  };
+}
+
+export interface BuildUniswapBurnParams {
+  chain: SupportedChain;
+  wallet: `0x${string}`;
+  tokenId: string;
+}
+
+/**
+ * Build an unsigned `burn()` tx that destroys the position NFT.
+ *
+ * Hard-refuses unless the position is already drained: liquidity == 0
+ * AND tokensOwed0 == 0 AND tokensOwed1 == 0. The on-chain call would
+ * revert otherwise; refusing at prepare time gives the caller a more
+ * actionable error pointing at the right sequence (decrease → collect
+ * → burn, or use rebalance).
+ */
+export async function buildUniswapBurn(
+  p: BuildUniswapBurnParams,
+): Promise<UnsignedTx> {
+  const cfg = CONTRACTS[p.chain]?.uniswap;
+  if (!cfg) {
+    throw new Error(`Uniswap V3 is not registered on ${p.chain}.`);
+  }
+  const positionManager = cfg.positionManager as `0x${string}`;
+  const tokenIdBig = BigInt(p.tokenId);
+  const pos = await readOwnedPosition(p.chain, positionManager, p.wallet, tokenIdBig);
+
+  if (pos.liquidity > 0n) {
+    throw new Error(
+      `Position #${p.tokenId} still has liquidity=${pos.liquidity}. ` +
+        `burn() reverts on a position with non-zero liquidity. Run ` +
+        `prepare_uniswap_v3_decrease_liquidity({ liquidityPct: 100 }) first, ` +
+        `then prepare_uniswap_v3_collect, then this. (Or use rebalance to ` +
+        `compose the whole thing in one tx.)`,
+    );
+  }
+  if (pos.tokensOwed0 > 0n || pos.tokensOwed1 > 0n) {
+    throw new Error(
+      `Position #${p.tokenId} has unharvested tokensOwed (${pos.tokensOwed0} token0, ` +
+        `${pos.tokensOwed1} token1). burn() reverts unless both are 0. Run ` +
+        `prepare_uniswap_v3_collect first to harvest them, then burn.`,
+    );
+  }
+
+  const data = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "burn",
+    args: [tokenIdBig],
+  });
+  return {
+    chain: p.chain,
+    to: positionManager,
+    data,
+    value: "0",
+    from: p.wallet,
+    description:
+      `Burn Uniswap V3 LP NFT #${p.tokenId} (irreversible — destroys the position record).`,
+    decoded: {
+      functionName: "burn",
+      args: { tokenId: p.tokenId },
+    },
+  };
 }
 
 // Re-export erc20Abi so future builders in this module don't need a

--- a/src/modules/lp/uniswap-v3/position-math.ts
+++ b/src/modules/lp/uniswap-v3/position-math.ts
@@ -17,6 +17,8 @@ import {
   encodeSqrtRatioX96,
   getAmount0DeltaRoundUp,
   getAmount1DeltaRoundUp,
+  getAmount0DeltaRoundDown,
+  getAmount1DeltaRoundDown,
 } from "./sqrt-price-math.js";
 import {
   MIN_SQRT_RATIO,
@@ -281,4 +283,111 @@ export function mintAmountsWithSlippage(args: {
     liquidity: liquidityImprecise,
   });
   return { amount0, amount1, liquidity: liquidityImprecise };
+}
+
+/**
+ * Returns `{ amount0, amount1 }` the position would burn at the given
+ * pool price for the given liquidity, using round-DOWN math (burn-side).
+ * SDK reference: `Position.amount0` + `Position.amount1` getters
+ * (which use `getAmount{0,1}Delta(..., roundUp: false)`).
+ */
+export function burnAmounts(args: {
+  pool: PoolState;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+}): { amount0: bigint; amount1: bigint } {
+  const sqrtRatioAX96 = getSqrtRatioAtTick(args.tickLower);
+  const sqrtRatioBX96 = getSqrtRatioAtTick(args.tickUpper);
+  if (args.pool.tickCurrent < args.tickLower) {
+    return {
+      amount0: getAmount0DeltaRoundDown(sqrtRatioAX96, sqrtRatioBX96, args.liquidity),
+      amount1: 0n,
+    };
+  }
+  if (args.pool.tickCurrent < args.tickUpper) {
+    return {
+      amount0: getAmount0DeltaRoundDown(
+        args.pool.sqrtRatioX96,
+        sqrtRatioBX96,
+        args.liquidity,
+      ),
+      amount1: getAmount1DeltaRoundDown(
+        sqrtRatioAX96,
+        args.pool.sqrtRatioX96,
+        args.liquidity,
+      ),
+    };
+  }
+  return {
+    amount0: 0n,
+    amount1: getAmount1DeltaRoundDown(sqrtRatioAX96, sqrtRatioBX96, args.liquidity),
+  };
+}
+
+/**
+ * Reuses ratiosAfterSlippage. Exposed so `burnAmountsWithSlippage`
+ * can re-enter without duplication. Inlined here to keep
+ * `ratiosAfterSlippage` private to this module — both helpers share
+ * the same algebra.
+ */
+function ratiosAfterSlippagePublic(
+  pool: PoolState,
+  slippageBps: number,
+): { sqrtRatioX96Lower: bigint; sqrtRatioX96Upper: bigint } {
+  return ratiosAfterSlippage(pool, slippageBps);
+}
+
+/**
+ * Compute the slippage-bounded `amount0Min` / `amount1Min` the
+ * `decreaseLiquidity(...)` call should pass — the user wants to
+ * receive *at least* these amounts after slippage. SDK reference:
+ * `Position.burnAmountsWithSlippage`.
+ *
+ * Mirrors `mintAmountsWithSlippage` but in burn direction:
+ *   - construct counterfactual pools at the slippage-shifted sqrt
+ *     ratios;
+ *   - compute `burnAmounts` on each;
+ *   - the worse-direction (smaller) amount per side is what we
+ *     guarantee — amount0 from the upper-price counterfactual, amount1
+ *     from the lower-price one.
+ */
+export function burnAmountsWithSlippage(args: {
+  pool: PoolState;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: bigint;
+  slippageBps: number;
+}): { amount0: bigint; amount1: bigint } {
+  const { sqrtRatioX96Lower, sqrtRatioX96Upper } = ratiosAfterSlippagePublic(
+    args.pool,
+    args.slippageBps,
+  );
+  const tickLowerCf = getTickAtSqrtRatio(sqrtRatioX96Lower);
+  const tickUpperCf = getTickAtSqrtRatio(sqrtRatioX96Upper);
+  const poolLowerCf: PoolState = {
+    fee: args.pool.fee,
+    sqrtRatioX96: sqrtRatioX96Lower,
+    tickCurrent: tickLowerCf,
+    tickSpacing: args.pool.tickSpacing,
+  };
+  const poolUpperCf: PoolState = {
+    fee: args.pool.fee,
+    sqrtRatioX96: sqrtRatioX96Upper,
+    tickCurrent: tickUpperCf,
+    tickSpacing: args.pool.tickSpacing,
+  };
+  const { amount0 } = burnAmounts({
+    pool: poolUpperCf,
+    tickLower: args.tickLower,
+    tickUpper: args.tickUpper,
+    liquidity: args.liquidity,
+  });
+  const { amount1 } = burnAmounts({
+    pool: poolLowerCf,
+    tickLower: args.tickLower,
+    tickUpper: args.tickUpper,
+    liquidity: args.liquidity,
+  });
+  return { amount0, amount1 };
 }

--- a/src/modules/lp/uniswap-v3/sqrt-price-math.ts
+++ b/src/modules/lp/uniswap-v3/sqrt-price-math.ts
@@ -1,13 +1,12 @@
 /**
  * Pure-bigint port of the slice of Uniswap V3's `SqrtPriceMath` +
- * `FullMath` + `encodeSqrtRatioX96` + `sqrt` helpers we need for LP
- * mint flows. Originally in `@uniswap/v3-sdk` and `@uniswap/sdk-core`.
+ * `FullMath` + `encodeSqrtRatioX96` + `sqrt` helpers used across LP
+ * flows. Originally in `@uniswap/v3-sdk` and `@uniswap/sdk-core`.
  *
- * Only the round-up paths are exposed: mint flows always round
- * required-amount up so the user deposits a hair more than the strict
- * minimum (avoiding a 1-wei revert). The round-down counterparts
- * exist on-chain for `burn` / fee-collection flows; we'll add them
- * when those builders land.
+ * Round-up variants serve the mint side (deposit a hair more than
+ * the strict minimum so a 1-wei rounding never reverts). Round-down
+ * variants serve the burn / decrease side (never overclaim what the
+ * protocol's accounting actually allocated).
  */
 
 /** Q64.96 fixed-point unit. */
@@ -105,4 +104,40 @@ export function getAmount1DeltaRoundUp(
     [sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96];
   }
   return mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, Q96);
+}
+
+/**
+ * Δamount0 across a price range, rounded down. Used at burn /
+ * decrease time — the protocol's accounting only credits what its
+ * own rounding allocated, never more.
+ *
+ * SDK reference: `SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, L, false)`.
+ */
+export function getAmount0DeltaRoundDown(
+  sqrtRatioAX96: bigint,
+  sqrtRatioBX96: bigint,
+  liquidity: bigint,
+): bigint {
+  if (sqrtRatioAX96 > sqrtRatioBX96) {
+    [sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96];
+  }
+  const numerator1 = liquidity << 96n;
+  const numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+  // Round-down: integer divide; no rounding-up correction.
+  return (numerator1 * numerator2) / sqrtRatioBX96 / sqrtRatioAX96;
+}
+
+/**
+ * Δamount1 across a price range, rounded down.
+ * SDK reference: `SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, L, false)`.
+ */
+export function getAmount1DeltaRoundDown(
+  sqrtRatioAX96: bigint,
+  sqrtRatioBX96: bigint,
+  liquidity: bigint,
+): bigint {
+  if (sqrtRatioAX96 > sqrtRatioBX96) {
+    [sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96];
+  }
+  return (liquidity * (sqrtRatioBX96 - sqrtRatioAX96)) / Q96;
 }

--- a/test/uniswap-v3-closeout.test.ts
+++ b/test/uniswap-v3-closeout.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Tests for the close-out lifecycle builders — M1c in
+ * `claude-work/plan-dex-liquidity-provision.md`. Three tools:
+ * `prepare_uniswap_v3_decrease_liquidity`, `_collect`, `_burn`.
+ *
+ * Mocks the RPC surface so positions(tokenId), ownerOf, slot0, etc.
+ * return deterministic values. Asserts:
+ *   - calldata for each tool decodes correctly
+ *   - ownership check rejects mismatched wallets (all three tools)
+ *   - decrease: liquidityPct vs liquidity mutual exclusion, range
+ *     validation
+ *   - collect: harvests with uint128.max caps
+ *   - burn: refuses unless drained, names the right next step on
+ *     refusal
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { decodeFunctionData } from "viem";
+import { uniswapPositionManagerAbi } from "../src/abis/uniswap-position-manager.js";
+
+const { readContractMock, multicallMock } = vi.hoisted(() => ({
+  readContractMock: vi.fn(),
+  multicallMock: vi.fn(),
+}));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+    multicall: multicallMock,
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD" as const;
+const OTHER_WALLET = "0x1111111111111111111111111111111111111111" as const;
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as const;
+const NPM = "0xC36442b4a4522E871399CD717aBDD847Ab11FE88" as const;
+const USDC_WETH_POOL = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8" as const;
+
+const TOKEN_ID = "12345";
+
+const FAKE_CURRENT_TICK = -201_960;
+const FAKE_SQRT_PRICE_X96 = 3_262_820_378_846_468_593_912_909n;
+const FAKE_POOL_LIQUIDITY = 10_000_000_000_000_000_000n;
+
+const POSITION_LIQUIDITY = 1_000_000n;
+
+function positionTuple(opts: {
+  liquidity?: bigint;
+  tokensOwed0?: bigint;
+  tokensOwed1?: bigint;
+  tickLower?: number;
+  tickUpper?: number;
+} = {}) {
+  return [
+    0n, // nonce
+    "0x0000000000000000000000000000000000000000" as `0x${string}`, // operator
+    USDC,
+    WETH,
+    3_000, // fee
+    opts.tickLower ?? -202_020,
+    opts.tickUpper ?? -201_900,
+    opts.liquidity ?? POSITION_LIQUIDITY,
+    0n, // feeGrowthInside0LastX128
+    0n, // feeGrowthInside1LastX128
+    opts.tokensOwed0 ?? 0n,
+    opts.tokensOwed1 ?? 0n,
+  ] as const;
+}
+
+function mockPositionRead(opts: {
+  owner?: `0x${string}`;
+  position?: ReturnType<typeof positionTuple>;
+  withSlot0?: boolean;
+} = {}) {
+  multicallMock.mockImplementation(
+    async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+      if (contracts[0]?.functionName === "positions" && contracts[1]?.functionName === "ownerOf") {
+        return [opts.position ?? positionTuple(), opts.owner ?? WALLET];
+      }
+      if (contracts[0]?.functionName === "decimals" && contracts[1]?.functionName === "symbol") {
+        return [6, "USDC", 18, "WETH"];
+      }
+      if (contracts[0]?.functionName === "slot0") {
+        return [
+          [FAKE_SQRT_PRICE_X96, FAKE_CURRENT_TICK, 0, 1, 1, 0, true],
+          FAKE_POOL_LIQUIDITY,
+        ];
+      }
+      throw new Error(
+        `unexpected multicall: ${JSON.stringify(contracts.map((c) => c.functionName))}`,
+      );
+    },
+  );
+  readContractMock.mockImplementation(
+    async ({ functionName }: { functionName: string }) => {
+      if (functionName === "getPool") return USDC_WETH_POOL;
+      throw new Error(`unexpected readContract: ${functionName}`);
+    },
+  );
+}
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  multicallMock.mockReset();
+});
+
+describe("buildUniswapDecrease", () => {
+  it("happy path: 100% decrease produces decreaseLiquidity() calldata", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapDecrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      liquidityPct: 100,
+      slippageBps: 50,
+    });
+    expect(tx.to.toLowerCase()).toBe(NPM.toLowerCase());
+    expect(tx.value).toBe("0");
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    expect(decoded.functionName).toBe("decreaseLiquidity");
+    const params = (decoded.args as readonly [{
+      tokenId: bigint;
+      liquidity: bigint;
+      amount0Min: bigint;
+      amount1Min: bigint;
+      deadline: bigint;
+    }])[0];
+    expect(params.tokenId).toBe(12_345n);
+    expect(params.liquidity).toBe(POSITION_LIQUIDITY); // full liquidity
+    // amount0Min/amount1Min should be non-negative; with 50 bps slippage
+    // they may both be 0 for a tiny position but that's fine.
+    expect(params.amount0Min).toBeGreaterThanOrEqual(0n);
+    expect(params.amount1Min).toBeGreaterThanOrEqual(0n);
+    expect(tx.description).toContain("Decrease Uniswap V3 LP position");
+    expect(tx.description).toContain("100%");
+  });
+
+  it("partial decrease: liquidityPct=50 burns half the position liquidity", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapDecrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      liquidityPct: 50,
+    });
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    const params = (decoded.args as readonly [{ liquidity: bigint }])[0];
+    expect(params.liquidity).toBe(POSITION_LIQUIDITY / 2n);
+  });
+
+  it("raw liquidity arg overrides liquidityPct calculation", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapDecrease({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      liquidity: "12345",
+    });
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    const params = (decoded.args as readonly [{ liquidity: bigint }])[0];
+    expect(params.liquidity).toBe(12_345n);
+  });
+
+  it("rejects passing both liquidityPct and liquidity", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapDecrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        liquidityPct: 50,
+        liquidity: "100",
+      }),
+    ).rejects.toThrow(/exactly one/);
+  });
+
+  it("rejects passing neither liquidityPct nor liquidity", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapDecrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+      }),
+    ).rejects.toThrow(/exactly one/);
+  });
+
+  it("rejects raw liquidity exceeding the position's liquidity", async () => {
+    mockPositionRead();
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapDecrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        liquidity: (POSITION_LIQUIDITY + 1n).toString(),
+      }),
+    ).rejects.toThrow(/exceeds position liquidity/);
+  });
+
+  it("rejects when position has zero liquidity (nothing to decrease)", async () => {
+    mockPositionRead({ position: positionTuple({ liquidity: 0n }) });
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapDecrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        liquidityPct: 100,
+      }),
+    ).rejects.toThrow(/zero liquidity already/);
+  });
+
+  it("hard-refuses on owner mismatch", async () => {
+    mockPositionRead({ owner: OTHER_WALLET });
+    const { buildUniswapDecrease } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapDecrease({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        liquidityPct: 100,
+      }),
+    ).rejects.toThrow(/is owned by/);
+  });
+});
+
+describe("buildUniswapCollect", () => {
+  it("happy path: encodes collect() with uint128.max caps", async () => {
+    mockPositionRead();
+    const { buildUniswapCollect } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapCollect({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+    });
+    expect(tx.to.toLowerCase()).toBe(NPM.toLowerCase());
+    expect(tx.value).toBe("0");
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    expect(decoded.functionName).toBe("collect");
+    const params = (decoded.args as readonly [{
+      tokenId: bigint;
+      recipient: string;
+      amount0Max: bigint;
+      amount1Max: bigint;
+    }])[0];
+    expect(params.tokenId).toBe(12_345n);
+    expect(params.recipient.toLowerCase()).toBe(WALLET.toLowerCase());
+    expect(params.amount0Max).toBe((1n << 128n) - 1n);
+    expect(params.amount1Max).toBe((1n << 128n) - 1n);
+  });
+
+  it("custom recipient routes the harvest elsewhere", async () => {
+    mockPositionRead();
+    const { buildUniswapCollect } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapCollect({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      recipient: OTHER_WALLET,
+    });
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    const params = (decoded.args as readonly [{ recipient: string }])[0];
+    expect(params.recipient.toLowerCase()).toBe(OTHER_WALLET.toLowerCase());
+  });
+
+  it("hard-refuses on owner mismatch", async () => {
+    mockPositionRead({ owner: OTHER_WALLET });
+    const { buildUniswapCollect } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapCollect({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+      }),
+    ).rejects.toThrow(/is owned by/);
+  });
+
+  it("succeeds even when tokensOwed=0 (fee growth still settles inside collect)", async () => {
+    mockPositionRead({
+      position: positionTuple({ tokensOwed0: 0n, tokensOwed1: 0n }),
+    });
+    const { buildUniswapCollect } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapCollect({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+    });
+    expect(tx.description).toContain("Collect Uniswap V3 LP position");
+  });
+});
+
+describe("buildUniswapBurn", () => {
+  it("happy path: drained position → burn(tokenId) calldata", async () => {
+    mockPositionRead({
+      position: positionTuple({
+        liquidity: 0n,
+        tokensOwed0: 0n,
+        tokensOwed1: 0n,
+      }),
+    });
+    const { buildUniswapBurn } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapBurn({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+    });
+    expect(tx.to.toLowerCase()).toBe(NPM.toLowerCase());
+    expect(tx.value).toBe("0");
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: tx.data,
+    });
+    expect(decoded.functionName).toBe("burn");
+    expect(decoded.args).toEqual([12_345n]);
+    expect(tx.description).toContain("Burn Uniswap V3 LP NFT");
+    expect(tx.description).toContain("irreversible");
+  });
+
+  it("refuses when liquidity > 0 and names the right next step", async () => {
+    mockPositionRead({ position: positionTuple({ liquidity: 1_000_000n }) });
+    const { buildUniswapBurn } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapBurn({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+      }),
+    ).rejects.toThrow(/decrease_liquidity.*liquidityPct: 100/);
+  });
+
+  it("refuses when tokensOwed > 0 and names the right next step", async () => {
+    mockPositionRead({
+      position: positionTuple({ liquidity: 0n, tokensOwed0: 100n, tokensOwed1: 0n }),
+    });
+    const { buildUniswapBurn } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapBurn({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+      }),
+    ).rejects.toThrow(/prepare_uniswap_v3_collect/);
+  });
+
+  it("hard-refuses on owner mismatch", async () => {
+    mockPositionRead({ owner: OTHER_WALLET });
+    const { buildUniswapBurn } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapBurn({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+      }),
+    ).rejects.toThrow(/is owned by/);
+  });
+});
+
+describe("burnAmounts + burnAmountsWithSlippage (port math)", () => {
+  it("burnAmounts at current price round-trips with mintAmounts (round-down ≤ round-up)", async () => {
+    const { burnAmounts, mintAmounts } = await import(
+      "../src/modules/lp/uniswap-v3/position-math.js"
+    );
+    const { getSqrtRatioAtTick } = await import(
+      "../src/modules/lp/uniswap-v3/tick-math.js"
+    );
+    const sqrtRatioX96 = getSqrtRatioAtTick(FAKE_CURRENT_TICK);
+    const pool = {
+      fee: 3_000,
+      sqrtRatioX96,
+      tickCurrent: FAKE_CURRENT_TICK,
+      tickSpacing: 60,
+    };
+    const args = {
+      pool,
+      tickLower: -202_020,
+      tickUpper: -201_900,
+      liquidity: 1_000_000n,
+    };
+    const minted = mintAmounts(args);
+    const burned = burnAmounts(args);
+    // Round-down (burn) ≤ round-up (mint) by construction. The diff is
+    // at most 1 wei per side from the rounding correction.
+    expect(burned.amount0).toBeLessThanOrEqual(minted.amount0);
+    expect(burned.amount1).toBeLessThanOrEqual(minted.amount1);
+    expect(minted.amount0 - burned.amount0).toBeLessThanOrEqual(1n);
+    expect(minted.amount1 - burned.amount1).toBeLessThanOrEqual(1n);
+  });
+
+  it("burnAmountsWithSlippage: higher slippage → looser (smaller) min amounts", async () => {
+    const { burnAmountsWithSlippage } = await import(
+      "../src/modules/lp/uniswap-v3/position-math.js"
+    );
+    const { getSqrtRatioAtTick } = await import(
+      "../src/modules/lp/uniswap-v3/tick-math.js"
+    );
+    const sqrtRatioX96 = getSqrtRatioAtTick(FAKE_CURRENT_TICK);
+    const args = {
+      pool: {
+        fee: 3_000,
+        sqrtRatioX96,
+        tickCurrent: FAKE_CURRENT_TICK,
+        tickSpacing: 60,
+      },
+      tickLower: -202_020,
+      tickUpper: -201_900,
+      liquidity: 1_000_000n,
+    };
+    const tight = burnAmountsWithSlippage({ ...args, slippageBps: 50 });
+    const loose = burnAmountsWithSlippage({ ...args, slippageBps: 500 });
+    // Looser slippage → smaller floor on at least one side.
+    expect(loose.amount0 + loose.amount1).toBeLessThanOrEqual(
+      tight.amount0 + tight.amount1,
+    );
+  });
+});


### PR DESCRIPTION
Three new LP tools completing the close-out path for Uniswap V3 LP positions. Builds on [#334 (M1a — mint)](https://github.com/szhygulin/vaultpilot-mcp/pull/334) and [#342 (M1b — increase)](https://github.com/szhygulin/vaultpilot-mcp/pull/342).

## Tools

| Tool | What it does | Hard refusals |
|---|---|---|
| `prepare_uniswap_v3_decrease_liquidity` | Removes liquidity (`liquidityPct: 1-100` OR raw `liquidity`). Withdrawn tokens become `tokensOwed` on the position — must call collect afterwards to actually move them. | Owner mismatch; position has zero liquidity; both args passed; raw exceeds position liquidity. |
| `prepare_uniswap_v3_collect` | Harvests every token owed + accrued fees up to `uint128.max` per side. Fee growth gets settled into tokensOwed inside the call, so even `tokensOwed{0,1}=0` may receive tokens. | Owner mismatch only. |
| `prepare_uniswap_v3_burn` | Destroys the position NFT. | Owner mismatch; `liquidity > 0` (names "run decrease_liquidity({ liquidityPct: 100 })"); `tokensOwed > 0` (names "run prepare_uniswap_v3_collect"). |

The standard close-out sequence is **decrease → collect → burn**, three separate signed txs. M1d will compose these (plus mint) into one `multicall()` for rebalance.

## Math additions

`src/modules/lp/uniswap-v3/sqrt-price-math.ts`:
- `getAmount0DeltaRoundDown` + `getAmount1DeltaRoundDown` — round-down counterparts of the existing round-up deltas. Burn side never overclaims what the protocol's accounting allocated.

`src/modules/lp/uniswap-v3/position-math.ts`:
- `burnAmounts` — equivalent to SDK's `Position.amount0`/`amount1` getters.
- `burnAmountsWithSlippage` — counterfactual-pool compose for `decreaseLiquidity`'s `amount0Min`/`amount1Min` floors.

## Builder helper

Extracted `readOwnedPosition` — reads `positions(tokenId) + ownerOf(tokenId)` in one multicall, asserts ownership. Used by all three new builders. The increase builder from M1b could be refactored to use this too; left as a follow-up.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1726/1726 pass parallel in 29s
- [x] 18 new tests in `test/uniswap-v3-closeout.test.ts`:
  - decrease: 100% / partial / raw / mutual-exclusion / over-position / zero-liquidity refuse / owner mismatch
  - collect: happy path, custom recipient, tokensOwed=0 still proceeds, owner mismatch
  - burn: happy, liquidity>0 refuse with next-step, tokensOwed>0 refuse with next-step, owner mismatch
  - math: `burnAmounts ≤ mintAmounts` round-trip, `burnAmountsWithSlippage` looser with higher slippage
- [ ] CI green

## Follow-ups

- M1d: `prepare_uniswap_v3_rebalance` — multicall compose (decrease + collect + burn + mint) — depends on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)