### PR TITLE
chore(release): bump to 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Patch release. One commit landed since v0.10.0:

- **[#388](https://github.com/szhygulin/vaultpilot-mcp/pull/388)** — startup self-check for skill-pin drift (closes design 4 of [#379](https://github.com/szhygulin/vaultpilot-mcp/issues/379)). Non-blocking fetch + sha256 of canonical \`SKILL.md\` from \`vaultpilot-security-skill\` master at server boot; on drift, emits a \`VAULTPILOT NOTICE — Skill pin drift detected\` block on the first tool response per session (deduped). Pure diagnostic; fails soft on network errors. Catches the exact failure class that prompted the v0.9.5 → drift saga (#375 → silent drift while the skill repo released v5 + Step 0 + the project rename without a coordinated MCP-side bump).

## Why patch, not minor

No public API changes; #388 is a server-side diagnostic only. Semver patch is the right shape.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Diff: 3 files, 5 insertions / 5 deletions (just the version-string bumps in \`package.json\` / \`server.json\` / \`package-lock.json\`)
- [ ] After merge: tag \`v0.10.1\` at the merge commit, push the tag — fires \`release-binaries.yml\` + \`publish.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)