### PR TITLE
feat(security): SE attestation framework (issue #325 P1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ import { getVaultPilotConfigStatus } from "./modules/diagnostics/index.js";
 import { getLedgerDeviceInfo } from "./modules/diagnostics/ledger-device-info.js";
 import { verifyLedgerFirmware } from "./modules/diagnostics/ledger-firmware-verify.js";
 import { verifyLedgerLiveCodesign } from "./modules/diagnostics/ledger-live-codesign-tool.js";
+import { verifyLedgerAttestation } from "./signing/se-attestation.js";
 
 import { getTransactionHistory } from "./modules/history/index.js";
 import { getTransactionHistoryInput } from "./modules/history/schemas.js";
@@ -269,6 +270,7 @@ import {
   getLedgerDeviceInfoInput,
   verifyLedgerFirmwareInput,
   verifyLedgerLiveCodesignInput,
+  verifyLedgerAttestationInput,
   getLedgerStatusInput,
   prepareAaveSupplyInput,
   prepareAaveWithdrawInput,
@@ -2921,6 +2923,28 @@ async function main() {
       inputSchema: verifyLedgerLiveCodesignInput.shape,
     },
     handler(verifyLedgerLiveCodesign)
+  );
+
+  registerTool(server,
+    "verify_ledger_attestation",
+    {
+      description:
+        "READ-ONLY Secure Element attestation challenge (issue #325 P1). " +
+        "INTENDED behavior: issue a fresh nonce APDU to the device, receive " +
+        "the SE's attestation signature, verify locally against Ledger's " +
+        "published attestation root CA. CURRENT behavior: returns " +
+        "`status: \"not-implemented\"` with a structured explanation — the " +
+        "actual cryptographic check is gated on live-device research that " +
+        "hasn't happened yet (canonical APDU for current firmware, PEM/DER " +
+        "of Ledger's attestation root CA, signature-verification algorithm). " +
+        "Sibling defenses cover most of the threat surface in the meantime: " +
+        "verify_ledger_firmware (P3, #354), verify_ledger_live_codesign " +
+        "(P4, #360), the WC peer pin (P5, #356), and the per-chain device " +
+        "identity binding at signing time. The tool surface is shipped now " +
+        "so future research can fill in the implementation without a redesign.",
+      inputSchema: verifyLedgerAttestationInput.shape,
+    },
+    handler(verifyLedgerAttestation)
   );
 
   registerTool(server,

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -622,6 +622,19 @@ export const getLedgerDeviceInfoInput = z.object({});
 export const verifyLedgerFirmwareInput = z.object({});
 
 /**
+ * `verify_ledger_attestation` — issue a nonce APDU to the Ledger SE
+ * and verify the response signature against Ledger's published
+ * attestation root CA. Issue #325 P1.
+ *
+ * Currently scaffolded; the actual cryptographic check is gated on
+ * live-device research (canonical APDU, root cert, verification
+ * algorithm). Returns `not-implemented` until that lands. Sibling
+ * checks (verify_ledger_firmware, verify_ledger_live_codesign, WC
+ * peer pin) cover most of the threat surface in the meantime.
+ */
+export const verifyLedgerAttestationInput = z.object({});
+
+/**
  * `verify_ledger_live_codesign` — verify the on-disk Ledger Live
  * binary carries a valid Ledger-issued code signature. Issue #325 P4.
  */
@@ -1634,6 +1647,7 @@ export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigSt
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;
 export type VerifyLedgerFirmwareArgs = z.infer<typeof verifyLedgerFirmwareInput>;
 export type VerifyLedgerLiveCodesignArgs = z.infer<typeof verifyLedgerLiveCodesignInput>;
+export type VerifyLedgerAttestationArgs = z.infer<typeof verifyLedgerAttestationInput>;
 
 /**
  * Litecoin (initial release) — minimal core surface: pair, single-address

--- a/src/signing/se-attestation.ts
+++ b/src/signing/se-attestation.ts
@@ -1,0 +1,96 @@
+/**
+ * Secure Element attestation framework (issue #325 P1).
+ *
+ * The full P1 design — issue a fresh nonce APDU, receive an SE
+ * signature, verify against Ledger's published attestation root CA —
+ * requires live-device research that hasn't happened yet:
+ *   1. The exact APDU sequence (`CLA=0xE0 INS=?? P1=?? P2=??`) is
+ *      not in any installed `@ledgerhq/*` typed surface this server
+ *      depends on. Ledger's older docs reference an attestation
+ *      scheme (`getDeviceAuth` / `provisionPath`) but the canonical
+ *      command for current firmware needs verification against a
+ *      real Nano S Plus / Nano X / Stax / Flex.
+ *   2. Ledger's published attestation root CA certificate (PEM/DER)
+ *      needs to be located + pinned in this repo. Public sources
+ *      reference the existence of such a certificate but a stable
+ *      publication URL hasn't been verified.
+ *   3. The verification algorithm — likely ECDSA over the device's
+ *      attestation key with the certificate chain rooted at Ledger's
+ *      provisioning CA — needs to be confirmed before we can
+ *      meaningfully assert "matches Ledger's root."
+ *
+ * Per the project's "Verify external-system facts before coding on
+ * them" rule (memory feedback), shipping plausible-but-unverified
+ * crypto here would be worse than shipping nothing — incorrect
+ * attestation logic creates a false sense of security and is harder
+ * to spot than an explicit gap.
+ *
+ * What this module DOES ship:
+ *   - The tool surface (`verifyLedgerAttestation`) so future research
+ *     fills in the APDU + cert + verification logic without a redesign
+ *   - A structured `not-implemented` verdict with a clear, agent-relayable
+ *     explanation of what's missing
+ *   - Type stability: the `LedgerAttestationResult` shape will not
+ *     change when the actual implementation lands, only the `status`
+ *     range expands and additional fields populate
+ *
+ * Sibling defenses already in place:
+ *   - P2 (app-version pinning, #350)
+ *   - P3 (firmware-version pinning, #354)
+ *   - P4 (Ledger Live binary codesign, #360)
+ *   - P5 (WC peer pinning, #356)
+ *   - Existing per-chain device identity pinning at signing time —
+ *     each USB signer asserts the device-derived address matches the
+ *     address paired at first connect, catching device-swap attacks
+ *     within the same seed (the attestation challenge would catch
+ *     swap to a different physical SE entirely)
+ */
+
+export type AttestationStatus =
+  | "verified"
+  | "mismatch"
+  | "no-device"
+  | "wrong-mode"
+  | "not-implemented"
+  | "error";
+
+export interface LedgerAttestationResult {
+  status: AttestationStatus;
+  /** SE serial / attestation key fingerprint when status === "verified". */
+  serial?: string;
+  /** Human-readable verdict line for the agent to relay to the user. */
+  message: string;
+  /** Set on `not-implemented` and `error` paths. */
+  reason?: string;
+}
+
+const NOT_IMPLEMENTED_REASON =
+  "SE attestation challenge is scaffolded but not yet wired to a live Ledger " +
+  "attestation flow. Three pieces are pending live-device verification before " +
+  "the actual cryptographic check can ship: (1) the canonical attestation APDU " +
+  "for current Ledger firmware (Nano S Plus / Nano X / Stax / Flex), (2) the " +
+  "PEM/DER of Ledger's published attestation root CA + a stable publication " +
+  "URL, (3) the signature-verification algorithm + cert chain. Tracked under " +
+  "issue #325 P1. Until those land, sibling defenses cover the threat surface: " +
+  "app-version pinning (#350), firmware pinning (#354 — verify_ledger_firmware " +
+  "tool), Ledger Live codesign (#360), WC peer pinning (#356), and per-chain " +
+  "device identity binding at signing time.";
+
+/**
+ * Run the SE attestation challenge against the connected Ledger.
+ *
+ * **Currently returns `not-implemented`** (see module docstring for
+ * why). The function exists so the tool surface is stable for a
+ * future completion PR.
+ */
+export async function verifyLedgerAttestation(): Promise<LedgerAttestationResult> {
+  return {
+    status: "not-implemented",
+    message:
+      "SE attestation check is not yet implemented — see the tool's docstring + " +
+      "issue #325 P1 for the live-device research required before this can ship. " +
+      "Sibling checks (verify_ledger_firmware, verify_ledger_live_codesign, " +
+      "and the WC peer pin) cover most of the threat surface in the meantime.",
+    reason: NOT_IMPLEMENTED_REASON,
+  };
+}

--- a/test/se-attestation.test.ts
+++ b/test/se-attestation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { verifyLedgerAttestation } from "../src/signing/se-attestation.ts";
+
+/**
+ * SE attestation framework tests (issue #325 P1). The actual crypto
+ * check isn't implemented yet — these tests pin the framework's
+ * `not-implemented` contract so future PRs that fill in the live-
+ * device research don't accidentally regress the surface shape.
+ */
+
+describe("verifyLedgerAttestation (framework PR)", () => {
+  it("returns status 'not-implemented' with a clear reason", async () => {
+    const result = await verifyLedgerAttestation();
+    expect(result.status).toBe("not-implemented");
+    expect(result.message.length).toBeGreaterThan(0);
+    expect(result.reason).toBeDefined();
+    expect(result.reason).toMatch(/live-device|attestation root|APDU/i);
+  });
+
+  it("references the sibling defenses in its message so users know what IS in place", async () => {
+    const result = await verifyLedgerAttestation();
+    const ref = result.reason ?? "";
+    // The reason should call out at least one sibling check by name —
+    // belt-and-suspenders against a "this tool does nothing" reading.
+    expect(
+      /verify_ledger_firmware|verify_ledger_live_codesign|peer pin|firmware pinning|codesign/i.test(
+        ref + " " + result.message,
+      ),
+    ).toBe(true);
+  });
+
+  it("never throws", async () => {
+    // Pure function today; the contract is "no exceptions, structured
+    // verdict only." Future implementations should preserve this.
+    await expect(verifyLedgerAttestation()).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **P1** lane of [#325](https://github.com/szhygulin/vaultpilot-mcp/issues/325) to the extent it can be closed without live-device research. **Stacked on #360 (P4)**.

Ships the tool surface for `verify_ledger_attestation` so future research fills in the live-device pieces without an API redesign. Currently returns `status: "not-implemented"` with a structured explanation pointing at the three research blockers.

## Why ship a framework PR instead of the full implementation

Per the project's "verify external-system facts before coding on them" rule, shipping plausible-but-unverified crypto would be **worse than this explicit gap** — incorrect attestation logic creates a false sense of security and is harder to spot than an explicit `not-implemented`. Three pieces need verification against a real Ledger:

1. **Canonical attestation APDU** for current firmware (Nano S Plus / Nano X / Stax / Flex). Older references mention `INS=0xC2` but no installed `@ledgerhq/*` package exposes a typed attestation helper, and surface-level web docs don't pin the current shape. Source-test on real hardware required.
2. **Ledger's published attestation root CA** (PEM/DER). Existence is referenced in security docs but a stable publication URL hasn't been verified.
3. **Verification algorithm + cert chain** — likely ECDSA over the device's attestation key with a chain rooted at Ledger's provisioning CA. Unconfirmed.

The `LedgerAttestationResult` shape is forward-stable: the implementation slots in cleanly when those three are resolved, no API redesign needed.

## What's shipped

- `src/signing/se-attestation.ts` — `verifyLedgerAttestation()` returning the structured `not-implemented` verdict.
- `verify_ledger_attestation` tool registered in `src/index.ts` so the MCP surface includes it.
- 3 tests pinning the framework's contract (status / message / "never throws") so future PRs filling in the implementation can't accidentally regress the surface.
- Plan file updated marking P3 / P4 / P5 shipped and detailing the remaining P1 research blockers.

## Sibling defenses already in place

While P1 awaits research, the following layers cover most of the issue's threat surface:
- **P2 (#350)** — app-version pinning at signing time
- **P3 (#354)** — `verify_ledger_firmware` tool (SE/MCU firmware)
- **P4 (#360)** — `verify_ledger_live_codesign` (Ledger Live binary)
- **P5 (#356)** — WC peer pinning
- Per-chain device identity binding — every USB signer asserts the device-derived address matches what was paired (catches device-swap to a different seed)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/se-attestation.test.ts` — 3/3 passing
- [x] Full suite: 1801/1801 passing
- [ ] Future live-device research PR — fills in actual attestation flow

Plan: [`claude-work/plan-device-trust-followups.md`](../blob/main/claude-work/plan-device-trust-followups.md). This is the final PR in the issue #325 wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)