### PR TITLE
chore(skill-pin): bump SHA-256 after vaultpilot-skill#9 (closes #375)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1397,7 +1397,7 @@ async function main() {
         "",
         "PIN DATA:",
         "  Expected SHA-256 of SKILL.md:",
-        "    cd689838314a700dfff80d4c881bf51190cd6c71c747f3152e7cab8d943df2cc",
+        "    1f437e7e0870438ebe7d4c8b40b210b54041bd31a16110152f091761fb053ff5",
         "  Expected in-file sentinel — NOTE: assembled from fragments below so the",
         "  full literal does not appear in these instructions (if it did, searching",
         "  context for it would always succeed and defeat the check). Concatenate:",


### PR DESCRIPTION
## Summary

Closes #375. Coordinated pin bump in lockstep with [vaultpilot-skill#9](https://github.com/szhygulin/vaultpilot-skill/pull/9) (which closed [vaultpilot-skill#8](https://github.com/szhygulin/vaultpilot-skill/issues/8) — the remaining \`<OWNER>\` placeholder in \`SKILL.md:20\`).

## Pin update

| | Value |
|---|---|
| Old | \`cd689838314a700dfff80d4c881bf51190cd6c71c747f3152e7cab8d943df2cc\` |
| New | \`1f437e7e0870438ebe7d4c8b40b210b54041bd31a16110152f091761fb053ff5\` |

Re-verified against the merged-master \`SKILL.md\`:

\`\`\`
$ curl -fsSL https://raw.githubusercontent.com/szhygulin/vaultpilot-skill/master/SKILL.md | sha256sum
1f437e7e0870438ebe7d4c8b40b210b54041bd31a16110152f091761fb053ff5  -
\`\`\`

Sentinel stays at v4 (\`VAULTPILOT_PREFLIGHT_INTEGRITY_v4_7655818578c7a044\`) — prose-only fix in vaultpilot-skill, no protocol change.

## Note on the issue's predicted hash

#375 predicted the post-fix hash as \`7ea855a4…\`, computed by applying the OWNER fix to the original \`10db66ad…\` baseline. By the time the issue was filed, that baseline was already stale — vaultpilot-skill PRs #4 + #5 had added Invariants #7 + #8 to \`SKILL.md\` since the original pin was set. The actual post-merge hash differs from the prediction; the pin in this PR is keyed off the live \`master\` tree post-#9.

This drift between "live master" and "the pin in main" was the prompt for [vaultpilot-skill#10](https://github.com/szhygulin/vaultpilot-skill/issues/10) — the integrity alarm should have fired during testing when the local \`SKILL.md\` diverged from the MCP-emitted pin, but it did not. That investigation is tracked separately.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Hash verified against live \`https://raw.githubusercontent.com/szhygulin/vaultpilot-skill/master/SKILL.md\`
- [ ] Live smoke: with the new vaultpilot-skill clone (post-#9) installed at \`~/.claude/skills/vaultpilot-preflight/\`, run any signing flow and confirm preflight check passes (no "skill integrity check FAILED" alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)