### PR TITLE
fix(demo): preview_send no longer requires WALLETCONNECT_PROJECT_ID (#395)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -87,6 +87,7 @@ import { getClient, verifyChainId } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
 import { resolveTokenMeta } from "../shared/token-meta.js";
 import { simulateTx } from "../simulation/index.js";
+import { isDemoMode } from "../../demo/index.js";
 import {
   buildAaveSupply,
   buildAaveWithdraw,
@@ -2818,7 +2819,12 @@ async function runEvmPreSignGuards(tx: UnsignedTx): Promise<void> {
         `and wait for confirmation before retrying. Use simulate_transaction to debug.`,
     );
   }
-  if (tx.from) {
+  // The WC account-match check is meaningless in demo mode: there's no paired
+  // session (and no project ID needed), and `send_transaction` returns a sim
+  // envelope rather than broadcasting. Calling getConnectedAccounts() here
+  // would throw inside getProjectId() and abort the whole preview flow before
+  // the integrity-check / hash output the demo is meant to showcase.
+  if (tx.from && !isDemoMode()) {
     const accounts = (await getConnectedAccounts()).map((a) => a.toLowerCase());
     const from = tx.from.toLowerCase();
     if (accounts.length > 0 && !accounts.includes(from)) {
@@ -2936,11 +2942,21 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     };
   }
   await runEvmPreSignGuards(tx);
+  // Demo mode never opens a WC session, so don't fall back to it for the
+  // sender address. Every prepare_* writes `tx.from` from the wallet arg,
+  // which is the persona address in demo mode — that's the value we want.
   const from =
-    tx.from ?? ((await getConnectedAccounts())[0] as `0x${string}` | undefined);
+    tx.from ??
+    (isDemoMode()
+      ? undefined
+      : ((await getConnectedAccounts())[0] as `0x${string}` | undefined));
   if (!from) {
     throw new Error(
-      "Cannot determine sender address for nonce/fee pin; pair Ledger Live first.",
+      isDemoMode()
+        ? "Cannot determine sender address for nonce/fee pin in demo mode. The prepare_* tool " +
+            "did not set tx.from; this is an internal bug. Re-run set_demo_wallet and the " +
+            "prepare_* tool, or file an issue with the failing tool name."
+        : "Cannot determine sender address for nonce/fee pin; pair Ledger Live first.",
     );
   }
   const pinned = await pinSendFields(tx.chain, from, tx.to, tx.data, tx.value);

--- a/test/preview-send-demo.test.ts
+++ b/test/preview-send-demo.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for issue #395.
+ *
+ * Repro from the issue: VAULTPILOT_DEMO=1, no WALLETCONNECT_PROJECT_ID, run
+ * set_demo_wallet → prepare_aave_withdraw → preview_send. The preview path
+ * threw "No WalletConnect project ID configured" because runEvmPreSignGuards
+ * called getConnectedAccounts() unconditionally, which initializes the WC
+ * SignClient and reads the project ID before any account lookup happens.
+ *
+ * Fix: skip the WC account-match check (and the connected-accounts fallback
+ * for tx.from) when isDemoMode() is true. send_transaction already returns
+ * a sim envelope in demo mode, so the WC transport is never actually used —
+ * the project-ID check is dead weight on the demo flow.
+ *
+ * The test deliberately does NOT mock src/signing/walletconnect.js so that
+ * any accidental call into that module (which is what the bug was) would
+ * still throw the real "No WalletConnect project ID configured" error and
+ * fail the test. The RPC + pre-sign-check mocks mirror preview-token-gate's
+ * setup so we only test the demo-mode branch in isolation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+function mockEvmRpcOnly() {
+  vi.doMock("../src/data/rpc.js", () => ({
+    getClient: () => ({
+      call: vi.fn().mockResolvedValue({ data: "0x" }),
+      getTransactionCount: vi.fn().mockResolvedValue(7),
+      getBlock: vi.fn().mockResolvedValue({ baseFeePerGas: 10_000_000_000n }),
+      estimateMaxPriorityFeePerGas: vi.fn().mockResolvedValue(2_000_000_000n),
+      estimateGas: vi.fn().mockResolvedValue(21_000n),
+    }),
+    verifyChainId: vi.fn().mockResolvedValue(undefined),
+    resetClients: () => {},
+  }));
+  vi.doMock("../src/signing/pre-sign-check.js", () => ({
+    assertTransactionSafe: vi.fn().mockResolvedValue(undefined),
+  }));
+}
+
+function makeDemoEvmTx() {
+  return {
+    chain: "ethereum" as const,
+    to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as `0x${string}`,
+    data: "0x" as `0x${string}`,
+    value: "1",
+    from: "0x8F9dE85C01070D2762d29A6Dd7ffEcC965b34361" as `0x${string}`,
+    description: "demo aave withdraw",
+  };
+}
+
+describe("preview_send in demo mode (issue #395)", () => {
+  const originalDemo = process.env.VAULTPILOT_DEMO;
+  const originalWcId = process.env.WALLETCONNECT_PROJECT_ID;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.VAULTPILOT_DEMO = "true";
+    delete process.env.WALLETCONNECT_PROJECT_ID;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalDemo === undefined) delete process.env.VAULTPILOT_DEMO;
+    else process.env.VAULTPILOT_DEMO = originalDemo;
+    if (originalWcId === undefined) delete process.env.WALLETCONNECT_PROJECT_ID;
+    else process.env.WALLETCONNECT_PROJECT_ID = originalWcId;
+  });
+
+  it("does not throw 'No WalletConnect project ID configured' — runs the integrity-check path through to a pinned hash", async () => {
+    mockEvmRpcOnly();
+    const { issueHandles } = await import("../src/signing/tx-store.js");
+    const stamped = issueHandles(makeDemoEvmTx());
+    const { previewSend } = await import("../src/modules/execution/index.js");
+
+    const preview = await previewSend({ handle: stamped.handle! });
+
+    expect(preview.previewToken).toMatch(/^[0-9a-f-]{36}$/);
+    expect(preview.preSignHash).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(preview.pinned.nonce).toBe(7);
+    expect(preview.from ?? stamped.from).toBeDefined();
+  });
+
+  it("still throws when tx.from is unset in demo mode — caller must pre-set it via prepare_*", async () => {
+    mockEvmRpcOnly();
+    const { issueHandles } = await import("../src/signing/tx-store.js");
+    const txWithoutFrom = { ...makeDemoEvmTx(), from: undefined };
+    const stamped = issueHandles(txWithoutFrom as ReturnType<typeof makeDemoEvmTx>);
+    const { previewSend } = await import("../src/modules/execution/index.js");
+
+    await expect(previewSend({ handle: stamped.handle! })).rejects.toThrow(
+      /demo mode/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- In demo mode, `runEvmPreSignGuards` called `getConnectedAccounts()` unconditionally for the WC account-match check. That path initializes the WalletConnect SignClient and reads `WALLETCONNECT_PROJECT_ID` before any account lookup, so a demo-mode user with no project ID saw "No WalletConnect project ID configured" thrown out of `preview_send` — hiding the pre-sign hash + CHECKS PERFORMED output the demo is meant to showcase.
- Skip the WC account-match check when `isDemoMode()` is true. `send_transaction` already returns a sim envelope rather than broadcasting in demo, so the WC transport is never actually used — the project-ID check is dead weight on the demo flow.
- Mirror the same guard at the `tx.from` fallback (defensive — every `prepare_*` writes `from`, so the fallback is unreachable in demo today, but the error message would have been just as misleading if it ever fired).

Fixes #395.

## Test plan

- [x] New regression test `test/preview-send-demo.test.ts`: deliberately does NOT mock `src/signing/walletconnect.js`, so any accidental call into it would still throw the real "No WalletConnect project ID configured" and fail the test. Exercises the demo-mode path through to a pinned `preSignHash` + `previewToken`.
- [x] Second case: `tx.from` unset in demo mode → still throws, but with a demo-flavored message (no WC reference).
- [x] `npx vitest run` — 157 files, 1925 tests, all green.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)