### PR TITLE
chore(license): add SPDX-License-Identifier header to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: BUSL-1.1
+
 License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 "Business Source License" is a trademark of MariaDB Corporation Ab.
 


### PR DESCRIPTION
## Summary

GitHub's auto-license-detection (via [Licensee](https://github.com/licensee/licensee)) doesn't recognize BUSL-1.1, so the GitHub API reports \`license.spdx_id: \"NOASSERTION\"\` for this repo. Downstream MCP directories like Glama show \"license not found\" even though:

- \`LICENSE\` is present at repo root ✓
- \`package.json\` \`license: \"BUSL-1.1\"\` is SPDX-valid ✓
- \`LICENSE\` ships with the npm tarball ✓

## What this PR does

Adds \`SPDX-License-Identifier: BUSL-1.1\` as the first line of the LICENSE file. Two-line change, no semantic effect.

## Why it might (partially) help

- Doesn't fix Licensee directly — Licensee pattern-matches body text, not SPDX headers
- BUT some scrapers (incl. potentially Glama) honor SPDX hints when GitHub's API returns NOASSERTION
- Defensible regardless — every modern packaging spec recommends SPDX headers in LICENSE files

## What it doesn't do

The structural fix is for Glama to fall back to npm \`package.json\` \`license\` when GitHub returns NOASSERTION. Filing that separately.

No version bump — metadata-only change, no API surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)