### PR TITLE
fix(npm): patch-package must be a runtime dep (closes #353)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "bs58check": "^3.0.1",
         "coinselect": "^3.1.13",
         "ledger-bitcoin": "^0.3.0",
+        "patch-package": "^8.0.1",
         "qrcode-terminal": "^0.12.0",
         "viem": "^2.21.0",
         "zod": "^3.23.8"
@@ -49,7 +50,6 @@
         "@types/node": "^22.0.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@yao-pkg/pkg": "^6.19.0",
-        "patch-package": "^8.0.1",
         "typescript": "^5.6.0",
         "vitest": "^4.1.4"
       },
@@ -4729,7 +4729,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@zod/core": {
@@ -5370,7 +5369,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5581,7 +5579,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6483,7 +6480,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6517,7 +6513,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -6623,7 +6618,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6760,7 +6754,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -6793,7 +6786,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7131,7 +7123,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -7191,7 +7182,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7240,7 +7230,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -7455,7 +7444,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
       "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -7505,7 +7493,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7521,7 +7508,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -7975,7 +7961,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7989,7 +7974,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8404,7 +8388,6 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -8487,7 +8470,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
       "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -8517,7 +8499,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -9426,7 +9407,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9645,7 +9625,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9833,7 +9812,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -9857,7 +9835,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist",
+    "patches",
     "README.md",
     "LICENSE"
   ],
@@ -157,6 +158,7 @@
     "bs58check": "^3.0.1",
     "coinselect": "^3.1.13",
     "ledger-bitcoin": "^0.3.0",
+    "patch-package": "^8.0.1",
     "qrcode-terminal": "^0.12.0",
     "viem": "^2.21.0",
     "zod": "^3.23.8"
@@ -165,7 +167,6 @@
     "@types/node": "^22.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@yao-pkg/pkg": "^6.19.0",
-    "patch-package": "^8.0.1",
     "typescript": "^5.6.0",
     "vitest": "^4.1.4"
   },


### PR DESCRIPTION
Closes #353.

## Actual root cause (not what the issue suspected)

The issue was reported as `npx -y -p vaultpilot-mcp vaultpilot-mcp-setup` exiting 127, with the assumption that **only** the secondary bin failed and the primary bin (`vaultpilot-mcp`) worked. The issue speculated about npx-secondary-bin quirks, missing shebangs, or postinstall-symlink bugs.

**Real cause**: `postinstall: patch-package` runs on every npm install (dev + end-user) but `patch-package` was in `devDependencies` only. End-user flow:

```
npm install vaultpilot-mcp
→ postinstall: patch-package
→ sh: 1: patch-package: not found    ← devDeps not installed
→ exit 127
→ npm aborts the install
→ npx finds no bin to invoke → 127 propagated to the user
```

**Both `vaultpilot-mcp` AND `vaultpilot-mcp-setup` failed identically.** The issue's claim that the primary bin worked was a warm-cache artifact — when I cleared `~/.npm/_npx` and re-ran with the original tarball, both invocations produced exit 127. The verbose npm log shows the failure plainly:

```
npm info run vaultpilot-mcp@0.9.4 postinstall node_modules/vaultpilot-mcp patch-package
npm info run vaultpilot-mcp@0.9.4 postinstall { code: 127, signal: null }
```

## Fix

Two-line change:

- Move `patch-package: ^8.0.1` from `devDependencies` to `dependencies`. patch-package is ~150 KB and its whole designed use case is running on every install (dev + consumer).
- Add `"patches"` to the `files` array so the patch files actually ship in the published tarball — without this, even a runtime patch-package would have nothing to apply.

The patches in `patches/` are load-bearing:
- `bigint-buffer+1.1.5.patch` — guards against CVE-2025-3194 (`toBigIntLE` buffer overflow). Already documented in `.snyk`.
- `@lifi+sdk+3.16.3.patch` — load-bearing per the existing dev workflow.

Both must be applied at consumer install time, not just dev.

## Verification

Reproduction (the issue's exact invocation):
```sh
rm -rf ~/.npm/_npx
npm pack && npx -y -p ./vaultpilot-mcp-0.9.4.tgz vaultpilot-mcp-setup --non-interactive --json
```

| | Before | After |
|---|---|---|
| Exit code | **127** | **0** |
| `postinstall` | `sh: 1: patch-package: not found` | both patches apply cleanly (`@lifi/sdk@3.16.3 ✔`, `bigint-buffer@1.1.5 ✔`) |
| npx cache `.bin/` after install | empty | both `vaultpilot-mcp` + `vaultpilot-mcp-setup` symlinked correctly |
| Direct exec of cached bin | n/a | exit 0 |

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1797/1797 pass
- [x] Reproduce on a clean `~/.npm/_npx` cache: pack the tarball + run both `vaultpilot-mcp --help` and `vaultpilot-mcp-setup --non-interactive --json`. Both exit 0.
- [x] Inspect tarball contents: `tar -tzvf` confirms `patches/` is present.
- [ ] CI green
- [ ] Once published, the canary test on a clean machine: `npx -y -p vaultpilot-mcp@<this-version> vaultpilot-mcp-setup --non-interactive --json` succeeds.

## Issue diagnosis correction

The issue cited three suspected causes (npx secondary-bin quirk / missing shebang / npm postinstall symlink bug). All three were red herrings. Worth noting in the closing comment so future bug reports about "npx secondary bins fail" don't end up here as duplicates — this was a much simpler postinstall-script-failure that masked itself as a binary-resolution issue because of the resulting empty cache directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)