### PR TITLE
ci(release): retry release-asset uploads on transient 5xx

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -133,24 +133,43 @@ jobs:
         # `scripts/smoke-test-binary.mjs` for the implementation.
         run: node scripts/smoke-test-binary.mjs ./release/${{ matrix.server_asset }}
 
-      - name: Upload assets to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            release/${{ matrix.server_asset }}
-            release/${{ matrix.setup_asset }}
-          fail_on_unmatched_files: true
-
-      - name: Upload assets to existing release (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag }}
-          files: |
-            release/${{ matrix.server_asset }}
-            release/${{ matrix.setup_asset }}
-          fail_on_unmatched_files: true
+      - name: Upload assets to release (with retry on transient 5xx)
+        # Replaces softprops/action-gh-release@v2 with `gh release upload`
+        # wrapped in a 3-attempt retry. Why: the v0.9.4 release lost
+        # vaultpilot-mcp-macos-arm64-server to a GitHub reverse-proxy
+        # 5xx ("Unicorn!" page) mid-upload — a transient error that
+        # softprops/action-gh-release@v2 surfaces as fatal. macOS runners
+        # push large assets at low Mbps; the upload sits near the proxy's
+        # idle-timeout edge, and a single retry usually clears it.
+        # `gh release upload --clobber` overwrites any stub asset left by
+        # a previous attempt so reruns are idempotent. Linear backoff
+        # (10s, 20s) is enough for transient API hiccups.
+        # `shell: bash` so Windows runners use Git Bash, not pwsh.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASSETS=(
+            "release/${{ matrix.server_asset }}"
+            "release/${{ matrix.setup_asset }}"
+          )
+          for asset in "${ASSETS[@]}"; do
+            for attempt in 1 2 3; do
+              if gh release upload "$TAG" "$asset" --clobber; then
+                echo "✅ uploaded $asset on attempt $attempt"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "❌ failed to upload $asset after 3 attempts"
+                exit 1
+              fi
+              backoff=$((attempt * 10))
+              echo "↻ upload of $asset failed (attempt $attempt); sleeping ${backoff}s"
+              sleep "$backoff"
+            done
+          done
 
   # OS-agnostic install scripts — uploaded once per release, not per
   # matrix leg. Hosted at the well-known path
@@ -180,21 +199,28 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - name: Upload to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            scripts/install.sh
-            scripts/install.ps1
-          fail_on_unmatched_files: true
-
-      - name: Upload to existing release (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag }}
-          files: |
-            scripts/install.sh
-            scripts/install.ps1
-          fail_on_unmatched_files: true
+      - name: Upload install scripts (with retry)
+        # Same retry-with-clobber approach as the binary upload job.
+        # Install scripts are small (~10 KB each) so 5xx is rare here,
+        # but consistency beats two divergent upload paths.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          ASSETS=(scripts/install.sh scripts/install.ps1)
+          for asset in "${ASSETS[@]}"; do
+            for attempt in 1 2 3; do
+              if gh release upload "$TAG" "$asset" --clobber; then
+                echo "✅ uploaded $asset on attempt $attempt"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "❌ failed to upload $asset after 3 attempts"
+                exit 1
+              fi
+              backoff=$((attempt * 10))
+              echo "↻ upload of $asset failed (attempt $attempt); sleeping ${backoff}s"
+              sleep "$backoff"
+            done
+          done


### PR DESCRIPTION
## Summary

Wraps release-asset uploads in a 3-attempt retry loop with linear backoff (10s, 20s) so transient GitHub reverse-proxy 5xx errors don't fail the whole release. Replaces the four `softprops/action-gh-release@v2` invocations in `release-binaries.yml` with `gh release upload --clobber` calls inside bash retry loops.

## Why

The v0.9.4 release lost `vaultpilot-mcp-macos-arm64-server` to a single transient \"Unicorn!\" HTML page (GitHub's generic 5xx) ~3 minutes into a 504 MB upload from a slow macos-14 runner. The setup binary from the same job uploaded fine; `linux-x64-server` (504 MB, concurrent, same release, same minute) also succeeded. The failure was a one-off API hiccup that a single retry would have cleared — but `softprops/action-gh-release@v2` surfaces 5xx as fatal with no retry.

This pattern matches v0.6.1, v0.7.0, v0.8.0, v0.8.2, v0.9.1, v0.9.3 — all had partial macOS upload failures or 24 h timeouts. Retry with backoff is the standard mitigation for transient cloud-API errors.

## Why `gh release upload`

- `gh` handles some 5xx retries internally, so the bash loop only catches the residual cases.
- `--clobber` overwrites any stub asset left by a previous failed attempt, making reruns idempotent (important for the `gh run rerun --failed` flow).
- The CLI is preinstalled on all GitHub-hosted runners across Linux / macOS / Windows.

## Other changes in this PR

- Collapse the release-event and workflow_dispatch-event uploads into one step. The only difference was the tag source — both now use `${{ github.event.release.tag_name || inputs.tag }}` like the existing `Checkout` step.
- `shell: bash` set explicitly so the Windows matrix leg uses Git Bash, not pwsh.

## Relationship to #346

[#346](https://github.com/szhygulin/vaultpilot-mcp/pull/346) (devDep prune, ~20 MB binary reduction) is the size-side mitigation. This PR is the upload-side mitigation. Together they reduce the probability of tripping GitHub's reverse-proxy idle-timeout AND survive the residual transient cases when a timeout still happens.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release-binaries.yml'))\"` — YAML parse OK.
- [ ] Real test happens at the next release. The next `release.published` event will exercise the new path on all four matrix legs simultaneously. Watch [release-binaries runs](https://github.com/szhygulin/vaultpilot-mcp/actions/workflows/release-binaries.yml) for any retry messages (`↻ upload of <asset> failed`) — if one shows up and then succeeds, the fix is working as intended.
- [ ] Workflow_dispatch path can also be exercised on demand: `gh workflow run release-binaries.yml -f tag=v0.9.4` would re-attempt uploads to v0.9.4.

## Closes

Closes [#330](https://github.com/szhygulin/vaultpilot-mcp/issues/330) once both this PR and #346 are merged AND we've confirmed via the next release that all eight expected binary assets land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)