### PR TITLE
feat(diagnostics): surface demoMode on get_vaultpilot_config_status (#371 — partial)

### DIFF
--- a/src/demo/fixtures.ts
+++ b/src/demo/fixtures.ts
@@ -421,7 +421,12 @@ export const DEMO_FIXTURES: Record<string, FixtureFn> = {
     },
     pairedLedger: { solana: 1, tron: 1, bitcoin: 1 },
     wcTopic: "...demo0000",
-    demoMode: true,
+    demoMode: {
+      active: true,
+      envVar: "VAULTPILOT_DEMO",
+      howToEnable:
+        "Demo mode is active — read tools return deterministic fixture data, signing tools refuse with a structured demo error. To exit, unset VAULTPILOT_DEMO and restart the MCP server.",
+    },
   }),
 
   get_marginfi_diagnostics: () => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1121,6 +1121,18 @@ async function main() {
         "NOT block the user's current request waiting on skill installation. Relay each once as",
         "informational, keep working on what the user asked for.",
         "",
+        "DEMO MODE — `VAULTPILOT_DEMO=true` env var: this server ships a try-before-install fixture",
+        "mode for prospective users who want to evaluate the read-only UX without committing to a",
+        "Ledger or API keys. When the env var is set at MCP-process boot, every read tool returns a",
+        "deterministic curated fixture (multi-chain portfolio, lending positions, LP positions, BTC",
+        "balance, TRON staking, Solana balances) and every signing tool refuses with a structured",
+        "`[VAULTPILOT_DEMO]` error. If the user asks 'how do I try this without a Ledger', 'is there",
+        "a demo mode', or 'show me what this can do without setup', call `get_vaultpilot_config_status`",
+        "— the response carries a `demoMode` field with `active` (is it on right now) and",
+        "`howToEnable` (the exact `claude mcp add ... --env VAULTPILOT_DEMO=true` recipe). Relay",
+        "`howToEnable` verbatim. The agent CANNOT toggle the env var mid-session — the MCP process",
+        "reads it at boot, so activation requires a restart.",
+        "",
         "HARD RULE — wallet enumeration: NEVER ask the user to paste a wallet address.",
         "If the user refers to their wallets collectively or positionally — \"my wallet\",",
         "\"my wallets\", \"all my accounts\", \"all my ledger accounts\", \"first account\",",
@@ -2839,16 +2851,22 @@ async function main() {
         "API-key presence + source per service (Etherscan, 1inch, TronGrid, WalletConnect — " +
         "boolean + source enum, never values), counts of paired Ledger accounts (Solana / TRON), " +
         "the WC session-topic SUFFIX (last 8 chars only — same convention as get_ledger_status), " +
-        "the agent-side preflight-skill install state, AND a `setupHints` array (rate-limit " +
+        "the agent-side preflight-skill install state, a `setupHints` array (rate-limit " +
         "nudges — surfaces when a no-key default RPC has been throttled past threshold; each " +
         "entry tells the user which provider to sign up for, the dashboard URL, and the wizard " +
-        "subcommand to add the key). Pure local I/O — reads " +
-        "~/.vaultpilot-mcp/config.json + process.env, no RPC calls, no network. Use this when " +
-        "the user asks 'is my config set up correctly' or 'why is my Solana balance read failing' " +
-        "before suggesting they re-run setup or paste keys. AGENT BEHAVIOR for setupHints: when " +
-        "the array is non-empty, surface each entry's `message` + `recommendation` + `providers` " +
-        "to the user as actionable advice. Unlike `suspectedPoisoning` (which is noise), " +
-        "`setupHints` are real remediation paths the user wants to act on.",
+        "subcommand to add the key), AND a `demoMode` field that surfaces whether " +
+        "`VAULTPILOT_DEMO=true` is active plus the activation recipe (issue #371 — agent-side " +
+        "discoverability for the no-Ledger try-before-install fixture mode). Pure local I/O — " +
+        "reads ~/.vaultpilot-mcp/config.json + process.env, no RPC calls, no network. Use this " +
+        "when the user asks 'is my config set up correctly' or 'why is my Solana balance read " +
+        "failing' before suggesting they re-run setup or paste keys. AGENT BEHAVIOR for " +
+        "setupHints: when the array is non-empty, surface each entry's `message` + " +
+        "`recommendation` + `providers` to the user as actionable advice. Unlike " +
+        "`suspectedPoisoning` (which is noise), `setupHints` are real remediation paths the user " +
+        "wants to act on. AGENT BEHAVIOR for demoMode: if the user asks 'how do I try this " +
+        "without a Ledger / API keys' or 'is there a demo mode', read `demoMode.howToEnable` and " +
+        "relay it verbatim — that field carries the exact `claude mcp add ... --env " +
+        "VAULTPILOT_DEMO=true` recipe.",
       inputSchema: getVaultPilotConfigStatusInput.shape,
     },
     configStatusHandler(getVaultPilotConfigStatus),

--- a/src/modules/diagnostics/index.ts
+++ b/src/modules/diagnostics/index.ts
@@ -27,6 +27,7 @@ import {
   getActiveHints,
   type SetupHint,
 } from "../../data/rate-limit-tracker.js";
+import { isDemoMode } from "../../demo/index.js";
 
 type EvmRpcSource =
   | "env-var"
@@ -135,6 +136,22 @@ interface VaultPilotConfigStatus {
    * remediation path the user wants to act on.
    */
   setupHints: SetupHint[];
+  /**
+   * Demo-mode discoverability surface (issue #371). The demo feature
+   * (`VAULTPILOT_DEMO=true`) lets a prospective user try the read-only
+   * UX with deterministic fixtures and no Ledger / RPC keys, but the
+   * env-var gate is invisible to an agent introspecting the server —
+   * this field makes it discoverable on the canonical "is my MCP set
+   * up?" tool. `active` reflects request-time env state; `howToEnable`
+   * carries the activation recipe so the agent can guide the user to
+   * the env-var + restart step (the agent itself can't toggle the var
+   * mid-session — the MCP process reads the env at boot).
+   */
+  demoMode: {
+    active: boolean;
+    envVar: "VAULTPILOT_DEMO";
+    howToEnable: string;
+  };
 }
 
 /**
@@ -229,5 +246,12 @@ export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): Va
       installed: existsSync(skillPath),
     },
     setupHints,
+    demoMode: {
+      active: isDemoMode(),
+      envVar: "VAULTPILOT_DEMO",
+      howToEnable: isDemoMode()
+        ? "Demo mode is active — read tools return deterministic fixture data, signing tools refuse with a structured demo error. To exit, unset VAULTPILOT_DEMO and restart the MCP server."
+        : "Set VAULTPILOT_DEMO=true in the MCP server environment and restart. Add via `claude mcp add vaultpilot-mcp --env VAULTPILOT_DEMO=true -- npx -y vaultpilot-mcp` (or edit the existing MCP entry's env). In demo mode read tools return curated multi-chain portfolio fixtures and every signing tool refuses — no Ledger, RPC keys, or pairing required.",
+    },
   };
 }

--- a/test/diagnostics-config-status.test.ts
+++ b/test/diagnostics-config-status.test.ts
@@ -40,6 +40,7 @@ beforeEach(async () => {
   delete process.env.TRON_API_KEY;
   delete process.env.WALLETCONNECT_PROJECT_ID;
   delete process.env.VAULTPILOT_SKILL_MARKER_PATH;
+  delete process.env.VAULTPILOT_DEMO;
 });
 
 afterEach(() => {
@@ -286,6 +287,40 @@ describe("get_vaultpilot_config_status — strict no-secrets contract", () => {
     // But the source classifications are still correct.
     expect(status.apiKeys.etherscan.source).toBe("env-var");
     expect(status.rpc.solana.source).toBe("env-var");
+  });
+});
+
+describe("get_vaultpilot_config_status — demo-mode discoverability (issue #371)", () => {
+  it("reports demoMode.active=false and the activation recipe when VAULTPILOT_DEMO is unset", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.demoMode.active).toBe(false);
+    expect(status.demoMode.envVar).toBe("VAULTPILOT_DEMO");
+    // The recipe must include the env-var name + the canonical `claude mcp add` form
+    // so an agent can relay it verbatim without paraphrasing the activation steps.
+    expect(status.demoMode.howToEnable).toContain("VAULTPILOT_DEMO=true");
+    expect(status.demoMode.howToEnable).toContain("claude mcp add");
+    expect(status.demoMode.howToEnable).toContain("restart");
+  });
+
+  it("reports demoMode.active=true with an exit recipe when VAULTPILOT_DEMO=true", async () => {
+    process.env.VAULTPILOT_DEMO = "true";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.demoMode.active).toBe(true);
+    expect(status.demoMode.envVar).toBe("VAULTPILOT_DEMO");
+    expect(status.demoMode.howToEnable).toContain("active");
+    expect(status.demoMode.howToEnable).toContain("unset");
+  });
+
+  it("does NOT treat truthy-ish values like '1' or 'TRUE' as enabled — strict 'true' only", async () => {
+    process.env.VAULTPILOT_DEMO = "1";
+    let { getVaultPilotConfigStatus } = await loadFresh();
+    expect(getVaultPilotConfigStatus().demoMode.active).toBe(false);
+
+    process.env.VAULTPILOT_DEMO = "TRUE";
+    ({ getVaultPilotConfigStatus } = await loadFresh());
+    expect(getVaultPilotConfigStatus().demoMode.active).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes part of #371. An agent connected to the MCP today cannot discover that demo mode (`VAULTPILOT_DEMO=true`) exists — nothing in the tool list, server-level `instructions`, or `get_vaultpilot_config_status` mentions it. This PR ships the two cheapest discoverability surfaces from the issue's option list:

- **Option 2** — `demoMode: { active, envVar, howToEnable }` field on `get_vaultpilot_config_status`. `active` is `isDemoMode()` at request time; `howToEnable` carries the literal `claude mcp add ... --env VAULTPILOT_DEMO=true` recipe when inactive (or an exit recipe when active) — verbatim-relayable, no paraphrasing.
- **Option 4** — DEMO MODE paragraph added to the server-level `instructions` block: what it is, when to point users at it, and the load-bearing detail that the agent **cannot** toggle the env var mid-session (the MCP reads it at boot — activation requires a restart).

Existing demo fixture for `get_vaultpilot_config_status` had a top-level `demoMode: true` boolean — narrowed to the new sub-object shape so demo and real responses stay structurally aligned. Broader fixture-shape divergence (`configExists` vs `configFileExists`, etc.) predates this PR and lands in a separate fixture-refresh PR per #371 triage.

**Follow-ups:**
- Option 3 (a `setupHints` entry that nudges first-run users — no keys + no pairings — toward demo mode) ships next, sequentially.
- Demo fixture refresh for newer features (Solana lending, BTC sends, etc.) ships separately.
- A demo write-flow showcase (architecture B: real `prepare_*` + `simulate_transaction`, gate only the broadcast step) ships separately.

## Test plan

- [x] `npm test` — 1839 tests pass (3 new in `test/diagnostics-config-status.test.ts`)
- [x] `npm run build` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)