### PR TITLE
feat(demo): exit_demo_mode tool — agent-guided handoff to operational mode

### DIFF
--- a/src/demo/exit-flow.ts
+++ b/src/demo/exit-flow.ts
@@ -1,0 +1,356 @@
+/**
+ * Demo → operational handoff guide. The MCP server can't *invoke* the
+ * setup wizard (a separate interactive binary) or modify the user's
+ * `claude mcp add` config — it can only describe what to do. This module
+ * builds a structured, decision-tree-shaped response the agent walks the
+ * user through to leave demo mode and configure real signing.
+ *
+ * Surfaced via the `exit_demo_mode` tool. The agent's job is to ASK the
+ * user the relevant questions first (do you have a Ledger? which chains?),
+ * then call this with their answers; the response is tailored to skip
+ * sections that don't apply.
+ *
+ * Stateless / read-only — does NOT actually unset VAULTPILOT_DEMO or
+ * mutate any process state. Demo mode is read from env at every tool call
+ * and the only real "exit" is restarting the MCP server with the env var
+ * absent. The tool's response makes that constraint explicit.
+ */
+
+import { isDemoMode, isLiveMode, getLiveWallet } from "./index.js";
+import {
+  getRuntimeSolanaRpcStatus,
+  getSolanaPublicErrorCount,
+} from "../data/runtime-rpc-overrides.js";
+
+export type DemoExitChain =
+  | "ethereum"
+  | "arbitrum"
+  | "polygon"
+  | "base"
+  | "optimism"
+  | "solana"
+  | "tron"
+  | "bitcoin"
+  | "litecoin";
+
+export interface ExitDemoArgs {
+  /** Whether the user confirmed they have a Ledger device. Drives whether signing
+   *  prep is included in the response. Pass `false` to get a deferral message. */
+  hasLedger?: boolean;
+  /** Whether the user has already run `vaultpilot-mcp-setup` previously. When
+   *  `true`, the response skips the setup-wizard walkthrough and points to the
+   *  shorter "just unset the env var" path. */
+  hasRunSetup?: boolean;
+  /** Chains the user intends to use. Drives which RPC / API keys to recommend
+   *  acquiring. Empty/undefined defaults to the EVM-only set. */
+  chains?: DemoExitChain[];
+  /** Whether the user wants help acquiring API keys. When `true`, the response
+   *  includes per-provider signup links. When `false`, recommends running setup
+   *  with whatever keys they already have. */
+  acquireKeys?: boolean;
+}
+
+interface ProviderRec {
+  service: string;
+  why: string;
+  signupUrl: string;
+  freeTier: string;
+}
+
+const PROVIDER_RECOMMENDATIONS: Record<string, ProviderRec[]> = {
+  ethereum: [
+    {
+      service: "Infura or Alchemy (EVM RPC)",
+      why: "Ethereum reads via a free-tier provider key. Public-fallback works for evaluation but rate-limits under sustained use.",
+      signupUrl: "https://app.infura.io/ — or — https://dashboard.alchemy.com/",
+      freeTier: "Both cover personal-volume use comfortably.",
+    },
+    {
+      service: "Etherscan V2",
+      why: "Required for `get_transaction_history`, `get_token_allowances`, `explain_tx`, address-poisoning scoring. Public Etherscan refuses unauthed multi-chain V2 calls.",
+      signupUrl: "https://etherscan.io/myapikey",
+      freeTier: "Free 5 calls/sec, 100K calls/day. Enough for any personal use.",
+    },
+  ],
+  solana: [
+    {
+      service: "Helius (Solana RPC)",
+      why: "Public Solana RPC throttles aggressively (you'll see 429s within seconds of any real walkthrough). Helius free tier is essentially required for usable Solana reads.",
+      signupUrl: "https://dashboard.helius.dev/",
+      freeTier: "Free tier covers personal-volume reads + writes. Default API key auto-created on first login.",
+    },
+  ],
+  tron: [
+    {
+      service: "TronGrid",
+      why: "Unauthenticated TronGrid throttles to ~15 req/min. Free key raises this 10x.",
+      signupUrl: "https://www.trongrid.io/dashboard/apikeys",
+      freeTier: "Free tier: 100K requests/day.",
+    },
+  ],
+  bitcoin: [
+    {
+      service: "BTC indexer (Esplora)",
+      why: "BTC reads via litecoinspace.org / mempool.space; both have generous public limits — usually no key needed for personal use.",
+      signupUrl: "(no signup needed for default; self-hosting Esplora is the upgrade path)",
+      freeTier: "Public default: no rate-limit issues observed for personal use.",
+    },
+  ],
+};
+
+PROVIDER_RECOMMENDATIONS.litecoin = PROVIDER_RECOMMENDATIONS.bitcoin;
+PROVIDER_RECOMMENDATIONS.arbitrum = PROVIDER_RECOMMENDATIONS.ethereum;
+PROVIDER_RECOMMENDATIONS.polygon = PROVIDER_RECOMMENDATIONS.ethereum;
+PROVIDER_RECOMMENDATIONS.base = PROVIDER_RECOMMENDATIONS.ethereum;
+PROVIDER_RECOMMENDATIONS.optimism = PROVIDER_RECOMMENDATIONS.ethereum;
+
+/**
+ * Build the exit-demo-mode guide. The structure of the response is the
+ * agent's script: snapshot of current state → preflight checklist → ordered
+ * steps → caveats → copy-paste recipe. Same shape regardless of args; some
+ * sections collapse to empty arrays / null when not applicable so the agent
+ * can render uniformly.
+ */
+export function buildExitDemoGuide(args: ExitDemoArgs = {}): {
+  currentState: {
+    demoActive: boolean;
+    subMode: "default" | "live" | "not-in-demo";
+    activePersonaId: string | null;
+    runtimeSolanaRpcSet: boolean;
+    solanaPublicErrorsThisSession: number;
+  };
+  outcome: "ready-to-exit" | "deferred-no-ledger" | "not-in-demo";
+  message: string;
+  whatYoullGain: string[];
+  whatYoullLose: string[];
+  preflightChecklist: { item: string; reason: string }[];
+  steps: { step: number; action: string; command: string | null; note?: string }[];
+  recommendedProviders: ProviderRec[];
+  copyPasteRecipe: string | null;
+  cautions: string[];
+} {
+  const live = getLiveWallet();
+  const runtimeSolanaRpcStatus = getRuntimeSolanaRpcStatus();
+  const currentState = {
+    demoActive: isDemoMode(),
+    subMode: isDemoMode()
+      ? isLiveMode()
+        ? ("live" as const)
+        : ("default" as const)
+      : ("not-in-demo" as const),
+    activePersonaId: live?.personaId ?? null,
+    runtimeSolanaRpcSet: runtimeSolanaRpcStatus.active,
+    solanaPublicErrorsThisSession: getSolanaPublicErrorCount(),
+  };
+
+  // Not currently in demo — return a no-op-ish response so the agent
+  // can clarify with the user that there's nothing to exit.
+  if (!currentState.demoActive) {
+    return {
+      currentState,
+      outcome: "not-in-demo",
+      message:
+        "VAULTPILOT_DEMO is unset — the server is already in operational mode. " +
+        "If signing tools aren't working, the issue is likely missing Ledger pairing or " +
+        "missing RPC keys; run `vaultpilot-mcp-setup` to configure, then `pair_ledger_live` " +
+        "to pair your Ledger.",
+      whatYoullGain: [],
+      whatYoullLose: [],
+      preflightChecklist: [],
+      steps: [],
+      recommendedProviders: [],
+      copyPasteRecipe: null,
+      cautions: [],
+    };
+  }
+
+  // No Ledger yet — recommend deferring the exit.
+  if (args.hasLedger === false) {
+    return {
+      currentState,
+      outcome: "deferred-no-ledger",
+      message:
+        "Real signing requires a Ledger hardware wallet — VaultPilot is non-custodial and " +
+        "never holds private keys. Without a Ledger, exiting demo mode would leave you " +
+        "with read-only access (which you already have in demo). Recommendation: stay in " +
+        "demo mode, walk through more flows to evaluate, then come back to `exit_demo_mode` " +
+        "after you have a Ledger device. Supported devices: Nano S Plus, Nano X, Stax, Flex.",
+      whatYoullGain: [],
+      whatYoullLose: [],
+      preflightChecklist: [
+        {
+          item: "Acquire a Ledger device",
+          reason:
+            "Nano S Plus is the cheapest entry point (~$80). Stax / Flex are the touchscreen models. Buy ONLY from ledger.com — never from third-party resellers (compromised devices in the supply chain).",
+        },
+      ],
+      steps: [],
+      recommendedProviders: [],
+      copyPasteRecipe: null,
+      cautions: [
+        "Buy your Ledger directly from ledger.com. Third-party resellers have shipped pre-tampered devices in past incidents.",
+      ],
+    };
+  }
+
+  // Standard ready-to-exit path. `hasLedger` undefined or true falls
+  // here — when undefined, the response includes "verify Ledger first"
+  // language so the agent can confirm before walking the user through.
+  const chains: DemoExitChain[] =
+    args.chains && args.chains.length > 0 ? args.chains : ["ethereum"];
+  const recommendedProviders = collectProviders(chains);
+
+  const whatYoullGain = [
+    "Real signing — every prepare_* / send_transaction goes to your Ledger for physical approval.",
+    "Reads run against YOUR addresses (your paired Ledger accounts), not a curated persona's.",
+    "Persistent state — Ledger pairing, RPC keys, contacts, etc. all persist across MCP-server restarts via `~/.vaultpilot-mcp/config.json`.",
+    "`pair_ledger_*`, `sign_message_*`, `request_capability` all become available (gated in demo).",
+    "WalletConnect EVM signing via Ledger Live, USB-HID signing for Solana / TRON / BTC / LTC.",
+  ];
+  const whatYoullLose = [
+    "Simulated-broadcast safety net — typos and incorrect tx parameters now have real on-chain consequences.",
+    "The curated persona walkthrough (defi-power-user / stable-saver / staking-maxi / whale).",
+    "Auto-retry on the Helius nudge — once you exit, you must have a Solana RPC key (env var, config, or `set_helius_api_key` re-set per session) for usable Solana reads.",
+  ];
+
+  const preflightChecklist: { item: string; reason: string }[] = [];
+  if (args.hasLedger !== true) {
+    preflightChecklist.push({
+      item: "Confirm your Ledger device is plugged in and unlocked",
+      reason:
+        "Real signing requires the device to be reachable over USB-HID (Solana / TRON / BTC / LTC) or via Ledger Live (WalletConnect for EVM).",
+    });
+  }
+  if (chains.includes("solana")) {
+    preflightChecklist.push({
+      item: "Acquire a Helius API key",
+      reason:
+        "Public Solana RPC throttles within seconds of any real walkthrough — Helius free tier is essentially required.",
+    });
+  }
+  if (chains.some((c) => ["ethereum", "arbitrum", "polygon", "base", "optimism"].includes(c))) {
+    preflightChecklist.push({
+      item: "Acquire an Etherscan V2 API key",
+      reason:
+        "Required for `get_transaction_history`, `get_token_allowances`, `explain_tx`, address-poisoning scoring. Public Etherscan refuses unauthed V2 calls.",
+    });
+  }
+  preflightChecklist.push({
+    item: "Acquire a WalletConnect Project ID (EVM only)",
+    reason:
+      "Required for `pair_ledger_live` (the WalletConnect-based Ledger Live pairing flow). Free at https://cloud.walletconnect.com/.",
+  });
+
+  const steps: { step: number; action: string; command: string | null; note?: string }[] = [];
+  let stepNum = 1;
+  if (args.hasRunSetup !== true) {
+    steps.push({
+      step: stepNum++,
+      action:
+        "Run the setup wizard to configure RPC URLs + API keys + WalletConnect Project ID. " +
+        "Interactive — paste keys when prompted. State written to ~/.vaultpilot-mcp/config.json (mode 0600).",
+      command: "npx -y vaultpilot-mcp-setup",
+    });
+  } else {
+    steps.push({
+      step: stepNum++,
+      action:
+        "Setup config already exists at ~/.vaultpilot-mcp/config.json — re-run the setup wizard if you want to add more keys, otherwise skip this step.",
+      command: "npx -y vaultpilot-mcp-setup  # only if you want to update keys",
+      note: "Re-running is idempotent — existing keys are preserved unless you explicitly overwrite them.",
+    });
+  }
+  steps.push({
+    step: stepNum++,
+    action:
+      "Edit your `claude mcp add` entry to remove the `--env VAULTPILOT_DEMO=true` flag (or " +
+      "delete the entry and re-add without it). The MCP reads VAULTPILOT_DEMO at boot, so " +
+      "the change only takes effect after a restart.",
+    command: null,
+    note:
+      "You can also unset VAULTPILOT_DEMO globally in your shell if you prefer that pattern.",
+  });
+  steps.push({
+    step: stepNum++,
+    action:
+      "Restart Claude Code (or whatever MCP client you're using). On restart, the server " +
+      "boots in operational mode — every tool runs real, signing is live, demo state is gone.",
+    command: null,
+  });
+  steps.push({
+    step: stepNum++,
+    action:
+      "Pair your Ledger Live wallet for EVM signing. Keep your Ledger device unlocked and " +
+      "Ledger Live open on your desktop during pairing.",
+    command: "(call pair_ledger_live in your next conversation)",
+    note:
+      "For Solana / TRON, USB-HID pairing happens automatically on first signing call — no separate pair_ledger step needed.",
+  });
+
+  const copyPasteRecipe = buildClaudeMcpAddRecipe(chains);
+
+  const cautions = [
+    "Real transactions move real money. Always verify the decoded calldata + Ledger blind-sign hash before approving on-device.",
+    "VaultPilot is non-custodial — your private keys never leave the Ledger. The server never sees them, and no upstream service does either.",
+    "If anything looks off in the prepare-receipt block (recipient, amount, contract address), ABORT on the device. There's no recall once a tx is broadcast.",
+  ];
+  if (args.hasLedger !== true) {
+    cautions.unshift(
+      "Confirm with the user FIRST that they have a Ledger device. Without one, you cannot sign transactions and exiting demo gives you no functionality you don't already have.",
+    );
+  }
+
+  return {
+    currentState,
+    outcome: "ready-to-exit",
+    message:
+      `Demo mode is currently ${currentState.subMode === "live" ? `LIVE (persona: ${currentState.activePersonaId})` : "DEFAULT"}. ` +
+      `Exiting requires (a) running the setup wizard if you haven't already, (b) editing your MCP-client config to drop VAULTPILOT_DEMO=true, (c) restarting. ` +
+      `Walk the user through the steps below — pause after each step to confirm before proceeding.`,
+    whatYoullGain,
+    whatYoullLose,
+    preflightChecklist,
+    steps,
+    recommendedProviders,
+    copyPasteRecipe,
+    cautions,
+  };
+}
+
+function collectProviders(chains: DemoExitChain[]): ProviderRec[] {
+  const seen = new Set<string>();
+  const out: ProviderRec[] = [];
+  for (const chain of chains) {
+    const recs = PROVIDER_RECOMMENDATIONS[chain] ?? [];
+    for (const rec of recs) {
+      if (seen.has(rec.service)) continue;
+      seen.add(rec.service);
+      out.push(rec);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a copy-paste-ready `claude mcp add` line tailored to the user's
+ * chain selection. We surface the env-var slots the user will populate,
+ * not literal keys (which the user has separately and we don't see).
+ */
+function buildClaudeMcpAddRecipe(chains: DemoExitChain[]): string {
+  const envFlags: string[] = [];
+  if (chains.some((c) => ["ethereum", "arbitrum", "polygon", "base", "optimism"].includes(c))) {
+    envFlags.push("--env RPC_PROVIDER=alchemy");
+    envFlags.push("--env RPC_API_KEY=<your-alchemy-key>");
+    envFlags.push("--env ETHERSCAN_API_KEY=<your-etherscan-key>");
+  }
+  if (chains.includes("solana")) {
+    envFlags.push("--env SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=<your-helius-key>");
+  }
+  if (chains.includes("tron")) {
+    envFlags.push("--env TRON_API_KEY=<your-trongrid-key>");
+  }
+  envFlags.push("--env WALLETCONNECT_PROJECT_ID=<your-walletconnect-project-id>");
+  // Note: omit VAULTPILOT_DEMO entirely — its absence is the exit signal.
+  const indented = envFlags.length > 0 ? "\n  " + envFlags.join(" \\\n  ") + " \\\n  " : "";
+  return `claude mcp add vaultpilot-mcp ${indented}-- npx -y vaultpilot-mcp`;
+}

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -99,8 +99,10 @@ export function alwaysGatedRefusalMessage(toolName: string): string {
   return (
     `[VAULTPILOT_DEMO] '${toolName}' is unavailable in demo mode regardless of live-wallet ` +
     `state. This tool either writes persistent off-chain state (Ledger pairing, GitHub) or ` +
-    `requires a real Ledger device — neither has an on-chain simulation equivalent. To use ` +
-    `it, unset VAULTPILOT_DEMO and restart the MCP server with a real Ledger paired.`
+    `requires a real Ledger device — neither has an on-chain simulation equivalent. ` +
+    `Ready to leave demo and use this for real? Call \`exit_demo_mode\` for a tailored ` +
+    `step-by-step setup guide (asks about your Ledger + chain selection). Otherwise: unset ` +
+    `VAULTPILOT_DEMO and restart the MCP server with a real Ledger paired.`
   );
 }
 
@@ -115,7 +117,9 @@ export function defaultModeRefusalMessage(toolName: string): string {
     `\`set_demo_wallet({ persona: "<id>" })\` first to enable the simulated transaction ` +
     `flow. Available personas: defi-power-user, stable-saver, staking-maxi, whale. ` +
     `In default demo mode (no live wallet), only read tools and \`set_demo_wallet\` work — ` +
-    `signing-class tools refuse to avoid any chance of fake-signing or fake-broadcasting.`
+    `signing-class tools refuse to avoid any chance of fake-signing or fake-broadcasting. ` +
+    `If you'd rather leave demo entirely and use this tool against your real wallet, call ` +
+    `\`exit_demo_mode\` for a step-by-step setup guide.`
   );
 }
 

--- a/src/demo/schemas.ts
+++ b/src/demo/schemas.ts
@@ -32,3 +32,44 @@ export type SetDemoWalletArgs = z.infer<typeof setDemoWalletInput>;
 export const getDemoWalletInput = z.object({});
 
 export type GetDemoWalletArgs = z.infer<typeof getDemoWalletInput>;
+
+export const exitDemoModeInput = z.object({
+  hasLedger: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the user confirmed they have a Ledger device. Pass `false` to get a deferral message recommending they stay in demo until they have hardware. Omit if unknown — the response includes a 'verify Ledger first' caution.",
+    ),
+  hasRunSetup: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the user has previously run `vaultpilot-mcp-setup`. When true, the response skips the setup-wizard walkthrough.",
+    ),
+  chains: z
+    .array(
+      z.enum([
+        "ethereum",
+        "arbitrum",
+        "polygon",
+        "base",
+        "optimism",
+        "solana",
+        "tron",
+        "bitcoin",
+        "litecoin",
+      ]),
+    )
+    .optional()
+    .describe(
+      "Chains the user intends to use. Drives which RPC / API keys to recommend. Defaults to ['ethereum'] when omitted.",
+    ),
+  acquireKeys: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the user wants help acquiring API keys. Affects recommendation tone — true expands signup links, false keeps the response short.",
+    ),
+});
+
+export type ExitDemoModeArgs = z.infer<typeof exitDemoModeInput>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,11 @@ import { PERSONAS } from "./demo/personas.js";
 import {
   setDemoWalletInput,
   getDemoWalletInput,
+  exitDemoModeInput,
   type SetDemoWalletArgs,
+  type ExitDemoModeArgs,
 } from "./demo/schemas.js";
