### PR TITLE
feat(lp): prepare_uniswap_v3_rebalance — multicall compose (M1d)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,7 @@ import {
   prepareUniswapV3DecreaseLiquidity,
   prepareUniswapV3Collect,
   prepareUniswapV3Burn,
+  prepareUniswapV3Rebalance,
   prepareLidoStake,
   prepareLidoUnstake,
   prepareEigenLayerDeposit,
@@ -265,6 +266,7 @@ import {
   prepareUniswapV3DecreaseLiquidityInput,
   prepareUniswapV3CollectInput,
   prepareUniswapV3BurnInput,
+  prepareUniswapV3RebalanceInput,
   prepareLidoStakeInput,
   prepareLidoUnstakeInput,
   prepareEigenLayerDepositInput,
@@ -2941,6 +2943,22 @@ async function main() {
       inputSchema: prepareUniswapV3BurnInput.shape,
     },
     txHandler("prepare_uniswap_v3_burn", prepareUniswapV3Burn)
+  );
+
+  registerTool(server,
+    "prepare_uniswap_v3_rebalance",
+    {
+      description:
+        "Build an unsigned Uniswap V3 LP rebalance transaction — moves a position from its current tick range to a new one in a single multicall. " +
+        "Composes (in order): decreaseLiquidity(100%) + collect + (optional) burn + mint(new range). " +
+        "The position's (token0, token1, fee) carry over; only the tick range changes. " +
+        "**Slippage is independently applied to the close + re-deposit phases** — the effective tolerance against the spot price is roughly 2× the input bps. The description block calls this out explicitly. " +
+        "v1 amount-source: the new mint's amount0Desired/amount1Desired are estimated from the position's expected burn amounts at current price; on-chain the actual mint pulls bounded by what was actually collected, with surplus refunded to the wallet by the NPM. " +
+        "Up to two ERC-20 approvals are chained ahead of the multicall (the mint phase still needs them — collect routes the tokens back to the wallet, then mint pulls them again via transferFrom). " +
+        "Hard-refuses on owner mismatch, mis-aligned new ticks, identical new range, or zero-liquidity position.",
+      inputSchema: prepareUniswapV3RebalanceInput.shape,
+    },
+    txHandler("prepare_uniswap_v3_rebalance", prepareUniswapV3Rebalance)
   );
 
   registerTool(server,

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -99,6 +99,7 @@ import {
   buildUniswapDecrease,
   buildUniswapCollect,
   buildUniswapBurn,
+  buildUniswapRebalance,
 } from "../lp/uniswap-v3/actions.js";
 import {
   buildLidoStake,
@@ -120,6 +121,7 @@ import type {
   PrepareUniswapV3DecreaseLiquidityArgs,
   PrepareUniswapV3CollectArgs,
   PrepareUniswapV3BurnArgs,
+  PrepareUniswapV3RebalanceArgs,
   PrepareLidoStakeArgs,
   PrepareLidoUnstakeArgs,
   PrepareEigenLayerDepositArgs,
@@ -2295,6 +2297,25 @@ export async function prepareUniswapV3Burn(
       wallet: args.wallet as `0x${string}`,
       chain: args.chain as SupportedChain,
       tokenId: args.tokenId,
+    }),
+  );
+}
+
+export async function prepareUniswapV3Rebalance(
+  args: PrepareUniswapV3RebalanceArgs,
+): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildUniswapRebalance({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      tokenId: args.tokenId,
+      newTickLower: args.newTickLower,
+      newTickUpper: args.newTickUpper,
+      burnOld: args.burnOld,
+      slippageBps: args.slippageBps,
+      acknowledgeHighSlippage: args.acknowledgeHighSlippage,
+      deadlineSec: args.deadlineSec,
+      approvalCap: args.approvalCap,
     }),
   );
 }

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -600,6 +600,7 @@ export const getVaultPilotConfigStatusInput = z.object({});
  * (CLA=0xb0 INS=0x01), and returns the name/version of the currently-
  * open app. Read-only, one USB round-trip, closes the transport before
  * returning.
+ * bump
  */
 export const getLedgerDeviceInfoInput = z.object({});
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1853,3 +1853,56 @@ export type PrepareUniswapV3CollectArgs = z.infer<
   typeof prepareUniswapV3CollectInput
 >;
 export type PrepareUniswapV3BurnArgs = z.infer<typeof prepareUniswapV3BurnInput>;
