### PR TITLE
feat(demo): refresh fixtures for tools shipped after demo v2

### DIFF
--- a/src/demo/fixtures.ts
+++ b/src/demo/fixtures.ts
@@ -26,6 +26,7 @@ export const DEMO_WALLET = {
   tron: "TDemoVAULTpilotxxxxxxxxxxxxxxxxxxxxx" as const,
   solana: "DEMo1111111111111111111111111111111111111111" as const,
   bitcoin: "bc1qdemo7xpyrkfsm7dl5kfjxgvm8azwj9c4yefzx0" as const,
+  litecoin: "ltc1qdemo7xpyrkfsm7dl5kfjxgvm8azwj9c4ydemo0" as const,
 };
 
 /**
@@ -404,23 +405,32 @@ export const DEMO_FIXTURES: Record<string, FixtureFn> = {
 
   get_vaultpilot_config_status: () => ({
     configPath: "~/.vaultpilot-mcp/config.json",
-    configExists: true,
-    version: "0.8.2",
+    configFileExists: true,
+    serverVersion: "demo",
     rpc: {
-      ethereum: { source: "demo-fixture" },
-      arbitrum: { source: "demo-fixture" },
-      polygon: { source: "demo-fixture" },
-      base: { source: "demo-fixture" },
-      optimism: { source: "demo-fixture" },
+      ethereum: { source: "env-var" },
+      arbitrum: { source: "env-var" },
+      polygon: { source: "env-var" },
+      base: { source: "env-var" },
+      optimism: { source: "env-var" },
+      solana: { source: "env-var" },
     },
     apiKeys: {
-      etherscan: { exists: true, source: "demo-fixture" },
-      oneinch: { exists: true, source: "demo-fixture" },
-      tronGrid: { exists: true, source: "demo-fixture" },
-      walletConnect: { exists: true, source: "demo-fixture" },
+      etherscan: { set: true, source: "config" },
+      oneInch: { set: true, source: "config" },
+      tronGrid: { set: true, source: "config" },
+      walletConnectProjectId: { set: true, source: "config" },
     },
-    pairedLedger: { solana: 1, tron: 1, bitcoin: 1 },
-    wcTopic: "...demo0000",
+    pairings: {
+      walletConnect: { sessionTopicSuffix: "demo0000" },
+      solana: { count: 1 },
+      tron: { count: 1 },
+    },
+    preflightSkill: {
+      expectedPath: "~/.claude/skills/vaultpilot-preflight/SKILL.md",
+      installed: true,
+    },
+    setupHints: [],
     demoMode: {
       active: true,
       envVar: "VAULTPILOT_DEMO",
@@ -792,6 +802,353 @@ export const DEMO_FIXTURES: Record<string, FixtureFn> = {
     availableVotes: 0,
     note: "demo fixture — user has no votes cast (matches get_tron_staking which has votes: [])",
   }),
+
+  // -------- v3: Litecoin reads (mirror BTC fixture shapes) ---------------------
+  get_ltc_balance: () => ({
+    address: DEMO_WALLET.litecoin,
+    confirmedSats: "5000000000",
+    unconfirmedSats: "0",
+    confirmedLtc: "50.0",
+    unconfirmedLtc: "0",
+  }),
+  get_ltc_block_tip: () => ({
+    height: 2_842_500,
+    hash: "demoltcblock0000000000000000000000000000000000000000000000000001",
+    timestamp: 1_745_625_600,
+    ageSeconds: 90,
+  }),
+  get_ltc_chain_tips: () => ({
+    tips: [
+      {
+        height: 2_842_500,
+        hash: "demoltcblock0000000000000000000000000000000000000000000000000001",
+        branchlen: 0,
+        status: "active",
+      },
+    ],
+  }),
+  get_ltc_mempool_summary: () => ({
+    size: 142,
+    bytes: 38_400,
+    usage: 105_600,
+    totalFee: "0.00012345",
+    minFee: "0.00001",
+  }),
+  get_ltc_block_stats: () => ({
+    height: 2_842_500,
+    avgFee: 1_500,
+    avgFeeRate: 5,
+    feeRatePercentiles: [1, 2, 5, 10, 20],
+    txs: 142,
+    totalFee: 213_000,
+    subsidy: 625_000_000,
+  }),
+  get_ltc_blocks_recent: (args) => {
+    const a = (args ?? {}) as { count?: number };
+    const count = Math.min(a.count ?? 144, 200);
+    return Array.from({ length: count }, (_, i) => ({
+      height: 2_842_500 - i,
+      hash: `demoltcblock${i.toString().padStart(4, "0")}000000000000000000000000000000000000000000000000000`,
+      timestamp: 1_745_625_600 - i * 150,
+      txCount: 100 + (i % 80),
+    }));
+  },
+  rescan_ltc_account: (args) => {
+    const a = (args ?? {}) as { accountIndex?: number };
+    return {
+      accountIndex: a.accountIndex ?? 0,
+      addressesScanned: 21,
+      addressesWithHistory: 4,
+      needsExtend: false,
+      unverifiedChains: [],
+      note: "demo fixture — cached txCount refreshed from indexer (no real RPC).",
+    };
+  },
+
+  // -------- v3: Curve LP positions (Ethereum stable_ng plain pools) -----------
+  get_curve_positions: () => ({
+    positions: [
+      {
+        chain: "ethereum",
+        pool: "0xDemoCurveStableNgPlainPoolUsdcUsdt00000",
+        poolName: "USDC/USDT (stable_ng)",
+        coins: ["USDC", "USDT"],
+        lpBalance: "1500.000000000000000000",
+        lpBalanceUsd: 1_502.34,
+        gaugeBalance: "0",
+        gaugeBalanceUsd: 0,
+        claimableCrv: "12.45",
+        claimableCrvUsd: 8.71,
+      },
+    ],
+    notes: [
+      "demo fixture — v0.1 scope is Ethereum stable_ng plain pools only; legacy pools and other chains land in follow-up PRs.",
+    ],
+  }),
+
+  // -------- v3: Safe (Gnosis Safe) multisig positions -------------------------
+  get_safe_positions: () => ({
+    safes: [
+      {
+        chain: "ethereum",
+        safeAddress: "0xDemoSafe0000000000000000000000000000Safe",
+        threshold: 2,
+        owners: [
+          DEMO_WALLET.evm,
+          "0xDemoCoSigner1111111111111111111111111111",
+          "0xDemoCoSigner2222222222222222222222222222",
+        ],
+        version: "1.4.1",
+        nativeBalance: "1.25",
+        nativeBalanceUsd: 2_895.11,
+        pendingTxCount: 1,
+        recentExecutedCount: 4,
+        modules: [],
+        guard: null,
+        risks: [],
+      },
+    ],
+    notes: [
+      "demo fixture — wallet is owner on one 2-of-3 Safe with $2.9k ETH balance and 1 pending tx awaiting a co-signer.",
+    ],
+  }),
+
+  // -------- v3: NFT reads (Reservoir-backed) ----------------------------------
+  get_nft_portfolio: () => ({
+    wallet: DEMO_WALLET.evm,
+    chains: ["ethereum"],
+    collections: [
+      {
+        chain: "ethereum",
+        contract: "0xDemoNftPudgyPenguins000000000000000000Pp",
+        name: "Pudgy Penguins (demo)",
+        tokenCount: 2,
+        floorEth: "9.5",
+        floorUsd: 22_002.86,
+        totalFloorEth: "19.0",
+        totalFloorUsd: 44_005.71,
+      },
+      {
+        chain: "ethereum",
+        contract: "0xDemoNftAzuki00000000000000000000000Azuki",
+        name: "Azuki (demo)",
+        tokenCount: 1,
+        floorEth: "4.2",
+        floorUsd: 9_727.58,
+        totalFloorEth: "4.2",
+        totalFloorUsd: 9_727.58,
+      },
+    ],
+    totalFloorEth: "23.2",
+    totalFloorUsd: 53_733.29,
+    coverage: [{ chain: "ethereum", errored: false }],
+    notes: [
+      "Floor != liquidation. `totalFloorUsd` is an upper bound — what the wallet would net selling everything immediately is typically lower after marketplace fees + slippage.",
+    ],
+  }),
+  get_nft_collection: (args) => {
+    const a = (args ?? {}) as { contract?: string; chain?: string };
+    return {
+      chain: a.chain ?? "ethereum",
+      contract: a.contract ?? "0xDemoNftPudgyPenguins000000000000000000Pp",
+      name: "Pudgy Penguins (demo)",
+      symbol: "PPG",
+      image: "https://demo.vaultpilot.example/pudgy.png",
+      description: "Deterministic demo collection metadata — not a real Reservoir lookup.",
+      floorAskEth: "9.5",
+      floorAskUsd: 22_002.86,
+      topBidEth: "9.1",
+      topBidUsd: 21_076.42,
+      volume: { "1day": "82.4", "7day": "612.5", "30day": "2410.7", allTime: "412900" },
+      ownerCount: 4_812,
+      totalSupply: 8_888,
+      royaltyBps: 500,
+      royaltyRecipient: "0xDemoRoyaltyRecipient000000000000000000Royalty",
+    };
+  },
+  get_nft_history: () => ({
+    wallet: DEMO_WALLET.evm,
+    activity: [
+      {
+        type: "sale",
+        chain: "ethereum",
+        contract: "0xDemoNftAzuki00000000000000000000000Azuki",
+        tokenId: "4242",
+        priceEth: "4.2",
+        priceUsd: 9_727.58,
+        timestamp: 1_745_022_400,
+        txHash: "0xdemo1nftsale1111111111111111111111111111111111111111111111111111",
+      },
+      {
+        type: "mint",
+        chain: "ethereum",
+        contract: "0xDemoNftPudgyPenguins000000000000000000Pp",
+        tokenId: "1234",
+        priceEth: "0.08",
+        priceUsd: 185.29,
+        timestamp: 1_744_500_000,
+        txHash: "0xdemo2nftmint2222222222222222222222222222222222222222222222222222",
+      },
+    ],
+    coverage: [{ chain: "ethereum", errored: false }],
+  }),
+
+  // -------- v3: Daily briefing + P&L summary (composed read tools) ------------
+  get_daily_briefing: (args) => {
+    const a = (args ?? {}) as { period?: "24h" | "7d" | "30d"; format?: "structured" | "markdown" | "both" };
+    const period = a.period ?? "24h";
+    const format = a.format ?? "both";
+    const structured = {
+      period,
+      portfolioTotal: { usd: 14_062.85, deltaUsd: 142.07, deltaPct: 0.0102 },
+      topMovers: [
+        { chain: "ethereum", asset: "ETH", deltaUsd: 92.3, deltaPct: 0.016 },
+        { chain: "solana", asset: "SOL", deltaUsd: 41.2, deltaPct: 0.022 },
+        { chain: "ethereum", asset: "stETH", deltaUsd: 8.57, deltaPct: 0.005 },
+      ],
+      healthAlerts: [],
+      activity: { received: 0, sent: 1, swapped: 1, supplied: 0, borrowed: 0, repaid: 0, withdrew: 0, other: 0 },
+      bestStablecoinYield: { available: false, reason: "demo fixture — section coverage parity with v1." },
+      liquidationCalendar: { available: false, reason: "demo fixture — section coverage parity with v1." },
+    };
+    const markdown =
+      `**Demo portfolio briefing (${period})**\n\n` +
+      `Total: $14,062.85 (+$142.07, +1.02% over the window). ETH up $92, SOL up $41, stETH yield +$8.57. ` +
+      `No Aave health-factor alerts; demo wallet HF = 4.85, well above threshold. ` +
+      `Activity: 1 swap, 1 send.`;
+    if (format === "structured") return structured;
+    if (format === "markdown") return { markdown };
+    return { ...structured, markdown };
+  },
+  get_pnl_summary: (args) => {
+    const a = (args ?? {}) as { period?: "24h" | "7d" | "30d" | "ytd" | "inception" };
+    const period = a.period ?? "30d";
+    return {
+      period,
+      pnlUsd: 412.55,
+      pnlPct: 0.0301,
+      perChain: {
+        ethereum: { pnlUsd: 268.4, walletValueChange: 350.0, netFlowUsd: 81.6 },
+        solana: { pnlUsd: 102.15, walletValueChange: 102.15, netFlowUsd: 0 },
+        arbitrum: { pnlUsd: 42.0, walletValueChange: 42.0, netFlowUsd: 0 },
+        tron: { pnlUsd: 0, walletValueChange: 0, netFlowUsd: 0 },
+      },
+      perAsset: [
+        { chain: "ethereum", asset: "ETH", pnlUsd: 215.5 },
+        { chain: "solana", asset: "SOL", pnlUsd: 102.15 },
+        { chain: "ethereum", asset: "stETH", pnlUsd: 52.9 },
+      ],
+      caveats: [
+        "demo fixture — wallet token balances only; gas costs not subtracted.",
+        "Bitcoin intentionally excluded from v1 P&L (lacks in-window flow accounting).",
+      ],
+    };
+  },
+
+  // -------- v3: Yield comparison + token allowances + non-EVM coin price ------
+  compare_yields: (args) => {
+    const a = (args ?? {}) as { asset?: string };
+    const asset = (a.asset ?? "USDC").toUpperCase();
+    return {
+      asset,
+      rows: [
+        { protocol: "compound-v3", chain: "ethereum", market: "cUSDCv3", supplyApr: 0.0541, supplyApy: 0.0556, tvl: 850_000_000, riskScore: 88, notes: [] },
+        { protocol: "aave-v3", chain: "arbitrum", market: asset, supplyApr: 0.0492, supplyApy: 0.0504, tvl: 412_000_000, riskScore: 85, notes: [] },
+        { protocol: "aave-v3", chain: "ethereum", market: asset, supplyApr: 0.0481, supplyApy: 0.0492, tvl: 1_280_000_000, riskScore: 90, notes: [] },
+        { protocol: "compound-v3", chain: "base", market: "cUSDCv3", supplyApr: 0.0455, supplyApy: 0.0465, tvl: 220_000_000, riskScore: 86, notes: [] },
+      ],
+      unavailable: [
+        { protocol: "morpho-blue", reason: "demo fixture — wallet-less market reader not yet split out." },
+        { protocol: "marginfi", reason: "demo fixture — wallet-less market reader not yet split out." },
+      ],
+    };
+  },
+  get_token_allowances: (args) => {
+    const a = (args ?? {}) as { token?: string; chain?: string };
+    return {
+      wallet: DEMO_WALLET.evm,
+      chain: a.chain ?? "ethereum",
+      token: a.token ?? "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      tokenSymbol: "USDC",
+      rows: [
+        {
+          spender: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+          spenderLabel: "Aave V3 Pool",
+          currentAllowance: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          currentAllowanceFormatted: "unlimited",
+          isUnlimited: true,
+          lastApprovedBlock: 21_500_000,
+          lastApprovedTxHash: "0xdemoAllowance00000000000000000000000000000000000000000000000000aave",
+          lastApprovedAt: 1_744_400_000,
+        },
+        {
+          spender: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          spenderLabel: "Uniswap V3 SwapRouter02",
+          currentAllowance: "1000000000",
+          currentAllowanceFormatted: "1000.0",
+          isUnlimited: false,
+          lastApprovedBlock: 21_530_000,
+          lastApprovedTxHash: "0xdemoAllowance0000000000000000000000000000000000000000000000000uniswap",
+          lastApprovedAt: 1_745_000_000,
+        },
+      ],
+      unlimitedCount: 1,
+      notes: [
+        "demo fixture — 1 unlimited approval (Aave V3 Pool) can move the entire balance including future top-ups; revoke via approve(spender, 0) if unused.",
+      ],
+    };
+  },
+  get_coin_price: (args) => {
+    const a = (args ?? {}) as { symbol?: string; coingeckoId?: string };
+    const symbol = (a.symbol ?? a.coingeckoId ?? "BTC").toUpperCase();
+    const priceTable: Record<string, number> = {
+      BTC: 95_142.18,
+      LTC: 92.45,
+      SOL: 184.21,
+      TRX: 0.241,
+      DOGE: 0.165,
+      XMR: 198.40,
+      ETH: 2_316.09,
+    };
+    const priceUsd = priceTable[symbol] ?? 1;
+    return {
+      symbol,
+      priceUsd,
+      source: "demo-fixture",
+      resolvedKey: a.coingeckoId ?? `coingecko:${symbol.toLowerCase()}`,
+      asOf: "2026-04-26T00:00:00Z",
+      confidence: 0.99,
+    };
+  },
+
+  // -------- v3: explain_tx narrative analysis ---------------------------------
+  explain_tx: (args) => {
+    const a = (args ?? {}) as { txHash?: string; chain?: string; format?: "structured" | "markdown" | "both" };
+    const txHash = a.txHash ?? "0xdemo1deadbeef000000000000000000000000000000000000000000000000demo";
+    const format = a.format ?? "both";
+    const structured = {
+      txHash,
+      chain: a.chain ?? "ethereum",
+      status: "success",
+      method: "swapExactTokensForTokens",
+      decodedEvents: [
+        { kind: "Transfer", token: "USDC", from: DEMO_WALLET.evm, to: "0xDemoUniswapPool0000000000000000000000Pool", amount: "1000.0" },
+        { kind: "Transfer", token: "WETH", from: "0xDemoUniswapPool0000000000000000000000Pool", to: DEMO_WALLET.evm, amount: "0.4318" },
+      ],
+      walletBalanceChanges: [
+        { token: "USDC", deltaFormatted: "-1000.0", deltaUsd: -1_000.0 },
+        { token: "WETH", deltaFormatted: "+0.4318", deltaUsd: 1_000.09 },
+      ],
+      feePaidUsd: 1.42,
+      heuristics: [],
+    };
+    const markdown =
+      `**Demo tx walkthrough** — \`${txHash.slice(0, 10)}…\`\n\n` +
+      `Method: \`swapExactTokensForTokens\` (Uniswap-style swap). Wallet sent 1,000 USDC and received 0.4318 WETH (~$1,000.09 net) for $1.42 in gas. No flagged heuristics — nothing surprising.`;
+    if (format === "structured") return structured;
+    if (format === "markdown") return { markdown };
+    return { ...structured, markdown };
+  },
 };
 
 /**

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -142,12 +142,12 @@ describe("getDemoFixture — deterministic, non-empty for fixtured tools", () =>
     expect(result._message).toContain("get_portfolio_summary");
   });
 
-  it("covers all priority tools the demo-mode plan calls out by name (v1 + v2)", async () => {
+  it("covers all priority tools the demo-mode plan calls out by name (v1 + v2 + v3)", async () => {
     const { getDemoFixture } = await import("../src/demo/index.js");
-    // v1 (24) + v2 (19) = 43 fixtured read tools. Locking them so a
-    // future fixture-table refactor can't silently drop one. If a tool
-    // here falls through to the `not-implemented` echo, the test fails
-    // with the offending tool name in the message.
+    // v1 (24) + v2 (19) + v3 (18) = 61 fixtured read tools. Locking them
+    // so a future fixture-table refactor can't silently drop one. If a
+    // tool here falls through to the `not-implemented` echo, the test
+    // fails with the offending tool name in the message.
     const fixturedTools = [
       // v1
       "get_ledger_status",
@@ -194,8 +194,27 @@ describe("getDemoFixture — deterministic, non-empty for fixtured tools", () =>
       "reverse_resolve_ens",
       "get_portfolio_diff",
       "list_tron_witnesses",
+      // v3 (issue #371 follow-up — fixture refresh for tools shipped after demo v2)
+      "get_ltc_balance",
+      "get_ltc_block_tip",
+      "get_ltc_chain_tips",
+      "get_ltc_mempool_summary",
+      "get_ltc_block_stats",
+      "get_ltc_blocks_recent",
+      "rescan_ltc_account",
+      "get_curve_positions",
+      "get_safe_positions",
+      "get_nft_portfolio",
+      "get_nft_collection",
+      "get_nft_history",
+      "get_daily_briefing",
+      "get_pnl_summary",
+      "compare_yields",
+      "get_token_allowances",
+      "get_coin_price",
+      "explain_tx",
     ];
-    expect(fixturedTools.length).toBe(43);
+    expect(fixturedTools.length).toBe(61);
     for (const tool of fixturedTools) {
       const result = getDemoFixture(tool, undefined) as Record<string, unknown>;
       expect(result, `expected fixture for ${tool}`).toBeDefined();
@@ -403,6 +422,132 @@ describe("demoSigningRefusalMessage — stable for pattern-matching agents", () 
     expect(msg).toContain("'prepare_swap'");
     expect(msg).toContain("disabled in demo mode");
     expect(msg).toContain("vaultpilot-mcp-setup");
+  });
+});
+
+describe("v3 fixtures — shape sanity for the post-v2 tool refresh (issue #371)", () => {
+  it("get_vaultpilot_config_status fixture is now structurally aligned with the real return shape", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const status = getDemoFixture("get_vaultpilot_config_status", undefined) as Record<string, unknown>;
+    // Real shape uses configFileExists + serverVersion + pairings (not configExists, version, pairedLedger).
+    expect(status.configFileExists).toBe(true);
+    expect(typeof status.serverVersion).toBe("string");
+    expect(status.pairings).toBeDefined();
+    expect((status.pairings as Record<string, unknown>).walletConnect).toBeDefined();
+    // Old field names must NOT appear — would mean the fixture rotted again.
+    expect(status.configExists).toBeUndefined();
+    expect(status.version).toBeUndefined();
+    expect(status.pairedLedger).toBeUndefined();
+    expect(status.wcTopic).toBeUndefined();
+    // Real-shape fields preflightSkill + setupHints + apiKey field name.
+    expect(status.preflightSkill).toBeDefined();
+    expect(Array.isArray(status.setupHints)).toBe(true);
+    const apiKeys = status.apiKeys as Record<string, { set: boolean }>;
+    expect(apiKeys.etherscan.set).toBe(true);
+    expect(apiKeys.walletConnectProjectId).toBeDefined();
+    expect((apiKeys as Record<string, unknown>).walletConnect).toBeUndefined();
+    // demoMode sub-object preserved from PR 1.
+    const demoMode = status.demoMode as { active: boolean; envVar: string };
+    expect(demoMode.active).toBe(true);
+    expect(demoMode.envVar).toBe("VAULTPILOT_DEMO");
+  });
+
+  it("LTC reads return realistic litecoin data with the demo wallet's LTC address", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const { DEMO_WALLET } = await import("../src/demo/fixtures.js");
+    const balance = getDemoFixture("get_ltc_balance", undefined) as {
+      address: string;
+      confirmedLtc: string;
+    };
+    expect(balance.address).toBe(DEMO_WALLET.litecoin);
+    expect(parseFloat(balance.confirmedLtc)).toBeGreaterThan(0);
+
+    const tip = getDemoFixture("get_ltc_block_tip", undefined) as {
+      height: number;
+      hash: string;
+    };
+    expect(tip.height).toBeGreaterThan(2_000_000);
+    expect(tip.hash.length).toBeGreaterThan(40);
+
+    // get_ltc_blocks_recent honors the count arg (capped at 200).
+    const recent = getDemoFixture("get_ltc_blocks_recent", { count: 10 }) as { length: number };
+    expect((recent as unknown as Array<unknown>).length).toBe(10);
+    const capped = getDemoFixture("get_ltc_blocks_recent", { count: 999 }) as Array<unknown>;
+    expect(capped.length).toBe(200);
+  });
+
+  it("compare_yields returns rows sorted by APR descending and lists unavailable protocols", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const yields = getDemoFixture("compare_yields", { asset: "USDC" }) as {
+      asset: string;
+      rows: { protocol: string; supplyApr: number }[];
+      unavailable: { protocol: string; reason: string }[];
+    };
+    expect(yields.asset).toBe("USDC");
+    expect(yields.rows.length).toBeGreaterThan(0);
+    // Sorted descending.
+    for (let i = 0; i < yields.rows.length - 1; i++) {
+      expect(yields.rows[i].supplyApr).toBeGreaterThanOrEqual(yields.rows[i + 1].supplyApr);
+    }
+    expect(yields.unavailable.length).toBeGreaterThan(0);
+  });
+
+  it("get_token_allowances flags the unlimited-approval count and labels known spenders", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    const allowances = getDemoFixture("get_token_allowances", undefined) as {
+      unlimitedCount: number;
+      rows: { spenderLabel?: string; isUnlimited: boolean }[];
+      notes: string[];
+    };
+    expect(allowances.unlimitedCount).toBeGreaterThanOrEqual(1);
+    const labeled = allowances.rows.find((r) => r.spenderLabel?.includes("Aave"));
+    expect(labeled?.isUnlimited).toBe(true);
+    expect(allowances.notes.join(" ")).toContain("unlimited");
+  });
+
+  it("get_coin_price returns table-backed prices for major non-EVM natives", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    for (const symbol of ["BTC", "LTC", "SOL", "TRX"]) {
+      const r = getDemoFixture("get_coin_price", { symbol }) as {
+        symbol: string;
+        priceUsd: number;
+        confidence: number;
+      };
+      expect(r.symbol).toBe(symbol);
+      expect(r.priceUsd).toBeGreaterThan(0);
+      expect(r.confidence).toBeGreaterThan(0.9);
+    }
+  });
+
+  it("explain_tx + get_daily_briefing + get_pnl_summary honor the format arg (structured | markdown | both)", async () => {
+    const { getDemoFixture } = await import("../src/demo/index.js");
+    // explain_tx — both is the default
+    const both = getDemoFixture("explain_tx", { txHash: "0xabc" }) as {
+      markdown?: string;
+      method?: string;
+    };
+    expect(both.markdown).toBeDefined();
+    expect(both.method).toBeDefined();
+    const onlyStruct = getDemoFixture("explain_tx", { txHash: "0xabc", format: "structured" }) as {
+      markdown?: string;
+      method?: string;
+    };
+    expect(onlyStruct.markdown).toBeUndefined();
+    expect(onlyStruct.method).toBeDefined();
+    const onlyMd = getDemoFixture("explain_tx", { txHash: "0xabc", format: "markdown" }) as {
+      markdown?: string;
+      method?: string;
+    };
+    expect(onlyMd.markdown).toBeDefined();
+    expect(onlyMd.method).toBeUndefined();
+
+    // daily_briefing same pattern
+    const dbStruct = getDemoFixture("get_daily_briefing", { format: "structured" }) as {
+      markdown?: string;
+      portfolioTotal?: unknown;
+    };
+    expect(dbStruct.markdown).toBeUndefined();
+    expect(dbStruct.portfolioTotal).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Demo mode last had its fixture surface bumped at commit `bbbedc7` (\"v2 — fixture the remaining 19 read tools\"). 18 read tools have shipped since and currently fall through to the structured `_demoFixture: \"not-implemented\"` payload, which is informative but breaks the narrative for users asking about LTC, NFTs, Curve, Safe, the daily briefing, P&L, yields, allowances, non-EVM prices, or tx explanations.

This PR also fixes a pre-existing shape divergence on `get_vaultpilot_config_status` flagged during #372 — the fixture used `configExists` / `version` / `pairedLedger` / `wcTopic` while the real return shape uses `configFileExists` / `serverVersion` / `pairings.{...}`. Now structurally aligned.

## What's in the v3 batch (18 tools, ~360 LoC of fixtures)

- **Litecoin reads (7)**: balance, block tip, chain tips, mempool summary, block stats, recent blocks, rescan account. Demo wallet gains a `litecoin` slot.
- **Curve LP (1)**: one stable_ng plain pool position (Ethereum, v0.1 scope).
- **Safe (1)**: 2-of-3 multisig where demo wallet is an owner, $2.9k ETH + 1 pending tx.
- **NFTs (3)**: portfolio (Pudgy + Azuki, ~\$54k floor), collection metadata, history (mint + sale).
- **Aggregates (2)**: daily_briefing (period-aware, format-aware structured/markdown/both), pnl_summary (per-chain + per-asset).
- **Yield + allowances + price + explain (4)**: compare_yields (4 rows sorted by APR), get_token_allowances (1 unlimited Aave + 1 capped Uniswap with provenance), get_coin_price (DefiLlama-shaped envelope, 7 majors), explain_tx (Uniswap-style swap walkthrough).

## Out of scope (intentional fall-through)

- Contacts CRUD, read-only invites, strategy share — operational, not part of a demo walkthrough
- BTC multisig admin (register/balance/utxos) — narrow feature
- PSBT manipulation (combine/finalize/sign) — signing-class adjacent
- Ledger USB-only verification tools — only meaningful with hardware plugged in

These keep returning the structured \"not-implemented\" payload, which is the correct UX (user sees what's covered without grepping source).

## Tests

- Locked fixture-coverage list bumped 43 → 61
- 6 new shape-sanity tests covering config_status alignment, LTC reads, compare_yields ordering, allowances flags, coin price table, format-aware aggregate fixtures
- Full suite 1850/1850

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1850 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)