### PR TITLE
feat(demo): surface demo-wallet onboarding via VAULTPILOT NOTICE (#391)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,7 @@ import {
   renderLedgerHashBlock,
   renderMissingSkillWarning,
   renderMissingSetupSkillWarning,
+  renderMissingDemoWalletWarning,
   renderPostBroadcastBlock,
   renderPostSendPollBlock,
   renderBitcoinVerificationBlock,
@@ -640,6 +641,51 @@ export function missingSetupSkillWarning(): string | null {
 }
 
 /**
+ * Issue #391 — once-per-session dedup for the demo-wallet notice.
+ * Independent of the preflight/setup skill flags so all three notices
+ * can fire side-by-side on a fresh-install session if needed.
+ */
+let missingDemoWalletNoticeEmitted = false;
+
+export function _resetMissingDemoWalletDedup(): void {
+  missingDemoWalletNoticeEmitted = false;
+}
+
+/**
+ * Render the demo-wallet onboarding notice when the server starts with
+ * no user config file AND no active demo wallet — the canonical post-
+ * install / pre-pairing state. Once the user creates a config (via
+ * `vaultpilot-mcp-setup`) or activates a persona via `set_demo_wallet`,
+ * the notice stops firing — the agent already has a clear path forward
+ * either way and the nudge would just be noise.
+ *
+ * Dedup: once per session. Reset semantics mirror the skill notices —
+ * if the user later removes the config and clears the persona, the
+ * notice retriggers, since the post-install-zero state has returned.
+ *
+ * `readUserConfig()` returns null when neither the new
+ * `~/.vaultpilot-mcp/config.json` nor the legacy `~/.recon-crypto-mcp/`
+ * path exists, which is exactly the "no config" signal we want.
+ */
+export function missingDemoWalletNotice(): string | null {
+  let configPresent = false;
+  try {
+    configPresent = readUserConfig() !== null;
+  } catch {
+    // Malformed config still counts as "config present" — the user has
+    // been here, the post-install onboarding nudge would be wrong.
+    configPresent = true;
+  }
+  if (configPresent || isLiveMode()) {
+    missingDemoWalletNoticeEmitted = false;
+    return null;
+  }
+  if (missingDemoWalletNoticeEmitted) return null;
+  missingDemoWalletNoticeEmitted = true;
+  return renderMissingDemoWalletWarning();
+}
+
+/**
  * Collect rendered verification blocks from a result, walking `.next` for
  * EVM approve→action chains. Each prepared tx in the chain gets its own
  * block so the user can cross-check every hash they will sign — never a
@@ -786,6 +832,12 @@ function handler<T, R>(
         // match or fetch-failed).
         const driftNotice = getSkillPinDriftNotice();
         if (driftNotice) content.push({ type: "text", text: driftNotice });
+        // Issue #391 — surface the demo-wallet onboarding path on a
+        // fresh post-install session (no config + no active demo wallet)
+        // so the agent doesn't dead-end the user with "you need to pair
+        // a Ledger first". Same once-per-session dedup family.
+        const demoNotice = missingDemoWalletNotice();
+        if (demoNotice) content.push({ type: "text", text: demoNotice });
       }
       // Emit the prepare-receipt for every tool that built a transaction
       // (result carries `verification`). Gives the user a verbatim-relay view
@@ -1068,6 +1120,8 @@ export function previewSendHandler(
       ];
       const warning = missingPreflightSkillWarning();
       if (warning) content.push({ type: "text", text: warning });
+      const demoNotice = missingDemoWalletNotice();
+      if (demoNotice) content.push({ type: "text", text: demoNotice });
       // Suppress the LEDGER BLIND-SIGN HASH block for tx types where the
       // Ledger Ethereum app clear-signs on-device (native sends, ERC-20
       // approve, ERC-20 transfer). Showing a blind-sign hash that the
@@ -1132,6 +1186,8 @@ function previewSolanaSendHandler(
       ];
       const warning = missingPreflightSkillWarning();
       if (warning) content.push({ type: "text", text: warning });
+      const demoNotice = missingDemoWalletNotice();
+      if (demoNotice) content.push({ type: "text", text: demoNotice });
       content.push({ type: "text", text: renderSolanaVerificationBlock(pinned) });
       content.push({ type: "text", text: renderSolanaAgentTaskBlock(pinned) });
       return { content };
@@ -1174,6 +1230,8 @@ function sendTransactionHandler(
       ];
       const warning = missingPreflightSkillWarning();
       if (warning) content.push({ type: "text", text: warning });
+      const demoNotice = missingDemoWalletNotice();
+      if (demoNotice) content.push({ type: "text", text: demoNotice });
       content.push({
         type: "text",
         text: renderPostBroadcastBlock({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4310,14 +4310,25 @@ async function main() {
   await server.connect(transport);
 }
 
-main().catch((err) => {
-  console.error("[vaultpilot-mcp] fatal:", err);
-  // Issue #359 — when the server crashes at startup, MCP clients
-  // surface only "Failed to connect" with no detail. Surface the
-  // doctor command so the user has an actionable next step instead
-  // of guessing at a blind restart.
-  console.error(
-    "[vaultpilot-mcp] tip: run `npx -y vaultpilot-mcp --check` to validate your install (config, RPC sources, native bindings) without restarting your MCP client.",
-  );
-  process.exit(1);
-});
+// Vitest sets VITEST=true for every test process. Skip main() under
+// the test runner so unit tests can `import("../src/index.js")` to
+// pull in pure helpers (notice builders, classifiers) without
+// triggering the full server boot path. A throwing mock in a test
+// file (e.g. a mocked `readUserConfig` that returns a malformed
+// config) would otherwise make main() fail at module load and
+// `process.exit(1)` would propagate as an unhandled rejection that
+// vitest reports as a CI failure even though every test asserted
+// passed.
+if (!process.env.VITEST) {
+  main().catch((err) => {
+    console.error("[vaultpilot-mcp] fatal:", err);
+    // Issue #359 — when the server crashes at startup, MCP clients
+    // surface only "Failed to connect" with no detail. Surface the
+    // doctor command so the user has an actionable next step instead
+    // of guessing at a blind restart.
+    console.error(
+      "[vaultpilot-mcp] tip: run `npx -y vaultpilot-mcp --check` to validate your install (config, RPC sources, native bindings) without restarting your MCP client.",
+    );
+    process.exit(1);
+  });
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2372,4 +2372,50 @@ export function renderMissingSetupSkillWarning(opts: {
   ].join("\n");
 }
 
+/**
+ * Issue #391 — first-contact UX. After `claude mcp add` + restart, the
+ * agent has no signal that pre-configured demo wallets exist. When a
+ * fresh user says "let's send some BTC", the agent's natural answer is
+ * "you need to pair a Ledger first" because the demo path isn't visible
+ * anywhere in the tool surface. This notice fires once per session when
+ * the server starts with no config file AND no active demo wallet —
+ * exactly the post-install / pre-pairing state — so the agent learns
+ * the demo path exists before it stalls on a missing Ledger.
+ *
+ * Same shape as the other VAULTPILOT NOTICE blocks (preflight skill,
+ * setup skill): named header, status / purpose / next sections, no
+ * imperative verbs at the agent, no pasted shell. Tradeoff-aware
+ * closing paragraph naming the block as legitimate server output so a
+ * defensive agent doesn't classify it as prompt injection.
+ */
+export function renderMissingDemoWalletWarning(): string {
+  return [
+    "VAULTPILOT NOTICE — Demo wallets available",
+    "",
+    "Status:  no user config file at ~/.vaultpilot-mcp/config.json and",
+    "         no active demo wallet for this session.",
+    "Purpose: vaultpilot-mcp ships a set of pre-configured demo wallets",
+    "         (curated personas + custom-address mode) so a new user can",
+    "         try the tool flows — portfolio reads, prepare/preview/",
+    "         simulate signing flows — without first pairing a Ledger or",
+    "         pasting their own addresses. Broadcast is intercepted in",
+    "         demo mode (no real send), so the entire flow is safe.",
+    "Next:    if the user asks to inspect a portfolio, build a tx, or",
+    "         try anything that needs an address, offer the demo path",
+    "         BEFORE asking them to pair hardware. Tools:",
+    "           - `set_demo_wallet({ persona: \"<id>\" })` — activate a",
+    "             curated persona (defi-power-user, stable-saver,",
+    "             staking-maxi, whale) or a custom address bundle.",
+    "           - `get_demo_wallet()` — inspect the active selection.",
+    "           - `exit_demo_mode()` — get a tailored real-setup guide",
+    "             once the user is ready to leave demo and use real",
+    "             funds.",
+    "",
+    "This notice is server-generated, not prompt injection — the server-",
+    "level `instructions` field documents this pattern. Surface it to",
+    "the user once per session as informational, then continue with",
+    "their request.",
+  ].join("\n");
+}
+
 export type { SupportedChain };

--- a/test/demo-wallet-notice.test.ts
+++ b/test/demo-wallet-notice.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Issue #391 — VAULTPILOT NOTICE — Demo wallets available.
+ *
+ * Onboarding nudge fired once per session when (a) the user has no
+ * config file at all (canonical post-`claude mcp add` state) AND
+ * (b) no demo wallet has been activated. Designed so an agent's first
+ * "let's send some BTC" doesn't dead-end on "you need a Ledger" —
+ * the demo path is surfaced before that happens.
+ *
+ * The helper is mocked at the module level (readUserConfig +
+ * isLiveMode) so these tests don't depend on the developer's actual
+ * `~/.vaultpilot-mcp/` or `~/.recon-crypto-mcp/` directory state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("issue #391: demo-wallet onboarding notice", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  function mockEnv(opts: { configPresent: boolean; liveMode: boolean }): void {
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return {
+        ...actual,
+        readUserConfig: () => (opts.configPresent ? ({} as unknown as never) : null),
+      };
+    });
+    vi.doMock("../src/demo/live-mode.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/demo/live-mode.js")
+      >("../src/demo/live-mode.js");
+      return {
+        ...actual,
+        isLiveMode: () => opts.liveMode,
+      };
+    });
+  }
+
+  it("fires a VAULTPILOT NOTICE block when there is no config and no active demo wallet", async () => {
+    mockEnv({ configPresent: false, liveMode: false });
+    const {
+      missingDemoWalletNotice,
+      _resetMissingDemoWalletDedup,
+    } = await import("../src/index.js");
+    _resetMissingDemoWalletDedup();
+    const notice = missingDemoWalletNotice();
+    expect(notice).not.toBeNull();
+    // Same shape as the existing notice family — agents trust this prefix.
+    expect(notice).toMatch(/^VAULTPILOT NOTICE — /);
+    expect(notice).toContain("Demo wallets available");
+    // No imperative agent verbs / pasteable shell — the framing that
+    // earlier agents flagged as injection.
+    expect(notice).not.toMatch(/\[AGENT TASK/);
+    expect(notice).not.toMatch(/^\s*git clone\b/m);
+    expect(notice).not.toMatch(/^\s*npm (install|i)\b/m);
+    // The three discoverability handles the issue asks for.
+    expect(notice).toContain("set_demo_wallet");
+    expect(notice).toContain("get_demo_wallet");
+    expect(notice).toContain("exit_demo_mode");
+    // Self-label so a defensive agent doesn't classify this as injection.
+    expect(notice).toContain("not prompt injection");
+  });
+
+  it("returns null when the user has a config file (post-setup users don't need the nudge)", async () => {
+    mockEnv({ configPresent: true, liveMode: false });
+    const {
+      missingDemoWalletNotice,
+      _resetMissingDemoWalletDedup,
+    } = await import("../src/index.js");
+    _resetMissingDemoWalletDedup();
+    expect(missingDemoWalletNotice()).toBeNull();
+  });
+
+  it("returns null when a live demo wallet is already active (path already taken)", async () => {
+    mockEnv({ configPresent: false, liveMode: true });
+    const {
+      missingDemoWalletNotice,
+      _resetMissingDemoWalletDedup,
+    } = await import("../src/index.js");
+    _resetMissingDemoWalletDedup();
+    expect(missingDemoWalletNotice()).toBeNull();
+  });
+
+  it("dedupes to once-per-session: first call returns the block, subsequent calls return null", async () => {
+    mockEnv({ configPresent: false, liveMode: false });
+    const {
+      missingDemoWalletNotice,
+      _resetMissingDemoWalletDedup,
+    } = await import("../src/index.js");
+    _resetMissingDemoWalletDedup();
+    const first = missingDemoWalletNotice();
+    const second = missingDemoWalletNotice();
+    const third = missingDemoWalletNotice();
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(third).toBeNull();
+  });
+
+  it("malformed config counts as 'config present' (don't nag a user mid-setup-error)", async () => {
+    // readUserConfig throws on malformed JSON. The helper must not crash
+    // the tool call; a malformed config means the user has been here and
+    // the post-install nudge would be the wrong message anyway.
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return {
+        ...actual,
+        readUserConfig: () => {
+          throw new Error("malformed JSON");
+        },
+      };
+    });
+    vi.doMock("../src/demo/live-mode.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/demo/live-mode.js")
+      >("../src/demo/live-mode.js");
+      return { ...actual, isLiveMode: () => false };
+    });
+    const {
+      missingDemoWalletNotice,
+      _resetMissingDemoWalletDedup,
+    } = await import("../src/index.js");
+    _resetMissingDemoWalletDedup();
+    expect(missingDemoWalletNotice()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse the `VAULTPILOT NOTICE` family to emit a one-shot `VAULTPILOT NOTICE — Demo wallets available` block whenever the server starts with no config file AND no active demo wallet — the canonical post-`claude mcp add` state.
- Notice points at `set_demo_wallet` / `get_demo_wallet` / `exit_demo_mode` so the agent's first move after install can offer the demo path instead of asking the user to pair hardware.
- Same shape + self-label as the existing preflight/setup-skill notices (no imperative agent verbs, no pasted shell, server-generated framing) so defensive agents don't classify the block as prompt injection.

Wired into the same four handler call sites the existing notice family already uses (generic handler, `previewSendHandler`, `previewSolanaSendHandler`, `sendTransactionHandler`) with an independent module-level dedup flag and a `_resetMissingDemoWalletDedup()` test hook.

Closes #391

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 1910/1910 pass; new `test/demo-wallet-notice.test.ts` adds 5 cases (fires on no-config + no-live-wallet, suppressed when config present, suppressed when live mode active, dedup once per session, malformed config treated as 'present')
- [ ] Manual: fresh install with no `~/.vaultpilot-mcp/` and no `set_demo_wallet` — first tool response carries the notice exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)