+
+// M1d — rebalance composes decrease + collect + burn + mint into one
+// multicall(bytes[]) against the NPM. Slippage is independently applied
+// to the close and re-deposit phases, so the effective tolerance is
+// roughly 2× input bps; the tool description surfaces this.
+export const prepareUniswapV3RebalanceInput = z.object({
+  wallet: walletSchema,
+  chain: chainEnum.default("ethereum"),
+  tokenId: z
+    .string()
+    .regex(/^[0-9]+$/)
+    .max(100)
+    .describe(
+      "ERC-721 tokenId of the LP NFT to rebalance. Must be owned by `wallet`. " +
+        "Its (token0, token1, fee) are reused for the new mint — only the tick " +
+        "range changes.",
+    ),
+  newTickLower: z
+    .number()
+    .int()
+    .describe(
+      "Lower tick of the NEW range. Must align to the position's fee-tier tickSpacing " +
+        "(100→1, 500→10, 3000→60, 10000→200) and be < newTickUpper.",
+    ),
+  newTickUpper: z.number().int(),
+  burnOld: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to also burn the old NFT in the same multicall. Default true — the old " +
+        "position has zero liquidity after the close phase and a stub NFT serves no " +
+        "purpose. Set to false to keep the old tokenId alive (e.g. for off-chain bookkeeping).",
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(500)
+    .optional()
+    .describe(
+      "Slippage tolerance in bps applied INDEPENDENTLY to the close phase " +
+        "(decreaseLiquidity floor) and the re-deposit phase (mint floor). The " +
+        "effective tolerance against the spot price is roughly 2× this value. " +
+        "Default 50 bps; soft cap 100 bps requires acknowledgeHighSlippage.",
+    ),
+  acknowledgeHighSlippage: z.boolean().optional(),
+  deadlineSec: z.number().int().min(60).max(3600).optional(),
+  approvalCap: approvalCapSchema,
+});
+
+export type PrepareUniswapV3RebalanceArgs = z.infer<
+  typeof prepareUniswapV3RebalanceInput
+>;

--- a/src/modules/lp/uniswap-v3/actions.ts
+++ b/src/modules/lp/uniswap-v3/actions.ts
@@ -29,6 +29,7 @@ import { resolveTokenPairMeta } from "../../shared/token-meta.js";
 import { parseSlippageBps } from "../preflight.js";
 import { TICK_SPACINGS, nearestUsableTick } from "./tick-math.js";
 import {
+  burnAmounts,
   burnAmountsWithSlippage,
   mintAmountsWithSlippage,
   type PoolState,
@@ -922,6 +923,341 @@ export async function buildUniswapBurn(
       args: { tokenId: p.tokenId },
     },
   };
