### PR TITLE
feat(security): pin WalletConnect peer to Ledger Live (issue #325 P5)

### DIFF
--- a/src/signing/walletconnect-peer-pin.ts
+++ b/src/signing/walletconnect-peer-pin.ts
@@ -1,0 +1,173 @@
+import type { SessionTypes } from "@walletconnect/types";
+
+/**
+ * WalletConnect peer pinning (issue #325 P5).
+ *
+ * The MCP's WalletConnect role is "dApp"; it proposes a session and
+ * the wallet (Ledger Live) approves. Once approved, every signing
+ * request flows over a relayed encrypted channel between the two —
+ * the MCP submits txs/messages, the wallet signs.
+ *
+ * Today's trust assumption: "the WC peer that approved our session is
+ * Ledger Live, because the user scanned the QR with Ledger Live and
+ * approved on the Ledger device." The MCP can't verify the wallet
+ * binary itself (P4 covers that), but it CAN verify the WC peer's
+ * advertised identity matches what Ledger Live publishes — name,
+ * canonical URL, icons hosted on `*.ledger.com`. A different wallet
+ * (Sparrow, MetaMask, an attacker's wallet) advertises different
+ * metadata, and the user would notice the prompt on the wrong app
+ * — but only if they look. This pin makes the discrepancy
+ * machine-checkable.
+ *
+ * What this catches:
+ *   - Another wallet impersonating Ledger Live at the WC peer level
+ *     (i.e., the user accidentally scanned the QR with the wrong app
+ *     and approved without noticing)
+ *   - A malicious WC relay swapping the peer metadata (the relay sees
+ *     metadata in the session_propose payload; if compromised it
+ *     could rewrite — but the MCP would notice the mismatch)
+ *
+ * What this misses (covered by other layers):
+ *   - A real-Ledger-Live version that's been tampered with (P4)
+ *   - A WC peer that lies about its name/url AND happens to spoof
+ *     Ledger Live's exact metadata (impossible to detect at this
+ *     layer alone; user's eyes on the device are the trust root)
+ *
+ * Pinning policy:
+ *   - `name === "Ledger Live"` exact match (Ledger publishes this
+ *     name; case-sensitive)
+ *   - `url` matches `https://*.ledger.com/...` OR is empty (Ledger
+ *     Live mobile sometimes omits the URL field)
+ *   - At least one icon URL hostname matches `*.ledger.com` (defense
+ *     against a peer that copies name+url but forgets the icon CDN)
+ *
+ * On mismatch we WARN-LOUDLY rather than refuse. Refusal would brick
+ * legitimate users running self-built Ledger Live or development
+ * builds where metadata sometimes differs. The verdict is surfaced to
+ * the agent so it can flag to the user; the user retains the on-device
+ * approval as the actual trust root.
+ */
+
+export type LedgerLivePinVerdict = "match" | "mismatch" | "missing-metadata";
+
+export interface PeerPinResult {
+  verdict: LedgerLivePinVerdict;
+  /** Peer's reported name. Empty string if missing. */
+  reportedName: string;
+  /** Peer's reported URL. Empty string if missing. */
+  reportedUrl: string;
+  /** Peer's reported icon hostnames (parsed from URLs). */
+  reportedIconHosts: string[];
+  /** Human-readable line for the agent to surface on `mismatch`. */
+  message: string;
+}
+
+const LEDGER_LIVE_NAME_EXACT = "Ledger Live";
+/** Hostname suffixes Ledger publishes from. */
+const LEDGER_HOST_SUFFIXES: ReadonlyArray<string> = [".ledger.com"];
+
+function hostMatchesLedger(host: string): boolean {
+  const lc = host.toLowerCase();
+  // Exact match for the bare apex (defensive — Ledger doesn't currently
+  // serve from the bare apex, but accepting it future-proofs).
+  if (lc === "ledger.com") return true;
+  return LEDGER_HOST_SUFFIXES.some((suffix) => lc.endsWith(suffix));
+}
+
+function safeUrlHostname(raw: string): string | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a WC session's peer metadata against the Ledger Live
+ * pin. Returns a structured verdict; does NOT throw.
+ */
+export function pinLedgerLivePeer(session: SessionTypes.Struct): PeerPinResult {
+  // SessionTypes.Struct.peer.metadata.{name, url, icons} are the
+  // standard WC v2 fields the wallet advertises.
+  const metadata = session.peer?.metadata;
+  const reportedName = metadata?.name ?? "";
+  const reportedUrl = metadata?.url ?? "";
+  const reportedIcons = Array.isArray(metadata?.icons) ? metadata.icons : [];
+  const reportedIconHosts = reportedIcons
+    .map((u) => safeUrlHostname(u))
+    .filter((h): h is string => h !== null);
+
+  if (!reportedName && !reportedUrl && reportedIconHosts.length === 0) {
+    return {
+      verdict: "missing-metadata",
+      reportedName,
+      reportedUrl,
+      reportedIconHosts,
+      message:
+        `WalletConnect peer reported no metadata (name + url + icons all empty). ` +
+        `This is unusual; legitimate Ledger Live always advertises name and url. ` +
+        `Verify the connection on-device before approving signing prompts — the ` +
+        `MCP cannot identify the peer.`,
+    };
+  }
+
+  // Name check: exact match. Ledger Live publishes "Ledger Live"
+  // verbatim; alternates ("Ledger Live Mobile", "Ledger Live Desktop")
+  // are NOT in current production metadata, so any deviation is a
+  // pinning failure.
+  const nameOk = reportedName === LEDGER_LIVE_NAME_EXACT;
+
+  // URL check: scheme can be omitted; hostname must match a Ledger
+  // suffix. Empty url is acceptable (some clients omit it on mobile).
+  const urlHost = safeUrlHostname(reportedUrl);
+  const urlOk = !reportedUrl || (urlHost !== null && hostMatchesLedger(urlHost));
+
+  // Icon check: at least one icon URL must point at a Ledger-hosted
+  // CDN. Acceptable to omit icons entirely — but if icons ARE present,
+  // at least one should be Ledger-hosted (catches peers that
+  // copy-paste name+url but forget the icon CDN).
+  const iconsOk =
+    reportedIconHosts.length === 0 ||
+    reportedIconHosts.some((h) => hostMatchesLedger(h));
+
+  if (nameOk && urlOk && iconsOk) {
+    return {
+      verdict: "match",
+      reportedName,
+      reportedUrl,
+      reportedIconHosts,
+      message: `WalletConnect peer matches Ledger Live pin.`,
+    };
+  }
+
+  const reasons: string[] = [];
+  if (!nameOk) {
+    reasons.push(
+      `name "${reportedName}" ≠ expected "${LEDGER_LIVE_NAME_EXACT}"`,
+    );
+  }
+  if (!urlOk) {
+    reasons.push(
+      `url "${reportedUrl}" doesn't match a *.ledger.com hostname`,
+    );
+  }
+  if (!iconsOk) {
+    reasons.push(
+      `none of the icon hosts (${reportedIconHosts.join(", ")}) match *.ledger.com`,
+    );
+  }
+
+  return {
+    verdict: "mismatch",
+    reportedName,
+    reportedUrl,
+    reportedIconHosts,
+    message:
+      `WalletConnect peer does NOT match the Ledger Live pin: ${reasons.join("; ")}. ` +
+      `If you intentionally connected via a non-Ledger-Live wallet (development ` +
+      `build, Sparrow, etc.), this is expected — but if you scanned the QR with ` +
+      `Ledger Live and see this warning, the peer may not be what it claims to be. ` +
+      `Verify on-device before approving any signing prompts.`,
+  };
+}

--- a/src/signing/walletconnect.ts
+++ b/src/signing/walletconnect.ts
@@ -1,6 +1,7 @@
 import { SignClient } from "@walletconnect/sign-client";
 import type { SessionTypes } from "@walletconnect/types";
 import { getSdkError } from "@walletconnect/utils";
+import { pinLedgerLivePeer, type PeerPinResult } from "./walletconnect-peer-pin.js";
 import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { PublicClient } from "viem";
@@ -121,6 +122,37 @@ let currentSession: SessionTypes.Struct | null = null;
 let peerUnreachable = false;
 
 /**
+ * Latest result from the Ledger Live peer pin (issue #325 P5). Set
+ * each time a session is restored OR newly approved; null when no
+ * session exists. Read by `getLedgerLivePinStatus()` so diagnostic
+ * tools (`get_ledger_status`) can surface mismatch warnings to the
+ * user without re-checking on every read.
+ */
+let lastPeerPinResult: PeerPinResult | null = null;
+
+/**
+ * Run the Ledger Live peer pin against `session` and stash the
+ * result. Logs a loud warning on mismatch — non-blocking, so a
+ * legitimate-but-unusual peer (dev build, self-built Ledger Live)
+ * doesn't brick signing. The user retains the on-device approval as
+ * the trust root.
+ */
+function applyPeerPin(session: SessionTypes.Struct): PeerPinResult {
+  const result = pinLedgerLivePeer(session);
+  lastPeerPinResult = result;
+  if (result.verdict !== "match") {
+    // eslint-disable-next-line no-console
+    console.warn(`[vaultpilot wc-peer-pin] ${result.message}`);
+  }
+  return result;
+}
+
+/** Latest peer-pin verdict, or null when no session is being tracked. */
+export function getLedgerLivePinStatus(): PeerPinResult | null {
+  return lastPeerPinResult;
+}
+
+/**
  * Background keepalive timer. While a session exists we ping the peer over
  * the relay every `KEEPALIVE_INTERVAL_MS` so the relay keeps the topic
  * subscription warm and we get a continuous reachability signal (used to
@@ -221,6 +253,7 @@ export async function getSignClient(): Promise<InstanceType<typeof SignClient>> 
   //     surface the unreachable hint, but KEEP the session so reopening
   //     LL-WC resumes via the next successful keepalive without a re-pair.
   if (currentSession) {
+    applyPeerPin(currentSession);
     const liveness = await verifySessionAlive(client, currentSession.topic);
     peerUnreachable = liveness !== "alive";
     startKeepalive(client, currentSession.topic);
@@ -239,6 +272,7 @@ function handleSessionEndedByPeer(): void {
   stopKeepalive();
   currentSession = null;
   peerUnreachable = false;
+  lastPeerPinResult = null;
   patchUserConfig({
     walletConnect: { sessionTopic: undefined, pairingTopic: undefined },
   });
@@ -397,6 +431,7 @@ export async function initiatePairing(): Promise<PairResult> {
       const session = await approval();
       currentSession = session;
       peerUnreachable = false;
+      applyPeerPin(session);
       patchUserConfig({
         walletConnect: {
           sessionTopic: session.topic,

--- a/test/walletconnect-peer-pin.test.ts
+++ b/test/walletconnect-peer-pin.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { pinLedgerLivePeer } from "../src/signing/walletconnect-peer-pin.ts";
+import type { SessionTypes } from "@walletconnect/types";
+
+/**
+ * Unit tests for the WalletConnect peer pin (issue #325 P5). Pure
+ * function — no transport, no SignClient. Just exercises the
+ * verdict logic over various peer-metadata shapes.
+ */
+
+function buildSession(metadata: Partial<{
+  name: string;
+  url: string;
+  description: string;
+  icons: string[];
+}>): SessionTypes.Struct {
+  return {
+    peer: {
+      publicKey: "00".repeat(32),
+      metadata: {
+        name: metadata.name ?? "",
+        url: metadata.url ?? "",
+        description: metadata.description ?? "",
+        icons: metadata.icons ?? [],
+      },
+    },
+  } as unknown as SessionTypes.Struct;
+}
+
+describe("pinLedgerLivePeer — match", () => {
+  it("matches canonical Ledger Live metadata", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "https://www.ledger.com",
+      icons: ["https://cdn.ledger.com/logo.png"],
+    });
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("match");
+  });
+
+  it("matches when url is empty (mobile clients omit it)", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "",
+      icons: ["https://cdn.ledger.com/logo.png"],
+    });
+    expect(pinLedgerLivePeer(session).verdict).toBe("match");
+  });
+
+  it("matches when icons array is empty (defensive — only refuse if BOTH url+icons fail Ledger check)", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "https://www.ledger.com",
+      icons: [],
+    });
+    expect(pinLedgerLivePeer(session).verdict).toBe("match");
+  });
+
+  it("matches a *.ledger.com subdomain url", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "https://my.ledger.com/some/path",
+      icons: [],
+    });
+    expect(pinLedgerLivePeer(session).verdict).toBe("match");
+  });
+});
+
+describe("pinLedgerLivePeer — mismatch", () => {
+  it("rejects an exact-name impostor (different name)", () => {
+    const session = buildSession({
+      name: "Ledger Wallet", // not the canonical name
+      url: "https://www.ledger.com",
+      icons: ["https://cdn.ledger.com/logo.png"],
+    });
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("mismatch");
+    expect(result.message).toMatch(/name "Ledger Wallet"/);
+  });
+
+  it("rejects a non-Ledger URL", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "https://attacker.example.com",
+      icons: ["https://cdn.ledger.com/logo.png"],
+    });
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("mismatch");
+    expect(result.message).toMatch(/url "https:\/\/attacker.example.com"/);
+  });
+
+  it("rejects when icons are present but none point at *.ledger.com", () => {
+    const session = buildSession({
+      name: "Ledger Live",
+      url: "https://www.ledger.com",
+      icons: ["https://attacker.example.com/logo.png"],
+    });
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("mismatch");
+    expect(result.message).toMatch(/icon hosts/);
+  });
+
+  it("rejects a different wallet (Sparrow)", () => {
+    const session = buildSession({
+      name: "Sparrow",
+      url: "https://sparrowwallet.com",
+      icons: ["https://sparrowwallet.com/logo.png"],
+    });
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("mismatch");
+  });
+
+  it("is case-sensitive on name (Ledger publishes 'Ledger Live' verbatim)", () => {
+    const session = buildSession({
+      name: "ledger live",
+      url: "https://www.ledger.com",
+      icons: [],
+    });
+    expect(pinLedgerLivePeer(session).verdict).toBe("mismatch");
+  });
+});
+
+describe("pinLedgerLivePeer — missing-metadata", () => {
+  it("returns missing-metadata when name+url+icons are all empty", () => {
+    const session = buildSession({});
+    const result = pinLedgerLivePeer(session);
+    expect(result.verdict).toBe("missing-metadata");
+    expect(result.message).toMatch(/no metadata/);
+  });
+
+  it("returns missing-metadata when peer.metadata itself is undefined", () => {
+    const session = {
+      peer: { publicKey: "00".repeat(32) },
+    } as unknown as SessionTypes.Struct;
+    expect(pinLedgerLivePeer(session).verdict).toBe("missing-metadata");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **P5** lane of [#325](https://github.com/szhygulin/vaultpilot-mcp/issues/325). Validates the WalletConnect peer's advertised metadata against a Ledger Live signature whenever a session is restored or newly approved.

## Pin policy

| Field | Rule |
|---|---|
| `name` | exact match `"Ledger Live"` |
| `url` | empty OR hostname matches `*.ledger.com` |
| `icons` | empty OR ≥ 1 icon URL hostname matches `*.ledger.com` |

The icon check defends against peers that copy `name` + `url` but forget the icon CDN — Ledger's published metadata always uses a `*.ledger.com` host for both.

## Behavior

- Verdict (`match` / `mismatch` / `missing-metadata`) logged via `console.warn` on non-match.
- Stashed in a module-level cache; `getLedgerLivePinStatus()` exposes it for diagnostic surfacing (e.g. future `get_ledger_status` extension).
- **Non-blocking** — refusing on mismatch would brick legitimate self-built / dev Ledger Live setups where metadata sometimes differs. The user retains the on-device approval as the trust root.

## What this catches / misses

**Catches**: another wallet impersonating Ledger Live at the WC peer level (e.g., user accidentally scans QR with the wrong app); a WC relay that rewrites peer metadata in the `session_propose` payload (relay sees plaintext metadata).

**Misses**: real-Ledger-Live-but-tampered (covered by P4); spoofed metadata that exactly mimics Ledger's published values (impossible at this layer alone; on-device approval is the trust root).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/walletconnect-peer-pin.test.ts` — 11/11 (match / mismatch / missing-metadata branches, case-sensitivity, subdomain handling)
- [x] Full suite: 1787/1787 passing
- [ ] Live smoke: connect via Ledger Live, confirm logs show `WalletConnect peer matches Ledger Live pin`; if available, connect via Sparrow or another wallet, confirm warning surfaces

Plan: [`claude-work/plan-device-trust-followups.md`](../blob/main/claude-work/plan-device-trust-followups.md). PR2 (P4 — Ledger Live binary codesign) will stack on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)