### PR TITLE
feat(demo): auto-demo mode on fresh install (no env var required)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,31 @@ If they have paired, you'll get back a full breakdown of native
 balances, tokens, lending, LP, and staking across whichever chains
 they have addresses on.
 
+### Auto demo mode on a fresh install
+
+A brand-new install (no `~/.vaultpilot-mcp/config.json` yet, no
+`VAULTPILOT_DEMO` env var set) boots into **auto-demo mode**: every
+read tool runs against real chain RPC, every signing-class tool
+refuses or is intercepted, and a curated set of demo personas
+(`defi-power-user`, `stable-saver`, `staking-maxi`, `whale`) is
+available via `set_demo_wallet`. The agent will see a one-shot
+`VAULTPILOT NOTICE — Auto demo mode active` block on the first tool
+response — surface it to the user and offer the demo path before
+asking them to pair hardware.
+
+The user has two ways to leave auto-demo when they're ready for real
+funds:
+
+1. **Run setup** (recommended): `npx -y -p vaultpilot-mcp vaultpilot-mcp-setup`
+   writes a config file. Auto-demo turns OFF on the next boot. Then
+   restart Claude Code and pair the Ledger via `pair_ledger_*`.
+2. **Explicit opt-out**: set `VAULTPILOT_DEMO=false` in the MCP client
+   config (e.g. `.claude.json`'s `env` block) and restart. Real mode
+   is active immediately even without a config file.
+
+`VAULTPILOT_DEMO=true` is the explicit opt-in path — useful for CI /
+scripted contexts where you want demo mode regardless of disk state.
+
 To prepare and sign a transaction, the typical flow is:
 
 1. `prepare_*` to build the unsigned tx (returns a `handle`).

--- a/src/check.ts
+++ b/src/check.ts
@@ -249,6 +249,50 @@ export function runDoctor(): DoctorReport {
     });
   }
 