+}
+
+export interface BuildUniswapRebalanceParams {
+  chain: SupportedChain;
+  wallet: `0x${string}`;
+  /** Position to rebalance — its (token0, token1, fee) are reused for the new mint. */
+  tokenId: string;
+  /** New lower tick (must align to feeTier's tickSpacing, must be < newTickUpper). */
+  newTickLower: number;
+  /** New upper tick. */
+  newTickUpper: number;
+  /**
+   * Whether to also burn the old NFT in the same multicall. v1 default
+   * is true — the old position has zero liquidity after the decrease+
+   * collect phases and a stub NFT serves no purpose. Set to false to
+   * keep the old tokenId alive (e.g. for off-chain bookkeeping).
+   */
+  burnOld?: boolean;
+  slippageBps?: number;
+  acknowledgeHighSlippage?: boolean;
+  deadlineSec?: number;
+  approvalCap?: string;
+}
+
+/**
+ * Build an unsigned `multicall()` tx that rebalances a Uniswap V3 LP
+ * position from its current tick range to a new one in a single
+ * transaction. Composes:
+ *
+ *   1. `decreaseLiquidity({ liquidity: 100% })` — burns the old
+ *      position's liquidity, settles tokens to `tokensOwed`.
+ *   2. `collect({ amount0Max=u128.max, amount1Max=u128.max })` —
+ *      moves the tokens from `tokensOwed` to the wallet (recipient).
+ *   3. `burn(oldTokenId)` — only if `burnOld: true` (default).
+ *   4. `mint({ ..., tickLower: newTickLower, tickUpper: newTickUpper })`
+ *      — opens a new position over the new range.
+ *
+ * Slippage is **compounded** across the close + re-deposit steps: a
+ * 50 bps user input applies to BOTH the burn-side floor and the
+ * mint-side floor, so the effective tolerance against the spot price
+ * is roughly 2× input bps. The description surfaces this explicitly so
+ * the user sees the real bound.
+ *
+ * v1 amount-source choice: the new mint's `amount0Desired`/
+ * `amount1Desired` are estimated from the position's expected burn
+ * amounts (`burnAmounts` at current price). On-chain, the actual
+ * minted amounts are bounded by what was actually collected; any
+ * surplus is refunded to the wallet by the NPM contract. This is the
+ * standard Uniswap UI client-side approach — a smart-contract-helper
+ * alternative would deploy a thin rebalancer contract and is out of
+ * scope.
+ *
+ * Hard refusals (same as the underlying tools):
+ *   - tokenId not owned by `wallet`
+ *   - tick alignment mismatch on the new range
+ *   - new range identical to old (no-op rebalance)
+ *
+ * NOTE on approvals: rebalance starts from a position that already
+ * holds the user's tokens — the close phase pulls them BACK to the
+ * wallet via collect, then the mint phase pulls them again via the
+ * NPM's transferFrom. So we still need ERC-20 approvals for the new
+ * mint. Up to two are chained ahead of the multicall().
+ */
+export async function buildUniswapRebalance(
+  p: BuildUniswapRebalanceParams,
+): Promise<UnsignedTx> {
+  const cfg = CONTRACTS[p.chain]?.uniswap;
+  if (!cfg) {
+    throw new Error(`Uniswap V3 is not registered on ${p.chain}.`);
+  }
+  const positionManager = cfg.positionManager as `0x${string}`;
+  const factoryAddr = cfg.factory as `0x${string}`;
+  const tokenIdBig = BigInt(p.tokenId);
+  const burnOld = p.burnOld ?? true;
+  const slippageBps = parseSlippageBps({
+    slippageBps: p.slippageBps,
+    acknowledgeHighSlippage: p.acknowledgeHighSlippage,
+  });
+
+  const pos = await readOwnedPosition(p.chain, positionManager, p.wallet, tokenIdBig);
+
+  if (pos.liquidity === 0n) {
+    throw new Error(
+      `Position #${p.tokenId} has zero liquidity — nothing to rebalance. ` +
+        `Use \`prepare_uniswap_v3_collect\` if there are still fees to harvest, ` +
+        `or \`prepare_uniswap_v3_burn\` to remove the empty NFT.`,
+    );
+  }
+  if (p.newTickLower >= p.newTickUpper) {
+    throw new Error(
+      `newTickLower (${p.newTickLower}) must be < newTickUpper (${p.newTickUpper}).`,
+    );
+  }
+  if (p.newTickLower === pos.tickLower && p.newTickUpper === pos.tickUpper) {
+    throw new Error(
+      `New range [${p.newTickLower}, ${p.newTickUpper}] is identical to the existing ` +
+        `position range. Refusing — rebalance is a no-op. Use ` +
+        `\`prepare_uniswap_v3_increase_liquidity\` if you want to add to this position.`,
+    );
+  }
+
+  const tickSpacing = TICK_SPACINGS[pos.fee];
+  if (!tickSpacing) {
+    throw new Error(
+      `Position #${p.tokenId} has unknown fee tier ${pos.fee}.`,
+    );
+  }
+  if (
+    p.newTickLower % tickSpacing !== 0 ||
+    p.newTickUpper % tickSpacing !== 0
+  ) {
+    throw new Error(
+      `newTickLower/newTickUpper must align to tickSpacing=${tickSpacing} for fee tier ${pos.fee}. ` +
+        `Got ${p.newTickLower}/${p.newTickUpper}; nearest usable: ` +
+        `${nearestUsableTick(p.newTickLower, tickSpacing)}/` +
+        `${nearestUsableTick(p.newTickUpper, tickSpacing)}.`,
+    );
+  }
+
+  const client = getClient(p.chain);
+  const [meta, poolAddr] = await Promise.all([
+    resolveTokenPairMeta(p.chain, [pos.token0, pos.token1]),
+    client.readContract({
+      address: factoryAddr,
+      abi: uniswapFactoryAbi,
+      functionName: "getPool",
+      args: [pos.token0, pos.token1, pos.fee],
+    }) as Promise<`0x${string}`>,
+  ]);
+  if (poolAddr === "0x0000000000000000000000000000000000000000") {
+    throw new Error(
+      `Uniswap V3 pool ${pos.token0}/${pos.token1} fee=${pos.fee} on ${p.chain} ` +
+        `does not resolve. Investigate.`,
+    );
+  }
+  const [decimals0, decimals1] = [meta[0].decimals, meta[1].decimals];
+  const [symbol0, symbol1] = [meta[0].symbol, meta[1].symbol];
+
+  const [slot0] = await client.multicall({
+    contracts: [
+      { address: poolAddr, abi: uniswapPoolAbi, functionName: "slot0" },
+    ],
+    allowFailure: false,
+  });
+  const sqrtPriceX96 = (slot0 as readonly [bigint, number, ...unknown[]])[0];
+  const currentTick = Number((slot0 as readonly [bigint, number, ...unknown[]])[1]);
+  const poolState: PoolState = {
+    fee: pos.fee,
+    sqrtRatioX96: sqrtPriceX96,
+    tickCurrent: currentTick,
+    tickSpacing,
+  };
+
+  const deadlineSec = p.deadlineSec ?? DEFAULT_DEADLINE_SEC;
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSec);
+
+  // ===== Close phase =====
+
+  // 1. decreaseLiquidity → amount0Min/amount1Min via burnAmountsWithSlippage.
+  const { amount0: closeAmount0Min, amount1: closeAmount1Min } =
+    burnAmountsWithSlippage({
+      pool: poolState,
+      tickLower: pos.tickLower,
+      tickUpper: pos.tickUpper,
+      liquidity: pos.liquidity,
+      slippageBps,
+    });
+  const decreaseData = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "decreaseLiquidity",
+    args: [
+      {
+        tokenId: tokenIdBig,
+        liquidity: pos.liquidity,
+        amount0Min: closeAmount0Min,
+        amount1Min: closeAmount1Min,
+        deadline,
+      },
+    ],
+  });
+
+  // 2. collect → harvest both decreased liquidity AND any accrued fees.
+  //    Recipient = wallet so the new mint can pull the tokens via approval.
+  const collectData = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "collect",
+    args: [
+      {
+        tokenId: tokenIdBig,
+        recipient: p.wallet,
+        amount0Max: U128_MAX,
+        amount1Max: U128_MAX,
+      },
+    ],
+  });
+
+  // 3. burn (optional). Skipped → the user keeps an empty stub NFT.
+  const burnData = burnOld
+    ? encodeFunctionData({
+        abi: uniswapPositionManagerAbi,
+        functionName: "burn",
+        args: [tokenIdBig],
+      })
+    : null;
+
+  // ===== Open phase =====
+
+  // 4. mint with the new range. amount0Desired/amount1Desired estimated
+  //    from the close-phase amounts (burnAmounts at current price);
+  //    actual mint pulls bounded by what was actually collected and
+  //    refunds any surplus.
+  // burnAmounts at current price (no slippage applied) approximates
+  // what `collect` will route to the wallet. Round-down math matches
+  // on-chain accounting more closely than the mint-side round-up.
+  const closeEstimate = burnAmounts({
+    pool: poolState,
+    tickLower: pos.tickLower,
+    tickUpper: pos.tickUpper,
+    liquidity: pos.liquidity,
+  });
+
+  const { amount0: mintAmount0Min, amount1: mintAmount1Min } =
+    mintAmountsWithSlippage({
+      pool: poolState,
+      tickLower: p.newTickLower,
+      tickUpper: p.newTickUpper,
+      amount0Desired: closeEstimate.amount0,
+      amount1Desired: closeEstimate.amount1,
+      slippageBps,
+    });
+  const mintData = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "mint",
+    args: [
+      {
+        token0: pos.token0,
+        token1: pos.token1,
+        fee: pos.fee,
+        tickLower: p.newTickLower,
+        tickUpper: p.newTickUpper,
+        amount0Desired: closeEstimate.amount0,
+        amount1Desired: closeEstimate.amount1,
+        amount0Min: mintAmount0Min,
+        amount1Min: mintAmount1Min,
+        recipient: p.wallet,
+        deadline,
+      },
+    ],
+  });
+
+  // ===== Compose multicall(bytes[]) =====
+
+  const innerCalls: `0x${string}`[] = [decreaseData, collectData];
+  if (burnData) innerCalls.push(burnData);
+  innerCalls.push(mintData);
+
+  const multicallData = encodeFunctionData({
+    abi: uniswapPositionManagerAbi,
+    functionName: "multicall",
+    args: [innerCalls],
+  });
+
+  const effectiveBpsLabel = `${slippageBps} bps each side (~${slippageBps * 2} bps total — close + re-deposit are independently bounded)`;
+  const rebalanceTx: UnsignedTx = {
+    chain: p.chain,
+    to: positionManager,
+    data: multicallData,
+    value: "0",
+    from: p.wallet,
+    description:
+      `Rebalance Uniswap V3 LP position #${p.tokenId} ` +
+      `(${symbol0}/${symbol1} at ${pos.fee / 10_000}% fee): ` +
+      `[${pos.tickLower}, ${pos.tickUpper}] → [${p.newTickLower}, ${p.newTickUpper}]. ` +
+      `Multicall: decreaseLiquidity(100%) + collect + ${burnOld ? "burn + " : ""}mint(new range). ` +
+      `Slippage ${effectiveBpsLabel}.`,
+    decoded: {
+      functionName: "multicall",
+      args: {
+        innerCalls: String(innerCalls.length),
+        steps: burnOld
+          ? "decreaseLiquidity → collect → burn → mint"
+          : "decreaseLiquidity → collect → mint",
+        oldRange: `[${pos.tickLower}, ${pos.tickUpper}]`,
+        newRange: `[${p.newTickLower}, ${p.newTickUpper}]`,
+        slippageBps: String(slippageBps),
+      },
+    },
+  };
+
+  // Approvals — after collect routes the tokens back to the wallet, the
+  // mint phase pulls them via the NPM's transferFrom. Estimate the
+  // mint-side requirements at the close-estimate amounts.
+  const approvals: Array<UnsignedTx | null> = [];
+  if (closeEstimate.amount0 > 0n) {
+    const cap0 = resolveApprovalCap(
+      p.approvalCap,
+      closeEstimate.amount0,
+      decimals0,
+    );
+    approvals.push(
+      await buildApprovalTx({
+        chain: p.chain,
+        wallet: p.wallet,
+        asset: pos.token0,
+        spender: positionManager,
+        amountWei: closeEstimate.amount0,
+        approvalAmount: cap0.approvalAmount,
+        approvalDisplay: cap0.display,
+        symbol: symbol0,
+        spenderLabel: "Uniswap V3 NonfungiblePositionManager",
+      }),
+    );
+  }
+  if (closeEstimate.amount1 > 0n) {
+    const cap1 = resolveApprovalCap(
+      p.approvalCap,
+      closeEstimate.amount1,
+      decimals1,
+    );
+    approvals.push(
+      await buildApprovalTx({
+        chain: p.chain,
+        wallet: p.wallet,
+        asset: pos.token1,
+        spender: positionManager,
+        amountWei: closeEstimate.amount1,
+        approvalAmount: cap1.approvalAmount,
+        approvalDisplay: cap1.display,
+        symbol: symbol1,
+        spenderLabel: "Uniswap V3 NonfungiblePositionManager",
+      }),
+    );
+  }
+
+  return chainApprovals(approvals, rebalanceTx);
 }
 
 // Re-export erc20Abi so future builders in this module don't need a

