### PR TITLE
feat(demo): generalize runtime-override + nudge, add set_etherscan_api_key

### DIFF
--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, lstatSync, cpSync }
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import type { UserConfig } from "../types/index.js";
+import { getRuntimeOverride } from "../data/runtime-rpc-overrides.js";
 
 // Pre-rename path. We still read from here if the new dir doesn't exist, and
 // copy the legacy dir on first write so existing users keep their WC pairing
@@ -142,8 +143,13 @@ export function getConfigPath(): string {
   return join(getConfigDir(), "config.json");
 }
 
-/** Pull the Etherscan API key from env (highest priority) or user config. */
+/** Pull the Etherscan API key from runtime override (highest), env, or user config. */
 export function resolveEtherscanApiKey(userConfig: UserConfig | null): string | undefined {
+  // Issue #371 follow-up: a runtime override (set via `set_etherscan_api_key`
+  // in demo mode) takes precedence over env/config — lets agents inject
+  // a key mid-session without restarting the MCP.
+  const override = getRuntimeOverride("etherscan");
+  if (override) return override;
   return process.env.ETHERSCAN_API_KEY || userConfig?.etherscanApiKey;
 }
 

--- a/src/data/apis/etherscan-v2.ts
+++ b/src/data/apis/etherscan-v2.ts
@@ -2,6 +2,7 @@ import { CHAIN_IDS } from "../../types/index.js";
 import type { SupportedChain } from "../../types/index.js";
 import { resolveEtherscanApiKey, readUserConfig } from "../../config/user-config.js";
 import { fetchWithTimeout } from "../http.js";
+import { recordPublicError } from "../runtime-rpc-overrides.js";
 
 /**
  * Etherscan V2 unified client.
@@ -61,7 +62,14 @@ export async function etherscanV2Fetch<T>(
   params: Record<string, string>
 ): Promise<T[]> {
   const apiKey = resolveEtherscanApiKey(readUserConfig());
-  if (!apiKey) throw new EtherscanApiKeyMissingError();
+  if (!apiKey) {
+    // Demo-mode nudge counter (issue #371 follow-up). Increment BEFORE
+    // throwing so the nudge surfaces on the failing tool's response.
+    // No-op outside demo mode (the counter only matters when the user
+    // is in evaluation mode and has no key set).
+    recordPublicError("etherscan");
+    throw new EtherscanApiKeyMissingError();
+  }
 
   const qs = new URLSearchParams({
     chainid: String(CHAIN_IDS[chain]),
@@ -119,7 +127,10 @@ export async function getEtherscanProxyPendingNonce(
   address: `0x${string}`,
 ): Promise<number> {
   const apiKey = resolveEtherscanApiKey(readUserConfig());
-  if (!apiKey) throw new EtherscanApiKeyMissingError();
+  if (!apiKey) {
+    recordPublicError("etherscan");
+    throw new EtherscanApiKeyMissingError();
+  }
   const qs = new URLSearchParams({
     chainid: String(CHAIN_IDS[chain]),
     module: "proxy",

--- a/src/data/runtime-rpc-overrides-schemas.ts
+++ b/src/data/runtime-rpc-overrides-schemas.ts
@@ -1,7 +1,7 @@
 /**
- * Zod input schema for `set_helius_api_key`. Lives in a sibling file so
- * src/index.ts stays free of inline zod definitions (matches the
- * convention every other module follows).
+ * Zod input schemas for the runtime API-key tools. Lives in a sibling
+ * file so src/index.ts stays free of inline zod definitions (matches
+ * the convention every other module follows).
  */
 
 import { z } from "zod";
@@ -19,3 +19,17 @@ export const setHeliusApiKeyInput = z.object({
 });
 
 export type SetHeliusApiKeyArgs = z.infer<typeof setHeliusApiKeyInput>;
+
+export const setEtherscanApiKeyInput = z.object({
+  apiKey: z
+    .string()
+    .min(1)
+    .describe(
+      "Etherscan V2 API key (34-char alphanumeric, e.g. ZQTKPM98R5N4YT8GMTBI3XR2P4HFZNTAYG). " +
+        "Get one for free at https://etherscan.io/myapikey. One key works across all 5 " +
+        "supported EVM chains via the V2 unified API. Stored in process memory only — " +
+        "survives until the MCP server restarts.",
+    ),
+});
+
+export type SetEtherscanApiKeyArgs = z.infer<typeof setEtherscanApiKeyInput>;

