### PR TITLE
perf(release): strip @mysten/sui from @lifi/sdk + narrow prebuild glob (~63 MB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     ],
     "assets": [
       "node_modules/node-hid/build/Release/*.node",
-      "node_modules/usb/prebuilds/**/*.node",
-      "node_modules/bufferutil/prebuilds/**/*.node",
-      "node_modules/utf-8-validate/prebuilds/**/*.node"
+      "node_modules/usb/prebuilds/{darwin-x64+arm64,linux-x64,win32-x64}/*.node",
+      "node_modules/bufferutil/prebuilds/{darwin-arm64,darwin-x64,linux-x64,win32-x64}/*.node",
+      "node_modules/utf-8-validate/prebuilds/{darwin-arm64,darwin-x64,linux-x64,win32-x64}/*.node"
     ],
     "outputPath": "release"
   },

--- a/patches/@lifi+sdk+3.16.3.patch
+++ b/patches/@lifi+sdk+3.16.3.patch
@@ -1,0 +1,64 @@
+diff --git a/node_modules/@lifi/sdk/package.json b/node_modules/@lifi/sdk/package.json
+index 261ba2a..1b7e7df 100644
+--- a/node_modules/@lifi/sdk/package.json
++++ b/node_modules/@lifi/sdk/package.json
+@@ -6,8 +6,6 @@
+     "@bigmi/core": "^0.7.1",
+     "@bitcoinerlab/secp256k1": "^1.2.0",
+     "@lifi/types": "17.65.0",
+-    "@mysten/sui": "^1.45.2",
+-    "@mysten/wallet-standard": "^0.19.9",
+     "@noble/curves": "^1.9.7",
+     "@solana/wallet-adapter-base": "^0.9.27",
+     "@solana/web3.js": "^1.98.4",
+@@ -31,7 +29,10 @@
+     "!src/**/*.mock.ts",
+     "!src/**/*.spec.ts",
+     "!src/**/*.handlers.ts",
+-    "!src/**/*.tsbuildinfo"
++    "!src/**/*.tsbuildinfo",
++    "!src/_cjs/core/Sui",
++    "!src/_esm/core/Sui",
++    "!src/_types/core/Sui"
+   ],
+   "homepage": "https://github.com/lifinance/sdk",
+   "keywords": [
+diff --git a/node_modules/@lifi/sdk/src/_cjs/index.js b/node_modules/@lifi/sdk/src/_cjs/index.js
+index a6fa54a..a5c6c7d 100644
+--- a/node_modules/@lifi/sdk/src/_cjs/index.js
++++ b/node_modules/@lifi/sdk/src/_cjs/index.js
+@@ -63,10 +63,12 @@ var types_js_2 = require("./core/Solana/types.js");
+ Object.defineProperty(exports, "isSolana", { enumerable: true, get: function () { return types_js_2.isSolana; } });
+ var StatusManager_js_1 = require("./core/StatusManager.js");
+ Object.defineProperty(exports, "StatusManager", { enumerable: true, get: function () { return StatusManager_js_1.StatusManager; } });
+-var Sui_js_1 = require("./core/Sui/Sui.js");
+-Object.defineProperty(exports, "Sui", { enumerable: true, get: function () { return Sui_js_1.Sui; } });
+-var types_js_3 = require("./core/Sui/types.js");
+-Object.defineProperty(exports, "isSui", { enumerable: true, get: function () { return types_js_3.isSui; } });
++// vaultpilot patch: Sui re-exports removed to keep @mysten/sui out of the
++// pkg snapshot (~25 MB savings). Restored as a stubbed `Sui` object and
++// `isSui` predicate so consumers that import them still resolve, but the
++// real Sui codepath is unreachable. We don't use Sui in this codebase.
++exports.Sui = undefined;
++exports.isSui = function () { return false; };
+ var types_js_4 = require("./core/UTXO/types.js");
+ Object.defineProperty(exports, "isUTXO", { enumerable: true, get: function () { return types_js_4.isUTXO; } });
+ var UTXO_js_1 = require("./core/UTXO/UTXO.js");
+diff --git a/node_modules/@lifi/sdk/src/_esm/index.js b/node_modules/@lifi/sdk/src/_esm/index.js
+index 9c881a3..69d8266 100644
+--- a/node_modules/@lifi/sdk/src/_esm/index.js
++++ b/node_modules/@lifi/sdk/src/_esm/index.js
+@@ -18,8 +18,11 @@ export { KeypairWalletAdapter, KeypairWalletName, } from './core/Solana/KeypairW
+ export { Solana } from './core/Solana/Solana.js';
+ export { isSolana } from './core/Solana/types.js';
+ export { StatusManager } from './core/StatusManager.js';
+-export { Sui } from './core/Sui/Sui.js';
+-export { isSui } from './core/Sui/types.js';
++// vaultpilot patch: Sui re-exports removed to keep @mysten/sui out of the
++// pkg snapshot (~25 MB savings). Restored as stubs so consumers that
++// import them still resolve. We don't use Sui in this codebase.
++export const Sui = undefined;
++export const isSui = () => false;
+ export { isUTXO } from './core/UTXO/types.js';
+ export { UTXO } from './core/UTXO/UTXO.js';
+ export { createConfig } from './createConfig.js';


### PR DESCRIPTION
## Summary

Tier 1 of the size-reduction work proposed in #346. Two complementary edits drop the linux-x64 binary from 483 MB → 420 MB (**−63 MB, −13%**), or 504 → 420 (**−17%**) compared to before #346.

1. **`patches/@lifi+sdk+3.16.3.patch`** — neuters the unused Sui codepath in `@lifi/sdk` so pkg's snapshot doesn't pull in `@mysten/sui` (23 MB) + `@mysten/wallet-standard` + their transitive cone (private `@noble/curves` variant, `@protobuf-ts/grpcweb-transport`, `@graphql-typed-document-node`, etc.).
2. **`package.json` `pkg.assets`** — narrows the prebuild glob to only our four supported targets (drops android, ARM Linux, 32-bit variants we never ship).

## Why three coordinated edits to @lifi/sdk

Removing the source-level `require()` (lines 66-69 of `_cjs/index.js`) was not enough — pkg also reads `package.json.dependencies` and `package.json.files` and snapshots based on both:

| Edit | What it fixes |
|---|---|
| Stub `Sui` / `isSui` in `_cjs/index.js` + `_esm/index.js` | Eliminates the static `require(\"./core/Sui/Sui.js\")` pkg follows |
| Remove `@mysten/sui` + `@mysten/wallet-standard` from `dependencies` | **Critical** — pkg eagerly snapshots listed dependencies regardless of whether they're required at runtime. This was the dominant ~50 MB chunk |
| Add `!src/_cjs/core/Sui`, `!src/_esm/core/Sui`, `!src/_types/core/Sui` to `files` | Stops pkg from snapshotting the @lifi/sdk Sui source files even when they're not in any require chain |

The patch is generated with `npx patch-package @lifi/sdk --exclude '$^'` (overriding patch-package's default exclusion of `package.json`). Applied automatically on every npm install via the existing `postinstall: patch-package` hook.

## Why the bigger-than-expected savings (63 MB vs 25 MB hoped)

`@mysten/sui` pulls its own pinned `@noble/curves` (vs the host's), plus `grpcweb-transport` and `graphql-typed-document-node` — all snapshotted by pkg as soon as the dep is listed. Removing at the package.json level prunes the entire transitive cone, not just `@mysten/sui`'s own ~23 MB.

## Verification

- [x] `npm test` — 1733/1733 pass.
- [x] `npx --package=@yao-pkg/pkg pkg . --target node22-linux-x64` produces a 420 MB binary.
- [x] `node scripts/smoke-test-binary.mjs` against the produced binary returns `tools: 162`.
- [x] `npx patch-package --reverse` then `npx patch-package` round-trips cleanly (idempotent application).
- [x] Confirmed via grep that no source file in this repo imports `Sui` or `isSui` from `@lifi/sdk` — only `createConfig`, `getQuote`, `getStatus`, `ChainId` come from there.

## Risk

`Sui = undefined` and `isSui = () => false` are the correct stub behavior for our use case: we don't have a Sui module and we don't expose @lifi/sdk's Sui types anywhere downstream. Anyone who tries to use them gets a clear runtime nothing rather than an obscure missing-export crash. If we ever add a Sui chain feature, we'd revert this patch — but that's an intentional decision with clear scope, not silent behavior loss.

## Cumulative state of the upload-failure mitigation

| PR | Mechanism | Effect |
|---|---|---|
| #346 (merged) | `npm prune --omit=dev` before pkg | 504 → 483 MB |
| #349 (open) | upload-retry-on-5xx in release-binaries.yml | survives transient API errors |
| **This PR** | Strip Sui transit + narrow prebuild glob | 483 → 420 MB |
| Tier 2 (deferred) | Strip Kamino kliquidity → Raydium / Orca | could shave ~100 MB more, but high risk; assess later |

420 MB is comfortably below the empirical 504 MB failure threshold. Combined with #349's retry, the upload failure that motivated #330 should be eliminated in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)