--- a/test/uniswap-v3-rebalance.test.ts
+++ b/test/uniswap-v3-rebalance.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for `buildUniswapRebalance` — M1d in
+ * `claude-work/plan-dex-liquidity-provision.md`. Composes
+ * decreaseLiquidity + collect + (optional) burn + mint into a single
+ * `multicall(bytes[])` call against the NonfungiblePositionManager.
+ *
+ * Asserts:
+ *   - calldata is a multicall(bytes[]) with the right inner-call count
+ *     and order
+ *   - each inner call decodes against the expected NPM function
+ *   - `burnOld: false` skips the burn step
+ *   - hard refusals: owner mismatch, identical new range, mis-aligned
+ *     new ticks, zero-liquidity position, newTickLower >= newTickUpper
+ *   - approvals are chained ahead of the multicall (the mint phase
+ *     still needs them)
+ *   - description surfaces the compounded slippage pattern
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { decodeFunctionData } from "viem";
+import { uniswapPositionManagerAbi } from "../src/abis/uniswap-position-manager.js";
+
+const { readContractMock, multicallMock } = vi.hoisted(() => ({
+  readContractMock: vi.fn(),
+  multicallMock: vi.fn(),
+}));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+    multicall: multicallMock,
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD" as const;
+const OTHER_WALLET = "0x1111111111111111111111111111111111111111" as const;
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as const;
+const NPM = "0xC36442b4a4522E871399CD717aBDD847Ab11FE88" as const;
+const USDC_WETH_POOL = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8" as const;
+
+const TOKEN_ID = "12345";
+
+const FAKE_CURRENT_TICK = -201_960;
+const FAKE_SQRT_PRICE_X96 = 3_262_820_378_846_468_593_912_909n;
+const FAKE_POOL_LIQUIDITY = 10_000_000_000_000_000_000n;
+const POSITION_LIQUIDITY = 100_000_000_000n;
+
+function positionTuple(opts: {
+  liquidity?: bigint;
+  tickLower?: number;
+  tickUpper?: number;
+} = {}) {
+  return [
+    0n,
+    "0x0000000000000000000000000000000000000000" as `0x${string}`,
+    USDC,
+    WETH,
+    3_000,
+    opts.tickLower ?? -202_020,
+    opts.tickUpper ?? -201_900,
+    opts.liquidity ?? POSITION_LIQUIDITY,
+    0n,
+    0n,
+    0n,
+    0n,
+  ] as const;
+}
+
+function mockHappyPath(opts: {
+  owner?: `0x${string}`;
+  position?: ReturnType<typeof positionTuple>;
+} = {}) {
+  multicallMock.mockImplementation(
+    async ({ contracts }: { contracts: Array<{ functionName: string }> }) => {
+      if (contracts[0]?.functionName === "positions" && contracts[1]?.functionName === "ownerOf") {
+        return [opts.position ?? positionTuple(), opts.owner ?? WALLET];
+      }
+      if (contracts[0]?.functionName === "decimals") return [6, "USDC", 18, "WETH"];
+      if (contracts[0]?.functionName === "slot0") {
+        return [
+          [FAKE_SQRT_PRICE_X96, FAKE_CURRENT_TICK, 0, 1, 1, 0, true],
+          FAKE_POOL_LIQUIDITY,
+        ];
+      }
+      throw new Error("unexpected multicall");
+    },
+  );
+  readContractMock.mockImplementation(
+    async ({ functionName }: { functionName: string }) => {
+      if (functionName === "getPool") return USDC_WETH_POOL;
+      if (functionName === "allowance") return 0n;
+      throw new Error(`unexpected readContract: ${functionName}`);
+    },
+  );
+}
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  multicallMock.mockReset();
+});
+
+describe("buildUniswapRebalance", () => {
+  it("happy path: encodes multicall(bytes[]) with [decrease, collect, burn, mint] inner calls (default burnOld=true)", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapRebalance({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      newTickLower: -201_780, // shifted right of the old [-202020, -201900] range
+      newTickUpper: -201_660,
+      slippageBps: 50,
+    });
+
+    // Walk past approvals — the mint phase still needs token0 + token1 approvals.
+    let cursor = tx;
+    while (cursor.next && cursor.description.startsWith("Approve")) cursor = cursor.next;
+    expect(cursor.to.toLowerCase()).toBe(NPM.toLowerCase());
+
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: cursor.data,
+    });
+    expect(decoded.functionName).toBe("multicall");
+    const innerCalls = decoded.args![0] as readonly `0x${string}`[];
+    expect(innerCalls).toHaveLength(4); // decrease + collect + burn + mint
+
+    const [innerDecrease, innerCollect, innerBurn, innerMint] = innerCalls;
+    expect(decodeFunctionData({ abi: uniswapPositionManagerAbi, data: innerDecrease }).functionName).toBe(
+      "decreaseLiquidity",
+    );
+    expect(decodeFunctionData({ abi: uniswapPositionManagerAbi, data: innerCollect }).functionName).toBe(
+      "collect",
+    );
+    expect(decodeFunctionData({ abi: uniswapPositionManagerAbi, data: innerBurn }).functionName).toBe(
+      "burn",
+    );
+    expect(decodeFunctionData({ abi: uniswapPositionManagerAbi, data: innerMint }).functionName).toBe(
+      "mint",
+    );
+
+    expect(cursor.description).toContain("Rebalance Uniswap V3 LP position");
+    expect(cursor.description).toContain("[-202020, -201900]");
+    expect(cursor.description).toContain("[-201780, -201660]");
+    // Compounded slippage callout
+    expect(cursor.description).toContain("close + re-deposit");
+  });
+
+  it("burnOld=false skips the burn step", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapRebalance({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      newTickLower: -201_780,
+      newTickUpper: -201_660,
+      burnOld: false,
+    });
+
+    let cursor = tx;
+    while (cursor.next && cursor.description.startsWith("Approve")) cursor = cursor.next;
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: cursor.data,
+    });
+    expect(decoded.functionName).toBe("multicall");
+    const innerCalls = decoded.args![0] as readonly `0x${string}`[];
+    expect(innerCalls).toHaveLength(3); // decrease + collect + mint, no burn
+    const fns = innerCalls.map(
+      (d) => decodeFunctionData({ abi: uniswapPositionManagerAbi, data: d }).functionName,
+    );
+    expect(fns).toEqual(["decreaseLiquidity", "collect", "mint"]);
+  });
+
+  it("decrease step uses 100% of the position's liquidity", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapRebalance({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      newTickLower: -201_780,
+      newTickUpper: -201_660,
+    });
+    let cursor = tx;
+    while (cursor.next && cursor.description.startsWith("Approve")) cursor = cursor.next;
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: cursor.data,
+    });
+    const innerCalls = decoded.args![0] as readonly `0x${string}`[];
+    const decreaseDecoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: innerCalls[0],
+    });
+    const decreaseParams = (decreaseDecoded.args as readonly [{ liquidity: bigint }])[0];
+    expect(decreaseParams.liquidity).toBe(POSITION_LIQUIDITY);
+  });
+
+  it("mint step uses the new tick range (not the old one)", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapRebalance({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      newTickLower: -201_780,
+      newTickUpper: -201_660,
+    });
+    let cursor = tx;
+    while (cursor.next && cursor.description.startsWith("Approve")) cursor = cursor.next;
+    const decoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: cursor.data,
+    });
+    const innerCalls = decoded.args![0] as readonly `0x${string}`[];
+    const mintDecoded = decodeFunctionData({
+      abi: uniswapPositionManagerAbi,
+      data: innerCalls[innerCalls.length - 1],
+    });
+    const mintParams = (mintDecoded.args as readonly [{
+      tickLower: number;
+      tickUpper: number;
+      token0: string;
+      token1: string;
+      fee: number;
+    }])[0];
+    expect(mintParams.tickLower).toBe(-201_780);
+    expect(mintParams.tickUpper).toBe(-201_660);
+    expect(mintParams.token0.toLowerCase()).toBe(USDC.toLowerCase());
+    expect(mintParams.token1.toLowerCase()).toBe(WETH.toLowerCase());
+    expect(mintParams.fee).toBe(3_000);
+  });
+
+  it("hard-refuses on owner mismatch", async () => {
+    mockHappyPath({ owner: OTHER_WALLET });
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapRebalance({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        newTickLower: -201_780,
+        newTickUpper: -201_660,
+      }),
+    ).rejects.toThrow(/is owned by/);
+  });
+
+  it("rejects when new range is identical to old", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapRebalance({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        newTickLower: -202_020, // same as position's tickLower
+        newTickUpper: -201_900, // same as position's tickUpper
+      }),
+    ).rejects.toThrow(/identical/);
+  });
+
+  it("rejects when newTickLower >= newTickUpper", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapRebalance({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        newTickLower: -201_660,
+        newTickUpper: -201_780, // smaller than newTickLower
+      }),
+    ).rejects.toThrow(/must be </);
+  });
+
+  it("rejects mis-aligned new ticks with nearest-usable-tick guidance", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapRebalance({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        newTickLower: -201_781, // not aligned to tickSpacing=60
+        newTickUpper: -201_660,
+      }),
+    ).rejects.toThrow(/align to tickSpacing=60/);
+  });
+
+  it("rejects when position has zero liquidity", async () => {
+    mockHappyPath({ position: positionTuple({ liquidity: 0n }) });
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    await expect(
+      buildUniswapRebalance({
+        chain: "ethereum",
+        wallet: WALLET,
+        tokenId: TOKEN_ID,
+        newTickLower: -201_780,
+        newTickUpper: -201_660,
+      }),
+    ).rejects.toThrow(/zero liquidity/);
+  });
+
+  it("emits up to two approvals ahead of the multicall (mint phase still needs them)", async () => {
+    mockHappyPath();
+    const { buildUniswapRebalance } = await import(
+      "../src/modules/lp/uniswap-v3/actions.js"
+    );
+    const tx = await buildUniswapRebalance({
+      chain: "ethereum",
+      wallet: WALLET,
+      tokenId: TOKEN_ID,
+      newTickLower: -201_780,
+      newTickUpper: -201_660,
+    });
+    // Approvals chain ahead. Walk and count.
+    let cursor: typeof tx | undefined = tx;
+    let approvalCount = 0;
+    while (cursor && cursor.description.startsWith("Approve")) {
+      approvalCount += 1;
+      cursor = cursor.next;
+    }
+    expect(approvalCount).toBeGreaterThanOrEqual(1);
+    expect(approvalCount).toBeLessThanOrEqual(2);
+    expect(cursor).toBeDefined();
+    expect(cursor!.description).toContain("Rebalance Uniswap V3 LP position");
+  });
+});