--- a/src/data/runtime-rpc-overrides.ts
+++ b/src/data/runtime-rpc-overrides.ts
@@ -1,169 +1,284 @@
 /**
- * Process-local runtime overrides for chain RPC endpoints. Currently
- * Solana-only — purpose-built for the Helius nudge in demo mode (issue
- * #371 follow-up): when a user hits public-fallback Solana RPC errors
- * during demo mode, the agent can call `set_helius_api_key` to inject a
- * Helius URL for the rest of the process lifetime without restarting.
+ * Process-local runtime overrides for chain RPC + 3rd-party API endpoints.
+ * Shipped originally as Helius-only at PR #383 (issue #371 follow-up); PR
+ * (this) generalizes the mechanism to support multiple services with a
+ * per-service config map.
  *
- * Override precedence (Solana resolver checks these in order):
- *   1. Runtime override (this module) — set via `set_helius_api_key`.
- *   2. SOLANA_RPC_URL env var.
- *   3. `userConfig.solanaRpcUrl`.
- *   4. Public fallback (rate-limited).
+ * Two responsibilities:
  *
- * State is module-local and ephemeral — a process restart resets to
- * env/config/public. Mirrors the demo live-mode design: demo state lives
- * only as long as the process. To persist a Helius key, run
- * `vaultpilot-mcp-setup` and pick "Solana RPC URL".
+ *   1. Override store — when an agent calls `set_<service>_api_key`,
+ *      the validated key is held in process memory and takes precedence
+ *      over env / userConfig / public-fallback resolution. Survives
+ *      until the MCP server restarts. To persist, the user runs
+ *      `vaultpilot-mcp-setup`.
  *
- * Also tracks Solana public-fallback error count for the auto-nudge:
- * every 10th error trips a `pendingHeliusNudge` flag that the
- * registerTool wrapper picks up and prepends to the next tool response.
- * Counter resets when an override is set.
+ *   2. Public-error counter + nudge — every public-fallback failure
+ *      increments a per-service counter; when the counter hits 1 (first
+ *      error of the session) or any multiple of 10, the next tool
+ *      response gets a structured nudge prepended directing the user to
+ *      the relevant `set_<service>_api_key` tool. Counter resets when
+ *      a key is set.
+ *
+ * Backward-compat shims (`setHeliusApiKey`, `consumePendingHeliusNudge`,
+ * etc.) preserve the surface from PR #383 — call sites in src/index.ts
+ * and src/modules/solana/rpc.ts are unchanged.
  */
 
-const HELIUS_MAINNET_URL_PREFIX = "https://mainnet.helius-rpc.com/?api-key=";
+export type ServiceId = "helius" | "etherscan";
+
+interface ServiceConfig {
+  id: ServiceId;
+  /** Display name for diagnostic surfaces + nudge prose. */
+  displayName: string;
+  /** Validation regex for the bare API key. Per-provider — formats differ. */
+  keyPattern: RegExp;
+  /** Human-readable hint for what the key shape should look like. */
+  keyFormatHint: string;
+  /**
+   * Construct the resolved value from a validated bare API key. Helius
+   * wraps the key in a URL (https://mainnet.helius-rpc.com/?api-key=KEY).
+   * Etherscan uses the bare key as-is in query params, so identity here.
+   */
+  buildResolvedValue: (apiKey: string) => string;
+  /** Signup URL surfaced in the nudge text. */
+  signupUrl: string;
+  /** Build the nudge block (markdown) given the current error count. */
+  renderNudge: (errorCount: number) => string;
+}
+
+/** Helius UUID format: 8-4-4-4-12 hex chars dash-separated. */
+const HELIUS_KEY_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 /**
- * Helius API keys are UUIDs (8-4-4-4-12 hex chars, dash-separated).
- * Validating the format prevents (a) accidental URL pastes, (b) prompt
- * injection where an attacker tries to redirect the Solana RPC to a
- * malicious endpoint by passing a full URL.
+ * Etherscan keys are 34-char strings of mixed upper-case alphanumerics.
+ * Example: ZQTKPM98R5N4YT8GMTBI3XR2P4HFZNTAYG. Etherscan accepts lower-case
+ * too in practice, so we normalize the regex to `[A-Za-z0-9]{34}` while
+ * preserving the user's original casing in the stored value.
  */
-const HELIUS_API_KEY_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const ETHERSCAN_KEY_PATTERN = /^[A-Za-z0-9]{34}$/;
 
