### PR TITLE
chore(release): bump to 0.9.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,14 @@
 
 ## Chat Output Formatting
 - Prefer Markdown hyperlinks over raw URLs everywhere: `[label](url)` instead of pasting the full URL inline. This keeps the chat scannable — long URLs (especially swiss-knife decoder URLs with multi-KB calldata query strings, Etherscan tx URLs with hashes, tenderly/phalcon simulation URLs) wrap the terminal into unreadable walls when pasted raw. Apply in user-facing responses AND in any text the server instructs the agent to render (verification blocks, prepare receipts, etc.). Raw URLs are acceptable only when the link is short and already scannable (e.g. a bare domain like `https://ledger.com`) or when explicitly required for machine-readable contexts (e.g. inside a JSON paste-block the user copies into another tool).
+
+## Push-Back Discipline
+- **If the user's request is built on a faulty premise that means the action won't achieve their stated goal, push back BEFORE acting — don't execute and then add a footnote.** Mid-response caveats ("Important caveat: this won't actually fix the thing you asked for") are evidence the wrong action was taken. The right move is to stop, surface the premise mismatch in plain terms, and ask which way to go.
+- Concrete tells that you're about to execute a misguided ask:
+  - Re-running a workflow against a frozen tag/commit/branch that predates the fix the user is trying to apply.
+  - Re-broadcasting a tx with the same nonce when the original was confirmed (would just revert).
+  - Re-querying an API with the same args after a deterministic failure.
+  - Wrapping a destructive action with a comment like "this won't really do what you want, but doing it anyway".
+- Format for push-back: one sentence stating the mismatch + the two or three concrete alternative paths + a question about which to pursue. Keep it short — the goal is to unblock the user's decision, not lecture.
+- If the user explicitly says "do it anyway" after the push-back, proceed. The discipline is about surfacing the issue, not vetoing the user.
+- **Past incident (2026-04-27)**: user asked to retrigger release-binaries.yml against the v0.9.4 tag to recover a missing macos-arm64 binary upload. The tag was frozen at a commit that predated the size + retry fixes (#346 / #349 / #361) just merged into main, so the rerun would have produced the same broken-upload-prone 504MB binary. Caught the issue mid-response but executed the rerun anyway. Right move was to flag the frozen-tag problem first and recommend cutting v0.9.5 (with all fixes baked in) as the alternative.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Patch release. Re-issues v0.9.4 (broken binary release per #330) with the full mitigation stack baked in, and adds a push-back-discipline section to CLAUDE.md.

## Why this exists

v0.9.4 shipped at commit \`fe1e4bb\`. GitHub's reverse-proxy 5xx'd the 504 MB \`vaultpilot-mcp-macos-arm64-server\` upload mid-stream — the binary was built and smoke-tested fine, the failure was an upload-side flake. The three follow-up PRs landed in main AFTER v0.9.4 was tagged:

- [#346](https://github.com/szhygulin/vaultpilot-mcp/pull/346) — devDep prune before pkg snapshot (504 → 483 MB)
- [#349](https://github.com/szhygulin/vaultpilot-mcp/pull/349) — upload retry on transient 5xx
- [#361](https://github.com/szhygulin/vaultpilot-mcp/pull/361) — strip @mysten/sui from @lifi/sdk via patch-package (483 → 420 MB)

Re-triggering release-binaries.yml against the v0.9.4 tag would rebuild from \`fe1e4bb\` and reproduce the 504 MB binary + missing-retry workflow — same risk surface. Cutting v0.9.5 from current main is the cleanest path: every fix bakes into the build automatically.

## CLAUDE.md push-back discipline

New section captures the lesson from the v0.9.4 incident: when the user's ask is built on a faulty premise (re-running a workflow against a frozen tag that predates the fix being applied), surface the mismatch BEFORE acting, not as a mid-response footnote. Mid-response caveats prove the wrong action got taken.

## Compatibility

Patch bump — pure release-infra hardening + a size strip that removes an unused codepath from a vendored SDK (no public-API change). No tool input or response-shape changes. Consumers on \`^0.9.0\` ranges pick this up automatically.

## Operator checklist (post-merge)

- [ ] Tag the merge commit \`v0.9.5\` and create a GitHub Release.
- [ ] Watch \`release-binaries.yml\` — with all three mitigations active, expect:
  - 4 platforms × server + setup = 8 binaries uploaded
  - Total upload sizes ~25% smaller than v0.9.3 / v0.9.4 builds
  - If a transient 5xx hits any single asset, the new retry-loop step prints \`↻ upload of <asset> failed (attempt N); sleeping Ns\` and recovers automatically
- [ ] Verify \`https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh\` resolves end-to-end on at least one platform.
- [ ] Close [#330](https://github.com/szhygulin/vaultpilot-mcp/issues/330) once the v0.9.5 release page shows the full asset set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)