### PR TITLE
chore(release): bump to 0.10.0 — demo saga drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.9.5",
+      "version": "0.10.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.9.5",
+      "version": "0.10.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {
@@ -70,6 +70,12 @@
           "description": "WalletConnect Cloud project ID. Required for Ledger Live signing via WalletConnect.",
           "isRequired": false,
           "isSecret": true
+        },
+        {
+          "name": "VAULTPILOT_DEMO",
+          "description": "Set to 'true' to enable demo mode — no Ledger required, real chain RPC reads, signing-class tools either refuse or return simulated-broadcast envelopes. See `set_demo_wallet` and `exit_demo_mode` tools for the full demo flow.",
+          "isRequired": false,
+          "isSecret": false
         }
       ]
     }


### PR DESCRIPTION
## Summary

Demo saga drop. Issue #371 shipped end to end, plus the runtime API-key flow that fills the read-side UX gaps the demo architecture flip introduced.

Bumps:
- \`package.json\` 0.9.5 → 0.10.0
- \`server.json\` (top-level + \`packages[0].version\`) 0.9.5 → 0.10.0
- \`server.json\` adds \`VAULTPILOT_DEMO\` to \`environmentVariables[]\`

## Highlights

- **Demo mode is now write-flow-capable** — #380 deleted fixtures, introduced live mode with curated personas (\`defi-power-user\` / \`stable-saver\` / \`staking-maxi\` / \`whale\`). Real RPC reads + prepare + simulate; \`send_transaction\` returns a simulation envelope.
- **\`set_demo_wallet\` / \`get_demo_wallet\`** — runtime wallet selection.
- **\`exit_demo_mode\`** — agent-guided handoff to operational mode with preflight + step-by-step + copy-paste \`claude mcp add\` recipe.
- **\`set_helius_api_key\` + \`set_etherscan_api_key\`** — runtime API-key injection. Auto-nudge on count 1 + every 10 public-RPC errors.
- **demoMode discoverability** — \`get_vaultpilot_config_status.demoMode\` surfaces activation recipe + live-mode state. First-run setupHint suggests demo as the zero-friction try-before-install path.

## Included PRs

#372 surface demoMode on get_vaultpilot_config_status
#374 emit demo-mode setupHint on fresh-install state
#377 fixture refresh (mostly reverted by #380)
#380 write-flow simulation via personas + simulated broadcast
#383 set_helius_api_key + auto-nudge on Solana RPC errors
#385 exit_demo_mode handoff guide
#386 generalize runtime-override + nudge to Etherscan
#381 / #382 docs(security): phishing-approval row + section
#376 refactor: dead-export sweep + BTC/LTC dedup
#373 fix(test): root-cause #344 — testTimeout bump
#384 chore: skill rename + pin bump

## Deliberately deferred

- Manual end-to-end smoke test of personas against current chain state (tracked in \`claude-work/plan-demo-saga-followups.md\` item #1; blocks further demo expansion).
- Markdown rendering of the simulation envelope (JSON-only today).
- README + docs update reflecting the current demo model.
- Reservoir runtime API key (NFT reads) — scoped out of #386 per design.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1888 tests pass
- [ ] CI green
- [ ] After merge: tag \`v0.10.0\`, create GitHub Release → fires \`publish.yml\` (npm + MCP Registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)