### PR TITLE
feat(diagnostics): emit demo-mode setupHint on fresh-install state (closes #371)

### DIFF
--- a/src/data/rate-limit-tracker.ts
+++ b/src/data/rate-limit-tracker.ts
@@ -43,22 +43,36 @@ export type RateLimitSource =
  * Public-facing setup hint. The agent reads this and surfaces it to
  * the user (in chat). The shape is deliberately verbose so an LLM
  * doesn't have to rewrite the prose — just relay the message.
+ *
+ * Two `kind`s today:
+ *  - `rate-limit`: a default no-key RPC source has been throttled past
+ *    threshold; user should add an API key. Carries `hits`,
+ *    `windowMinutes`, `providers`, `setupCommand`.
+ *  - `demo-mode`: fresh-install state (no keys / pairings / custom
+ *    RPC, demo off) — agent should suggest `VAULTPILOT_DEMO=true` as
+ *    the zero-friction try-before-install path (issue #371). The
+ *    rate-limit-specific fields are omitted.
+ *
+ * Default kind is `rate-limit` for backward compatibility with the
+ * pre-#371 shape.
  */
 export interface SetupHint {
+  /** Discriminator for downstream filtering — agents can route on this. */
+  kind: "rate-limit" | "demo-mode";
   /** Stable identifier for deduping in the agent's mind / on-disk caches. */
   source: string;
-  /** How many 429s this source has seen in the rolling window. */
-  hits: number;
-  /** Window length in minutes — context for the hits count. */
-  windowMinutes: number;
+  /** Rate-limit only: how many 429s this source has seen in the rolling window. */
+  hits?: number;
+  /** Rate-limit only: window length in minutes — context for the hits count. */
+  windowMinutes?: number;
   /** One-line headline for chat. */
   message: string;
   /** Longer prose, including the actionable command. */
   recommendation: string;
-  /** Provider name(s) the user can sign up for, with dashboard URL. */
-  providers: Array<{ name: string; dashboardUrl: string }>;
-  /** Wizard subcommand to run (interactive — adds the key to config). */
-  setupCommand: string;
+  /** Rate-limit only: provider name(s) the user can sign up for, with dashboard URL. */
+  providers?: Array<{ name: string; dashboardUrl: string }>;
+  /** Rate-limit only: wizard subcommand to run (interactive — adds the key to config). */
+  setupCommand?: string;
 }
 
 /** Threshold + window. ~3 hits in 5 min before nudging — high enough to mean "sustained". */
@@ -123,7 +137,8 @@ export interface HintRenderContext {
 function renderHint(source: RateLimitSource): SetupHint {
   const key = sourceKey(source);
   const arr = hits.get(key) ?? [];
-  const base: Pick<SetupHint, "source" | "hits" | "windowMinutes"> = {
+  const base: Pick<SetupHint, "kind" | "source" | "hits" | "windowMinutes"> = {
+    kind: "rate-limit",
     source: key,
     hits: arr.length,
     windowMinutes: Math.floor(WINDOW_MS / 60_000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2851,21 +2851,24 @@ async function main() {
         "API-key presence + source per service (Etherscan, 1inch, TronGrid, WalletConnect — " +
         "boolean + source enum, never values), counts of paired Ledger accounts (Solana / TRON), " +
         "the WC session-topic SUFFIX (last 8 chars only — same convention as get_ledger_status), " +
-        "the agent-side preflight-skill install state, a `setupHints` array (rate-limit " +
-        "nudges — surfaces when a no-key default RPC has been throttled past threshold; each " +
-        "entry tells the user which provider to sign up for, the dashboard URL, and the wizard " +
-        "subcommand to add the key), AND a `demoMode` field that surfaces whether " +
-        "`VAULTPILOT_DEMO=true` is active plus the activation recipe (issue #371 — agent-side " +
-        "discoverability for the no-Ledger try-before-install fixture mode). Pure local I/O — " +
-        "reads ~/.vaultpilot-mcp/config.json + process.env, no RPC calls, no network. Use this " +
-        "when the user asks 'is my config set up correctly' or 'why is my Solana balance read " +
+        "the agent-side preflight-skill install state, a `setupHints` array (each entry has a " +
+        "`kind` discriminator: `rate-limit` nudges surface when a no-key default RPC has been " +
+        "throttled past threshold and tell the user which provider to sign up for + the wizard " +
+        "subcommand; `demo-mode` nudges fire on a fresh-install state — no keys, no pairings, " +
+        "no custom RPC — suggesting `VAULTPILOT_DEMO=true` as the zero-friction first-time path " +
+        "per issue #371), AND a `demoMode` field that surfaces whether `VAULTPILOT_DEMO=true` " +
+        "is active plus the activation recipe. Pure local I/O — reads " +
+        "~/.vaultpilot-mcp/config.json + process.env, no RPC calls, no network. Use this when " +
+        "the user asks 'is my config set up correctly' or 'why is my Solana balance read " +
         "failing' before suggesting they re-run setup or paste keys. AGENT BEHAVIOR for " +
         "setupHints: when the array is non-empty, surface each entry's `message` + " +
-        "`recommendation` + `providers` to the user as actionable advice. Unlike " +
-        "`suspectedPoisoning` (which is noise), `setupHints` are real remediation paths the user " +
-        "wants to act on. AGENT BEHAVIOR for demoMode: if the user asks 'how do I try this " +
-        "without a Ledger / API keys' or 'is there a demo mode', read `demoMode.howToEnable` and " +
-        "relay it verbatim — that field carries the exact `claude mcp add ... --env " +
+        "`recommendation` to the user as actionable advice (rate-limit hints also carry " +
+        "`providers` + `setupCommand`; demo-mode hints carry just message + recommendation, " +
+        "with the env-var recipe inline in `recommendation`). Unlike `suspectedPoisoning` " +
+        "(which is noise), `setupHints` are real remediation paths the user wants to act on. " +
+        "AGENT BEHAVIOR for demoMode: if the user asks 'how do I try this without a Ledger / " +
+        "API keys' or 'is there a demo mode', read `demoMode.howToEnable` and relay it " +
+        "verbatim — that field carries the exact `claude mcp add ... --env " +
         "VAULTPILOT_DEMO=true` recipe.",
       inputSchema: getVaultPilotConfigStatusInput.shape,
     },

--- a/src/modules/diagnostics/index.ts
+++ b/src/modules/diagnostics/index.ts
@@ -222,19 +222,60 @@ export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): Va
     tronUsingDefault,
   });
 
+  // Issue #371 — first-run demo-mode hint. Fires when the user looks
+  // like a fresh install (no API keys, no pairings, no custom RPC,
+  // demo not already active). Self-clearing: the moment the user adds
+  // a key or pairs a wallet, one of these checks flips and the hint
+  // disappears without state. Suppressed when demo IS active to avoid
+  // pointing the user at a feature they're already in.
+  const etherscanKey = classifyApiKey("ETHERSCAN_API_KEY", cfg?.etherscanApiKey);
+  const oneInchKey = classifyApiKey("ONEINCH_API_KEY", cfg?.oneInchApiKey);
+  const wcProjectKey = classifyApiKey(
+    "WALLETCONNECT_PROJECT_ID",
+    cfg?.walletConnect?.projectId,
+  );
+  const noKeys =
+    !etherscanKey.set &&
+    !oneInchKey.set &&
+    !tronGridKey.set &&
+    !wcProjectKey.set;
+  const noPairings =
+    (cfg?.pairings?.solana?.length ?? 0) === 0 &&
+    (cfg?.pairings?.tron?.length ?? 0) === 0 &&
+    !sessionTopicSuffix;
+  const allRpcDefault =
+    evmUsingDefault.ethereum &&
+    evmUsingDefault.arbitrum &&
+    evmUsingDefault.polygon &&
+    evmUsingDefault.base &&
+    evmUsingDefault.optimism &&
+    solanaUsingDefault;
+  if (!isDemoMode() && noKeys && noPairings && allRpcDefault) {
+    setupHints.push({
+      kind: "demo-mode",
+      source: "demo-mode-suggestion",
+      message:
+        "No setup detected — try demo mode to evaluate VaultPilot without a Ledger or API keys.",
+      recommendation:
+        "VaultPilot ships a try-before-install demo mode (`VAULTPILOT_DEMO=true`). " +
+        "Activate by adding `--env VAULTPILOT_DEMO=true` to your `claude mcp add " +
+        "vaultpilot-mcp` command (or edit the existing MCP entry's env), then restart " +
+        "Claude Code. Read tools return curated multi-chain portfolio fixtures and " +
+        "every signing tool refuses — no Ledger, RPC keys, or pairing required. Unset " +
+        "the env var and restart to exit demo mode and proceed with real setup.",
+    });
+  }
+
   return {
     configPath,
     configFileExists: existsSync(configPath),
     serverVersion: readServerVersion(),
     rpc,
     apiKeys: {
-      etherscan: classifyApiKey("ETHERSCAN_API_KEY", cfg?.etherscanApiKey),
-      oneInch: classifyApiKey("ONEINCH_API_KEY", cfg?.oneInchApiKey),
+      etherscan: etherscanKey,
+      oneInch: oneInchKey,
       tronGrid: tronGridKey,
-      walletConnectProjectId: classifyApiKey(
-        "WALLETCONNECT_PROJECT_ID",
-        cfg?.walletConnect?.projectId,
-      ),
+      walletConnectProjectId: wcProjectKey,
     },
     pairings: {
       walletConnect: sessionTopicSuffix ? { sessionTopicSuffix } : {},

--- a/test/diagnostics-config-status.test.ts
+++ b/test/diagnostics-config-status.test.ts
@@ -324,6 +324,66 @@ describe("get_vaultpilot_config_status — demo-mode discoverability (issue #371
   });
 });
 
+describe("get_vaultpilot_config_status — first-run demo-mode hint (issue #371 Option 3)", () => {
+  it("emits a demo-mode setupHint when nothing is configured (no keys, no pairings, no custom RPC, demo off)", async () => {
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    const demoHint = status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode");
+    expect(demoHint).toBeDefined();
+    expect(demoHint.source).toBe("demo-mode-suggestion");
+    // The recommendation carries the activation recipe inline since
+    // demo hints don't use the rate-limit `setupCommand` field.
+    expect(demoHint.recommendation).toContain("VAULTPILOT_DEMO=true");
+    expect(demoHint.recommendation).toContain("claude mcp add");
+    expect(demoHint.recommendation).toContain("restart");
+    // Demo hints should NOT carry rate-limit-specific fields.
+    expect(demoHint.hits).toBeUndefined();
+    expect(demoHint.providers).toBeUndefined();
+    expect(demoHint.setupCommand).toBeUndefined();
+  });
+
+  it("does NOT emit the demo-mode hint when VAULTPILOT_DEMO is already active", async () => {
+    process.env.VAULTPILOT_DEMO = "true";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    const demoHint = status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode");
+    expect(demoHint).toBeUndefined();
+  });
+
+  it("self-clears when the user adds an Etherscan API key", async () => {
+    process.env.ETHERSCAN_API_KEY = "k";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode")).toBeUndefined();
+  });
+
+  it("self-clears when the user has a Solana pairing", async () => {
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "irrelevant-but-flips-rpc-source" },
+      pairings: {
+        solana: [
+          {
+            address: "wallet1",
+            path: "44'/501'/0'",
+            accountIndex: 0,
+            appVersion: "1",
+          },
+        ],
+      },
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode")).toBeUndefined();
+  });
+
+  it("self-clears when any chain has a custom RPC URL", async () => {
+    process.env.ETHEREUM_RPC_URL = "https://my-eth.example.com/";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode")).toBeUndefined();
+  });
+});
+
 describe("get_vaultpilot_config_status — basic shape", () => {
   it("includes serverVersion + configPath + configFileExists", async () => {
     const { getVaultPilotConfigStatus } = await loadFresh();

--- a/test/rate-limit-tracker.test.ts
+++ b/test/rate-limit-tracker.test.ts
@@ -64,9 +64,12 @@ describe("rate-limit tracker — threshold + window", () => {
     const hints = getActiveHints(ALL_DEFAULT);
     expect(hints.length).toBe(1);
     expect(hints[0].source).toBe("evm:ethereum");
-    expect(hints[0].providers.length).toBeGreaterThan(0);
+    // Rate-limit hints carry the `kind: "rate-limit"` discriminator
+    // so callers can distinguish them from `demo-mode` hints (issue #371).
+    expect(hints[0].kind).toBe("rate-limit");
+    expect(hints[0].providers!.length).toBeGreaterThan(0);
     // Sanity: providers point at real signup dashboards.
-    expect(hints[0].providers.some((p) => p.dashboardUrl.startsWith("https://"))).toBe(true);
+    expect(hints[0].providers!.some((p) => p.dashboardUrl.startsWith("https://"))).toBe(true);
   });
 
   it("trims hits outside the rolling window (5 min)", () => {
@@ -165,10 +168,10 @@ describe("rate-limit tracker — independent per-source counters", () => {
     expect(hints.map((h) => h.source).sort()).toEqual(["solana", "tron"]);
     // Solana hint points at Helius.
     const solana = hints.find((h) => h.source === "solana")!;
-    expect(solana.providers[0].name).toBe("Helius");
+    expect(solana.providers![0].name).toBe("Helius");
     // TRON hint points at TronGrid.
     const tron = hints.find((h) => h.source === "tron")!;
-    expect(tron.providers[0].name).toBe("TronGrid");
+    expect(tron.providers![0].name).toBe("TronGrid");
   });
 
   it("each EVM chain tracked independently", () => {
@@ -190,8 +193,8 @@ describe("rate-limit tracker — hint shape sanity", () => {
     recordRateLimit({ kind: "evm", chain: "polygon" });
     recordRateLimit({ kind: "evm", chain: "polygon" });
     const hint = getActiveHints(ALL_DEFAULT)[0];
-    expect(hint.providers.map((p) => p.name).sort()).toEqual(["Alchemy", "Infura"]);
-    for (const p of hint.providers) {
+    expect(hint.providers!.map((p) => p.name).sort()).toEqual(["Alchemy", "Infura"]);
+    for (const p of hint.providers!) {
       expect(() => new URL(p.dashboardUrl)).not.toThrow();
       expect(p.dashboardUrl.startsWith("https://")).toBe(true);
     }


### PR DESCRIPTION
## Summary

Closes #371. Final piece of the demo-discoverability triplet — #372 shipped Options 2 + 4 (the `demoMode` field on `get_vaultpilot_config_status` + a paragraph in server-level `instructions`); this PR ships **Option 3**: a `setupHints` entry that automatically fires on fresh-install state.

**Trigger condition** (all must hold):
- Demo mode NOT already active (no point pointing at a feature the user is already in)
- No API keys configured (Etherscan, 1inch, TronGrid, WalletConnect)
- No Ledger pairings (Solana, TRON, WalletConnect session)
- All RPC sources resolved to `public-fallback` (no env vars, no provider keys, no custom URLs)

**Self-clearing.** The moment the user adds a key, pairs a wallet, or sets a custom RPC URL, one of the conditions flips and the hint disappears — no per-session dismissal state.

## SetupHint shape changes

- New `kind: \"rate-limit\" | \"demo-mode\"` discriminator. Agents that already filter on hints can route on this; existing rate-limit hints set `kind: \"rate-limit\"`.
- `hits`, `windowMinutes`, `providers`, `setupCommand` are now optional. Rate-limit hints still populate all four (existing test contracts unchanged); demo-mode hints carry just `message` + `recommendation` since the activation recipe lives inline in `recommendation`.
- Tool description on `get_vaultpilot_config_status` updated to document both hint kinds + AGENT BEHAVIOR for each.

Minor refactor: lifted `classifyApiKey` calls out of the return literal in `getVaultPilotConfigStatus` so the demo-hint detector can reuse them without re-classifying.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1844 tests pass (5 new in `test/diagnostics-config-status.test.ts`; 1 strengthened in `test/rate-limit-tracker.test.ts` to lock the kind discriminator contract)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)