### PR TITLE
feat(demo): set_helius_api_key + auto-nudge every 10 public-Solana RPC errors

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,6 +1,7 @@
 import { mainnet, arbitrum, polygon, base, optimism } from "viem/chains";
 import type { Chain } from "viem";
 import type { RpcProvider, SupportedChain, UserConfig } from "../types/index.js";
+import { getRuntimeSolanaRpc } from "../data/runtime-rpc-overrides.js";
 
 export const VIEM_CHAINS: Record<SupportedChain, Chain> = {
   ethereum: mainnet,
@@ -246,6 +247,14 @@ function resolveRpcUrlRaw(chain: SupportedChain, userConfig: UserConfig | null):
  * before being handed to `Connection` — same safety bar as EVM RPCs.
  */
 export function resolveSolanaRpcUrl(userConfig: UserConfig | null): string {
+  // Issue #371 follow-up: a runtime override (set via `set_helius_api_key`
+  // in demo mode) takes precedence over env/config/public-fallback. The
+  // override is constructed by the override module from a validated
+  // bare API key, so we skip validateRpcUrl here — the URL has already
+  // passed shape validation and is hardcoded to the canonical Helius
+  // mainnet endpoint.
+  const override = getRuntimeSolanaRpc();
+  if (override) return override;
   const envUrl = process.env.SOLANA_RPC_URL;
   if (envUrl) {
     validateRpcUrl("solana", envUrl);

--- a/src/data/runtime-rpc-overrides-schemas.ts
+++ b/src/data/runtime-rpc-overrides-schemas.ts
@@ -1,0 +1,21 @@
+/**
+ * Zod input schema for `set_helius_api_key`. Lives in a sibling file so
+ * src/index.ts stays free of inline zod definitions (matches the
+ * convention every other module follows).
+ */
+
+import { z } from "zod";
+
+export const setHeliusApiKeyInput = z.object({
+  apiKey: z
+    .string()
+    .min(1)
+    .describe(
+      "Helius API key (UUID format: 8-4-4-4-12 hex chars). Get one for free at " +
+        "https://dashboard.helius.dev/. Pass the bare key — the server constructs the " +
+        "canonical Helius mainnet URL internally. Stored in process memory only — survives " +
+        "until the MCP server restarts.",
+    ),
+});
+
+export type SetHeliusApiKeyArgs = z.infer<typeof setHeliusApiKeyInput>;

--- a/src/data/runtime-rpc-overrides.ts
+++ b/src/data/runtime-rpc-overrides.ts
@@ -1,0 +1,169 @@
+/**
+ * Process-local runtime overrides for chain RPC endpoints. Currently
+ * Solana-only — purpose-built for the Helius nudge in demo mode (issue
+ * #371 follow-up): when a user hits public-fallback Solana RPC errors
+ * during demo mode, the agent can call `set_helius_api_key` to inject a
+ * Helius URL for the rest of the process lifetime without restarting.
+ *
+ * Override precedence (Solana resolver checks these in order):
+ *   1. Runtime override (this module) — set via `set_helius_api_key`.
+ *   2. SOLANA_RPC_URL env var.
+ *   3. `userConfig.solanaRpcUrl`.
+ *   4. Public fallback (rate-limited).
+ *
+ * State is module-local and ephemeral — a process restart resets to
+ * env/config/public. Mirrors the demo live-mode design: demo state lives
+ * only as long as the process. To persist a Helius key, run
+ * `vaultpilot-mcp-setup` and pick "Solana RPC URL".
+ *
+ * Also tracks Solana public-fallback error count for the auto-nudge:
+ * every 10th error trips a `pendingHeliusNudge` flag that the
+ * registerTool wrapper picks up and prepends to the next tool response.
+ * Counter resets when an override is set.
+ */
+
+const HELIUS_MAINNET_URL_PREFIX = "https://mainnet.helius-rpc.com/?api-key=";
+
+/**
+ * Helius API keys are UUIDs (8-4-4-4-12 hex chars, dash-separated).
+ * Validating the format prevents (a) accidental URL pastes, (b) prompt
+ * injection where an attacker tries to redirect the Solana RPC to a
+ * malicious endpoint by passing a full URL.
+ */
+const HELIUS_API_KEY_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+interface SolanaOverride {
+  apiKey: string;
+  url: string;
+  setAt: number;
+}
+
+let solanaOverride: SolanaOverride | null = null;
+let solanaPublicErrorCount = 0;
+let pendingHeliusNudge = false;
+
+/**
+ * Validates and stores a Helius API key. Constructs the canonical
+ * Helius mainnet URL internally — callers pass the bare key (matches
+ * the dashboard copy-paste UX). Throws on malformed keys rather than
+ * silently storing garbage.
+ */
+export function setHeliusApiKey(apiKey: string): { url: string; setAt: number } {
+  if (typeof apiKey !== "string" || apiKey.length === 0) {
+    throw new Error(
+      "[VAULTPILOT] set_helius_api_key: apiKey must be a non-empty string. " +
+        "Copy the key from https://dashboard.helius.dev/api-keys (looks like a UUID).",
+    );
+  }
+  if (apiKey.includes("://") || apiKey.startsWith("http")) {
+    throw new Error(
+      "[VAULTPILOT] set_helius_api_key: pass the bare API key, not a URL. " +
+        "The server constructs the canonical Helius mainnet URL internally.",
+    );
+  }
+  if (!HELIUS_API_KEY_PATTERN.test(apiKey)) {
+    throw new Error(
+      "[VAULTPILOT] set_helius_api_key: apiKey doesn't match the Helius UUID format " +
+        "(8-4-4-4-12 hex chars, e.g. b7d6f3a1-1234-5678-9abc-def012345678). " +
+        "Double-check the value you copied from https://dashboard.helius.dev/api-keys.",
+    );
+  }
+  const url = `${HELIUS_MAINNET_URL_PREFIX}${apiKey}`;
+  const setAt = Date.now();
+  solanaOverride = { apiKey, url, setAt };
+  // Setting an override resets the error counter + clears any pending
+  // nudge — the user has acted on the recommendation, no need to nag.
+  solanaPublicErrorCount = 0;
+  pendingHeliusNudge = false;
+  return { url, setAt };
+}
+
+/** Returns the override URL if set, else null. */
+export function getRuntimeSolanaRpc(): string | null {
+  return solanaOverride === null ? null : solanaOverride.url;
+}
+
+/**
+ * Returns a redacted view of the override for diagnostic surfaces.
+ * NEVER returns the raw API key — only the last 4 chars + setAt.
+ * Mirrors the strict no-secrets contract on get_vaultpilot_config_status.
+ */
+export function getRuntimeSolanaRpcStatus(): {
+  active: boolean;
+  apiKeySuffix?: string;
+  setAt?: number;
+} {
+  if (solanaOverride === null) return { active: false };
+  return {
+    active: true,
+    apiKeySuffix: solanaOverride.apiKey.slice(-4),
+    setAt: solanaOverride.setAt,
+  };
+}
+
+/** Clears the runtime override, returning to env/config/public-fallback. */
+export function clearRuntimeSolanaRpc(): void {
+  solanaOverride = null;
+}
+
+/**
+ * Increment the Solana-public-error counter and check the nudge
+ * threshold. Called from `fetchWithRateLimitDetect` whenever the public
+ * Solana RPC returns 429 (or other non-success). When a runtime override
+ * is set, this is a no-op — overrides bypass the public-fallback path
+ * entirely, and the counter doesn't increment for keyed traffic.
+ *
+ * Threshold: every 10th error fires the nudge (i.e., count % 10 === 0).
+ * Reset when `setHeliusApiKey` is called.
+ */
+export function recordSolanaPublicError(): void {
+  if (solanaOverride !== null) return;
+  solanaPublicErrorCount += 1;
+  if (solanaPublicErrorCount % 10 === 0) {
+    pendingHeliusNudge = true;
+  }
+}
+
+/** Read-only counter accessor for tests + diagnostic surfaces. */
+export function getSolanaPublicErrorCount(): number {
+  return solanaPublicErrorCount;
+}
+
+/**
+ * Pop-style accessor: if the nudge flag is set, return the canned text
+ * and clear the flag (so it appears on exactly one tool response per
+ * threshold crossing). The registerTool wrapper calls this after every
+ * tool response and prepends the result if non-null.
+ */
+export function consumePendingHeliusNudge(): string | null {
+  if (!pendingHeliusNudge) return null;
+  pendingHeliusNudge = false;
+  return renderHeliusNudge(solanaPublicErrorCount);
+}
+
+/**
+ * Build the agent-facing nudge block. Pulled out for testability — same
+ * text every time a nudge fires, parameterized only by the error count
+ * so the user sees "we've hit 10 errors", "we've hit 20 errors", etc.
+ */
+function renderHeliusNudge(errorCount: number): string {
+  return (
+    `[VAULTPILOT_DEMO — Helius setup nudge]\n\n` +
+    `Public Solana RPC has hit ${errorCount} rate-limit errors this session. ` +
+    `It will only get worse — public Solana endpoints throttle aggressively under any real walkthrough.\n\n` +
+    `Free Helius API key takes 60 seconds:\n` +
+    `  1. Open [Helius dashboard](https://dashboard.helius.dev/) — sign in with GitHub or email.\n` +
+    `  2. Dashboard auto-creates a default API key on first login. Copy it (UUID format: 8-4-4-4-12 hex).\n` +
+    `  3. Paste the key into chat. The agent will call \`set_helius_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
+    `The key is held in process memory only — survives until the MCP server restarts. ` +
+    `To persist across restarts, exit demo mode (unset VAULTPILOT_DEMO + restart) and run ` +
+    `\`vaultpilot-mcp-setup\` to save the key to ~/.vaultpilot-mcp/config.json.`
+  );
+}
+
+/** Test-only: reset all module state between tests. */
+export function _resetRuntimeRpcOverridesForTests(): void {
+  solanaOverride = null;
+  solanaPublicErrorCount = 0;
+  pendingHeliusNudge = false;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,15 @@ import {
   getDemoWalletInput,
   type SetDemoWalletArgs,
 } from "./demo/schemas.js";
+import {
+  setHeliusApiKey,
+  getRuntimeSolanaRpcStatus,
+  consumePendingHeliusNudge,
+} from "./data/runtime-rpc-overrides.js";
+import {
+  setHeliusApiKeyInput,
+  type SetHeliusApiKeyArgs,
+} from "./data/runtime-rpc-overrides-schemas.js";
 
 import {
   getLendingPositions,
@@ -779,6 +788,15 @@ function handler<T, R>(
       for (const block of await collectVerificationBlocks(result)) {
         content.push({ type: "text", text: block });
       }
+      // Helius setup nudge — fires every 10th public-Solana-RPC error in
+      // demo mode. Pop-and-clear so it appears on exactly one response per
+      // threshold crossing. No-op outside demo mode (the error counter
+      // never increments without VAULTPILOT_DEMO since the nudge is
+      // demo-specific UX — but the consumer guard double-checks).
+      if (isDemoMode()) {
+        const nudge = consumePendingHeliusNudge();
+        if (nudge) content.push({ type: "text", text: nudge });
+      }
       return { content };
     } catch (error) {
       // Issue #326: the legacy `error instanceof Error ? error.message :
@@ -786,8 +804,20 @@ function handler<T, R>(
       // underlying SDK (WalletConnect, viem) threw an Error whose .message
       // was itself a structured object. Use the hardened helper instead so
       // the agent (and the user) sees the actual failure cause.
+      const errorContent: { type: "text"; text: string }[] = [
+        { type: "text" as const, text: `Error: ${safeErrorMessage(error)}` },
+      ];
+      // Surface the Helius nudge on the failing call too — when the
+      // 10th public-Solana-RPC 429 trips the threshold, the same call
+      // is what's failing. Showing the nudge on the error response
+      // gives the user an immediate path forward rather than waiting
+      // for a successful next call to surface it.
+      if (isDemoMode()) {
+        const nudge = consumePendingHeliusNudge();
+        if (nudge) errorContent.push({ type: "text", text: nudge });
+      }
       return {
-        content: [{ type: "text" as const, text: `Error: ${safeErrorMessage(error)}` }],
+        content: errorContent,
         isError: true,
       };
     }
@@ -4019,6 +4049,46 @@ async function main() {
           description: p.description,
           addresses: p.addresses,
         })),
+      };
+    })
+  );
+
+  // ---- Module 9c: Runtime Solana RPC override (Helius nudge — issue #371 follow-up) ----
+  registerTool(server,
+    "set_helius_api_key",
+    {
+      description:
+        "Set a Helius API key for Solana RPC reads at runtime — no restart required. The " +
+        "server constructs the canonical Helius mainnet URL (`https://mainnet.helius-rpc.com/" +
+        "?api-key=<KEY>`) internally and uses it for every subsequent Solana call until the " +
+        "process restarts. Takes precedence over SOLANA_RPC_URL env var and userConfig. " +
+        "Designed for the demo-mode flow where users want to fix Solana rate-limits without " +
+        "restarting their MCP client, but works in any mode. " +
+        "INPUT: bare API key only (UUID format, 8-4-4-4-12 hex). Pasting a URL is rejected to " +
+        "prevent prompt-injection redirects to malicious endpoints. " +
+        "WHERE TO GET ONE: https://dashboard.helius.dev/ — sign in (GitHub or email), copy the " +
+        "default API key auto-created on first login. Free tier covers personal-volume Solana " +
+        "reads + writes. " +
+        "PERSISTENCE: process memory only. To save across restarts, run `vaultpilot-mcp-setup` " +
+        "(after exiting demo mode if applicable) and pick \"Solana RPC URL\" — paste the same " +
+        "key there. " +
+        "AGENT BEHAVIOR: when the user pastes a key in chat ('here's my Helius key: <uuid>'), " +
+        "call this tool immediately. NEVER echo the key back in any subsequent response — " +
+        "treat it as secret-shaped even though Helius keys can be regenerated.",
+      inputSchema: setHeliusApiKeyInput.shape,
+    },
+    handler((args: SetHeliusApiKeyArgs) => {
+      const { setAt } = setHeliusApiKey(args.apiKey);
+      const status = getRuntimeSolanaRpcStatus();
+      return {
+        ok: true,
+        source: "runtime-override",
+        apiKeySuffix: status.apiKeySuffix,
+        setAt,
+        message:
+          "Helius API key set. All subsequent Solana reads use the Helius mainnet endpoint " +
+          "for the rest of this MCP-server process. The key is held in memory only — to " +
+          "persist across restarts, run `vaultpilot-mcp-setup` and pick \"Solana RPC URL\".",
       };
     })
   );