### PR DESCRIPTION
**Stacked PR — base branch is `feat/lp-uniswap-v3-closeout` ([#348 (M1c)](https://github.com/szhygulin/vaultpilot-mcp/pull/348)). Merge #348 first, then re-target this PR to main.**

Final Uniswap V3 LP write tool, closing Phase 1 of [`claude-work/plan-dex-liquidity-provision.md`](claude-work/plan-dex-liquidity-provision.md).

## Behavior

Composes 3-4 inner calls into a single `multicall(bytes[])` against the NonfungiblePositionManager:

1. `decreaseLiquidity(100% of position)` — burns the old liquidity, settles to tokensOwed.
2. `collect(amount0Max=u128.max, amount1Max=u128.max, recipient=wallet)` — moves the tokens from tokensOwed to the wallet.
3. `burn(oldTokenId)` — only when `burnOld: true` (default).
4. `mint(newRange)` — opens a new position with the same `(token0, token1, fee)` but the new tick range.

**Slippage is independently applied** to the close phase (decreaseLiquidity floor) and the re-deposit phase (mint floor). The effective tolerance against the spot price is roughly 2× the user input. The description block surfaces this explicitly.

**Approvals still required**: collect routes the harvested tokens BACK to the wallet, then mint pulls them via `transferFrom`. Up to two ERC-20 approvals chain ahead of the multicall via M0's `chainApprovals`.

**Amount-source**: `mint`'s `amount0Desired` / `amount1Desired` are estimated from `burnAmounts` at current price (round-down, matches on-chain accounting more closely than the round-up mint side). On-chain, the actual mint pulls bounded by what was actually collected; surplus is refunded to the wallet by the NPM. Standard Uniswap UI client-side approach — a smart-contract-helper alternative would deploy a thin rebalancer contract and is out of scope.

## Hard refusals

- tokenId not owned by `wallet`
- position has zero liquidity (nothing to rebalance)
- `newTickLower >= newTickUpper`
- new range identical to existing (no-op)
- mis-aligned new ticks (with nearest-usable-tick guidance)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1736/1736 pass parallel in 29s
- [x] 10 new tests in `test/uniswap-v3-rebalance.test.ts`:
  - Happy path: `multicall(bytes[])` with `[decrease, collect, burn, mint]` in order; default `burnOld=true`
  - `burnOld=false` skips the burn step → 3 inner calls
  - Decrease step uses 100% of position liquidity
  - Mint step uses the NEW tick range and the SAME `(token0, token1, fee)`
  - Owner mismatch refusal
  - Identical new range refusal
  - `newTickLower >= newTickUpper` refusal
  - Mis-aligned new tick refusal with guidance
  - Zero-liquidity position refusal
  - Approval chaining: 1-2 approvals ahead of the multicall
- [ ] CI green
- [ ] One real mainnet rebalance with minimal amounts on a known position, signed on a real Ledger device

## Closes Phase 1 of the LP plan

| Tool | PR |
|---|---|
| `prepare_uniswap_v3_mint` | [#334 (M1a)](https://github.com/szhygulin/vaultpilot-mcp/pull/334) ✓ merged |
| `prepare_uniswap_v3_increase_liquidity` | [#342 (M1b)](https://github.com/szhygulin/vaultpilot-mcp/pull/342) ✓ merged |
| `prepare_uniswap_v3_decrease_liquidity` + `_collect` + `_burn` | [#348 (M1c)](https://github.com/szhygulin/vaultpilot-mcp/pull/348) — base of this PR |
| `prepare_uniswap_v3_rebalance` | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)