+import { buildExitDemoGuide } from "./demo/exit-flow.js";
 import {
   setHeliusApiKey,
   getRuntimeSolanaRpcStatus,
@@ -1280,6 +1283,12 @@ async function main() {
         "to surface the persona list, then `set_demo_wallet({ persona: \"...\" })` to upgrade to",
         "live mode. The agent CANNOT toggle VAULTPILOT_DEMO mid-session (MCP reads env at boot)",
         "but CAN toggle live-mode wallets at any time via `set_demo_wallet`.",
+        "When the user signals they want to LEAVE demo and switch to real-signing operational",
+        "mode (\"I have my Ledger now\", \"set this up for real\", \"exit demo\"), call",
+        "`exit_demo_mode` for a step-by-step setup guide. The tool is informational — it",
+        "doesn't actually unset VAULTPILOT_DEMO (which is impossible mid-process anyway), it",
+        "produces a tailored decision tree the agent walks the user through. ASK the user about",
+        "their Ledger + chain selection BEFORE calling so the response is targeted.",
         "",
         "HARD RULE — wallet enumeration: NEVER ask the user to paste a wallet address.",
         "If the user refers to their wallets collectively or positionally — \"my wallet\",",
@@ -4091,6 +4100,31 @@ async function main() {
           "persist across restarts, run `vaultpilot-mcp-setup` and pick \"Solana RPC URL\".",
       };
     })