--- a/src/modules/diagnostics/index.ts
+++ b/src/modules/diagnostics/index.ts
@@ -28,6 +28,7 @@ import {
   type SetupHint,
 } from "../../data/rate-limit-tracker.js";
 import { isDemoMode, getLiveWallet, isLiveMode } from "../../demo/index.js";
+import { getRuntimeSolanaRpc } from "../../data/runtime-rpc-overrides.js";
 
 type EvmRpcSource =
   | "env-var"
@@ -36,7 +37,11 @@ type EvmRpcSource =
   | "custom-url-config"
   | "public-fallback";
 
-type SolanaRpcSource = "env-var" | "config-url" | "public-fallback";
+type SolanaRpcSource =
+  | "runtime-override"
+  | "env-var"
+  | "config-url"
+  | "public-fallback";
 
 type ApiKeySource = "env-var" | "config" | "unset";
 
@@ -79,6 +84,7 @@ function classifyEvmRpcSource(chain: SupportedChain): EvmRpcSource {
 }
 
 function classifySolanaRpcSource(): SolanaRpcSource {
+  if (getRuntimeSolanaRpc()) return "runtime-override";
   if (process.env.SOLANA_RPC_URL) return "env-var";
   if (readUserConfig()?.solanaRpcUrl) return "config-url";
   return "public-fallback";

--- a/src/modules/solana/rpc.ts
+++ b/src/modules/solana/rpc.ts
@@ -2,6 +2,10 @@ import { Connection } from "@solana/web3.js";
 import { resolveSolanaRpcUrl } from "../../config/chains.js";
 import { readUserConfig } from "../../config/user-config.js";
 import { recordRateLimit } from "../../data/rate-limit-tracker.js";
+import {
+  getRuntimeSolanaRpc,
+  recordSolanaPublicError,
+} from "../../data/runtime-rpc-overrides.js";
 
 /**
  * Cached `Connection` for Solana mainnet. Lazy-initialized on first use.
@@ -10,6 +14,9 @@ import { recordRateLimit } from "../../data/rate-limit-tracker.js";
  * alongside the EVM `resetClients` listener).
  */
 let cachedConnection: Connection | undefined;
+/** URL the cached connection was constructed against — when the runtime
+ * override flips this changes, and `getSolanaConnection` rebuilds. */
+let cachedConnectionUrl: string | undefined;
 
 /**
  * fetch shim handed to web3.js's `Connection({ fetch })`. Forwards
@@ -30,13 +37,24 @@ async function fetchWithRateLimitDetect(
   const res = await fetch(input, init);
   if (res.status === 429) {
     recordRateLimit({ kind: "solana" });
+    // Increment the demo-mode Helius nudge counter — only counts when no
+    // runtime override is set, so the nudge doesn't fire after the user
+    // adds a key. Every 10th error trips a `pendingHeliusNudge` flag the
+    // registerTool wrapper picks up on the next response.
+    recordSolanaPublicError();
   }
   return res;
 }
 
 export function getSolanaConnection(): Connection {
-  if (cachedConnection) return cachedConnection;
   const url = resolveSolanaRpcUrl(readUserConfig());
+  // Issue #371 follow-up: when `set_helius_api_key` flips the runtime
+  // override, the resolved URL changes mid-process. Rebuild the cached
+  // Connection if the URL no longer matches what we built it against —
+  // otherwise the override has no effect until restart.
+  if (cachedConnection && cachedConnectionUrl === url) {
+    return cachedConnection;
+  }
   // `confirmed` is the sweet spot for read-only portfolio/history queries —
   // `processed` is racy (may return state rolled back a slot later) and
   // `finalized` adds ~13s of latency for no meaningful safety win on reads.
@@ -44,13 +62,22 @@ export function getSolanaConnection(): Connection {
     commitment: "confirmed",
     fetch: fetchWithRateLimitDetect as never,
   });
+  cachedConnectionUrl = url;
   return cachedConnection;
 }
 
 /** Test-only: drop the cached connection so a mocked `@solana/web3.js` is picked up on next call. */
 export function resetSolanaConnection(): void {
   cachedConnection = undefined;
+  cachedConnectionUrl = undefined;
 }
+
+// Suppress unused-import linter on getRuntimeSolanaRpc — kept imported so
+// future Solana paths that don't go through the cached `Connection` (e.g.
+// a `@solana/kit` createSolanaRpc call) can also pick up the override
+// without re-deriving the precedence chain. Removing this unused import
+// would force re-add work later.
+void getRuntimeSolanaRpc;
 
 /**
  * Resolve the mainnet RPC URL string. Same source-of-truth as

--- a/test/runtime-rpc-overrides.test.ts
+++ b/test/runtime-rpc-overrides.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the runtime Solana RPC override + Helius nudge mechanism
+ * (issue #371 follow-up — add demo-mode UX for fixing public-Solana
+ * rate-limits without restarting the MCP server).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  setHeliusApiKey,
+  getRuntimeSolanaRpc,
+  getRuntimeSolanaRpcStatus,
+  clearRuntimeSolanaRpc,
+  recordSolanaPublicError,
+  getSolanaPublicErrorCount,
+  consumePendingHeliusNudge,
+  _resetRuntimeRpcOverridesForTests,
+} from "../src/data/runtime-rpc-overrides.js";
+
+const VALID_KEY = "b7d6f3a1-1234-5678-9abc-def012345678";
+
+beforeEach(() => {
+  _resetRuntimeRpcOverridesForTests();
+});
+
+describe("setHeliusApiKey — input validation", () => {
+  it("accepts a UUID-format API key and stores the canonical Helius URL", () => {
+    const { url } = setHeliusApiKey(VALID_KEY);
+    expect(url).toBe(`https://mainnet.helius-rpc.com/?api-key=${VALID_KEY}`);
+    expect(getRuntimeSolanaRpc()).toBe(url);
+  });
+
+  it("rejects empty / non-string input", () => {
+    expect(() => setHeliusApiKey("")).toThrow(/must be a non-empty string/);
+    // @ts-expect-error — testing runtime validation
+    expect(() => setHeliusApiKey(undefined)).toThrow(/must be a non-empty string/);
+    // @ts-expect-error — testing runtime validation
+    expect(() => setHeliusApiKey(null)).toThrow(/must be a non-empty string/);
+  });
+
+  it("rejects URLs (so prompt injection can't redirect to a malicious endpoint)", () => {
+    expect(() =>
+      setHeliusApiKey("https://attacker.example.com/?api-key=stealth"),
+    ).toThrow(/pass the bare API key, not a URL/);
+    expect(() =>
+      setHeliusApiKey("http://malicious.example.com/"),
+    ).toThrow(/pass the bare API key, not a URL/);
+    expect(() =>
+      setHeliusApiKey("data://something/?api-key=foo"),
+    ).toThrow(/pass the bare API key, not a URL/);
+  });
+
+  it("rejects malformed UUIDs", () => {
+    expect(() => setHeliusApiKey("not-a-uuid")).toThrow(/Helius UUID format/);
+    expect(() => setHeliusApiKey("12345678-1234-1234-1234-12345678")).toThrow(
+      /Helius UUID format/,
+    );
+    expect(() =>
+      // wrong segment lengths
+      setHeliusApiKey("12345678-1234-1234-1234-1234567890ab-extra"),
+    ).toThrow(/Helius UUID format/);
+  });
+});
+
+describe("Runtime override precedence + status surface", () => {
+  it("getRuntimeSolanaRpc returns null when no override is set", () => {
+    expect(getRuntimeSolanaRpc()).toBeNull();
+    expect(getRuntimeSolanaRpcStatus().active).toBe(false);
+  });
+
+  it("status surface reports last-4 of API key only — never the full value", () => {
+    setHeliusApiKey(VALID_KEY);
+    const status = getRuntimeSolanaRpcStatus();
+    expect(status.active).toBe(true);
+    expect(status.apiKeySuffix).toBe(VALID_KEY.slice(-4));
+    expect(typeof status.setAt).toBe("number");
+    // Sweep: nothing in the status surface should contain the full key.
+    expect(JSON.stringify(status)).not.toContain(VALID_KEY);
+  });
+
+  it("clearRuntimeSolanaRpc returns to null state", () => {
+    setHeliusApiKey(VALID_KEY);
+    expect(getRuntimeSolanaRpc()).not.toBeNull();
+    clearRuntimeSolanaRpc();
+    expect(getRuntimeSolanaRpc()).toBeNull();
+    expect(getRuntimeSolanaRpcStatus().active).toBe(false);
+  });
+});
+
+describe("Solana public-error counter — tracks exactly when no override is set", () => {
+  it("counter increments on each call when no override is set", () => {
+    expect(getSolanaPublicErrorCount()).toBe(0);
+    recordSolanaPublicError();
+    recordSolanaPublicError();
+    recordSolanaPublicError();
+    expect(getSolanaPublicErrorCount()).toBe(3);
+  });
+
+  it("counter does NOT increment once an override is set (keyed traffic doesn't count)", () => {
+    setHeliusApiKey(VALID_KEY);
+    recordSolanaPublicError();
+    recordSolanaPublicError();
+    expect(getSolanaPublicErrorCount()).toBe(0);
+  });
+
+  it("counter resets to 0 when setHeliusApiKey is called", () => {
+    recordSolanaPublicError();
+    recordSolanaPublicError();
+    expect(getSolanaPublicErrorCount()).toBe(2);
+    setHeliusApiKey(VALID_KEY);
+    expect(getSolanaPublicErrorCount()).toBe(0);
+  });
+});
+
+describe("Helius nudge — fires every 10th public error, clears on consume", () => {
+  it("does NOT fire on counts 1-9", () => {
+    for (let i = 0; i < 9; i++) recordSolanaPublicError();
+    expect(consumePendingHeliusNudge()).toBeNull();
+  });
+
+  it("fires on count 10", () => {
+    for (let i = 0; i < 10; i++) recordSolanaPublicError();
+    const nudge = consumePendingHeliusNudge();
+    expect(nudge).not.toBeNull();
+    expect(nudge!).toContain("VAULTPILOT_DEMO");
+    expect(nudge!).toContain("Helius");
+    expect(nudge!).toContain("set_helius_api_key");
+    expect(nudge!).toContain("dashboard.helius.dev");
+    // Mentions the count so the user sees how often they've been throttled.
+    expect(nudge!).toContain("10");
+  });
+
+  it("consume is pop-style — clears the flag after returning the text", () => {
+    for (let i = 0; i < 10; i++) recordSolanaPublicError();
+    expect(consumePendingHeliusNudge()).not.toBeNull();
+    // Second consume returns null — only one response per threshold crossing.
+    expect(consumePendingHeliusNudge()).toBeNull();
+  });
+
+  it("re-fires on the next threshold (count 20)", () => {
+    for (let i = 0; i < 10; i++) recordSolanaPublicError();
+    consumePendingHeliusNudge(); // pop the first one
+    for (let i = 0; i < 9; i++) recordSolanaPublicError();
+    expect(consumePendingHeliusNudge()).toBeNull();
+    recordSolanaPublicError(); // 20th
+    const nudge = consumePendingHeliusNudge();
+    expect(nudge).not.toBeNull();
+    expect(nudge!).toContain("20");
+  });
+
+  it("does NOT fire after a successful set_helius_api_key (counter zeroed)", () => {
+    for (let i = 0; i < 9; i++) recordSolanaPublicError();
+    setHeliusApiKey(VALID_KEY);
+    // Even if more public errors come in (which shouldn't, since override
+    // is active — but guard anyway), they don't count.
+    recordSolanaPublicError();
+    expect(consumePendingHeliusNudge()).toBeNull();
+  });
+});
+
+describe("classifySolanaRpcSource integration — runtime-override wins", () => {
+  it("runtime-override takes precedence over env / config / public-fallback", async () => {
+    // Reset everything that could leak from another test.
+    delete process.env.SOLANA_RPC_URL;
+    setHeliusApiKey(VALID_KEY);
+    // classifySolanaRpcSource is internal to diagnostics, but the
+    // public surface is `get_vaultpilot_config_status`. Spinning up the
+    // full diagnostic is heavy — the contract here is that
+    // resolveSolanaRpcUrl returns the override. That's the load-bearing
+    // claim agents and tests rely on.
+    const { resolveSolanaRpcUrl } = await import("../src/config/chains.js");
+    const resolved = resolveSolanaRpcUrl(null);
+    expect(resolved).toBe(`https://mainnet.helius-rpc.com/?api-key=${VALID_KEY}`);
+  });
+
+  it("falls through to env when no runtime override is set", async () => {
+    process.env.SOLANA_RPC_URL = "https://my-helius.example.com/?api-key=ENV";
+    const { resolveSolanaRpcUrl } = await import("../src/config/chains.js");
+    expect(resolveSolanaRpcUrl(null)).toBe(
+      "https://my-helius.example.com/?api-key=ENV",
+    );
+    delete process.env.SOLANA_RPC_URL;
+  });
+});


### PR DESCRIPTION
## Summary

Closes the biggest UX gap left by removing the fixture-based demo (PR #380): without a Helius key, public Solana RPC rate-limits within seconds of any real walkthrough, and the user had no in-session path to fix it without restarting the MCP server.

## Mechanism

1. **New tool `set_helius_api_key({ apiKey })`** — validates a UUID-format Helius key, constructs the canonical mainnet URL internally, stores in process-local override.
2. **`resolveSolanaRpcUrl` updated** — checks the runtime override before env / config / public-fallback. The cached `Connection` rebuilds on URL change so the override takes effect mid-process without restart.
3. **Auto-nudge** — Solana fetch interceptor counts public-fallback 429s; every 10th error sets a `pendingHeliusNudge` flag. The shared response handler pops the flag (success AND error paths) and prepends a structured nudge. Re-fires at 20, 30, etc.
4. **Stops cold once a key is set** — `setHeliusApiKey` zeroes the counter and clears the flag.

## Security

- Rejects URL-shaped input (`://`, `http*`) so prompt injection can't redirect Solana traffic to a malicious endpoint. Only bare API keys matching the Helius UUID format pass.
- Status surface reports **last-4 chars only** of the API key — never the full value. Mirrors the strict no-secrets contract on `get_vaultpilot_config_status`.
- Tool description directs the agent to NEVER echo the key back in subsequent responses.

## Persistence

Runtime-only by design — survives until restart. To save across restarts, run `vaultpilot-mcp-setup` and paste the same key. Both the tool description and the nudge text spell this out.

## Diagnostics

- New `runtime-override` value in the `SolanaRpcSource` enum.
- Existing `solanaUsingDefault` rate-limit setupHint correctly disengages once a Helius key is set (`runtime-override` is not `public-fallback`).

## Tests (17 new)

- apiKey validation (empty / URL / non-UUID rejection)
- runtime override precedence
- status surface redacts to last-4 chars
- error counter increments only when no override is set; resets on setHeliusApiKey
- nudge fires on 10/20, not 1-9/11-19
- resolveSolanaRpcUrl integration confirms override wins

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1865 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)