### PR TITLE
fix(demo): always enumerate personas + clearer env-state message (#392)

### DIFF
--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -31,6 +31,7 @@ import {
   clearLiveWallet,
   type LiveWalletState,
 } from "./live-mode.js";
+import { PERSONAS, type Persona } from "./personas.js";
 
 /**
  * True when `VAULTPILOT_DEMO=true` is set in the environment. Read at
@@ -39,6 +40,122 @@ import {
  */
 export function isDemoMode(): boolean {
   return process.env.VAULTPILOT_DEMO === "true";
+}
+
+/**
+ * Three-state classifier for the VAULTPILOT_DEMO env var (issue #392).
+ *
+ * The strict literal `=== "true"` gate is intentional — boot-time env
+ * vars are the only safe place to flip demo mode (an in-session prompt
+ * injection can't mutate them), and a sloppy truthy parse would expand
+ * the surface for accidentally-on demo. The cost of strictness is that
+ * `VAULTPILOT_DEMO=1` silently behaves as "unset", which sent users
+ * down the wrong debugging path: they'd re-edit the MCP client config
+ * to ADD the var when it was already present with a wrong value.
+ *
+ * Splitting "unset" from "invalid" lets `get_demo_wallet`'s message
+ * tell the user which mistake they made.
+ */
+export type DemoModeEnvState = "enabled" | "invalid" | "unset";
+
+export function getDemoModeEnvState(): DemoModeEnvState {
+  const value = process.env.VAULTPILOT_DEMO;
+  if (value === undefined) return "unset";
+  if (value === "true") return "enabled";
+  return "invalid";
+}
+
+/**
+ * Sanitize the env-var value for echo-back in the `get_demo_wallet`
+ * response. Caps at 32 chars and replaces ASCII control characters
+ * with `?`. The env var is arbitrary user-supplied input — an attacker
+ * who can set the environment can already do worse, but the JSON
+ * response shouldn't relay control bytes downstream where some logger
+ * or chat renderer might mis-interpret them.
+ */
+export function redactInvalidDemoEnvValue(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const stripped = raw.replace(/[\x00-\x1F\x7F]/g, "?");
+  if (stripped.length <= 32) return stripped;
+  return stripped.slice(0, 29) + "...";
+}
+
+interface PersonaSummary {
+  id: Persona["id"];
+  description: Persona["description"];
+  addresses: Persona["addresses"];
+}
+
+/**
+ * Build the `get_demo_wallet` response. Pure function (no I/O beyond
+ * reading env + the in-process live-wallet state) so it's directly
+ * unit-testable and the registered handler in `src/index.ts` stays a
+ * one-liner.
+ *
+ * Issue #392 contract: personas are ALWAYS returned (regardless of
+ * env state) so an agent can offer the user a choice without first
+ * asking them to set an env var blind. When demo isn't active, the
+ * message tells the user which mistake they made (env unset vs. set
+ * to something other than the literal `"true"`).
+ */
+export type GetDemoWalletResponse =
+  | {
+      demoActive: true;
+      mode: "default" | "live";
+      envState: "enabled";
+      active: LiveWalletState | null;
+      personas: PersonaSummary[];
+    }
+  | {
+      demoActive: false;
+      mode: null;
+      envState: "unset" | "invalid";
+      message: string;
+      personas: PersonaSummary[];
+    };
+
+export function buildGetDemoWalletResponse(): GetDemoWalletResponse {
+  const personas: PersonaSummary[] = Object.values(PERSONAS).map((p) => ({
+    id: p.id,
+    description: p.description,
+    addresses: p.addresses,
+  }));
+  const envState = getDemoModeEnvState();
+  if (envState === "enabled") {
+    const live = getLiveWallet();
+    return {
+      demoActive: true,
+      mode: live === null ? "default" : "live",
+      envState,
+      active: live,
+      personas,
+    };
+  }
+  let message: string;
+  if (envState === "unset") {
+    message =
+      "VAULTPILOT_DEMO is unset — server is in normal mode. The personas " +
+      "below are listed for discovery so you can offer the user a choice. " +
+      "To activate demo mode, set `VAULTPILOT_DEMO=true` (exact literal, " +
+      "lowercase) in the MCP client config (e.g. `.claude.json`'s `env` " +
+      "block for this server) and restart Claude Code.";
+  } else {
+    const raw = process.env.VAULTPILOT_DEMO ?? "";
+    const safe = redactInvalidDemoEnvValue(raw);
+    message =
+      `VAULTPILOT_DEMO is set to '${safe}' but the server expects the ` +
+      `exact literal 'true' — server is in normal mode. The personas ` +
+      `below are listed for discovery. Common confusion: '1', 'yes', ` +
+      `'on', 'TRUE' are all rejected; only lowercase 'true' enables ` +
+      `demo. Fix the value in the MCP client config and restart.`;
+  }
+  return {
+    demoActive: false,
+    mode: null,
+    envState,
+    message,
+    personas,
+  };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   alwaysGatedRefusalMessage,
   defaultModeRefusalMessage,
   buildSimulationEnvelope,
+  buildGetDemoWalletResponse,
   isLiveMode,
   getLiveWallet,
   setLivePersona,
@@ -4051,34 +4052,19 @@ async function main() {
     "get_demo_wallet",
     {
       description:
-        "DEMO MODE ONLY — report the active demo wallet (live mode) or confirm default mode " +
-        "(no wallet set). Also enumerates the available personas + their addresses + " +
-        "descriptions, so the agent can offer the user a choice without hardcoding the list. " +
-        "When VAULTPILOT_DEMO is unset, returns `{ demoActive: false }` — the tool stays " +
-        "registered so agents can always discover the surface.",
+        "Report the active demo wallet (live mode), confirm default demo mode (no wallet " +
+        "set), or report why demo mode isn't active when the env var is missing or " +
+        "misconfigured. ALWAYS enumerates the available personas + their addresses + " +
+        "descriptions regardless of VAULTPILOT_DEMO state, so the agent can offer the " +
+        "user a choice without hardcoding the list (issue #392). " +
+        "RESPONSE: `{ demoActive, mode, envState: 'enabled' | 'unset' | 'invalid', " +
+        "personas, [active], [message] }`. When envState is 'unset' or 'invalid' the " +
+        "`message` field tells the user how to fix it (set `VAULTPILOT_DEMO=true` exact " +
+        "literal, lowercase). When envState is 'enabled', `active` carries the current " +
+        "live wallet (or null in default demo mode).",
       inputSchema: getDemoWalletInput.shape,
     },
-    handler(() => {
-      if (!isDemoMode()) {
-        return {
-          demoActive: false,
-          mode: null,
-          message: "VAULTPILOT_DEMO is unset — the server is in normal mode.",
-          personas: [],
-        };
-      }
-      const live = getLiveWallet();
-      return {
-        demoActive: true,
-        mode: live === null ? "default" : "live",
-        active: live,
-        personas: Object.values(PERSONAS).map((p) => ({
-          id: p.id,
-          description: p.description,
-          addresses: p.addresses,
-        })),
-      };
-    })
+    handler(() => buildGetDemoWalletResponse())
   );
 
   // ---- Module 9c: Runtime Solana RPC override (Helius nudge — issue #371 follow-up) ----

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -324,3 +324,162 @@ describe("assertNotDemoForSetup — refuses to write real config in demo mode", 
     expect(() => assertNotDemoForSetup()).not.toThrow();
   });
 });