+  // Demo-mode classification — `--check` is the canonical pre-restart
+  // surface, so it should tell the user (and any assisting agent)
+  // whether the next boot will be in demo or real mode and why.
+  // Surfaced as `warn` for demo (not `fail`) so the doctor exits 0;
+  // demo isn't an install error, it's a deliberate configuration.
+  const envValue = process.env.VAULTPILOT_DEMO;
+  const envEnabled = envValue === "true";
+  const envDisabled = envValue === "false";
+  const envInvalid = envValue !== undefined && !envEnabled && !envDisabled;
+  if (envEnabled) {
+    checks.push({
+      name: "demo-mode",
+      status: "warn",
+      message:
+        "Demo mode is ON via VAULTPILOT_DEMO=true. Signing tools refuse, broadcast is intercepted to a simulation envelope. To use real funds, unset VAULTPILOT_DEMO and restart.",
+    });
+  } else if (envInvalid) {
+    checks.push({
+      name: "demo-mode",
+      status: "warn",
+      message: `VAULTPILOT_DEMO is set to '${envValue}' — server expects the exact literal 'true' (or 'false' to opt out). Treated as normal mode. Fix the value or remove the var.`,
+    });
+  } else if (envDisabled) {
+    checks.push({
+      name: "demo-mode",
+      status: "ok",
+      message:
+        "Demo mode is OFF via explicit VAULTPILOT_DEMO=false (suppresses auto-demo on fresh installs).",
+    });
+  } else if (!configExists && !legacyExists) {
+    checks.push({
+      name: "demo-mode",
+      status: "warn",
+      message:
+        "Auto-demo will activate on next boot: VAULTPILOT_DEMO is unset and no config file exists. Signing tools will refuse, broadcast intercepted. To opt out, run `vaultpilot-mcp-setup` (writes config, restart-gated) or set VAULTPILOT_DEMO=false.",
+    });
+  } else {
+    checks.push({
+      name: "demo-mode",
+      status: "ok",
+      message: "Demo mode is OFF (env unset + config present). Signing routes through Ledger as normal.",
+    });
+  }
+
   return {
     ok: checks.every((c) => c.status !== "fail"),
     checks,

--- a/src/demo/auto-detect.ts
+++ b/src/demo/auto-detect.ts
@@ -1,0 +1,48 @@
+/**
+ * Auto-demo detection (issue #391/#392 follow-up).
+ *
+ * The original demo-mode gate (`VAULTPILOT_DEMO=true`) requires editing
+ * the MCP client config (e.g. `.claude.json`'s `env` block) and
+ * restarting Claude Code — friction that killed the try-before-install
+ * path #391/#392 tried to surface. Auto-demo flips that default: a fresh
+ * install with no config file is implicitly in demo mode, so an agent
+ * can offer personas + simulated signing the moment the user says "let's
+ * try it" — no env-var dance.
+ *
+ * Trigger: `readUserConfig() === null` — i.e. no config file in either
+ * the new (`~/.vaultpilot-mcp/`) or legacy (`~/.recon-crypto-mcp/`)
+ * location. `readUserConfig` already handles both paths.
+ *
+ * Pairings are NOT a separate signal because they live INSIDE
+ * `config.json` (`pairings.solana`, `pairings.bitcoin`, etc.). Config
+ * absence implies no pairings; config presence implies the user has
+ * either run `vaultpilot-mcp-setup` or paired hardware — either way,
+ * past the "fresh install" state.
+ *
+ * Boot-time, latched: detection runs once at process start, the result
+ * is frozen for the rest of the process. A user who pairs / runs setup
+ * mid-session stays in their initial mode until restart. This keeps the
+ * security boundary crisp (mode change requires off-process state +
+ * restart, mirroring the env-var commitment) and avoids weird
+ * mid-session mode flips.
+ *
+ * Failure mode: `readUserConfig` throws on malformed JSON. We catch and
+ * treat malformed-config as "config present" — the user has been here,
+ * the auto-demo nudge would be wrong. Fail closed (real mode) when
+ * config state is ambiguous; an explicit `VAULTPILOT_DEMO=true` is the
+ * way to force demo regardless of disk state.
+ */
+import { readUserConfig } from "../config/user-config.js";
+
+/**
+ * Pure detection function — caller invokes once at boot via
+ * `initDemoMode()` in `./index.ts` to populate the latched value.
+ * Re-exported for direct unit testing.
+ */
+export function detectAutoDemoMode(): boolean {
+  try {
+    return readUserConfig() === null;
+  } catch {
+    return false;
+  }
+}

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -1,26 +1,39 @@
 /**
- * Demo / try-before-install mode (issue #371). `VAULTPILOT_DEMO=true` is
- * the single env-var gate.
+ * Demo / try-before-install mode.
  *
- * Two sub-modes coexist behind that gate:
+ * Two activation paths land in the same demo-mode state machine:
  *
- *   1. **Default demo mode** (env set, no live wallet): every read tool
- *      runs against real chain RPC, every signing-class tool refuses
- *      with a structured `[VAULTPILOT_DEMO]` error. A prospective user
- *      can browse any address they pass without committing to a Ledger.
+ *   1. **Explicit env** (`VAULTPILOT_DEMO=true`, issue #371) — the
+ *      original boot-time opt-in. Useful for CI / non-interactive
+ *      contexts and as an "I really mean it" override.
+ *   2. **Auto / fresh-install** (issue #391/#392 follow-up) — when the
+ *      env var is unset AND no config file exists, the server boots
+ *      into demo mode by default. The first install of vaultpilot-mcp
+ *      can offer personas + simulated signing without the user editing
+ *      `.claude.json` and restarting Claude Code.
  *
- *   2. **Live demo mode** (env set + `set_demo_wallet` called): a
- *      curated persona or custom address bundle is active. Reads still
- *      run real RPC, prepare_* / simulate_* / preview_* still run real,
- *      but `send_transaction` is intercepted and returns a simulation
- *      envelope (no signing, no broadcast). The handful of tools that
- *      write disk / GH / hardware state stay refused even in live mode.
+ * Two sub-modes coexist behind whichever gate fired:
  *
- * Activation transitions are runtime, not boot-time: an agent in default
- * mode can call `set_demo_wallet({ persona: "..." })` to upgrade to live
- * mode for the remainder of the process lifetime; calling
- * `set_demo_wallet({})` returns to default. State is process-local and
- * resets on restart — demo state is ephemeral by design.
+ *   - **Default demo** (no live wallet set): every read tool runs
+ *     against real chain RPC, every signing-class tool refuses with a
+ *     structured `[VAULTPILOT_DEMO]` error pointing at `set_demo_wallet`.
+ *   - **Live demo** (`set_demo_wallet` called): a curated persona or
+ *     custom address bundle is active. Reads + prepare_* / simulate_* /
+ *     preview_* run real; only `send_transaction` is intercepted and
+ *     returns a simulation envelope (no signing, no broadcast).
+ *
+ * Mode is **latched at boot**: once `initDemoMode()` runs, the auto-
+ * detection result is frozen for the rest of the process. A user who
+ * pairs a Ledger or runs `vaultpilot-mcp-setup` mid-session stays in
+ * their initial mode until restart. This keeps the security boundary
+ * crisp — a mode change requires off-process state (env mutation OR
+ * config-file write) PLUS a process restart, mirroring the original
+ * env-var commitment that an in-session prompt injection couldn't
+ * touch.
+ *
+ * Live-wallet selection (`set_demo_wallet({ persona: ... })`) is the
+ * ONE runtime transition allowed within demo mode. It only changes
+ * sub-mode (default → live), never crosses the demo/real boundary.
  */
 
 import {
@@ -32,36 +45,111 @@ import {
   type LiveWalletState,
 } from "./live-mode.js";
 import { PERSONAS, type Persona } from "./personas.js";
+import { detectAutoDemoMode } from "./auto-detect.js";
 
 /**
- * True when `VAULTPILOT_DEMO=true` is set in the environment. Read at
- * tool-call time (not module load) so a single process can be flipped
- * via env mutation in tests without re-imports.
+ * Latched auto-detection result. `null` = not yet initialized;
+ * `true` = boot detected fresh-install state (no config); `false` =
+ * config was present at boot, auto-demo is off.
+ *
+ * `null` is treated as `false` by `getDemoModeReason()` so a forgotten
+ * `initDemoMode()` call fails closed (real mode), not open (auto-demo).
+ * Tests that need the latched-true behavior call `initDemoMode()` (or
+ * `_setAutoDemoForTests(true)`) explicitly.
  */
-export function isDemoMode(): boolean {
-  return process.env.VAULTPILOT_DEMO === "true";
+let autoDemoLatched: boolean | null = null;
+
+/**
+ * Run auto-detection once at boot and latch the result. Idempotent:
+ * later calls in the same process are no-ops, so the latched value is
+ * frozen for the process lifetime. Call this from the entry point
+ * BEFORE registering tools so the first `isDemoMode()` evaluation
+ * during tool dispatch sees the resolved state.
+ */
+export function initDemoMode(): void {
+  if (autoDemoLatched !== null) return;
+  autoDemoLatched = detectAutoDemoMode();
 }
 
 /**
- * Three-state classifier for the VAULTPILOT_DEMO env var (issue #392).
+ * Test-only: reset the latch so different test cases can simulate
+ * different boot states. Production code MUST NOT call this.
+ */
+export function _resetAutoDemoLatchForTests(): void {
+  autoDemoLatched = null;
+}
+
+/**
+ * Test-only: directly set the latched value without going through disk
+ * detection. Useful for tests that don't want to set up tmp config dirs.
+ */
+export function _setAutoDemoLatchForTests(value: boolean | null): void {
+  autoDemoLatched = value;
+}
+
+/**
+ * Why the server is (or isn't) in demo mode. Drives error-message
+ * branching: an `auto-fresh-install` user gets pointed at
+ * `vaultpilot-mcp-setup` as the leave path (since they have no env var
+ * to unset), an `explicit-env` user gets pointed at `unset
+ * VAULTPILOT_DEMO + restart`.
+ */
+export type DemoModeReason =
+  | "explicit-env"        // VAULTPILOT_DEMO=true
+  | "auto-fresh-install"  // env unset + no config at boot → auto-demo on
+  | "explicit-opt-out"    // VAULTPILOT_DEMO=false (deliberate real mode)
+  | "invalid-env"         // env set to something other than true/false (#392)
+  | "off";                // env unset + config present at boot
+
+export function getDemoModeReason(): DemoModeReason {
+  const envState = getDemoModeEnvState();
+  if (envState === "enabled") return "explicit-env";
+  if (envState === "disabled") return "explicit-opt-out";
+  if (envState === "invalid") return "invalid-env";
+  // env unset → auto-detection branch.
+  if (autoDemoLatched === true) return "auto-fresh-install";
+  return "off";
+}
+
+/**
+ * True when the server is in demo mode for any reason (explicit env or
+ * auto-detected fresh install). Read at tool-call time so tests can
+ * flip the latched state via `_setAutoDemoLatchForTests`.
+ *
+ * Note: `invalid-env` (e.g. VAULTPILOT_DEMO=1) does NOT auto-fall
+ * through to auto-demo even when config is absent. The user explicitly
+ * tried to configure the env var; honoring that signal — by NOT
+ * auto-flipping into demo — keeps the behavior predictable, and the
+ * `get_demo_wallet` message tells them their literal was wrong.
+ */
+export function isDemoMode(): boolean {
+  const reason = getDemoModeReason();
+  return reason === "explicit-env" || reason === "auto-fresh-install";
+}
+
+/**
+ * Four-state classifier for the VAULTPILOT_DEMO env var.
  *
  * The strict literal `=== "true"` gate is intentional — boot-time env
  * vars are the only safe place to flip demo mode (an in-session prompt
  * injection can't mutate them), and a sloppy truthy parse would expand
  * the surface for accidentally-on demo. The cost of strictness is that
- * `VAULTPILOT_DEMO=1` silently behaves as "unset", which sent users
- * down the wrong debugging path: they'd re-edit the MCP client config
- * to ADD the var when it was already present with a wrong value.
+ * `VAULTPILOT_DEMO=1` silently behaved as "unset" pre-#392, which
+ * sent users down the wrong debugging path. Splitting "unset" /
+ * "disabled" / "invalid" / "enabled" lets the response message tell
+ * the user which mistake they made.
  *
- * Splitting "unset" from "invalid" lets `get_demo_wallet`'s message
- * tell the user which mistake they made.
+ * `disabled` (env=false) is the auto-demo escape hatch — a user who
+ * wants real mode on a fresh install (no config yet) sets this to
+ * suppress the auto-detection.
  */
-export type DemoModeEnvState = "enabled" | "invalid" | "unset";
+export type DemoModeEnvState = "enabled" | "disabled" | "invalid" | "unset";
 
 export function getDemoModeEnvState(): DemoModeEnvState {
   const value = process.env.VAULTPILOT_DEMO;
   if (value === undefined) return "unset";
   if (value === "true") return "enabled";
+  if (value === "false") return "disabled";
   return "invalid";
 }
 
@@ -102,14 +190,16 @@ export type GetDemoWalletResponse =
   | {
       demoActive: true;
       mode: "default" | "live";
-      envState: "enabled";
+      reason: "explicit-env" | "auto-fresh-install";
+      envState: DemoModeEnvState;
       active: LiveWalletState | null;
       personas: PersonaSummary[];
     }
   | {
       demoActive: false;
       mode: null;
-      envState: "unset" | "invalid";
+      reason: "explicit-opt-out" | "invalid-env" | "off";
+      envState: DemoModeEnvState;
       message: string;
       personas: PersonaSummary[];
     };
@@ -120,38 +210,55 @@ export function buildGetDemoWalletResponse(): GetDemoWalletResponse {
     description: p.description,
     addresses: p.addresses,
   }));
+  const reason = getDemoModeReason();
   const envState = getDemoModeEnvState();
-  if (envState === "enabled") {
+  if (reason === "explicit-env" || reason === "auto-fresh-install") {
     const live = getLiveWallet();
     return {
       demoActive: true,
       mode: live === null ? "default" : "live",
+      reason,
       envState,
       active: live,
       personas,
     };
   }
   let message: string;
-  if (envState === "unset") {
+  if (reason === "explicit-opt-out") {
     message =
-      "VAULTPILOT_DEMO is unset — server is in normal mode. The personas " +
-      "below are listed for discovery so you can offer the user a choice. " +
-      "To activate demo mode, set `VAULTPILOT_DEMO=true` (exact literal, " +
-      "lowercase) in the MCP client config (e.g. `.claude.json`'s `env` " +
-      "block for this server) and restart Claude Code.";
-  } else {
+      "VAULTPILOT_DEMO is set to 'false' — server is in normal mode by " +
+      "explicit opt-out (suppresses the auto-demo path that would " +
+      "otherwise activate on a fresh install with no config file). The " +
+      "personas below are listed for discovery; to enable demo mode, " +
+      "either set `VAULTPILOT_DEMO=true` (exact literal, lowercase) or " +
+      "unset the var entirely on a host with no `~/.vaultpilot-mcp/" +
+      "config.json` (auto-demo). Restart Claude Code after either " +
+      "change.";
+  } else if (reason === "invalid-env") {
     const raw = process.env.VAULTPILOT_DEMO ?? "";
     const safe = redactInvalidDemoEnvValue(raw);
     message =
       `VAULTPILOT_DEMO is set to '${safe}' but the server expects the ` +
-      `exact literal 'true' — server is in normal mode. The personas ` +
-      `below are listed for discovery. Common confusion: '1', 'yes', ` +
-      `'on', 'TRUE' are all rejected; only lowercase 'true' enables ` +
-      `demo. Fix the value in the MCP client config and restart.`;
+      `exact literal 'true' (or 'false' to explicitly opt out) — server ` +
+      `is in normal mode. The personas below are listed for discovery. ` +
+      `Common confusion: '1', 'yes', 'on', 'TRUE' are all rejected; ` +
+      `only lowercase 'true' enables demo. Fix the value in the MCP ` +
+      `client config and restart.`;
+  } else {
+    // reason === "off": env unset + config file detected at boot.
+    // Auto-demo opted out structurally (the user has set up real-mode
+    // already). Personas still listed for discovery.
+    message =
+      "VAULTPILOT_DEMO is unset and a user config was detected at boot — " +
+      "server is in normal mode (auto-demo only fires on a fresh install " +
+      "with no config). The personas below are listed for discovery; to " +
+      "switch this session to demo, set `VAULTPILOT_DEMO=true` (exact " +
+      "literal, lowercase) in the MCP client config and restart.";
   }
   return {
     demoActive: false,
     mode: null,
+    reason,
     envState,
     message,
     personas,
@@ -210,16 +317,36 @@ export function isBroadcastTool(toolName: string): boolean {
 
 /**
  * Structured refusal for the always-gated set. Single source of truth so
- * the message is consistent across every blocked tool.
+ * the message is consistent across every blocked tool. Branches on
+ * `getDemoModeReason()` so the leave-demo path matches how demo got
+ * activated:
+ *
+ *   - explicit-env: "unset VAULTPILOT_DEMO and restart" (existing copy).
+ *   - auto-fresh-install: "run vaultpilot-mcp-setup, restart, then pair"
+ *     — there's no env var to unset; setup writes the config that turns
+ *     auto-demo OFF on the next boot.
  */
 export function alwaysGatedRefusalMessage(toolName: string): string {
-  return (
+  const reason = getDemoModeReason();
+  const baseRefusal =
     `[VAULTPILOT_DEMO] '${toolName}' is unavailable in demo mode regardless of live-wallet ` +
     `state. This tool either writes persistent off-chain state (Ledger pairing, GitHub) or ` +
     `requires a real Ledger device — neither has an on-chain simulation equivalent. ` +
     `Ready to leave demo and use this for real? Call \`exit_demo_mode\` for a tailored ` +
-    `step-by-step setup guide (asks about your Ledger + chain selection). Otherwise: unset ` +
-    `VAULTPILOT_DEMO and restart the MCP server with a real Ledger paired.`
+    `step-by-step setup guide (asks about your Ledger + chain selection).`;
+  if (reason === "auto-fresh-install") {
+    return (
+      baseRefusal +
+      ` Auto-demo is on because no \`~/.vaultpilot-mcp/config.json\` was detected at boot — ` +
+      `the leave path is to run \`npx -y -p vaultpilot-mcp vaultpilot-mcp-setup\` (writes a ` +
+      `config), restart Claude Code, then pair your Ledger. Alternatively, set ` +
+      `\`VAULTPILOT_DEMO=false\` in the MCP client config to explicitly opt out before pairing.`
+    );
+  }
+  // explicit-env (or any unexpected reason — fail to the existing copy).
+  return (
+    baseRefusal +
+    ` Otherwise: unset VAULTPILOT_DEMO and restart the MCP server with a real Ledger paired.`
   );
 }
 
@@ -295,17 +422,27 @@ function makeSimulatedTxHash(handle: string): string {
 }
 
 /**
- * Used by the setup wizard to refuse writing real config in demo mode —
- * a user who runs `vaultpilot-mcp-setup` while VAULTPILOT_DEMO=true is
- * almost certainly experimenting and shouldn't be silently writing
- * Ledger pairing state to disk. Throws with an actionable error.
+ * Used by the setup wizard to refuse writing real config when the user
+ * is experimenting under explicit demo mode. Auto-demo (fresh-install
+ * with no config) explicitly ALLOWS setup — running setup IS the
+ * canonical way to leave auto-demo, and refusing here would create a
+ * deadlock for a brand-new user.
+ *
+ *   - explicit-env (`VAULTPILOT_DEMO=true`): refuse. The user is
+ *     deliberately in evaluation mode; silently writing pairing state
+ *     to disk is the foot-gun this guard exists to catch.
+ *   - auto-fresh-install (env unset, no config): allow. This is the
+ *     intended progression: fresh install → auto-demo → run setup →
+ *     restart → real mode.
  */
 export function assertNotDemoForSetup(): void {
-  if (isDemoMode()) {
+  if (getDemoModeReason() === "explicit-env") {
     throw new Error(
-      "[VAULTPILOT_DEMO] Setup is disabled in demo mode — running `vaultpilot-mcp-setup` " +
-        "would write a real config (pairing state, indexer URLs) to disk while the server " +
-        "is operating in evaluation mode. Unset VAULTPILOT_DEMO and re-run setup.",
+      "[VAULTPILOT_DEMO] Setup is disabled when VAULTPILOT_DEMO=true is explicitly set — " +
+        "running `vaultpilot-mcp-setup` would write a real config (pairing state, indexer " +
+        "URLs) to disk while the server is operating in evaluation mode. Unset " +
+        "VAULTPILOT_DEMO and re-run setup. (Auto-demo on a fresh install does NOT block " +
+        "setup — running setup IS the way out of auto-demo.)",
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   defaultModeRefusalMessage,
   buildSimulationEnvelope,
   buildGetDemoWalletResponse,
+  getDemoModeReason,
+  initDemoMode,
   isLiveMode,
   getLiveWallet,
   setLivePersona,
@@ -653,37 +655,33 @@ export function _resetMissingDemoWalletDedup(): void {
 }
 
 /**
- * Render the demo-wallet onboarding notice when the server starts with
- * no user config file AND no active demo wallet — the canonical post-
- * install / pre-pairing state. Once the user creates a config (via
- * `vaultpilot-mcp-setup`) or activates a persona via `set_demo_wallet`,
- * the notice stops firing — the agent already has a clear path forward
- * either way and the nudge would just be noise.
+ * Render the demo-mode onboarding notice once per session when the
+ * server is in demo mode (any reason — explicit env or auto-detected
+ * fresh install) AND no live wallet is active yet. Once the user
+ * activates a persona via `set_demo_wallet`, or restarts into a
+ * non-demo mode (config written, env unset), the notice stops firing.
  *
- * Dedup: once per session. Reset semantics mirror the skill notices —
- * if the user later removes the config and clears the persona, the
- * notice retriggers, since the post-install-zero state has returned.
+ * The auto-fresh-install reason latches at boot via `initDemoMode()`
+ * in `src/demo/index.ts`, so the notice's auto-vs-explicit copy
+ * branch is stable for the whole process even if the user writes a
+ * config mid-session.
  *
- * `readUserConfig()` returns null when neither the new
- * `~/.vaultpilot-mcp/config.json` nor the legacy `~/.recon-crypto-mcp/`
- * path exists, which is exactly the "no config" signal we want.
+ * Dedup: once per session, reset semantics mirror the skill notices.
  */
 export function missingDemoWalletNotice(): string | null {
-  let configPresent = false;
-  try {
-    configPresent = readUserConfig() !== null;
-  } catch {
-    // Malformed config still counts as "config present" — the user has
-    // been here, the post-install onboarding nudge would be wrong.
-    configPresent = true;
-  }
-  if (configPresent || isLiveMode()) {
+  const reason = getDemoModeReason();
+  // Notice only fires while we're in demo mode AND no live wallet
+  // is set yet. Outside demo mode, the notice would be misleading.
+  if (
+    (reason !== "auto-fresh-install" && reason !== "explicit-env") ||
+    isLiveMode()
+  ) {
     missingDemoWalletNoticeEmitted = false;
     return null;
   }
   if (missingDemoWalletNoticeEmitted) return null;
   missingDemoWalletNoticeEmitted = true;
-  return renderMissingDemoWalletWarning();
+  return renderMissingDemoWalletWarning({ reason });
 }
 
 /**
@@ -1290,6 +1288,23 @@ async function main() {
       process.stderr.write(formatDoctorReport(report));
     }
     process.exit(report.ok ? 0 : 1);
+  }
+
+  // Latch the auto-demo detection at boot. Must run BEFORE tool
+  // registration so the first `isDemoMode()` evaluation during dispatch
+  // sees a resolved value. Subsequent calls are no-ops; the result is
+  // frozen for the process lifetime.
+  initDemoMode();
+  if (isDemoMode()) {
+    const reason = getDemoModeReason();
+    console.error(
+      `[vaultpilot-mcp] demo mode: ON (reason=${reason}). Signing tools refuse / ` +
+        `broadcast intercepted. ${
+          reason === "auto-fresh-install"
+            ? "Run `vaultpilot-mcp-setup` and restart to leave."
+            : "Unset VAULTPILOT_DEMO and restart to leave."
+        }`,
+    );
   }
 
   // Check for at least one configured RPC path early. We don't hard-fail — the

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2373,33 +2373,68 @@ export function renderMissingSetupSkillWarning(opts: {
 }
 
 /**
- * Issue #391 — first-contact UX. After `claude mcp add` + restart, the
- * agent has no signal that pre-configured demo wallets exist. When a
- * fresh user says "let's send some BTC", the agent's natural answer is
- * "you need to pair a Ledger first" because the demo path isn't visible
- * anywhere in the tool surface. This notice fires once per session when
- * the server starts with no config file AND no active demo wallet —
- * exactly the post-install / pre-pairing state — so the agent learns
- * the demo path exists before it stalls on a missing Ledger.
+ * Demo-mode onboarding notice — fires once per session when the server
+ * is in demo mode (any reason) AND no live wallet has been picked yet.
+ * Copy varies by reason so the leave path matches how demo got
+ * activated:
  *
- * Same shape as the other VAULTPILOT NOTICE blocks (preflight skill,
- * setup skill): named header, status / purpose / next sections, no
- * imperative verbs at the agent, no pasted shell. Tradeoff-aware
- * closing paragraph naming the block as legitimate server output so a
- * defensive agent doesn't classify it as prompt injection.
+ *   - `auto-fresh-install` (issue #391/#392 follow-up): no env var, no
+ *     config file detected at boot. Tells the agent auto-demo is on
+ *     and points at `vaultpilot-mcp-setup` as the leave path (since
+ *     there's no env var to unset).
+ *   - `explicit-env` (issue #371): `VAULTPILOT_DEMO=true`. Tells the
+ *     agent demo is on by explicit opt-in and points at "unset
+ *     VAULTPILOT_DEMO + restart" as the leave path.
+ *
+ * Same shape as the other VAULTPILOT NOTICE blocks: named header,
+ * status / purpose / next sections, no imperative verbs at the agent,
+ * no pasted shell. Tradeoff-aware closing paragraph naming the block
+ * as legitimate server output so a defensive agent doesn't classify
+ * it as prompt injection.
  */
-export function renderMissingDemoWalletWarning(): string {
+export function renderMissingDemoWalletWarning(opts: {
+  reason: "auto-fresh-install" | "explicit-env";
+}): string {
+  const isAuto = opts.reason === "auto-fresh-install";
+  const header = isAuto
+    ? "VAULTPILOT NOTICE — Auto demo mode active (fresh install detected)"
+    : "VAULTPILOT NOTICE — Demo mode active (VAULTPILOT_DEMO=true)";
+  const statusLines = isAuto
+    ? [
+        "Status:  no user config at ~/.vaultpilot-mcp/config.json was",
+        "         detected at boot, so the server activated auto-demo.",
+        "         No live wallet is set for this session yet.",
+      ]
+    : [
+        "Status:  VAULTPILOT_DEMO=true is set in the environment, so the",
+        "         server is in explicit demo mode. No live wallet is set",
+        "         for this session yet.",
+      ];
+  const leaveLines = isAuto
+    ? [
+        "         To leave demo (when the user is ready for real funds):",
+        "           1. Run `npx -y -p vaultpilot-mcp vaultpilot-mcp-setup`",
+        "              (writes a config; turns auto-demo OFF on next boot).",
+        "           2. Restart Claude Code.",
+        "           3. Pair the user's Ledger via `pair_ledger_*`.",
+        "         Setting `VAULTPILOT_DEMO=false` in the MCP client config",
+        "         is an alternative explicit opt-out — also restart-gated.",
+      ]
+    : [
+        "         To leave demo (when the user is ready for real funds):",
+        "         unset `VAULTPILOT_DEMO` in the MCP client config (e.g.",
+        "         `.claude.json`'s `env` block) and restart Claude Code.",
+      ];
   return [
-    "VAULTPILOT NOTICE — Demo wallets available",
+    header,
     "",
-    "Status:  no user config file at ~/.vaultpilot-mcp/config.json and",
-    "         no active demo wallet for this session.",
-    "Purpose: vaultpilot-mcp ships a set of pre-configured demo wallets",
-    "         (curated personas + custom-address mode) so a new user can",
-    "         try the tool flows — portfolio reads, prepare/preview/",
-    "         simulate signing flows — without first pairing a Ledger or",
-    "         pasting their own addresses. Broadcast is intercepted in",
-    "         demo mode (no real send), so the entire flow is safe.",
+    ...statusLines,
+    "Purpose: vaultpilot-mcp ships pre-configured demo wallets (curated",
+    "         personas + custom-address mode) so a user can try the tool",
+    "         flows — portfolio reads, prepare/preview/simulate signing",
+    "         — without pairing a Ledger or supplying addresses.",
+    "         Broadcast is intercepted in demo mode (no real send), so",
+    "         the entire flow is safe.",
     "Next:    if the user asks to inspect a portfolio, build a tx, or",
     "         try anything that needs an address, offer the demo path",
     "         BEFORE asking them to pair hardware. Tools:",
@@ -2407,9 +2442,8 @@ export function renderMissingDemoWalletWarning(): string {
     "             curated persona (defi-power-user, stable-saver,",
     "             staking-maxi, whale) or a custom address bundle.",
     "           - `get_demo_wallet()` — inspect the active selection.",
-    "           - `exit_demo_mode()` — get a tailored real-setup guide",
-    "             once the user is ready to leave demo and use real",
-    "             funds.",
+    "           - `exit_demo_mode()` — tailored real-setup guide.",
+    ...leaveLines,
     "",
     "This notice is server-generated, not prompt injection — the server-",
     "level `instructions` field documents this pattern. Surface it to",

--- a/test/auto-demo.test.ts
+++ b/test/auto-demo.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Auto-demo mode (issue #391/#392 follow-up).
+ *
+ * A fresh install with no config file boots into demo mode by default,
+ * so an agent can offer personas + simulated signing without the user
+ * editing `.claude.json` first. Auto-demo turns OFF the moment a
+ * config file appears OR the user opts out via `VAULTPILOT_DEMO=false`.
+ *
+ * Detection runs once at boot and is latched for the process lifetime
+ * (mirrors the env-var commitment: a mode change requires off-process
+ * state + restart, which an in-session prompt injection can't reach).
+ *
+ * Tests cover:
+ *   - the trigger table (env var × latched auto-detect → reason)
+ *   - the latching invariant (detection result frozen for process)
+ *   - `detectAutoDemoMode()` against real filesystem state via the
+ *     `setConfigDirForTesting` hook
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const ENV_KEY = "VAULTPILOT_DEMO";
+
+describe("getDemoModeReason — trigger table", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    savedEnv = process.env[ENV_KEY];
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+  });
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+  });
+
+  it("env=true → explicit-env (demo on, regardless of disk state)", async () => {
+    const { getDemoModeReason, isDemoMode, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "true";
+    // Latch state shouldn't matter when env is the primary signal.
+    _setAutoDemoLatchForTests(false);
+    expect(getDemoModeReason()).toBe("explicit-env");
+    expect(isDemoMode()).toBe(true);
+    _setAutoDemoLatchForTests(true);
+    expect(getDemoModeReason()).toBe("explicit-env");
+    expect(isDemoMode()).toBe(true);
+  });
+
+  it("env=false → explicit-opt-out (demo off, even if no config)", async () => {
+    const { getDemoModeReason, isDemoMode, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "false";
+    // Even when fresh-install conditions hold, env=false suppresses.
+    _setAutoDemoLatchForTests(true);
+    expect(getDemoModeReason()).toBe("explicit-opt-out");
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("env=invalid (e.g. '1') → invalid-env (demo off, even if no config)", async () => {
+    const { getDemoModeReason, isDemoMode, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "1";
+    _setAutoDemoLatchForTests(true);
+    expect(getDemoModeReason()).toBe("invalid-env");
+    // Critical: invalid env does NOT fall through to auto-demo. The
+    // user tried to set the var; honoring that signal — by NOT
+    // auto-flipping — keeps the behavior predictable.
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("env unset + latched=true → auto-fresh-install (demo on)", async () => {
+    const { getDemoModeReason, isDemoMode, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    _setAutoDemoLatchForTests(true);
+    expect(getDemoModeReason()).toBe("auto-fresh-install");
+    expect(isDemoMode()).toBe(true);
+  });
+
+  it("env unset + latched=false → off (demo off, normal mode)", async () => {
+    const { getDemoModeReason, isDemoMode, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    _setAutoDemoLatchForTests(false);
+    expect(getDemoModeReason()).toBe("off");
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("env unset + latch never initialized → off (fail closed, real mode)", async () => {
+    const { getDemoModeReason, isDemoMode, _resetAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    delete process.env[ENV_KEY];
+    _resetAutoDemoLatchForTests();
+    // Forgetting to call initDemoMode() must not silently flip the
+    // server into demo mode — fail closed (real) is the safer default.
+    expect(getDemoModeReason()).toBe("off");
+    expect(isDemoMode()).toBe(false);
+  });
+});
+
+describe("detectAutoDemoMode — readUserConfig signal", () => {
+  // We mock readUserConfig directly rather than fixturing the
+  // filesystem because `setConfigDirForTesting` only redirects the new
+  // path (~/.vaultpilot-mcp/) — the legacy fallback path is fixed at
+  // module-load time via homedir(), so a developer machine that has a
+  // legacy ~/.recon-crypto-mcp/config.json will leak through. Mocking
+  // is more deterministic.
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns true when readUserConfig returns null (fresh install)", async () => {
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return { ...actual, readUserConfig: () => null };
+    });
+    const { detectAutoDemoMode } = await import("../src/demo/auto-detect.js");
+    expect(detectAutoDemoMode()).toBe(true);
+  });
+
+  it("returns false when readUserConfig returns a config object (user has set up or paired)", async () => {
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return { ...actual, readUserConfig: () => ({} as unknown as never) };
+    });
+    const { detectAutoDemoMode } = await import("../src/demo/auto-detect.js");
+    expect(detectAutoDemoMode()).toBe(false);
+  });
+
+  it("returns false on malformed config — fail closed (real mode) when state is ambiguous", async () => {
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return {
+        ...actual,
+        readUserConfig: () => {
+          throw new Error("malformed JSON");
+        },
+      };
+    });
+    const { detectAutoDemoMode } = await import("../src/demo/auto-detect.js");
+    expect(detectAutoDemoMode()).toBe(false);
+  });
+});
+
+describe("initDemoMode — latching invariant", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  it("freezes detection at first call: a config appearing mid-process does NOT flip the latched value", async () => {
+    // Phase 1: boot with no config → detector returns true.
+    let configPresent = false;
+    vi.doMock("../src/config/user-config.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/config/user-config.js")
+      >("../src/config/user-config.js");
+      return {
+        ...actual,
+        readUserConfig: () => (configPresent ? ({} as unknown as never) : null),
+      };
+    });
+    const {
+      initDemoMode,
+      getDemoModeReason,
+      _resetAutoDemoLatchForTests,
+    } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+    initDemoMode();
+    expect(getDemoModeReason()).toBe("auto-fresh-install");
+    // Phase 2: user runs setup mid-session, config appears, but the
+    // latched value stays `auto-fresh-install` until process restart.
+    configPresent = true;
+    initDemoMode();
+    expect(getDemoModeReason()).toBe("auto-fresh-install");
+  });
+
+  it("subsequent initDemoMode() calls are no-ops (idempotent)", async () => {
+    const {
+      initDemoMode,
+      getDemoModeReason,
+      _resetAutoDemoLatchForTests,
+      _setAutoDemoLatchForTests,
+    } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+    _setAutoDemoLatchForTests(true);
+    // initDemoMode should NOT overwrite the explicitly-set latch.
+    initDemoMode();
+    expect(getDemoModeReason()).toBe("auto-fresh-install");
+  });
+});
+
+describe("buildGetDemoWalletResponse — auto-demo branch", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    savedEnv = process.env[ENV_KEY];
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    const { _resetLiveWalletForTests } = await import(
+      "../src/demo/live-mode.js"
+    );
+    _resetAutoDemoLatchForTests();
+    _resetLiveWalletForTests();
+  });
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    const { _resetLiveWalletForTests } = await import(
+      "../src/demo/live-mode.js"
+    );
+    _resetAutoDemoLatchForTests();
+    _resetLiveWalletForTests();
+  });
+
+  it("auto-fresh-install: demoActive=true with reason='auto-fresh-install'", async () => {
+    delete process.env[ENV_KEY];
+    const { buildGetDemoWalletResponse, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(true);
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(true);
+    if (r.demoActive) {
+      expect(r.reason).toBe("auto-fresh-install");
+      expect(r.envState).toBe("unset");
+      expect(r.mode).toBe("default");
+    }
+  });
+
+  it("explicit-opt-out: demoActive=false with reason='explicit-opt-out' and the right message", async () => {
+    process.env[ENV_KEY] = "false";
+    const { buildGetDemoWalletResponse } = await import("../src/demo/index.js");
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(false);
+    if (!r.demoActive) {
+      expect(r.reason).toBe("explicit-opt-out");
+      expect(r.envState).toBe("disabled");
+      expect(r.message).toContain("set to 'false'");
+      expect(r.message).toContain("explicit opt-out");
+    }
+  });
+
+  it("off (env unset + config present): message names the config-detected branch", async () => {
+    delete process.env[ENV_KEY];
+    const { buildGetDemoWalletResponse, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(false);
+    const r = buildGetDemoWalletResponse();
+    expect(r.demoActive).toBe(false);
+    if (!r.demoActive) {
+      expect(r.reason).toBe("off");
+      expect(r.message).toContain("user config was detected at boot");
+    }
+  });
+});
+
+describe("alwaysGatedRefusalMessage — branches on reason", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    savedEnv = process.env[ENV_KEY];
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+  });
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+  });
+
+  it("auto-fresh-install: leave path is `vaultpilot-mcp-setup`, not `unset VAULTPILOT_DEMO`", async () => {
+    delete process.env[ENV_KEY];
+    const { alwaysGatedRefusalMessage, _setAutoDemoLatchForTests } =
+      await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(true);
+    const msg = alwaysGatedRefusalMessage("pair_ledger_solana");
+    expect(msg).toContain("Auto-demo is on");
+    expect(msg).toContain("vaultpilot-mcp-setup");
+    expect(msg).not.toContain("unset VAULTPILOT_DEMO and restart");
+  });
+
+  it("explicit-env: leave path is `unset VAULTPILOT_DEMO and restart` (existing copy preserved)", async () => {
+    process.env[ENV_KEY] = "true";
+    const { alwaysGatedRefusalMessage } = await import("../src/demo/index.js");
+    const msg = alwaysGatedRefusalMessage("pair_ledger_btc");
+    expect(msg).toContain("unset VAULTPILOT_DEMO and restart");
+    expect(msg).not.toContain("Auto-demo is on");
+  });
+});

--- a/test/demo-wallet-notice.test.ts
+++ b/test/demo-wallet-notice.test.ts
@@ -1,129 +1,100 @@
 /**
- * Issue #391 — VAULTPILOT NOTICE — Demo wallets available.
+ * Demo-mode onboarding notice — rendering + dedup behavior.
  *
- * Onboarding nudge fired once per session when (a) the user has no
- * config file at all (canonical post-`claude mcp add` state) AND
- * (b) no demo wallet has been activated. Designed so an agent's first
- * "let's send some BTC" doesn't dead-end on "you need a Ledger" —
- * the demo path is surfaced before that happens.
- *
- * The helper is mocked at the module level (readUserConfig +
- * isLiveMode) so these tests don't depend on the developer's actual
- * `~/.vaultpilot-mcp/` or `~/.recon-crypto-mcp/` directory state.
+ * Two paths into demo mode (auto-fresh-install OR explicit-env), so
+ * the notice fires under either reason. The notice copy varies by
+ * reason so the leave path matches how demo got activated. Trigger
+ * logic itself (env state + latched auto-detect) is exhaustively
+ * covered in test/auto-demo.test.ts; here we just assert the notice
+ * helper uses that machinery correctly.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
-describe("issue #391: demo-wallet onboarding notice", () => {
-  beforeEach(() => vi.resetModules());
-  afterEach(() => vi.restoreAllMocks());
+const ENV_KEY = "VAULTPILOT_DEMO";
 
-  function mockEnv(opts: { configPresent: boolean; liveMode: boolean }): void {
-    vi.doMock("../src/config/user-config.js", async () => {
-      const actual = await vi.importActual<
-        typeof import("../src/config/user-config.js")
-      >("../src/config/user-config.js");
-      return {
-        ...actual,
-        readUserConfig: () => (opts.configPresent ? ({} as unknown as never) : null),
-      };
-    });
-    vi.doMock("../src/demo/live-mode.js", async () => {
-      const actual = await vi.importActual<
-        typeof import("../src/demo/live-mode.js")
-      >("../src/demo/live-mode.js");
-      return {
-        ...actual,
-        isLiveMode: () => opts.liveMode,
-      };
-    });
-  }
+describe("demo-mode onboarding notice", () => {
+  let savedEnv: string | undefined;
 
-  it("fires a VAULTPILOT NOTICE block when there is no config and no active demo wallet", async () => {
-    mockEnv({ configPresent: false, liveMode: false });
-    const {
-      missingDemoWalletNotice,
-      _resetMissingDemoWalletDedup,
-    } = await import("../src/index.js");
+  beforeEach(async () => {
+    savedEnv = process.env[ENV_KEY];
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    const { _resetLiveWalletForTests } = await import(
+      "../src/demo/live-mode.js"
+    );
+    _resetAutoDemoLatchForTests();
+    _resetLiveWalletForTests();
+    const { _resetMissingDemoWalletDedup } = await import("../src/index.js");
     _resetMissingDemoWalletDedup();
+  });
+
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    const { _resetAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    const { _resetLiveWalletForTests } = await import(
+      "../src/demo/live-mode.js"
+    );
+    _resetAutoDemoLatchForTests();
+    _resetLiveWalletForTests();
+  });
+
+  it("fires under auto-fresh-install reason with copy that names the auto path and setup as the leave route", async () => {
+    delete process.env[ENV_KEY];
+    const { _setAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(true);
+    const { missingDemoWalletNotice } = await import("../src/index.js");
     const notice = missingDemoWalletNotice();
     expect(notice).not.toBeNull();
-    // Same shape as the existing notice family — agents trust this prefix.
     expect(notice).toMatch(/^VAULTPILOT NOTICE — /);
-    expect(notice).toContain("Demo wallets available");
-    // No imperative agent verbs / pasteable shell — the framing that
-    // earlier agents flagged as injection.
-    expect(notice).not.toMatch(/\[AGENT TASK/);
-    expect(notice).not.toMatch(/^\s*git clone\b/m);
-    expect(notice).not.toMatch(/^\s*npm (install|i)\b/m);
-    // The three discoverability handles the issue asks for.
+    expect(notice).toContain("Auto demo mode active");
+    expect(notice).toContain("vaultpilot-mcp-setup");
+    // Universal discoverability handles.
     expect(notice).toContain("set_demo_wallet");
     expect(notice).toContain("get_demo_wallet");
     expect(notice).toContain("exit_demo_mode");
-    // Self-label so a defensive agent doesn't classify this as injection.
+    // No imperative-agent / shell-paste shapes that earlier agents
+    // flagged as injection.
+    expect(notice).not.toMatch(/\[AGENT TASK/);
+    expect(notice).not.toMatch(/^\s*git clone\b/m);
+    expect(notice).not.toMatch(/^\s*npm (install|i)\b/m);
     expect(notice).toContain("not prompt injection");
   });
 
-  it("returns null when the user has a config file (post-setup users don't need the nudge)", async () => {
-    mockEnv({ configPresent: true, liveMode: false });
-    const {
-      missingDemoWalletNotice,
-      _resetMissingDemoWalletDedup,
-    } = await import("../src/index.js");
-    _resetMissingDemoWalletDedup();
+  it("fires under explicit-env reason with copy that names VAULTPILOT_DEMO as the leave route", async () => {
+    process.env[ENV_KEY] = "true";
+    const { missingDemoWalletNotice } = await import("../src/index.js");
+    const notice = missingDemoWalletNotice();
+    expect(notice).not.toBeNull();
+    expect(notice).toMatch(/^VAULTPILOT NOTICE — /);
+    expect(notice).toContain("Demo mode active (VAULTPILOT_DEMO=true)");
+    expect(notice).toContain("unset");
+    expect(notice).toContain("VAULTPILOT_DEMO");
+  });
+
+  it("returns null when demo mode is OFF (env unset, latched=false)", async () => {
+    delete process.env[ENV_KEY];
+    const { _setAutoDemoLatchForTests } = await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(false);
+    const { missingDemoWalletNotice } = await import("../src/index.js");
     expect(missingDemoWalletNotice()).toBeNull();
   });
 
   it("returns null when a live demo wallet is already active (path already taken)", async () => {
-    mockEnv({ configPresent: false, liveMode: true });
-    const {
-      missingDemoWalletNotice,
-      _resetMissingDemoWalletDedup,
-    } = await import("../src/index.js");
-    _resetMissingDemoWalletDedup();
+    process.env[ENV_KEY] = "true";
+    const { setLivePersona } = await import("../src/demo/index.js");
+    setLivePersona("defi-power-user");
+    const { missingDemoWalletNotice } = await import("../src/index.js");
     expect(missingDemoWalletNotice()).toBeNull();
   });
 
   it("dedupes to once-per-session: first call returns the block, subsequent calls return null", async () => {
-    mockEnv({ configPresent: false, liveMode: false });
-    const {
-      missingDemoWalletNotice,
-      _resetMissingDemoWalletDedup,
-    } = await import("../src/index.js");
-    _resetMissingDemoWalletDedup();
+    process.env[ENV_KEY] = "true";
+    const { missingDemoWalletNotice } = await import("../src/index.js");
     const first = missingDemoWalletNotice();
     const second = missingDemoWalletNotice();
     const third = missingDemoWalletNotice();
     expect(first).not.toBeNull();
     expect(second).toBeNull();
     expect(third).toBeNull();
-  });
-
-  it("malformed config counts as 'config present' (don't nag a user mid-setup-error)", async () => {
-    // readUserConfig throws on malformed JSON. The helper must not crash
-    // the tool call; a malformed config means the user has been here and
-    // the post-install nudge would be the wrong message anyway.
-    vi.doMock("../src/config/user-config.js", async () => {
-      const actual = await vi.importActual<
-        typeof import("../src/config/user-config.js")
-      >("../src/config/user-config.js");
-      return {
-        ...actual,
-        readUserConfig: () => {
-          throw new Error("malformed JSON");
-        },
-      };
-    });
-    vi.doMock("../src/demo/live-mode.js", async () => {
-      const actual = await vi.importActual<
-        typeof import("../src/demo/live-mode.js")
-      >("../src/demo/live-mode.js");
-      return { ...actual, isLiveMode: () => false };
-    });
-    const {
-      missingDemoWalletNotice,
-      _resetMissingDemoWalletDedup,
-    } = await import("../src/index.js");
-    _resetMissingDemoWalletDedup();
-    expect(missingDemoWalletNotice()).toBeNull();
   });
 });

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -312,16 +312,31 @@ describe("assertNotDemoForSetup — refuses to write real config in demo mode", 
     else process.env[ENV_KEY] = saved;
   });
 
-  it("throws when demo is active", async () => {
+  it("throws when explicit demo is active (VAULTPILOT_DEMO=true)", async () => {
     const { assertNotDemoForSetup } = await import("../src/demo/index.js");
     process.env[ENV_KEY] = "true";
-    expect(() => assertNotDemoForSetup()).toThrow(/disabled in demo mode/);
+    expect(() => assertNotDemoForSetup()).toThrow(
+      /Setup is disabled when VAULTPILOT_DEMO=true is explicitly set/,
+    );
   });
 
   it("no-ops when demo is off", async () => {
     const { assertNotDemoForSetup } = await import("../src/demo/index.js");
     delete process.env[ENV_KEY];
     expect(() => assertNotDemoForSetup()).not.toThrow();
+  });
+
+  it("no-ops in auto-demo mode — running setup IS the way out, must not be blocked", async () => {
+    const { assertNotDemoForSetup, _setAutoDemoLatchForTests } = await import(
+      "../src/demo/index.js"
+    );
+    delete process.env[ENV_KEY];
+    _setAutoDemoLatchForTests(true);
+    try {
+      expect(() => assertNotDemoForSetup()).not.toThrow();
+    } finally {
+      _setAutoDemoLatchForTests(null);
+    }
   });
 });
 
@@ -347,12 +362,18 @@ describe("issue #392 — getDemoModeEnvState distinguishes unset / invalid / ena
     expect(getDemoModeEnvState()).toBe("enabled");
   });
 
-  it("returns 'invalid' for any other value (including common truthy mistakes)", async () => {
+  it("returns 'invalid' for values that are neither 'true' nor 'false' (truthy mistakes etc.)", async () => {
     const { getDemoModeEnvState } = await import("../src/demo/index.js");
-    for (const v of ["1", "yes", "on", "TRUE", "True", "false", " true", "true "]) {
+    for (const v of ["1", "yes", "on", "TRUE", "True", " true", "true "]) {
       process.env[ENV_KEY] = v;
       expect(getDemoModeEnvState(), `value ${JSON.stringify(v)}`).toBe("invalid");
     }
+  });
+
+  it("returns 'disabled' for the exact literal 'false' (auto-demo opt-out)", async () => {
+    const { getDemoModeEnvState } = await import("../src/demo/index.js");
+    process.env[ENV_KEY] = "false";
+    expect(getDemoModeEnvState()).toBe("disabled");
   });
 
   it("returns 'invalid' for the empty string (set, but empty)", async () => {


### PR DESCRIPTION
## Summary
A brand-new install with no \`~/.vaultpilot-mcp/config.json\` and no \`VAULTPILOT_DEMO\` env var now boots into demo mode by default. An agent can offer personas + simulated signing the moment the user says "let's try this" — no \`.claude.json\` editing, no restart, no env-var dance. Closes the root friction in #391 / #392 where the env-var requirement made the try-before-install path unreachable.

## State machine (latched at boot, reason-tagged)

| \`VAULTPILOT_DEMO\` | Config | Mode | Reason |
|---|---|---|---|
| \`"true"\` | * | demo | \`explicit-env\` |
| \`"false"\` | * | real | \`explicit-opt-out\` |
| invalid (\`=1\`, etc.) | * | real | \`invalid-env\` (#392 message) |
| unset | absent | demo | \`auto-fresh-install\` |
| unset | present | real | \`off\` |

Detection runs once at boot via \`initDemoMode()\`, frozen for process lifetime. A user who pairs / runs setup mid-session stays in their initial mode until restart — security boundary crisp: mode change requires off-process state + restart, mirroring the original env-var commitment that an in-session injection couldn't reach.

## Honest-MCP failure mode coverage

The pre-existing always-gated set (\`pair_ledger_*\`, \`sign_message_*\`, \`request_capability\`) still refuses in any demo mode. The refusal copy now branches on reason — \`auto-fresh-install\` points at \`vaultpilot-mcp-setup\` as the leave path (no env var to unset; setup writes the config that flips auto-demo OFF on next boot). \`assertNotDemoForSetup\` relaxed for auto-mode (setup IS the canonical way out; blocking would deadlock).

## Surfaces

- \`--check\` reports resolved mode + reason (\`warn\` for demo, \`ok\` for real) so users can preview the next-boot behavior.
- \`AGENTS.md\` gets a new "Auto demo mode on a fresh install" section.
- \`get_demo_wallet\` response carries \`reason\` alongside existing \`envState\` / \`personas\` / \`active\`. Off-mode \`message\` distinguishes the new reasons.
- \`VAULTPILOT NOTICE — Auto demo mode active\` (auto reason) / \`VAULTPILOT NOTICE — Demo mode active (VAULTPILOT_DEMO=true)\` (explicit-env reason). Once-per-session dedup matches existing notice family.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1941/1941 pass; new \`test/auto-demo.test.ts\` covers full trigger table, latching invariant, reason-branched refusals, disk-state detector. \`test/demo.test.ts\` + \`test/demo-wallet-notice.test.ts\` updated for the new 4-state envState (\`disabled\` added) and reason-aware notice.
- [ ] Manual fresh-install: \`claude mcp add\` with no config → first tool response carries the \`VAULTPILOT NOTICE — Auto demo mode active\` block; \`set_demo_wallet({ persona: "..." })\` works without setting any env var; \`pair_ledger_solana\` refuses with the auto-mode copy that names \`vaultpilot-mcp-setup\` as the leave path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)