+  );
+
+  // ---- Module 9d: Demo → operational handoff guide ----
+  registerTool(server,
+    "exit_demo_mode",
+    {
+      description:
+        "Build a step-by-step guide for the user to exit demo mode and switch to operational " +
+        "(real signing) mode. The MCP server CANNOT actually unset VAULTPILOT_DEMO or invoke " +
+        "the setup wizard — both require user action outside the MCP. This tool produces a " +
+        "tailored decision tree the agent walks the user through. Stateless / read-only — " +
+        "calling it does NOT change demo state. " +
+        "AGENT BEHAVIOR — call this tool ONLY after explicitly confirming with the user that " +
+        "they want to leave demo mode (e.g., 'I'm ready to set this up for real', 'I have my " +
+        "Ledger now', 'exit demo'). DO NOT call it as a probe — the response is verbose and " +
+        "presumes intent. Before calling, ASK the user: (1) do you have a Ledger device? " +
+        "(2) have you already run `vaultpilot-mcp-setup`? (3) which chains do you intend to " +
+        "use? Pass the answers as args so the response is tailored. " +
+        "If hasLedger=false, the response recommends DEFERRING the exit (without a Ledger, " +
+        "operational mode gives no functionality demo doesn't already have). Surface that " +
+        "verbatim. " +
+        "Outside demo mode, the tool returns a no-op response indicating there's nothing to exit.",
+      inputSchema: exitDemoModeInput.shape,
+    },
+    handler((args: ExitDemoModeArgs) => buildExitDemoGuide(args))
   );
 
   // ---- Module 10: Capability requests (agent → maintainers) ----