+
+describe("issue #392 — getDemoModeEnvState distinguishes unset / invalid / enabled", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("returns 'unset' when the env var is absent", async () => {
+    const { getDemoModeEnvState } = await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    expect(getDemoModeEnvState()).toBe("unset");
+  });
+
+  it("returns 'enabled' only on the exact literal 'true'", async () => {
+    const { getDemoModeEnvState } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "true";
+    expect(getDemoModeEnvState()).toBe("enabled");
+  });
+
+  it("returns 'invalid' for any other value (including common truthy mistakes)", async () => {
+    const { getDemoModeEnvState } = await import("../src/demo/index.js");
+    for (const v of ["1", "yes", "on", "TRUE", "True", "false", " true", "true "]) {
+      process.env[ENV_KEY] = v;
+      expect(getDemoModeEnvState(), `value ${JSON.stringify(v)}`).toBe("invalid");
+    }
+  });
+
+  it("returns 'invalid' for the empty string (set, but empty)", async () => {
+    const { getDemoModeEnvState } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "";
+    expect(getDemoModeEnvState()).toBe("invalid");
+  });
+});
+
+describe("issue #392 — redactInvalidDemoEnvValue caps length and strips control chars", () => {
+  it("passes short, printable values through unchanged", async () => {
+    const { redactInvalidDemoEnvValue } = await import("../src/demo/index.js");
+    expect(redactInvalidDemoEnvValue("1")).toBe("1");
+    expect(redactInvalidDemoEnvValue("yes")).toBe("yes");
+    expect(redactInvalidDemoEnvValue("TRUE")).toBe("TRUE");
+  });
+
+  it("truncates values longer than 32 chars with an ellipsis", async () => {
+    const { redactInvalidDemoEnvValue } = await import("../src/demo/index.js");
+    const long = "a".repeat(100);
+    const out = redactInvalidDemoEnvValue(long);
+    expect(out.length).toBe(32);
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("replaces ASCII control characters with '?'", async () => {
+    const { redactInvalidDemoEnvValue } = await import("../src/demo/index.js");
+    expect(redactInvalidDemoEnvValue("a\x00b\x1fc\x7fd")).toBe("a?b?c?d");
+    // Newline + tab also replaced (they would corrupt the JSON-string layout
+    // when relayed to a chat renderer).
+    expect(redactInvalidDemoEnvValue("a\nb\tc")).toBe("a?b?c");
+  });
+});
+
+describe("issue #392 — buildGetDemoWalletResponse always lists personas", () => {
+  let saved: string | undefined;
+  beforeEach(async () => {
+    saved = process.env[ENV_KEY];
+    const { _resetLiveWalletForTests } = await import("../src/demo/live-mode.js");
+    _resetLiveWalletForTests();
+  });
+  afterEach(async () => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+    const { _resetLiveWalletForTests } = await import("../src/demo/live-mode.js");
+    _resetLiveWalletForTests();
+  });
+
+  it("returns the four personas regardless of env state (the core #392 fix)", async () => {
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    for (const v of [undefined, "1", "true", "yes"]) {
+      if (v === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = v;
+      const r = buildGetDemoWalletResponse();
+      const ids = r.personas.map((p) => p.id).sort();
+      expect(ids, `personas with VAULTPILOT_DEMO=${JSON.stringify(v)}`).toEqual(
+        ["defi-power-user", "stable-saver", "staking-maxi", "whale"].sort(),
+      );
+    }
+  });
+
+  it("when env is unset: demoActive=false, envState='unset', message names the literal", async () => {
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(false);
+    expect(r.envState).toBe("unset");
+    expect(r.mode).toBeNull();
+    if (!r.demoActive) {
+      expect(r.message).toContain("VAULTPILOT_DEMO is unset");
+      expect(r.message).toContain("VAULTPILOT_DEMO=true");
+    }
+  });
+
+  it("when env is invalid: message echoes the (sanitized) value and explains the strict literal", async () => {
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "1";
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(false);
+    expect(r.envState).toBe("invalid");
+    if (!r.demoActive) {
+      expect(r.message).toContain("set to '1'");
+      expect(r.message).toContain("expects the exact literal 'true'");
+      // The most common mistakes are called out so the user (and agent)
+      // doesn't burn a debugging cycle on truthy-parse assumptions.
+      expect(r.message).toMatch(/'1'.*'yes'.*'on'.*'TRUE'|'TRUE'.*'on'.*'yes'.*'1'/);
+    }
+  });
+
+  it("redacts an attacker-shaped invalid value before echoing it back", async () => {
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "x".repeat(200) + "\n\x00";
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(false);
+    if (!r.demoActive) {
+      // No raw newline / NUL leaks into the response.
+      expect(r.message).not.toMatch(/[\n\x00]/);
+      // The displayed value is bounded.
+      const m = r.message.match(/set to '([^']*)'/);
+      expect(m).not.toBeNull();
+      expect(m![1].length).toBeLessThanOrEqual(32);
+    }
+  });
+
+  it("when env is enabled and no live wallet: demoActive=true, mode='default', active=null", async () => {
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "true";
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(true);
+    expect(r.envState).toBe("enabled");
+    if (r.demoActive) {
+      expect(r.mode).toBe("default");
+      expect(r.active).toBeNull();
+    }
+  });
+
+  it("when env is enabled and a persona is active: demoActive=true, mode='live', active populated", async () => {
+    const { buildGetDemoWalletResponse, setLivePersona } = await import(
+      "../src/demo/index.js"
+    );
+    process.env[ENV_KEY] = "true";
+    setLivePersona("defi-power-user");
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(true);
+    if (r.demoActive) {
+      expect(r.mode).toBe("live");
+      expect(r.active?.personaId).toBe("defi-power-user");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `get_demo_wallet` now ALWAYS returns the persona catalog (defi-power-user, stable-saver, staking-maxi, whale) regardless of `VAULTPILOT_DEMO` state, so an agent can offer the user a choice without first asking them to edit MCP client config blind.
- New `envState` field in the response (`'enabled' | 'invalid' | 'unset'`) distinguishes the two failure modes that previously both rendered as "VAULTPILOT_DEMO is unset". When env is set-but-wrong (e.g. `=1`, `=yes`, `=TRUE`), the message echoes the sanitized value back: `"set to '1' but expects the exact literal 'true'"` — turning an opaque debugging cycle into a one-look fix.
- Strict `=== "true"` literal kept as the security gate. Loosening to truthy parsing would expand the accidentally-on surface; boot-time env vars are intentionally the only flip an in-session prompt injection can't reach. Issue option (D) declined for that reason.

Refactor: response builder extracted to `buildGetDemoWalletResponse()` in `src/demo/index.ts` so the registered handler is a one-liner and the response shape is directly unit-testable.

Defensive: `redactInvalidDemoEnvValue` strips ASCII control chars and caps the echoed value at 32 chars before relay — env vars are arbitrary user input, the JSON response shouldn't carry control bytes downstream.

Closes #392
Related: #391, #393

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 1918/1918 pass; 13 new cases added under three `issue #392` describes covering env-state classifier (4), value sanitizer (3), and response builder (6: persona-list always-present invariant, three envState branches, value redaction, live-wallet path).
- [ ] Manual: with `VAULTPILOT_DEMO` unset, call `get_demo_wallet` → personas listed + actionable message; with `VAULTPILOT_DEMO=1`, message names the value and the strict literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)