### PR TITLE
fix(install): postinstall → prepare so consumer installs work (closes #368)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "vaultpilot-mcp",
       "version": "0.9.4",
-      "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bundle": "pkg .",
-    "postinstall": "patch-package"
+    "prepare": "patch-package"
   },
   "pkg": {
     "scripts": [


### PR DESCRIPTION
Closes #368.

The \`postinstall: patch-package\` script ran on every consumer install of \`vaultpilot-mcp\`, but \`patch-package\` was a devDependency. \`npm install --omit=dev\` (the default for \`npx -y vaultpilot-mcp\` and typical user installs) does NOT install devDependencies, so postinstall exited 127 (\"command not found\") and npm rolled the entire install back. End result: \`node_modules/vaultpilot-mcp\` never existed on disk, every \`claude mcp list\` showed \"Failed to connect\" forever, and there was no actionable error in the Claude Code UI because the failure happened silently inside an npm postinstall hook the client never sees. This was the actual blocker behind \"Failed to connect\" / \"connecting…\" symptoms.

## Why \`prepare\`, not \"move patch-package to dependencies\"

Even with patch-package in dependencies, the postinstall would still fail. \`patch-package\` is invoked from \`node_modules/vaultpilot-mcp/\`'s cwd and looks for \`./node_modules/@lifi/sdk\` to apply the patch against — but in any consumer's hoisted layout the deps live at the top-level \`node_modules/\`, not nested under our package. Verified empirically: with patch-package moved to dependencies, postinstall runs but errors with \"Patch file found for package sdk which is not present at node_modules/@lifi/sdk\". **patch-package was never designed for the published-package-consumer-install scenario.**

\`prepare\` runs at:
- dev \`npm install\` / \`npm ci\` in the repo (patches applied locally)
- before \`npm publish\` (so the dev's locally-applied patches are captured in the published tarball's \`dist/\`)
- **NOT** on consumer installs from the registry

The patches (bigint-buffer null-buffer guard, @lifi/sdk Sui-deps strip) take effect at dev / CI / build time where they're load-bearing — pkg snapshots a patched \`node_modules\` into the binary, and tsc transpiles against patched types. They do NOT take effect on consumer npm installs.

## What consumers lose

| Patch | Lost effect | Severity |
|---|---|---|
| bigint-buffer null-buffer guard | Defense-in-depth TypeError throw on null/non-Buffer input | Belt-and-suspenders. Audit shows no caller in our code passes anything but a real Buffer to the affected functions |
| @lifi/sdk Sui-deps strip | @mysten/sui + @mysten/wallet-standard transitive deps install on consumer side | Build-size only — we don't import them at runtime |

Both losses are tolerable. Net trade: **the install actually works for consumers**, vs. marginal hardening + slightly larger node_modules.

## Verification

- [x] \`npm pack\` + \`npm install --omit=dev ./vaultpilot-mcp-*.tgz\` in a clean dir: install completes, \`node_modules/vaultpilot-mcp/dist/index.js\` lands on disk, \`--check\` exits 0 with the all-green doctor report (**the install IS actually usable now**, vs. silent failure before)
- [x] Local \`npm install\` / \`npm ci\` still applies patches via \`prepare\` (verified \`toBigIntLE\` has the guard inserted)
- [x] 1833/1833 tests pass
- [x] \`npm run build\` clean

## Diff size

2 lines changed across \`package.json\` + \`package-lock.json\`. The \`hasInstallScript: true\` flag in the lockfile auto-clears when postinstall is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)