-interface SolanaOverride {
+const SERVICE_CONFIGS: Record<ServiceId, ServiceConfig> = {
+  helius: {
+    id: "helius",
+    displayName: "Helius (Solana RPC)",
+    keyPattern: HELIUS_KEY_PATTERN,
+    keyFormatHint:
+      "UUID format: 8-4-4-4-12 hex chars (e.g. b7d6f3a1-1234-5678-9abc-def012345678)",
+    buildResolvedValue: (apiKey) =>
+      `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
+    signupUrl: "https://dashboard.helius.dev/",
+    renderNudge: (errorCount) =>
+      `[VAULTPILOT_DEMO — Helius setup nudge]\n\n` +
+      `Public Solana RPC has hit ${errorCount} rate-limit error${errorCount === 1 ? "" : "s"} this session. ` +
+      `Public Solana endpoints throttle aggressively under any real walkthrough.\n\n` +
+      `Free Helius API key takes 60 seconds:\n` +
+      `  1. Open [Helius dashboard](https://dashboard.helius.dev/) — sign in with GitHub or email.\n` +
+      `  2. Dashboard auto-creates a default API key on first login. Copy it (UUID format: 8-4-4-4-12 hex).\n` +
+      `  3. Paste the key into chat. The agent will call \`set_helius_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
+      `The key is held in process memory only — survives until the MCP server restarts. ` +
+      `To persist across restarts, exit demo mode (unset VAULTPILOT_DEMO + restart) and run ` +
+      `\`vaultpilot-mcp-setup\` to save the key to ~/.vaultpilot-mcp/config.json.`,
+  },
+  etherscan: {
+    id: "etherscan",
+    displayName: "Etherscan V2 (EVM tx history + allowances)",
+    keyPattern: ETHERSCAN_KEY_PATTERN,
+    keyFormatHint: "34-char alphanumeric (uppercase + digits, no dashes)",
+    // Etherscan uses the key as-is in query params; identity transform.
+    buildResolvedValue: (apiKey) => apiKey,
+    signupUrl: "https://etherscan.io/myapikey",
+    renderNudge: (errorCount) =>
+      `[VAULTPILOT_DEMO — Etherscan setup nudge]\n\n` +
+      `Etherscan V2 has rejected ${errorCount} call${errorCount === 1 ? "" : "s"} this session. ` +
+      `Etherscan refuses unauthed multi-chain V2 calls — every \`get_transaction_history\`, ` +
+      `\`get_token_allowances\`, \`explain_tx\`, and address-poisoning scoring call needs a key.\n\n` +
+      `Free Etherscan key takes 60 seconds:\n` +
+      `  1. Open [Etherscan API dashboard](https://etherscan.io/myapikey) — sign in.\n` +
+      `  2. Click "Add" to create a new API key. Copy it (34-char alphanumeric).\n` +
+      `  3. Paste into chat. The agent will call \`set_etherscan_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
+      `Free tier covers personal-volume use comfortably (5 calls/sec, 100K calls/day). ` +
+      `One key works across Ethereum / Arbitrum / Polygon / Base / Optimism via the V2 unified API. ` +
+      `The key is held in process memory only — survives until the MCP server restarts. ` +
+      `To persist, run \`vaultpilot-mcp-setup\` and save it to ~/.vaultpilot-mcp/config.json.`,
+  },
+};
+
+interface OverrideState {
   apiKey: string;
-  url: string;
+  resolvedValue: string;
   setAt: number;
 }
 
-let solanaOverride: SolanaOverride | null = null;
-let solanaPublicErrorCount = 0;
-let pendingHeliusNudge = false;
+const overrides = new Map<ServiceId, OverrideState>();
+const errorCounts = new Map<ServiceId, number>();
+const pendingNudges = new Set<ServiceId>();
 
 /**
- * Validates and stores a Helius API key. Constructs the canonical
- * Helius mainnet URL internally — callers pass the bare key (matches
- * the dashboard copy-paste UX). Throws on malformed keys rather than
- * silently storing garbage.
+ * Validate + store an API key for the given service. Throws on
+ * malformed input rather than storing garbage. Side effects: resets
+ * the per-service error counter + clears any pending nudge for this
+ * service (the user has acted on the recommendation).
  */
-export function setHeliusApiKey(apiKey: string): { url: string; setAt: number } {
+export function setRuntimeOverride(
+  service: ServiceId,
+  apiKey: string,
+): { resolvedValue: string; setAt: number; apiKeySuffix: string } {
+  const cfg = SERVICE_CONFIGS[service];
   if (typeof apiKey !== "string" || apiKey.length === 0) {
     throw new Error(
-      "[VAULTPILOT] set_helius_api_key: apiKey must be a non-empty string. " +
-        "Copy the key from https://dashboard.helius.dev/api-keys (looks like a UUID).",
+      `[VAULTPILOT] set_${service}_api_key: apiKey must be a non-empty string. ` +
+        `Get one at ${cfg.signupUrl}.`,
     );
   }
   if (apiKey.includes("://") || apiKey.startsWith("http")) {
     throw new Error(
-      "[VAULTPILOT] set_helius_api_key: pass the bare API key, not a URL. " +
-        "The server constructs the canonical Helius mainnet URL internally.",
+      `[VAULTPILOT] set_${service}_api_key: pass the bare API key, not a URL. ` +
+        `The server constructs any required URL internally.`,
     );
   }
-  if (!HELIUS_API_KEY_PATTERN.test(apiKey)) {
+  if (!cfg.keyPattern.test(apiKey)) {
     throw new Error(
-      "[VAULTPILOT] set_helius_api_key: apiKey doesn't match the Helius UUID format " +
-        "(8-4-4-4-12 hex chars, e.g. b7d6f3a1-1234-5678-9abc-def012345678). " +
-        "Double-check the value you copied from https://dashboard.helius.dev/api-keys.",
+      `[VAULTPILOT] set_${service}_api_key: apiKey doesn't match the expected ` +
+        `${cfg.displayName} format (${cfg.keyFormatHint}). Double-check what you ` +
+        `copied from ${cfg.signupUrl}.`,
     );
   }
-  const url = `${HELIUS_MAINNET_URL_PREFIX}${apiKey}`;
+  const resolvedValue = cfg.buildResolvedValue(apiKey);
   const setAt = Date.now();
-  solanaOverride = { apiKey, url, setAt };
-  // Setting an override resets the error counter + clears any pending
-  // nudge — the user has acted on the recommendation, no need to nag.
-  solanaPublicErrorCount = 0;
-  pendingHeliusNudge = false;
-  return { url, setAt };
+  overrides.set(service, { apiKey, resolvedValue, setAt });
+  errorCounts.set(service, 0);
+  pendingNudges.delete(service);
+  return { resolvedValue, setAt, apiKeySuffix: apiKey.slice(-4) };
 }
 
-/** Returns the override URL if set, else null. */
-export function getRuntimeSolanaRpc(): string | null {
-  return solanaOverride === null ? null : solanaOverride.url;
+/** Returns the resolved value (URL for Helius, bare key for Etherscan) or null. */
+export function getRuntimeOverride(service: ServiceId): string | null {
+  return overrides.get(service)?.resolvedValue ?? null;
 }
 
 /**
- * Returns a redacted view of the override for diagnostic surfaces.
- * NEVER returns the raw API key — only the last 4 chars + setAt.
- * Mirrors the strict no-secrets contract on get_vaultpilot_config_status.
+ * Redacted status for diagnostic surfaces. Returns last-4 of the API
+ * key + setAt; NEVER the raw key. Mirrors the strict no-secrets contract
+ * on get_vaultpilot_config_status.
  */
+export function getRuntimeOverrideStatus(service: ServiceId): {
+  active: boolean;
+  apiKeySuffix?: string;
+  setAt?: number;
+} {
+  const o = overrides.get(service);
+  if (o === undefined) return { active: false };
+  return { active: true, apiKeySuffix: o.apiKey.slice(-4), setAt: o.setAt };
+}
+
+/** Clears the runtime override for one service. */
+export function clearRuntimeOverride(service: ServiceId): void {
+  overrides.delete(service);
+}
+
+/**
+ * Increment the per-service error counter and check the nudge threshold.
+ * Cadence: nudge fires on the FIRST error (count 1) and every multiple
+ * of 10 thereafter (10, 20, 30, ...). First-error nudge gives immediate
+ * feedback for services that fail 100% of the time without a key
+ * (Etherscan); the every-10 cadence handles services that throttle
+ * gracefully (Helius/Solana — most calls succeed but slowly).
+ *
+ * No-op when an override is set — overrides bypass the public-fallback
+ * path entirely, and keyed traffic shouldn't trigger the nudge.
+ */
+export function recordPublicError(service: ServiceId): void {
+  if (overrides.has(service)) return;
+  const next = (errorCounts.get(service) ?? 0) + 1;
+  errorCounts.set(service, next);
+  if (next === 1 || next % 10 === 0) {
+    pendingNudges.add(service);
+  }
+}
+
+/** Read-only counter accessor for tests + diagnostic surfaces. */
+export function getPublicErrorCount(service: ServiceId): number {
+  return errorCounts.get(service) ?? 0;
+}
+
+/**
+ * Pop-style accessor: if a nudge is pending for this service, return
+ * the rendered text and clear the flag. Used directly by tests + the
+ * Helius backward-compat shim.
+ */
+export function consumePendingNudge(service: ServiceId): string | null {
+  if (!pendingNudges.has(service)) return null;
+  pendingNudges.delete(service);
+  const cfg = SERVICE_CONFIGS[service];
+  const count = errorCounts.get(service) ?? 0;
+  return cfg.renderNudge(count);
+}
+
+/**
+ * Consume ALL pending nudges across services, in registration order.
+ * The registerTool wrapper calls this once per tool response (instead
+ * of per-service consumePendingNudge calls), so a session that has
+ * tripped both Helius and Etherscan thresholds gets both nudges on
+ * the next response.
+ */
+export function consumeAllPendingNudges(): { service: ServiceId; nudge: string }[] {
+  const out: { service: ServiceId; nudge: string }[] = [];
+  for (const service of Object.keys(SERVICE_CONFIGS) as ServiceId[]) {
+    const nudge = consumePendingNudge(service);
+    if (nudge !== null) out.push({ service, nudge });
+  }
+  return out;
+}
+
+// ============================================================================
+// Backward-compat shims for the Helius/Solana surface from PR #383.
+// Existing call sites in src/index.ts + src/modules/solana/rpc.ts +
+// src/config/chains.ts + src/modules/diagnostics/index.ts are unchanged.
+// ============================================================================
+
+/** @deprecated Use `setRuntimeOverride("helius", apiKey)`. Retained for the existing tool-call surface. */
+export function setHeliusApiKey(apiKey: string): { url: string; setAt: number } {
+  const r = setRuntimeOverride("helius", apiKey);
+  return { url: r.resolvedValue, setAt: r.setAt };
+}
+
+/** @deprecated Use `getRuntimeOverride("helius")`. */
+export function getRuntimeSolanaRpc(): string | null {
+  return getRuntimeOverride("helius");
+}
+
+/** @deprecated Use `getRuntimeOverrideStatus("helius")`. */
 export function getRuntimeSolanaRpcStatus(): {
   active: boolean;
   apiKeySuffix?: string;
   setAt?: number;
 } {
-  if (solanaOverride === null) return { active: false };
-  return {
-    active: true,
-    apiKeySuffix: solanaOverride.apiKey.slice(-4),
-    setAt: solanaOverride.setAt,
-  };
+  return getRuntimeOverrideStatus("helius");
 }
 
-/** Clears the runtime override, returning to env/config/public-fallback. */
+/** @deprecated Use `clearRuntimeOverride("helius")`. */
 export function clearRuntimeSolanaRpc(): void {
-  solanaOverride = null;
+  clearRuntimeOverride("helius");
 }
 
-/**
- * Increment the Solana-public-error counter and check the nudge
- * threshold. Called from `fetchWithRateLimitDetect` whenever the public
- * Solana RPC returns 429 (or other non-success). When a runtime override
- * is set, this is a no-op — overrides bypass the public-fallback path
- * entirely, and the counter doesn't increment for keyed traffic.
- *
- * Threshold: every 10th error fires the nudge (i.e., count % 10 === 0).
- * Reset when `setHeliusApiKey` is called.
- */
+/** @deprecated Use `recordPublicError("helius")`. */
 export function recordSolanaPublicError(): void {
-  if (solanaOverride !== null) return;
-  solanaPublicErrorCount += 1;
-  if (solanaPublicErrorCount % 10 === 0) {
-    pendingHeliusNudge = true;
-  }
+  recordPublicError("helius");
 }
 
-/** Read-only counter accessor for tests + diagnostic surfaces. */
+/** @deprecated Use `getPublicErrorCount("helius")`. */
 export function getSolanaPublicErrorCount(): number {
-  return solanaPublicErrorCount;
+  return getPublicErrorCount("helius");
 }
 
-/**
- * Pop-style accessor: if the nudge flag is set, return the canned text
- * and clear the flag (so it appears on exactly one tool response per
- * threshold crossing). The registerTool wrapper calls this after every
- * tool response and prepends the result if non-null.
- */
+/** @deprecated Use `consumePendingNudge("helius")`. */
 export function consumePendingHeliusNudge(): string | null {
-  if (!pendingHeliusNudge) return null;
-  pendingHeliusNudge = false;
-  return renderHeliusNudge(solanaPublicErrorCount);
-}
-
-/**
- * Build the agent-facing nudge block. Pulled out for testability — same
- * text every time a nudge fires, parameterized only by the error count
- * so the user sees "we've hit 10 errors", "we've hit 20 errors", etc.
- */
-function renderHeliusNudge(errorCount: number): string {
-  return (
-    `[VAULTPILOT_DEMO — Helius setup nudge]\n\n` +
-    `Public Solana RPC has hit ${errorCount} rate-limit errors this session. ` +
-    `It will only get worse — public Solana endpoints throttle aggressively under any real walkthrough.\n\n` +
-    `Free Helius API key takes 60 seconds:\n` +
-    `  1. Open [Helius dashboard](https://dashboard.helius.dev/) — sign in with GitHub or email.\n` +
-    `  2. Dashboard auto-creates a default API key on first login. Copy it (UUID format: 8-4-4-4-12 hex).\n` +
-    `  3. Paste the key into chat. The agent will call \`set_helius_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
-    `The key is held in process memory only — survives until the MCP server restarts. ` +
-    `To persist across restarts, exit demo mode (unset VAULTPILOT_DEMO + restart) and run ` +
-    `\`vaultpilot-mcp-setup\` to save the key to ~/.vaultpilot-mcp/config.json.`
-  );
+  return consumePendingNudge("helius");
 }
 
 /** Test-only: reset all module state between tests. */
 export function _resetRuntimeRpcOverridesForTests(): void {
-  solanaOverride = null;
-  solanaPublicErrorCount = 0;
-  pendingHeliusNudge = false;
+  overrides.clear();
+  errorCounts.clear();
+  pendingNudges.clear();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,15 @@ import { buildExitDemoGuide } from "./demo/exit-flow.js";
 import {
   setHeliusApiKey,
   getRuntimeSolanaRpcStatus,
-  consumePendingHeliusNudge,
+  setRuntimeOverride,
+  getRuntimeOverrideStatus,
+  consumeAllPendingNudges,
 } from "./data/runtime-rpc-overrides.js";
 import {
   setHeliusApiKeyInput,
+  setEtherscanApiKeyInput,
   type SetHeliusApiKeyArgs,
+  type SetEtherscanApiKeyArgs,
 } from "./data/runtime-rpc-overrides-schemas.js";
 
 import {
@@ -791,14 +795,14 @@ function handler<T, R>(
       for (const block of await collectVerificationBlocks(result)) {
         content.push({ type: "text", text: block });
       }
-      // Helius setup nudge — fires every 10th public-Solana-RPC error in
-      // demo mode. Pop-and-clear so it appears on exactly one response per
-      // threshold crossing. No-op outside demo mode (the error counter
-      // never increments without VAULTPILOT_DEMO since the nudge is
-      // demo-specific UX — but the consumer guard double-checks).
+      // Setup nudges (Helius / Etherscan) — fire on first public-fallback
+      // error of the session and every 10th thereafter. Pop-and-clear so
+      // each nudge appears on exactly one response per threshold crossing.
+      // No-op outside demo mode.
       if (isDemoMode()) {
-        const nudge = consumePendingHeliusNudge();
-        if (nudge) content.push({ type: "text", text: nudge });
+        for (const { nudge } of consumeAllPendingNudges()) {
+          content.push({ type: "text", text: nudge });
+        }
       }
       return { content };
     } catch (error) {
@@ -810,14 +814,14 @@ function handler<T, R>(
       const errorContent: { type: "text"; text: string }[] = [
         { type: "text" as const, text: `Error: ${safeErrorMessage(error)}` },
       ];
-      // Surface the Helius nudge on the failing call too — when the
-      // 10th public-Solana-RPC 429 trips the threshold, the same call
-      // is what's failing. Showing the nudge on the error response
-      // gives the user an immediate path forward rather than waiting
-      // for a successful next call to surface it.
+      // Surface setup nudges on the failing call too — when the
+      // threshold trips, the call that failed is the one the user
+      // wants help on. Showing the nudge here gives an immediate path
+      // forward rather than waiting for a successful next call.
       if (isDemoMode()) {
-        const nudge = consumePendingHeliusNudge();
-        if (nudge) errorContent.push({ type: "text", text: nudge });
+        for (const { nudge } of consumeAllPendingNudges()) {
+          errorContent.push({ type: "text", text: nudge });
+        }
       }
       return {
         content: errorContent,
@@ -4098,6 +4102,45 @@ async function main() {
           "Helius API key set. All subsequent Solana reads use the Helius mainnet endpoint " +
           "for the rest of this MCP-server process. The key is held in memory only — to " +
           "persist across restarts, run `vaultpilot-mcp-setup` and pick \"Solana RPC URL\".",
+      };
+    })
+  );
+
+  registerTool(server,
+    "set_etherscan_api_key",
+    {
+      description:
+        "Set an Etherscan V2 API key for EVM transaction-history / allowance-enumeration / " +
+        "tx-explanation reads at runtime — no restart required. Takes precedence over " +
+        "ETHERSCAN_API_KEY env var and userConfig. One key works across all 5 supported EVM " +
+        "chains (Ethereum / Arbitrum / Polygon / Base / Optimism) via Etherscan's V2 unified " +
+        "API. Designed for the demo-mode flow where users want to enable tx-history / " +
+        "allowance / explain_tx tools without restarting their MCP client, but works in any " +
+        "mode. " +
+        "INPUT: bare API key only (34-char alphanumeric, e.g. ZQTKPM98R5N4YT8GMTBI3XR2P4HFZNTAYG). " +
+        "Pasting a URL is rejected to prevent prompt-injection redirects. " +
+        "WHERE TO GET ONE: https://etherscan.io/myapikey — sign in, click \"Add\", copy the " +
+        "key. Free tier covers personal-volume use comfortably (5 calls/sec, 100K calls/day). " +
+        "PERSISTENCE: process memory only. To save across restarts, run `vaultpilot-mcp-setup` " +
+        "(after exiting demo mode if applicable) and paste the same key when prompted. " +
+        "AGENT BEHAVIOR: when the user pastes a key in chat ('here's my Etherscan key: <34 " +
+        "chars>'), call this tool immediately. NEVER echo the key back in any subsequent " +
+        "response — treat it as secret-shaped.",
+      inputSchema: setEtherscanApiKeyInput.shape,
+    },
+    handler((args: SetEtherscanApiKeyArgs) => {
+      const r = setRuntimeOverride("etherscan", args.apiKey);
+      const status = getRuntimeOverrideStatus("etherscan");
+      return {
+        ok: true,
+        source: "runtime-override",
+        apiKeySuffix: status.apiKeySuffix,
+        setAt: r.setAt,
+        message:
+          "Etherscan V2 API key set. All subsequent EVM tx-history / allowance / explain_tx " +
+          "calls use this key for the rest of this MCP-server process. The key is held in " +
+          "memory only — to persist across restarts, run `vaultpilot-mcp-setup` and paste " +
+          "the same key when prompted.",
       };
     })
   );

--- a/test/runtime-rpc-overrides.test.ts
+++ b/test/runtime-rpc-overrides.test.ts
@@ -49,14 +49,14 @@ describe("setHeliusApiKey — input validation", () => {
   });
 
   it("rejects malformed UUIDs", () => {
-    expect(() => setHeliusApiKey("not-a-uuid")).toThrow(/Helius UUID format/);
+    expect(() => setHeliusApiKey("not-a-uuid")).toThrow(/UUID format/);
     expect(() => setHeliusApiKey("12345678-1234-1234-1234-12345678")).toThrow(
-      /Helius UUID format/,
+      /UUID format/,
     );
     expect(() =>
       // wrong segment lengths
       setHeliusApiKey("12345678-1234-1234-1234-1234567890ab-extra"),
-    ).toThrow(/Helius UUID format/);
+    ).toThrow(/UUID format/);
   });
 });
 
@@ -110,35 +110,47 @@ describe("Solana public-error counter — tracks exactly when no override is set
   });
 });
 
-describe("Helius nudge — fires every 10th public error, clears on consume", () => {
-  it("does NOT fire on counts 1-9", () => {
-    for (let i = 0; i < 9; i++) recordSolanaPublicError();
+describe("Helius nudge — fires on first error + every 10th thereafter", () => {
+  it("fires on count 1 (first error of the session)", () => {
+    recordSolanaPublicError();
+    const nudge = consumePendingHeliusNudge();
+    expect(nudge).not.toBeNull();
+    // Mentions the count so the user sees how often they've been throttled.
+    // Singular form on count 1 (no trailing 's').
+    expect(nudge!).toContain("hit 1 rate-limit error");
+  });
+
+  it("does NOT re-fire on counts 2-9 after the first nudge has been consumed", () => {
+    recordSolanaPublicError();
+    consumePendingHeliusNudge(); // pop the count=1 nudge
+    for (let i = 0; i < 8; i++) recordSolanaPublicError(); // counts 2..9
     expect(consumePendingHeliusNudge()).toBeNull();
   });
 
-  it("fires on count 10", () => {
-    for (let i = 0; i < 10; i++) recordSolanaPublicError();
+  it("re-fires on count 10 after the count=1 nudge was consumed", () => {
+    recordSolanaPublicError();
+    consumePendingHeliusNudge();
+    for (let i = 0; i < 9; i++) recordSolanaPublicError(); // brings to 10
     const nudge = consumePendingHeliusNudge();
     expect(nudge).not.toBeNull();
     expect(nudge!).toContain("VAULTPILOT_DEMO");
     expect(nudge!).toContain("Helius");
     expect(nudge!).toContain("set_helius_api_key");
     expect(nudge!).toContain("dashboard.helius.dev");
-    // Mentions the count so the user sees how often they've been throttled.
-    expect(nudge!).toContain("10");
+    expect(nudge!).toContain("hit 10 rate-limit errors");
   });
 
   it("consume is pop-style — clears the flag after returning the text", () => {
-    for (let i = 0; i < 10; i++) recordSolanaPublicError();
+    recordSolanaPublicError();
     expect(consumePendingHeliusNudge()).not.toBeNull();
     // Second consume returns null — only one response per threshold crossing.
     expect(consumePendingHeliusNudge()).toBeNull();
   });
 
-  it("re-fires on the next threshold (count 20)", () => {
+  it("re-fires on the next threshold (count 20) after pop at 10", () => {
     for (let i = 0; i < 10; i++) recordSolanaPublicError();
-    consumePendingHeliusNudge(); // pop the first one
-    for (let i = 0; i < 9; i++) recordSolanaPublicError();
+    consumePendingHeliusNudge(); // pop the count=10 (count=1 already consumed implicitly via the same flag)
+    for (let i = 0; i < 9; i++) recordSolanaPublicError(); // 11..19
     expect(consumePendingHeliusNudge()).toBeNull();
     recordSolanaPublicError(); // 20th
     const nudge = consumePendingHeliusNudge();
@@ -153,6 +165,136 @@ describe("Helius nudge — fires every 10th public error, clears on consume", ()
     // is active — but guard anyway), they don't count.
     recordSolanaPublicError();
     expect(consumePendingHeliusNudge()).toBeNull();
+  });
+});
+
+describe("Etherscan override (issue #371 PR generalization)", () => {
+  const VALID_ETHERSCAN_KEY = "ZQTKPM98R5N4YT8GMTBI3XR2P4HFZNTAYG"; // 34 chars
+
+  it("setRuntimeOverride('etherscan', key) stores the bare key (no URL wrapping)", async () => {
+    const { setRuntimeOverride, getRuntimeOverride } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    setRuntimeOverride("etherscan", VALID_ETHERSCAN_KEY);
+    // Etherscan resolves to the bare key (used as-is in query params),
+    // unlike Helius which wraps in a URL.
+    expect(getRuntimeOverride("etherscan")).toBe(VALID_ETHERSCAN_KEY);
+  });
+
+  it("rejects URL-shaped input (security: no prompt-injection redirects)", async () => {
+    const { setRuntimeOverride } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    expect(() =>
+      setRuntimeOverride("etherscan", "https://malicious.example.com/?api=stealth"),
+    ).toThrow(/pass the bare API key, not a URL/);
+  });
+
+  it("rejects malformed keys (wrong length / dashes / etc.)", async () => {
+    const { setRuntimeOverride } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    expect(() => setRuntimeOverride("etherscan", "too-short")).toThrow(
+      /Etherscan V2/,
+    );
+    // UUID-shaped (Helius's format) is wrong for Etherscan — too-many dashes.
+    expect(() =>
+      setRuntimeOverride("etherscan", "b7d6f3a1-1234-5678-9abc-def012345678"),
+    ).toThrow(/Etherscan V2/);
+    // 33 chars (off by one) — must be exactly 34.
+    expect(() =>
+      setRuntimeOverride("etherscan", "ZQTKPM98R5N4YT8GMTBI3XR2P4HFZNTAY"),
+    ).toThrow(/Etherscan V2/);
+  });
+
+  it("Etherscan + Helius counters are independent (per-service state)", async () => {
+    const {
+      recordPublicError,
+      getPublicErrorCount,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    recordPublicError("helius");
+    recordPublicError("helius");
+    recordPublicError("etherscan");
+    expect(getPublicErrorCount("helius")).toBe(2);
+    expect(getPublicErrorCount("etherscan")).toBe(1);
+  });
+
+  it("nudge fires on first Etherscan error + every 10th thereafter", async () => {
+    const {
+      recordPublicError,
+      consumePendingNudge,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    // Count 1 → fires.
+    recordPublicError("etherscan");
+    const first = consumePendingNudge("etherscan");
+    expect(first).not.toBeNull();
+    expect(first!).toContain("Etherscan");
+    expect(first!).toContain("set_etherscan_api_key");
+    expect(first!).toContain("etherscan.io/myapikey");
+    expect(first!).toContain("rejected 1 call");
+    // Counts 2-9 → no fire.
+    for (let i = 0; i < 8; i++) recordPublicError("etherscan");
+    expect(consumePendingNudge("etherscan")).toBeNull();
+    // Count 10 → fires.
+    recordPublicError("etherscan");
+    const tenth = consumePendingNudge("etherscan");
+    expect(tenth).not.toBeNull();
+    expect(tenth!).toContain("rejected 10 calls");
+  });
+
+  it("setting an Etherscan key zeroes the counter + clears pending nudge", async () => {
+    const {
+      recordPublicError,
+      setRuntimeOverride,
+      getPublicErrorCount,
+      consumePendingNudge,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    recordPublicError("etherscan");
+    expect(getPublicErrorCount("etherscan")).toBe(1);
+    setRuntimeOverride("etherscan", VALID_ETHERSCAN_KEY);
+    expect(getPublicErrorCount("etherscan")).toBe(0);
+    expect(consumePendingNudge("etherscan")).toBeNull();
+  });
+
+  it("consumeAllPendingNudges returns both Helius + Etherscan when both pending", async () => {
+    const {
+      recordPublicError,
+      consumeAllPendingNudges,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    recordPublicError("helius");
+    recordPublicError("etherscan");
+    const all = consumeAllPendingNudges();
+    expect(all.length).toBe(2);
+    const services = all.map((x) => x.service).sort();
+    expect(services).toEqual(["etherscan", "helius"]);
+    // Subsequent call: both consumed, returns empty.
+    expect(consumeAllPendingNudges()).toEqual([]);
+  });
+
+  it("Etherscan status surface redacts to last-4 chars", async () => {
+    const {
+      setRuntimeOverride,
+      getRuntimeOverrideStatus,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    setRuntimeOverride("etherscan", VALID_ETHERSCAN_KEY);
+    const status = getRuntimeOverrideStatus("etherscan");
+    expect(status.active).toBe(true);
+    expect(status.apiKeySuffix).toBe(VALID_ETHERSCAN_KEY.slice(-4));
+    expect(JSON.stringify(status)).not.toContain(VALID_ETHERSCAN_KEY);
+  });
+
+  it("resolveEtherscanApiKey integration — runtime-override wins over env + config", async () => {
+    delete process.env.ETHERSCAN_API_KEY;
+    const { setRuntimeOverride } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    setRuntimeOverride("etherscan", VALID_ETHERSCAN_KEY);
+    const { resolveEtherscanApiKey } = await import("../src/config/user-config.js");
+    expect(resolveEtherscanApiKey(null)).toBe(VALID_ETHERSCAN_KEY);
+    // Env var doesn't override the runtime setting.
+    process.env.ETHERSCAN_API_KEY = "DIFFERENT_KEY_VIA_ENV_VAR_THAT_LOSES_MMM";
+    expect(resolveEtherscanApiKey(null)).toBe(VALID_ETHERSCAN_KEY);
+    delete process.env.ETHERSCAN_API_KEY;
   });
 });
 


### PR DESCRIPTION
## Summary

Item #2 from the [demo-saga punch list](../../blob/main/claude-work/plan-demo-saga-followups.md). Closes the second-most-painful demo UX gap after Helius (#383): without an Etherscan V2 key, \`get_transaction_history\` / \`get_token_allowances\` / \`explain_tx\` / address-poisoning scoring all hard-fail (Etherscan refuses unauthed multi-chain V2 calls — no anonymous tier).

## Refactor

\`src/data/runtime-rpc-overrides.ts\` collapses to a generic per-service store keyed by \`ServiceId\`. Each service supplies a config struct: key validation regex, format hint, URL-or-identity constructor, nudge text. Adding a third service now means one entry in \`SERVICE_CONFIGS\`.

The existing Helius surface (\`setHeliusApiKey\`, \`consumePendingHeliusNudge\`, etc.) is preserved as \`@deprecated\` shims delegating to the generic API. All call sites in \`src/index.ts\` + \`src/modules/solana/rpc.ts\` + \`src/config/chains.ts\` + \`src/modules/diagnostics/index.ts\` are unchanged.

## New service: Etherscan V2

- **Key format**: 34-char alphanumeric (per-provider regex; UUID-shaped Helius keys rejected for Etherscan and vice versa).
- **Identity URL transform**: Etherscan uses the bare key in query params — no URL wrapping (Helius wraps in a full mainnet URL).
- **Resolved at**: \`resolveEtherscanApiKey\` in \`user-config.ts\` checks runtime override first, then env, then config.
- **Error counter**: both \`etherscanV2Fetch\` and \`getEtherscanProxyPendingNonce\` call \`recordPublicError(\"etherscan\")\` when no key is set, so the nudge surfaces on the failing tool's response.

## Cadence change (universal)

Nudge now fires on **count 1 AND every multiple of 10** (was: every multiple of 10). First-error nudge gives immediate feedback for services that fail 100% of the time without a key (Etherscan); the every-10 cadence still handles services that throttle gracefully (Helius). Applied universally — Helius gets a slightly faster first nudge as a bonus.

## Per-tool response

\`registerTool\` wrapper now calls \`consumeAllPendingNudges\` once per response instead of \`consumePendingHeliusNudge\`. A session that has tripped both Helius and Etherscan thresholds gets both nudges on the next response.

## Security (unchanged from #383)

- URL-shaped input rejected (\`://\` or \`http*\` prefix) for both services — prevents prompt-injection redirects.
- Status surface redacts to last-4 chars only.
- Tool descriptions direct agents to never echo keys back.

## Tests

- 10 new in \`test/runtime-rpc-overrides.test.ts\` — Etherscan validation / counter independence / nudge cadence / consume-all / redaction / resolver integration
- Existing Helius cadence tests updated for the \"fire on 1\" change
- Full suite: **1888 tests pass**

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1888 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)