### PR TITLE
docs(claude.md): add SDK scope-probing discipline section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@
 - Do not repeat the same informational tool call (e.g., lending_positions, compound_positions) within a single turn. Cache results mentally and reuse.
 - If a tool returns ambiguous or empty data, verify once with a different method; do not enter polling loops without user consent.
 
+## SDK Scope-Probing Discipline
+- **When a plan proposes adopting a new third-party SDK (DeFi protocol clients, wallet libraries, aggregators), scope-probe the package BEFORE committing the plan, not at code time.** Invoke the `rnd` skill. Spend 15-30 minutes on: (1) `npm view <pkg>` for runtime deps + last-published date; (2) install into `/tmp/<pkg>-probe/` and read `dist/*.d.ts`; (3) check the transit graph for `*-contracts` packages, hardhat, ethersproject v5, or other parallel core libraries; (4) confirm the API exposes UNSIGNED tx output (compatible with our Ledger flow) rather than internally-signing-and-broadcasting helpers.
+- **Document the probe verdict in the plan with a table**: SDK / version / red flags / decision (adopt / cherry-pick / skip). Future-you will need to justify the choice.
+- **Real cost of skipping the probe**: PR #334 (Uniswap V3 mint) initially adopted `@uniswap/v3-sdk` per Option C (cherry-pick math, viem-encode calldata). The d.ts inspection at probe time stopped one level deep — Snyk caught the rest at PR-CI time when `@uniswap/swap-router-contracts → hardhat-watcher → hardhat → @sentry/node + undici + mocha + solc` showed up. ~2 hours to refactor: drop the SDK, port `getSqrtRatioAtTick` + `Position.fromAmounts` + `mintAmountsWithSlippage` to native bigint (~470 LoC) and lock bit-exactness via fixture tests.
+- **Real reward of doing the probe**: Phase 2 (Curve) + Phase 3 (Balancer) planning (2026-04-27) — `@curvefi/api` was rejected at probe time (signing-tightly-coupled to ethers, would force a viem↔ethers bridge across every prepare flow); `@balancer-labs/sdk` (V2) was rejected at probe time (stale, ethersproject-bound, Snyk-failure-equivalent); `@balancer/sdk` (V3) was accepted at probe time after confirming viem-native + bundling V2 helpers too — net result: 1 SDK adopted instead of 3, no architectural mismatch, plans grounded in known-good integration shape. Avoids a Uniswap-style dep-tree disaster and validates the probe-at-plan-time discipline.
+
 ## Security Incident Response Tone
 - When diagnosing malware/compromise, start with evidence-based scoping before recommending destructive actions (wipe, nuke, rotate-all). Never delete evidence files before reading them.
 


### PR DESCRIPTION
Codifies the rule that's been quietly forming across the LP plan since [#334](https://github.com/szhygulin/vaultpilot-mcp/pull/334): **probe third-party SDKs at plan time, not at code time.**

## What this adds

A new \`## SDK Scope-Probing Discipline\` section in \`CLAUDE.md\`, between \`Tool Usage Discipline\` and \`Security Incident Response Tone\`. Four bullets:

1. **The rule** — when a plan proposes adopting a new third-party SDK, run a 15-30 minute probe (`npm view`, install into `/tmp`, read `dist/*.d.ts`, check transit graph for hardhat / ethersproject / *-contracts, confirm unsigned-tx output compatibility) BEFORE committing the plan.
2. **The output shape** — document SDK / version / red flags / decision in the plan as a table. Future-you needs to justify the choice.
3. **Cost of skipping (Uniswap saga)** — #334 initially adopted `@uniswap/v3-sdk` per Option C; Snyk caught `swap-router-contracts → hardhat-watcher → hardhat → sentry + undici + mocha + solc` at PR-CI time. ~2 hours refactor: drop SDK, port `getSqrtRatioAtTick` + `Position.fromAmounts` + `mintAmountsWithSlippage` to native bigint (~470 LoC) with bit-exactness fixture tests.
4. **Reward of doing it (Phase 2/3 planning, 2026-04-27)** — `@curvefi/api` rejected (signing-tightly-coupled to ethers); `@balancer-labs/sdk` V2 rejected (stale, ethersproject-bound); `@balancer/sdk` V3 accepted after confirming viem-native + bundles V2 helpers too. **1 SDK adopted instead of 3.** Avoids a Uniswap-style dep-tree disaster.

## Test plan

- [x] Diff is +6 lines, docs-only, scoped to a single section addition
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)