--- a/test/exit-demo-mode.test.ts
+++ b/test/exit-demo-mode.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the exit_demo_mode handoff guide (issue #371 follow-up — demo
+ * → operational mode switch). Covers the decision-tree branches:
+ *
+ *   - not in demo → no-op response
+ *   - hasLedger=false → deferral message
+ *   - hasLedger=true / undefined + various chain combos → tailored steps
+ *   - hasRunSetup=true → setup-wizard step is skipped / softened
+ *   - copy-paste recipe matches the chain selection
+ *   - cautions surface security warnings about real signing
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const ENV_KEY = "VAULTPILOT_DEMO";
+
+beforeEach(async () => {
+  delete process.env[ENV_KEY];
+  const { _resetLiveWalletForTests } = await import("../src/demo/live-mode.js");
+  _resetLiveWalletForTests();
+  const { _resetRuntimeRpcOverridesForTests } = await import(
+    "../src/data/runtime-rpc-overrides.js"
+  );
+  _resetRuntimeRpcOverridesForTests();
+});
+
+afterEach(async () => {
+  delete process.env[ENV_KEY];
+  const { _resetLiveWalletForTests } = await import("../src/demo/live-mode.js");
+  _resetLiveWalletForTests();
+  const { _resetRuntimeRpcOverridesForTests } = await import(
+    "../src/data/runtime-rpc-overrides.js"
+  );
+  _resetRuntimeRpcOverridesForTests();
+});
+
+describe("exit_demo_mode — outside demo", () => {
+  it("returns 'not-in-demo' outcome with a no-op-style message", async () => {
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({});
+    expect(r.outcome).toBe("not-in-demo");
+    expect(r.currentState.demoActive).toBe(false);
+    expect(r.message).toContain("VAULTPILOT_DEMO is unset");
+    expect(r.message).toContain("operational mode");
+    expect(r.steps).toEqual([]);
+    expect(r.copyPasteRecipe).toBeNull();
+  });
+});
+
+describe("exit_demo_mode — hasLedger=false → deferral", () => {
+  it("recommends staying in demo until the user has a Ledger", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: false });
+    expect(r.outcome).toBe("deferred-no-ledger");
+    expect(r.message).toContain("Real signing requires a Ledger");
+    expect(r.message).toContain("non-custodial");
+    // The deferral path includes a checklist item nudging the user to acquire one.
+    expect(r.preflightChecklist.length).toBeGreaterThan(0);
+    expect(r.preflightChecklist[0].item).toContain("Acquire a Ledger");
+    // And a security caution about supply-chain pre-tampering.
+    expect(r.cautions.join(" ")).toContain("ledger.com");
+  });
+});
+
+describe("exit_demo_mode — hasLedger=true → ready-to-exit", () => {
+  it("returns ready-to-exit with all sections populated when chains is omitted (defaults to ethereum)", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true });
+    expect(r.outcome).toBe("ready-to-exit");
+    expect(r.steps.length).toBeGreaterThan(0);
+    // Ethereum default → Etherscan + Infura/Alchemy recommendations surface.
+    const providerNames = r.recommendedProviders.map((p) => p.service).join(" ");
+    expect(providerNames).toContain("Etherscan");
+    expect(providerNames).toMatch(/Infura|Alchemy/);
+    // Steps include setup wizard (command field) + restart action.
+    const allActions = r.steps.map((s) => s.action).join(" ");
+    const allCommands = r.steps.map((s) => s.command ?? "").join(" ");
+    expect(allCommands).toContain("vaultpilot-mcp-setup");
+    expect(allActions).toContain("Restart Claude Code");
+    // Copy-paste recipe surfaces the EVM env-var slots.
+    expect(r.copyPasteRecipe).toContain("ETHERSCAN_API_KEY");
+    expect(r.copyPasteRecipe).toContain("WALLETCONNECT_PROJECT_ID");
+    expect(r.copyPasteRecipe).not.toContain("VAULTPILOT_DEMO");
+  });
+
+  it("includes Helius recommendation + SOLANA_RPC_URL slot when chains includes solana", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true, chains: ["solana", "ethereum"] });
+    expect(r.outcome).toBe("ready-to-exit");
+    const providerNames = r.recommendedProviders.map((p) => p.service).join(" ");
+    expect(providerNames).toContain("Helius");
+    expect(r.copyPasteRecipe).toContain("SOLANA_RPC_URL");
+    expect(r.copyPasteRecipe).toContain("helius-rpc.com");
+  });
+
+  it("includes TronGrid + TRON_API_KEY slot when chains includes tron", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true, chains: ["tron"] });
+    const providerNames = r.recommendedProviders.map((p) => p.service).join(" ");
+    expect(providerNames).toContain("TronGrid");
+    expect(r.copyPasteRecipe).toContain("TRON_API_KEY");
+  });
+
+  it("hasRunSetup=true softens the setup-wizard step rather than skipping it", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true, hasRunSetup: true });
+    const setupStep = r.steps.find((s) =>
+      s.action.includes("setup wizard") || s.action.includes("config already exists"),
+    );
+    expect(setupStep).toBeDefined();
+    expect(setupStep!.action).toContain("config already exists");
+    expect(setupStep!.note).toContain("idempotent");
+  });
+
+  it("hasRunSetup=false / undefined includes the full setup-wizard walkthrough", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true });
+    const setupStep = r.steps.find((s) =>
+      s.action.includes("setup wizard") || s.action.includes("Run the setup"),
+    );
+    expect(setupStep).toBeDefined();
+    expect(setupStep!.command).toContain("vaultpilot-mcp-setup");
+  });
+
+  it("hasLedger=undefined adds a 'verify Ledger first' checklist item + caution", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({});
+    expect(r.outcome).toBe("ready-to-exit");
+    const cklItems = r.preflightChecklist.map((c) => c.item).join(" ");
+    expect(cklItems).toContain("Confirm your Ledger");
+    expect(r.cautions[0]).toContain("Confirm with the user FIRST");
+  });
+
+  it("currentState reflects live-mode active status", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const { setLivePersona } = await import("../src/demo/live-mode.js");
+    setLivePersona("defi-power-user");
+    const r = buildExitDemoGuide({ hasLedger: true });
+    expect(r.currentState.subMode).toBe("live");
+    expect(r.currentState.activePersonaId).toBe("defi-power-user");
+    expect(r.message).toContain("LIVE");
+    expect(r.message).toContain("defi-power-user");
+  });
+
+  it("cautions cover real-money + Ledger-verification + non-custodial", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true });
+    const allCautions = r.cautions.join(" ");
+    expect(allCautions).toContain("Real transactions move real money");
+    expect(allCautions).toContain("non-custodial");
+    expect(allCautions).toMatch(/decoded calldata|prepare-receipt/);
+  });
+
+  it("whatYoullGain + whatYoullLose are non-empty arrays of human-readable strings", async () => {
+    process.env[ENV_KEY] = "true";
+    const { buildExitDemoGuide } = await import("../src/demo/exit-flow.js");
+    const r = buildExitDemoGuide({ hasLedger: true });
+    expect(r.whatYoullGain.length).toBeGreaterThan(0);
+    expect(r.whatYoullLose.length).toBeGreaterThan(0);
+    expect(r.whatYoullGain.join(" ")).toContain("Real signing");
+    expect(r.whatYoullLose.join(" ").toLowerCase()).toContain("simulated");
+  });
+});
+
+describe("exit_demo_mode — refusal messages reference exit_demo_mode (discoverability)", () => {
+  it("alwaysGatedRefusalMessage mentions exit_demo_mode", async () => {
+    const { alwaysGatedRefusalMessage } = await import("../src/demo/index.js");
+    const msg = alwaysGatedRefusalMessage("pair_ledger_solana");
+    expect(msg).toContain("exit_demo_mode");
+  });
+
+  it("defaultModeRefusalMessage mentions exit_demo_mode as the alternative path", async () => {
+    const { defaultModeRefusalMessage } = await import("../src/demo/index.js");
+    const msg = defaultModeRefusalMessage("prepare_native_send");
+    expect(msg).toContain("exit_demo_mode");
+    // Original set_demo_wallet path is still surfaced — the alternative.
+    expect(msg).toContain("set_demo_wallet");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last UX gap in the demo saga: a smooth way for users to leave demo and switch to real-signing operational mode. Today's exit path (unset env + restart + run setup + pair Ledger) is multi-step and undocumented in-tool.

## New tool

\`exit_demo_mode({ hasLedger?, hasRunSetup?, chains?, acquireKeys? })\` — stateless / read-only. The MCP cannot actually unset its own \`VAULTPILOT_DEMO\` (read at boot) or invoke the setup wizard (separate interactive binary). The tool's job is to **guide the agent to guide the user** through the steps.

## Decision tree

- **Outside demo** → \`not-in-demo\` outcome, no-op message.
- **\`hasLedger=false\`** → \`deferred-no-ledger\` outcome. Recommends staying in demo until the user has hardware. Without a Ledger, exiting gives no functionality demo doesn't already have.
- **\`hasLedger=true\` / undefined** → \`ready-to-exit\` outcome with:
  - preflight checklist (Ledger device, RPC keys, WalletConnect Project ID per chain)
  - ordered steps (run setup wizard → edit \`claude mcp add\` → restart → pair Ledger)
  - per-chain provider recommendations (Helius for Solana, Etherscan V2 for EVM, TronGrid, etc.)
  - **copy-paste \`claude mcp add\` recipe** with all relevant \`--env\` slots filled in
  - cautions about real-money signing + non-custodial trust model
- **\`hasRunSetup=true\`** softens the setup-wizard step (re-running is idempotent).

## Per-chain recommendations

| Chain | Provider | Why |
|---|---|---|
| EVM | Infura/Alchemy + Etherscan V2 + WalletConnect Project ID | RPC + tx history + EVM signing pairing |
| Solana | Helius | public RPC throttles within seconds |
| TRON | TronGrid | unauthed throttles to ~15 req/min |
| BTC / LTC | public Esplora | generous limits, no signup needed |

## Refusal-message discoverability

Both \`alwaysGatedRefusalMessage\` and \`defaultModeRefusalMessage\` now mention \`exit_demo_mode\` so users hitting the demo wall have a discoverable path forward. \`set_demo_wallet\` stays in the default-mode message as the alternative (stay in demo with a persona vs. leave demo entirely).

## Agent behavior locked in

Tool description + server-level \`instructions\` block both direct the agent to: (1) **confirm with the user** before calling, (2) ask about Ledger + chain selection BEFORE calling so the response is tailored, (3) **never call as a probe** — the response is verbose and presumes intent.

## Tests (13 new)

All decision-tree branches: outside-demo, deferral, ready-to-exit (per-chain combos, with/without setup, with/without Ledger), live-mode currentState, recipe-shape, refusal-message discoverability.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1878 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)