### PR TITLE
feat(btc): native BTC ↔ EVM/Solana bridge via LiFi (#397)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,7 @@ import {
   getBitcoinTxHistory,
   prepareBitcoinNativeSend,
   prepareBitcoinRbfBump,
+  prepareBitcoinLifiSwap,
   registerBtcMultisigWallet,
   unregisterBtcMultisigWallet,
   signBtcMultisigPsbt,
@@ -279,6 +280,7 @@ import {
   getBitcoinTxHistoryInput,
   prepareBitcoinNativeSendInput,
   prepareBitcoinRbfBumpInput,
+  prepareBitcoinLifiSwapInput,
   registerBitcoinMultisigWalletInput,
   unregisterBitcoinMultisigWalletInput,
   signBitcoinMultisigPsbtInput,
@@ -2736,6 +2738,33 @@ async function main() {
       inputSchema: prepareBitcoinNativeSendInput.shape,
     },
     handler(prepareBitcoinNativeSend, { toolName: "prepare_btc_send" })
+  );
+
+  registerTool(server,
+    "prepare_btc_lifi_swap",
+    {
+      description:
+        "Build an unsigned Bitcoin PSBT-v0 that bridges native BTC to a token " +
+        "on another chain via LiFi's aggregator. LiFi auctions the route across " +
+        "intent solvers (NEAR Intents, Garden, Thorswap, Chainflip, Symbiosis, …) " +
+        "and returns a PSBT depositing to the chosen solver's vault address with " +
+        "an OP_RETURN memo committing to the cross-chain destination. " +
+        "Destinations: every EVM chain (`ethereum`/`arbitrum`/`polygon`/`base`/" +
+        "`optimism`) and Solana — TRON has no LiFi route from BTC and is rejected. " +
+        "Source-side scope (Phase 1, mirrors prepare_btc_send): native segwit and " +
+        "taproot only. Returns a 15-min handle the agent forwards to send_transaction; " +
+        "the Ledger BTC app clear-signs every output (vault deposit + OP_RETURN + " +
+        "change-back-to-source + LiFi fee output) on-screen, so there is NO blind-sign " +
+        "hash to pre-match in chat. The verification block surfaces the vault address, " +
+        "OP_RETURN bytes (hex + ASCII prefix), expected and minimum output on the " +
+        "destination, slippage, the chosen solver, and execution duration estimate. " +
+        "Server-side checks before forwarding: every PSBT input belongs to the source " +
+        "address, exactly one OP_RETURN output is present, the deposit output address " +
+        "matches the LiFi-advertised vault, and `nonWitnessUtxo` is hydrated on every " +
+        "input (Ledger 2.x rejects segwit/taproot inputs without it).",
+      inputSchema: prepareBitcoinLifiSwapInput.shape,
+    },
+    handler(prepareBitcoinLifiSwap, { toolName: "prepare_btc_lifi_swap" })
   );
 
   registerTool(server,

--- a/src/modules/btc/lifi-swap.ts
+++ b/src/modules/btc/lifi-swap.ts
@@ -1,0 +1,600 @@
+import { createRequire } from "node:module";
+import { formatUnits } from "viem";
+import { fetchBitcoinQuote } from "../swap/lifi.js";
+import { assertBitcoinAddress } from "./address.js";
+import { getBitcoinIndexer } from "./indexer.js";
+import {
+  getPairedBtcByAddress,
+  type BtcAddressType as PairedBtcAddressType,
+} from "../../signing/btc-usb-signer.js";
+import { issueBitcoinHandle } from "../../signing/btc-tx-store.js";
+import { assertSlippageOk } from "../swap/index.js";
+import {
+  SOLANA_ADDRESS,
+  EVM_ADDRESS,
+} from "../../shared/address-patterns.js";
+import { SATS_PER_BTC, BTC_DECIMALS } from "../../config/btc.js";
+import type {
+  SupportedChain,
+  UnsignedBitcoinTx,
+} from "../../types/index.js";
+
+/**
+ * BTC-source LiFi swap/bridge builder. Mirrors `buildBitcoinNativeSend`
+ * in the contract it returns (an `UnsignedBitcoinTx` ready for the
+ * Ledger BTC signer), but the PSBT itself is constructed by LiFi rather
+ * than coin-selected locally:
+ *
+ *  1. Call LiFi's quote endpoint with `fromChain=BTC` (chain id
+ *     `20000000000001`). LiFi auctions the route across solvers (NEAR
+ *     Intents, Garden Finance, Thorswap, Chainflip, Symbiosis, etc.)
+ *     and returns a PSBT-v0 hex committing to a deposit-to-vault output
+ *     plus an OP_RETURN memo whose contents the chosen solver decodes
+ *     server-side to release funds on the destination chain.
+ *
+ *  2. Hydrate the PSBT — LiFi's response carries `witnessUtxo` only on
+ *     each input. Ledger BTC app 2.x rejects segwit/taproot inputs
+ *     without `nonWitnessUtxo` ("Security risk: unverified inputs",
+ *     0x6985). We re-fetch each prev-tx's hex from our indexer and
+ *     attach. Same fix path as the equivalent native_send guard
+ *     (issue #213).
+ *
+ *  3. Cross-check the PSBT against what we asked LiFi for:
+ *      - every input's prevout script must equal the paired source's
+ *        scriptPubKey (a compromised aggregator can't hand us inputs
+ *        the device couldn't sign anyway, but a sanity-check refuses
+ *        the call before it ever reaches USB).
+ *      - the deposit output's recipient must equal
+ *        `transactionRequest.to` (the vault address LiFi advertised).
+ *      - exactly one OP_RETURN output must be present (the memo
+ *        committing to the cross-chain destination).
+ *
+ *  4. Decode the OP_RETURN bytes for the verification block. The memo
+ *     is solver-specific (`=|lifi…` for NEAR Intents, raw bridge tags
+ *     for Thorswap/Chainflip). We surface it as hex + ASCII-readable
+ *     prefix so the user has SOMETHING to compare against the route
+ *     description, but the trust anchor is `(vault address, OP_RETURN
+ *     bytes)` resolving server-side at LiFi — not a memo we
+ *     independently parse.
+ *
+ *  5. Identify the change output. LiFi sends change back to the source
+ *     address (chain=0) — same simplification the existing
+ *     `prepare_btc_send` Phase-1 builder ships with. Ledger flags the
+ *     output with the "unusual change path" notice but the funds
+ *     return to the user's own wallet either way; consistent with
+ *     existing UX.
+ *
+ * Phase-1 source-side scope (matches `prepare_btc_send`): native segwit
+ * + taproot only. Legacy and P2SH-wrapped sources are deferred — the
+ * SAME rationale (Ledger sign path consistency) applies.
+ *
+ * Destination scope: any LiFi-routable destination — every EVM chain in
+ * `SupportedChain`, plus Solana. TRON has no LiFi route from BTC
+ * (empirical: returns `tool: null`); rejected up-front with a clear
+ * error rather than a generic "no route found" surface bubble.
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjs = requireCjs("bitcoinjs-lib") as {
+  Psbt: {
+    new (opts?: { network?: unknown }): BitcoinjsPsbt;
+    fromHex(hex: string, opts?: { network?: unknown }): BitcoinjsPsbt;
+    fromBase64(b64: string, opts?: { network?: unknown }): BitcoinjsPsbt;
+  };
+  address: {
+    toOutputScript(address: string, network?: unknown): Buffer;
+    fromOutputScript(script: Buffer, network?: unknown): string;
+  };
+  networks: { bitcoin: unknown };
+};
+
+interface BitcoinjsPsbt {
+  txInputs: Array<{ hash: Buffer; index: number; sequence?: number }>;
+  txOutputs: Array<{ script: Buffer; value: number; address?: string }>;
+  data: {
+    inputs: Array<{
+      witnessUtxo?: { script: Buffer; value: number };
+      nonWitnessUtxo?: Buffer;
+    }>;
+  };
+  updateInput(
+    inputIndex: number,
+    updateData: { nonWitnessUtxo?: Buffer },
+  ): unknown;
+  toBase64(): string;
+}
+
+const NETWORK = bitcoinjs.networks.bitcoin;
+
+/**
+ * Map our paired addressType to the signer's `addressFormat`. Phase 1
+ * source restriction below means only the segwit + taproot rows are
+ * actually reachable, but the table is exhaustive so a future
+ * legacy/p2sh widening doesn't have to touch this file.
+ */
+const ADDRESS_FORMAT_BY_TYPE: Record<
+  PairedBtcAddressType,
+  UnsignedBitcoinTx["addressFormat"]
+> = {
+  legacy: "legacy",
+  "p2sh-segwit": "p2sh",
+  segwit: "bech32",
+  taproot: "bech32m",
+};
+
+function accountPathFromLeaf(leafPath: string): string {
+  const parts = leafPath.split("/");
+  if (parts.length < 5) {
+    throw new Error(
+      `Invalid Bitcoin leaf path "${leafPath}" — expected at least 5 segments.`,
+    );
+  }
+  return parts.slice(0, -2).join("/");
+}
+
+function satsToBtcString(sats: bigint): string {
+  const negative = sats < 0n;
+  const abs = negative ? -sats : sats;
+  const whole = abs / SATS_PER_BTC;
+  const frac = abs - whole * SATS_PER_BTC;
+  const fracStr = frac
+    .toString()
+    .padStart(BTC_DECIMALS, "0")
+    .replace(/0+$/, "") || "0";
+  const body = fracStr === "0" ? whole.toString() : `${whole.toString()}.${fracStr}`;
+  return negative ? `-${body}` : body;
+}
+
+function parseBtcAmountToSats(amount: string): bigint {
+  if (!/^\d+(\.\d{1,8})?$/.test(amount)) {
+    throw new Error(
+      `Invalid BTC amount "${amount}" — expected a decimal with up to 8 fractional ` +
+        `digits (e.g. "0.001", "0.5"). "max" is not supported for LiFi swaps because ` +
+        `the bridge needs an exact deposit amount committed up-front.`,
+    );
+  }
+  const [whole, frac = ""] = amount.split(".");
+  const padded = frac.padEnd(BTC_DECIMALS, "0");
+  return BigInt(whole) * SATS_PER_BTC + BigInt(padded);
+}
+
+/**
+ * Reverse a 32-byte hash buffer into a hex txid string. PSBT inputs
+ * carry the prevout hash in little-endian (internal) order; txid display
+ * uses the byte-reversed (big-endian / RPC) form.
+ */
+function bufferToTxid(hash: Buffer): string {
+  const reversed = Buffer.from(hash).reverse();
+  return reversed.toString("hex");
+}
+
+/**
+ * Parse an OP_RETURN script's pushed payload bytes. Returns null when the
+ * script is not a single-pushdata OP_RETURN. Spec: BIP-30 / SIP — any
+ * bytes pushed by an opcode after `0x6a`.
+ */
+function parseOpReturnPayload(script: Buffer): Buffer | null {
+  if (script.length < 2 || script[0] !== 0x6a) return null;
+  const op = script[1];
+  // OP_PUSHBYTES_1..75: length is the opcode itself.
+  if (op >= 0x01 && op <= 0x4b) {
+    const want = op;
+    if (script.length !== 2 + want) return null;
+    return script.slice(2, 2 + want);
+  }
+  // OP_PUSHDATA1: 1-byte length follows.
+  if (op === 0x4c) {
+    if (script.length < 3) return null;
+    const want = script[2];
+    if (script.length !== 3 + want) return null;
+    return script.slice(3, 3 + want);
+  }
+  // OP_PUSHDATA2 / OP_PUSHDATA4 unreachable for memo-sized payloads;
+  // refuse rather than half-parse.
+  return null;
+}
+
+/**
+ * Best-effort ASCII view of the OP_RETURN payload. Returns the
+ * printable-prefix substring up to the first non-printable byte; if no
+ * printable prefix exists, returns the empty string. Used purely for
+ * the verification block's user-facing memo display — the canonical
+ * representation is the hex.
+ */
+function asciiPrefix(payload: Buffer): string {
+  let end = 0;
+  while (end < payload.length) {
+    const b = payload[end];
+    if (b >= 0x20 && b <= 0x7e) end++;
+    else break;
+  }
+  return payload.slice(0, end).toString("ascii");
+}
+
+export interface BuildBitcoinLifiSwapArgs {
+  /**
+   * Paired BTC source address. Phase-1 source restriction: native
+   * segwit (`bc1q…`) or taproot (`bc1p…`). Multi-source consolidation
+   * is out of scope for swap (LiFi's quote endpoint takes a single
+   * `fromAddress` and runs its own UTXO scan; piping in user-side
+   * coin-selection across multiple addresses would diverge from
+   * what LiFi committed in the PSBT and break solver matching).
+   */
+  wallet: string;
+  /** Destination chain — EVM `SupportedChain` or `"solana"`. */
+  toChain: SupportedChain | "solana";
+  /**
+   * Destination token. EVM hex when `toChain` is EVM; SPL mint
+   * (base58) when `toChain === "solana"`. `"native"` resolves to the
+   * chain's conventional native sentinel.
+   */
+  toToken: string | "native";
+  /**
+   * Destination wallet — REQUIRED. The Bitcoin source address is not
+   * a valid recipient on any destination chain.
+   */
+  toAddress: string;
+  /** Decimal BTC string (up to 8 fractional digits, e.g. "0.005"). */
+  amount: string;
+  /** Slippage in basis points. Default 50 (0.5%). Hard cap 500 (5%). */
+  slippageBps?: number;
+  /** Required when `slippageBps > 100`. Mirror of `prepare_swap` guard. */
+  acknowledgeHighSlippage?: boolean;
+}
+
+export async function buildBitcoinLifiSwap(
+  args: BuildBitcoinLifiSwapArgs,
+): Promise<UnsignedBitcoinTx> {
+  assertSlippageOk(args.slippageBps, args.acknowledgeHighSlippage);
+  assertBitcoinAddress(args.wallet);
+  const paired = getPairedBtcByAddress(args.wallet);
+  if (!paired) {
+    throw new Error(
+      `Bitcoin address ${args.wallet} is not paired. Run \`pair_ledger_btc\` to register ` +
+        `the four standard address types and retry with one of the resulting addresses.`,
+    );
+  }
+  if (paired.addressType !== "segwit" && paired.addressType !== "taproot") {
+    throw new Error(
+      `Bitcoin LiFi swaps from ${paired.addressType} addresses are not supported in ` +
+        `Phase 1 — only native segwit (bc1q…) and taproot (bc1p…). Move funds to your ` +
+        `paired segwit or taproot address first.`,
+    );
+  }
+
+  // Destination addressing checks. Reject EVM-shaped addresses for Solana
+  // destinations and Solana-shaped addresses for EVM destinations up-front
+  // — LiFi will silently route to a wrong-format destination on its side
+  // and funds end up unspendable.
+  if (args.toChain === "solana") {
+    if (!SOLANA_ADDRESS.test(args.toAddress)) {
+      throw new Error(
+        `toAddress "${args.toAddress}" is not a valid Solana base58 address ` +
+          `(expected 43-44 chars). Refusing to route a BTC bridge to an unparseable ` +
+          `Solana destination.`,
+      );
+    }
+  } else {
+    if (!EVM_ADDRESS.test(args.toAddress)) {
+      throw new Error(
+        `toAddress "${args.toAddress}" is not a valid EVM address. ` +
+          `For toChain="${args.toChain}" pass a 0x-prefixed 40-hex-char address.`,
+      );
+    }
+  }
+
+  const fromAmountSats = parseBtcAmountToSats(args.amount);
+  if (fromAmountSats <= 0n) {
+    throw new Error(`Resolved BTC amount ${fromAmountSats} sats is not positive.`);
+  }
+
+  const quote = await fetchBitcoinQuote({
+    fromAddress: args.wallet,
+    fromAmount: fromAmountSats.toString(),
+    toChain: args.toChain,
+    toToken: args.toToken,
+    toAddress: args.toAddress,
+    ...(args.slippageBps !== undefined
+      ? { slippage: args.slippageBps / 10_000 }
+      : {}),
+  });
+
+  const txRequest = quote.transactionRequest;
+  if (!txRequest || !txRequest.to || !txRequest.data) {
+    throw new Error(
+      "LiFi did not return a transactionRequest for this BTC quote. The aggregator may " +
+        "have no route — try a different destination chain/token, or a larger amount.",
+    );
+  }
+  const psbtHex = (txRequest.data as string).startsWith("0x")
+    ? (txRequest.data as string).slice(2)
+    : (txRequest.data as string);
+  if (!/^[0-9a-fA-F]+$/.test(psbtHex) || psbtHex.length % 2 !== 0) {
+    throw new Error(
+      "LiFi returned a transactionRequest.data that is not a hex PSBT. " +
+        "Refusing to forward a malformed payload to the Ledger BTC app.",
+    );
+  }
+
+  // Decode the PSBT for inspection + verification + hydration.
+  let psbt: BitcoinjsPsbt;
+  try {
+    psbt = bitcoinjs.Psbt.fromHex(psbtHex, { network: NETWORK });
+  } catch (err) {
+    throw new Error(
+      `Failed to decode LiFi PSBT: ${(err as Error).message}. Refusing to forward to Ledger.`,
+    );
+  }
+
+  // 1. Cross-check inputs all belong to the source address. A LiFi
+  //    response that pulls inputs from foreign addresses (whether by
+  //    bug or because someone tampered with the response in transit)
+  //    would not be signable by our Ledger anyway — but refusing here
+  //    surfaces the problem with a clear message instead of an
+  //    opaque device-side error.
+  const sourceScript = bitcoinjs.address.toOutputScript(args.wallet, NETWORK);
+  if (psbt.txInputs.length === 0) {
+    throw new Error(
+      `LiFi PSBT has no inputs — refusing to forward an empty deposit to the Ledger.`,
+    );
+  }
+  for (let i = 0; i < psbt.txInputs.length; i++) {
+    const witnessUtxo = psbt.data.inputs[i]?.witnessUtxo;
+    if (!witnessUtxo) {
+      throw new Error(
+        `LiFi PSBT input ${i} has no witnessUtxo. Refusing to forward a non-segwit/` +
+          `non-taproot input — Phase 1 source scope is segwit/taproot only.`,
+      );
+    }
+    if (!witnessUtxo.script.equals(sourceScript)) {
+      throw new Error(
+        `LiFi PSBT input ${i} comes from a different scriptPubKey than the source ` +
+          `address ${args.wallet}. The aggregator selected UTXOs from another address; ` +
+          `refusing to forward — the Ledger could not sign these inputs anyway.`,
+      );
+    }
+  }
+
+  // 2. Walk outputs: vault deposit + OP_RETURN memo + change-back-to-
+  //    source + LiFi fee. Capture each so the verification block has
+  //    the full picture.
+  if (psbt.txOutputs.length < 2) {
+    throw new Error(
+      `LiFi PSBT has ${psbt.txOutputs.length} outputs — expected at least 2 ` +
+        `(deposit + OP_RETURN memo). Refusing to forward.`,
+    );
+  }
+  const vaultAddress = txRequest.to as string;
+  const vaultOutputScript = bitcoinjs.address.toOutputScript(vaultAddress, NETWORK);
+
+  let vaultOutputIndex = -1;
+  let opReturnOutputIndex = -1;
+  let opReturnPayload: Buffer | null = null;
+
+  type OutputInfo = {
+    address: string;
+    amountSats: bigint;
+    isChange: boolean;
+    isVault: boolean;
+    isOpReturn: boolean;
+    isLifiFee: boolean;
+    opReturnHex?: string;
+    opReturnAscii?: string;
+  };
+  const outputInfos: OutputInfo[] = [];
+
+  for (let i = 0; i < psbt.txOutputs.length; i++) {
+    const out = psbt.txOutputs[i];
+    const isOpReturn = out.script.length > 0 && out.script[0] === 0x6a;
+    if (isOpReturn) {
+      const payload = parseOpReturnPayload(out.script);
+      if (!payload) {
+        throw new Error(
+          `LiFi PSBT output ${i} is OP_RETURN but the pushdata layout is not parseable ` +
+            `(script ${out.script.toString("hex")}). Refusing to forward an undecodable memo.`,
+        );
+      }
+      if (opReturnOutputIndex !== -1) {
+        throw new Error(
+          `LiFi PSBT has multiple OP_RETURN outputs (indices ${opReturnOutputIndex}, ${i}). ` +
+            `Expected exactly one memo output; refusing to forward.`,
+        );
+      }
+      opReturnOutputIndex = i;
+      opReturnPayload = payload;
+      outputInfos.push({
+        address: "OP_RETURN",
+        amountSats: BigInt(out.value),
+        isChange: false,
+        isVault: false,
+        isOpReturn: true,
+        isLifiFee: false,
+        opReturnHex: payload.toString("hex"),
+        opReturnAscii: asciiPrefix(payload),
+      });
+      continue;
+    }
+
+    let address: string;
+    try {
+      address = bitcoinjs.address.fromOutputScript(out.script, NETWORK);
+    } catch {
+      throw new Error(
+        `LiFi PSBT output ${i} has a non-standard script (${out.script.toString("hex")}) ` +
+          `the BTC indexer cannot map to an address. Refusing to forward — the Ledger ` +
+          `BTC app would clear-sign an opaque output and the user can't verify it.`,
+      );
+    }
+
+    const isVault = out.script.equals(vaultOutputScript);
+    const isChange = out.script.equals(sourceScript) && !isVault;
+    if (isVault && vaultOutputIndex !== -1) {
+      throw new Error(
+        `LiFi PSBT has multiple outputs to the vault address ${vaultAddress} ` +
+          `(indices ${vaultOutputIndex}, ${i}). Refusing to forward.`,
+      );
+    }
+    if (isVault) vaultOutputIndex = i;
+
+    outputInfos.push({
+      address,
+      amountSats: BigInt(out.value),
+      isChange,
+      isVault,
+      isOpReturn: false,
+      isLifiFee: !isVault && !isChange,
+    });
+  }
+
+  if (vaultOutputIndex === -1) {
+    throw new Error(
+      `LiFi PSBT has no output to the vault address ${vaultAddress} declared in ` +
+        `transactionRequest.to. The aggregator's PSBT and routing metadata disagree; ` +
+        `refusing to forward — re-fetch the quote.`,
+    );
+  }
+  if (opReturnOutputIndex === -1 || !opReturnPayload) {
+    throw new Error(
+      `LiFi PSBT has no OP_RETURN memo output. Cross-chain bridges via LiFi commit ` +
+        `the destination via an OP_RETURN tag; without it the deposit cannot be ` +
+        `matched to a route. Refusing to forward.`,
+    );
+  }
+
+  // 3. Hydrate every input with nonWitnessUtxo (Ledger 2.x requirement,
+  //    issue #213). Fan the prev-tx fetches out in parallel — typical
+  //    BTC LiFi deposits use 1-3 inputs, so we don't even bother
+  //    deduping by txid; the indexer's HTTP cache absorbs any repeats.
+  const indexer = getBitcoinIndexer();
+  const uniqueTxids = [
+    ...new Set(psbt.txInputs.map((i) => bufferToTxid(i.hash))),
+  ];
+  const prevTxHexEntries = await Promise.all(
+    uniqueTxids.map(async (txid) => [txid, await indexer.getTxHex(txid)] as const),
+  );
+  const prevTxHexByTxid = new Map(prevTxHexEntries);
+  for (let i = 0; i < psbt.txInputs.length; i++) {
+    const txid = bufferToTxid(psbt.txInputs[i].hash);
+    const hex = prevTxHexByTxid.get(txid);
+    if (!hex) {
+      throw new Error(
+        `Internal error: prev-tx hex missing for ${txid} after fan-out fetch.`,
+      );
+    }
+    if (!psbt.data.inputs[i].nonWitnessUtxo) {
+      psbt.updateInput(i, { nonWitnessUtxo: Buffer.from(hex, "hex") });
+    }
+  }
+  const psbtBase64 = psbt.toBase64();
+
+  // 4. Build the decoded outputs list for the verification block.
+  const decodedOutputs = outputInfos.map((o) => {
+    const base = {
+      address: o.address,
+      amountSats: o.amountSats.toString(),
+      amountBtc: satsToBtcString(o.amountSats),
+      isChange: o.isChange,
+    };
+    if (o.isChange) {
+      // change goes back to the source address (chain=0, same path
+      // as the source itself). Ledger surfaces an "unusual change
+      // path" notice — informational, not blocking.
+      return { ...base, changePath: paired.path };
+    }
+    return base;
+  });
+
+  // 5. Per-source breakdown — every input came from `args.wallet`
+  //    per the input-source check above, so this is a single-row
+  //    table.
+  const totalInputSats = psbt.data.inputs.reduce(
+    (sum, inp) => sum + BigInt(inp.witnessUtxo?.value ?? 0),
+    0n,
+  );
+  const decodedSources = [
+    {
+      address: args.wallet,
+      pulledSats: totalInputSats.toString(),
+      pulledBtc: satsToBtcString(totalInputSats),
+      inputCount: psbt.txInputs.length,
+    },
+  ];
+
+  // 6. Fee = inputs - outputs.
+  const totalOutputSats = outputInfos.reduce(
+    (sum, o) => sum + o.amountSats,
+    0n,
+  );
+  const feeSats = totalInputSats - totalOutputSats;
+  if (feeSats < 0n) {
+    throw new Error(
+      `LiFi PSBT outputs (${totalOutputSats} sats) exceed inputs (${totalInputSats} sats). ` +
+        `Negative fee — refusing to forward a malformed PSBT to the Ledger.`,
+    );
+  }
+  // Approximate vsize for a fee-rate display. P2WPKH/P2TR inputs ≈ 68 vbytes,
+  // outputs ≈ 31 vbytes (OP_RETURN ~10), header 10. Same approximation the
+  // native_send builder uses; precise vsize requires signing (sig sizes vary).
+  const vsize = 10 + psbt.txInputs.length * 68 + outputInfos.length * 31;
+  const feeRate = vsize > 0 ? Number(feeSats) / vsize : 0;
+
+  // 7. Quote summary for the verification block.
+  const fromTokSym = quote.action.fromToken.symbol;
+  const toTokSym = quote.action.toToken.symbol;
+  const toDecimals = quote.action.toToken.decimals;
+  const expectedOut = formatUnits(BigInt(quote.estimate.toAmount), toDecimals);
+  const minOut = formatUnits(BigInt(quote.estimate.toAmountMin), toDecimals);
+  const description =
+    `Bridge ${args.amount} BTC → ~${expectedOut} ${toTokSym} on ${args.toChain} via LiFi (${quote.tool})`;
+
+  const sources = [
+    {
+      address: args.wallet,
+      path: paired.path,
+      publicKey: paired.publicKey,
+    },
+  ];
+  const inputSources = psbt.txInputs.map(() => args.wallet);
+  const accountPath = accountPathFromLeaf(paired.path);
+  const opReturnHex = opReturnPayload.toString("hex");
+  const opReturnAsciiHint = asciiPrefix(opReturnPayload);
+
+  const tx: Omit<UnsignedBitcoinTx, "handle" | "fingerprint"> = {
+    chain: "bitcoin",
+    action: "native_send",
+    from: args.wallet,
+    sources,
+    inputSources,
+    psbtBase64,
+    accountPath,
+    addressFormat: ADDRESS_FORMAT_BY_TYPE[paired.addressType],
+    description,
+    decoded: {
+      functionName: "bitcoin.lifi_swap",
+      args: {
+        from: args.wallet,
+        toChain: args.toChain,
+        toToken: `${toTokSym} (${quote.action.toToken.address})`,
+        toAddress: args.toAddress,
+        amountSent: args.amount,
+        amountSentSym: fromTokSym,
+        expectedOut: `${expectedOut} ${toTokSym}`,
+        minOut: `${minOut} ${toTokSym}`,
+        slippageBps: String(args.slippageBps ?? 50),
+        route: quote.tool,
+        executionDurationSec: String(quote.estimate.executionDuration ?? "?"),
+        vault: vaultAddress,
+        opReturnHex,
+        ...(opReturnAsciiHint ? { opReturnAscii: opReturnAsciiHint } : {}),
+      },
+      outputs: decodedOutputs,
+      sources: decodedSources,
+      feeSats: feeSats.toString(),
+      feeBtc: satsToBtcString(feeSats),
+      feeRateSatPerVb: Math.round(feeRate * 100) / 100,
+      rbfEligible: false,
+    },
+    vsize,
+  };
+  return issueBitcoinHandle(tx);
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -172,6 +172,7 @@ import type {
   GetBitcoinTxHistoryArgs,
   PrepareBitcoinNativeSendArgs,
   PrepareBitcoinRbfBumpArgs,
+  PrepareBitcoinLifiSwapArgs,
   RegisterBitcoinMultisigWalletArgs,
   SignBitcoinMultisigPsbtArgs,
   CombineBitcoinPsbtsArgs,
@@ -1245,6 +1246,21 @@ export async function prepareBitcoinRbfBump(args: PrepareBitcoinRbfBumpArgs) {
     txid: args.txid,
     newFeeRate: args.newFeeRate,
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
+  });
+}
+
+export async function prepareBitcoinLifiSwap(args: PrepareBitcoinLifiSwapArgs) {
+  const { buildBitcoinLifiSwap } = await import("../btc/lifi-swap.js");
+  return buildBitcoinLifiSwap({
+    wallet: args.wallet,
+    toChain: args.toChain as Parameters<typeof buildBitcoinLifiSwap>[0]["toChain"],
+    toToken: args.toToken,
+    toAddress: args.toAddress,
+    amount: args.amount,
+    ...(args.slippageBps !== undefined ? { slippageBps: args.slippageBps } : {}),
+    ...(args.acknowledgeHighSlippage !== undefined
+      ? { acknowledgeHighSlippage: args.acknowledgeHighSlippage }
+      : {}),
   });
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1357,6 +1357,86 @@ export const prepareBitcoinRbfBumpInput = z.object({
     ),
 });
 
+/**
+ * BTC-source LiFi swap / cross-chain bridge. The user signs a Bitcoin
+ * PSBT-v0 on Ledger over USB; the LiFi-selected solver (NEAR Intents,
+ * Garden, Thorswap, Chainflip, Symbiosis, …) decodes the OP_RETURN memo
+ * server-side and releases funds on the destination chain after the
+ * BTC deposit confirms.
+ *
+ * Source-chain scope (Phase 1 — matches `prepare_btc_send`): native
+ * segwit (`bc1q…`) and taproot (`bc1p…`) only.
+ *
+ * Destination scope: every EVM chain in `SupportedChain`, plus Solana.
+ * TRON has no LiFi route from BTC and is rejected up-front. For native
+ * Litecoin source/dest support: LiFi exposes only Bitcoin from the
+ * Bitcoin-fork family even though the underlying NEAR Intents protocol
+ * supports LTC/DOGE/BCH/ZEC — tracked as a separate primitive.
+ */
+export const prepareBitcoinLifiSwapInput = z.object({
+  wallet: bitcoinAddressSchema.describe(
+    "Paired Bitcoin source address. Phase 1 source-side scope: native segwit " +
+      "(`bc1q…`) and taproot (`bc1p…`) only. Multi-source consolidation is " +
+      "out of scope here — LiFi runs its own UTXO scan against `fromAddress` " +
+      "and bakes the input set into the PSBT."
+  ),
+  toChain: z
+    .enum([
+      ...(SUPPORTED_CHAINS as unknown as [string, ...string[]]),
+      "solana",
+    ])
+    .describe(
+      'Destination chain. EVM `SupportedChain` (ethereum/arbitrum/polygon/' +
+        'base/optimism) for an EVM bridge, or `"solana"` for native SOL/SPL ' +
+        "delivery. TRON is NOT routable from BTC via LiFi (rejected with a " +
+        "clear error)."
+    ),
+  toToken: z
+    .string()
+    .max(80)
+    .describe(
+      'Destination token. EVM hex when `toChain` is EVM; SPL mint (base58) ' +
+        'when `toChain === "solana"`. `"native"` resolves to the chain\'s ' +
+        "conventional native sentinel (`0x0…0` for EVM, wrapped-SOL mint " +
+        "for Solana)."
+    ),
+  toAddress: z
+    .string()
+    .max(80)
+    .describe(
+      "Destination wallet — REQUIRED. The Bitcoin source address is not a " +
+        "valid recipient on any destination chain. Format must match the " +
+        "destination (Solana base58 for `\"solana\"`, EVM hex otherwise)."
+    ),
+  amount: z
+    .string()
+    .max(50)
+    .regex(/^\d+(\.\d{1,8})?$/)
+    .describe(
+      'Decimal BTC string (up to 8 fractional digits, e.g. "0.005"). "max" is ' +
+        "NOT supported — bridges commit to an exact deposit amount via the " +
+        "OP_RETURN memo at quote time, so the amount must be known up-front."
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Slippage tolerance in basis points (50 = 0.5%, 100 = 1%). Default ~50. " +
+        "Hard-capped at 500 (5%); above 100 (1%) requires `acknowledgeHighSlippage: " +
+        "true` to opt in. Cross-chain bridges may impose their own minimums above this."
+    ),
+  acknowledgeHighSlippage: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required when `slippageBps > 100`. Mirrors the `prepare_swap` guard — " +
+        "forces the caller to state that an unusually-high slippage is intentional."
+    ),
+});
+
 export const registerBitcoinMultisigWalletInput = z.object({
   name: z
     .string()
@@ -1642,6 +1722,7 @@ export type UnregisterBitcoinMultisigWalletArgs = z.infer<
   typeof unregisterBitcoinMultisigWalletInput
 >;
 export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInput>;
+export type PrepareBitcoinLifiSwapArgs = z.infer<typeof prepareBitcoinLifiSwapInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -238,3 +238,107 @@ export async function fetchSolanaQuote(req: LifiSolanaQuoteRequest) {
 // Re-export so the Solana wrapper module can use the wSOL constant without
 // re-defining it (single source of truth).
 export { SOLANA_WSOL_MINT, SOLANA_NATIVE_SENTINEL };
+
+/**
+ * LiFi numeric chain ID for native Bitcoin. Source: live
+ * `https://li.quest/v1/chains?chainTypes=UTXO` returns
+ * `{ id: 20000000000001, key: "btc", chainType: "UTXO" }`. Hoisted as a
+ * constant so the BTC quote helper doesn't have to reach into the SDK
+ * (the `ChainId` enum bundled with `@lifi/types` does include BTC under
+ * `BTC = 20000000000001`, but spelling it here keeps lifi.ts independent
+ * of SDK-version drift on this exact constant).
+ */
+export const LIFI_BITCOIN_CHAIN_ID = 20000000000001 as const;
+
+/**
+ * LiFi sentinel for the native BTC token. The chains endpoint reports
+ * `nativeToken.address: "bitcoin"` for BTC — not 0x0…0 like EVM, not a
+ * mint like Solana. The aggregator's quote endpoint accepts this exact
+ * lowercase string.
+ */
+export const LIFI_BITCOIN_NATIVE_SENTINEL = "bitcoin";
+
+/**
+ * Quote request for a BTC-source LiFi swap/bridge. Constrained to the
+ * destination chain types LiFi actually exposes a route for from native
+ * BTC: every EVM chain in `SupportedChain`, plus Solana. TRON is NOT in
+ * LiFi's BTC route table (empirical: `fromChain=BTC&toChain=TRX` returns
+ * `tool: null, toAmount: null` — no aggregator path).
+ *
+ * Why BTC source has its own request type rather than widening
+ * `LifiQuoteRequest`:
+ *   - `fromAddress` is a Bitcoin bech32 / legacy / p2sh string, not 0x-hex
+ *   - `fromToken` is the literal `"bitcoin"` sentinel, not a 0x token addr
+ *   - exact-out (`toAmount`) is unsupported for BTC source — bridge
+ *     deposit-tag-style memos commit to a fromAmount at quote time
+ */
+export interface LifiBitcoinQuoteRequest {
+  /** Bitcoin source wallet (bech32/taproot/p2sh/legacy). LiFi reads UTXOs from this address. */
+  fromAddress: string;
+  /** Raw integer satoshi amount as a string (e.g. "500000" for 0.005 BTC). */
+  fromAmount: string;
+  /**
+   * Destination chain. EVM `SupportedChain` for an EVM bridge target,
+   * `"solana"` for native SOL/SPL delivery. Other chains rejected by the
+   * upstream API.
+   */
+  toChain: SupportedChain | "solana";
+  /**
+   * Destination token. EVM hex when `toChain` is EVM; SPL mint (base58)
+   * when `toChain === "solana"`. `"native"` resolves to the chain's
+   * conventional native sentinel (`0x0…0` for EVM, wSOL mint for Solana).
+   */
+  toToken: string | "native";
+  /**
+   * Destination wallet — REQUIRED. The Bitcoin source address is not a
+   * valid recipient on any other chain; LiFi has no source-defaults
+   * fallback for cross-chain-type routes.
+   */
+  toAddress: string;
+  /** Optional slippage override — LiFi default is 0.5% (0.005). */
+  slippage?: number;
+}
+
+/**
+ * Fetch a LiFi quote with Bitcoin as the source chain. The response's
+ * `transactionRequest` has a different shape than EVM/Solana sources:
+ *   - `to` — the BTC vault deposit address chosen by the routing solver
+ *     (NEAR Intents / Garden / Thorswap / Chainflip / etc.; LiFi
+ *     auctions the route across them per request)
+ *   - `data` — a hex-encoded PSBT v0 (NOT EVM calldata). The PSBT
+ *     carries the OP_RETURN memo committing to the destination chain +
+ *     recipient + minOut. `data` field naming is shared with the EVM
+ *     shape but the bytes are a Bitcoin PSBT.
+ *   - `value` — satoshi amount that the deposit output (output #0)
+ *     pays to the vault. Includes any LiFi-side fee outputs the PSBT
+ *     also contains.
+ *
+ * The PSBT inputs are pre-selected by LiFi from `fromAddress`'s on-chain
+ * UTXO set (LiFi runs its own indexer pass). Each input carries
+ * `witnessUtxo` only — `nonWitnessUtxo` is missing, which Ledger BTC
+ * app 2.x rejects (issue #213). Caller MUST hydrate prev-tx hex on every
+ * input before forwarding the PSBT to `signPsbtBuffer`.
+ */
+export async function fetchBitcoinQuote(req: LifiBitcoinQuoteRequest) {
+  initLifi();
+  const toIsSolana = req.toChain === "solana";
+  const toChainId = toIsSolana
+    ? LIFI_SOLANA_CHAIN_ID
+    : CHAIN_IDS[req.toChain as SupportedChain];
+  const toTokenResolved =
+    req.toToken === "native"
+      ? toIsSolana
+        ? SOLANA_WSOL_MINT
+        : NATIVE
+      : req.toToken;
+  return getQuote({
+    fromChain: LIFI_BITCOIN_CHAIN_ID as LifiChainId,
+    toChain: toChainId as LifiChainId,
+    fromToken: LIFI_BITCOIN_NATIVE_SENTINEL,
+    toToken: toTokenResolved,
+    fromAmount: req.fromAmount,
+    fromAddress: req.fromAddress,
+    toAddress: req.toAddress,
+    ...(req.slippage !== undefined ? { slippage: req.slippage } : {}),
+  });
+}

--- a/test/btc-lifi-swap.test.ts
+++ b/test/btc-lifi-swap.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pjoin } from "node:path";
+import { createRequire } from "node:module";
+import { setConfigDirForTesting } from "../src/config/user-config.js";
+
+/**
+ * `prepare_btc_lifi_swap` unit tests. The LiFi quote endpoint is
+ * mocked via `fetchBitcoinQuote`; we hand the builder a synthetic PSBT
+ * that mirrors the real LiFi-on-NEAR-Intents shape (4 outputs: vault
+ * deposit, OP_RETURN memo, change-back-to-source, LiFi fee). The test
+ * pins the load-bearing invariants:
+ *
+ *  - input scripts must equal the source's scriptPubKey (refusal path)
+ *  - exactly one OP_RETURN output (multi-OP_RETURN refused)
+ *  - vault output address matches `transactionRequest.to`
+ *  - `nonWitnessUtxo` is hydrated on every input from the indexer
+ *  - the verification block surfaces vault, OP_RETURN hex, expected/min
+ *    output, route tool, slippage
+ *  - destinations LiFi cannot route to (TRON) are NOT exposed by the
+ *    schema enum, so the builder doesn't need a runtime guard for them
+ *  - destination address format mismatches are refused up-front (EVM
+ *    hex for "solana", base58 for EVM)
+ */
+
+const requireCjs = createRequire(import.meta.url);
+const bitcoinjsForFixtures = requireCjs("bitcoinjs-lib") as {
+  Transaction: new () => {
+    version: number;
+    addInput(hash: Buffer, index: number, sequence?: number): unknown;
+    addOutput(script: Buffer, value: number): unknown;
+    toHex(): string;
+  };
+  Psbt: {
+    new (opts?: { network?: unknown }): {
+      addInput(input: {
+        hash: string | Buffer;
+        index: number;
+        sequence?: number;
+        witnessUtxo?: { script: Buffer; value: number };
+      }): unknown;
+      addOutput(output: { address?: string; script?: Buffer; value: number }): unknown;
+      toHex(): string;
+      toBase64(): string;
+    };
+    fromBase64(b64: string): {
+      data: { inputs: Array<{ nonWitnessUtxo?: Buffer }> };
+    };
+  };
+  address: {
+    toOutputScript(addr: string, network?: unknown): Buffer;
+  };
+  payments: {
+    embed(opts: { data: Buffer[] }): { output: Buffer };
+  };
+  networks: { bitcoin: unknown };
+};
+
+const NETWORK = bitcoinjsForFixtures.networks.bitcoin;
+
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SEGWIT_PUBKEY =
+  "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd";
+const VAULT_ADDR = "1GhGCZJ65hfkycqxaTTDGyKncouGL2dFox"; // P2PKH; LiFi/NEAR Intents vault
+const LIFI_FEE_ADDR = "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu"; // LiFi fee output (well-formed P2WPKH)
+const FAKE_TXID =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+
+/**
+ * Build a minimal mainnet prev-tx hex with a single output at `vout`
+ * paying `address` `value` sats. Issue #213 — Ledger 2.x requires
+ * `nonWitnessUtxo` on every PSBT input, hydrated from this prev-tx.
+ */
+function buildPrevTxHex(value: number, address: string, vout = 0): string {
+  const tx = new bitcoinjsForFixtures.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  for (let i = 0; i <= vout; i++) {
+    const script = bitcoinjsForFixtures.address.toOutputScript(address, NETWORK);
+    tx.addOutput(script, i === vout ? value : 0);
+  }
+  return tx.toHex();
+}
+
+/**
+ * Construct a synthetic LiFi-shaped PSBT: 1 segwit input from `source`,
+ * outputs in this order — vault deposit, OP_RETURN memo,
+ * change-back-to-source, LiFi-fee. Returns the hex-encoded PSBT (LiFi
+ * wire shape is hex; the builder accepts both 0x-prefixed and bare hex).
+ */
+function buildLifiShapedPsbtHex(opts: {
+  source: string;
+  inputValue: number;
+  inputTxid?: string;
+  inputVout?: number;
+  vault?: string;
+  vaultValue: number;
+  memoBytes: Buffer;
+  changeValue: number;
+  changeAddress?: string; // override to test "change to non-source" case
+  feeOutputAddress?: string;
+  feeOutputValue?: number;
+  extraOpReturnBytes?: Buffer; // for the multi-OP_RETURN refusal test
+}): string {
+  const psbt = new bitcoinjsForFixtures.Psbt({ network: NETWORK });
+  const sourceScript = bitcoinjsForFixtures.address.toOutputScript(
+    opts.source,
+    NETWORK,
+  );
+  psbt.addInput({
+    hash: opts.inputTxid ?? FAKE_TXID,
+    index: opts.inputVout ?? 0,
+    sequence: 0xfffffffd,
+    witnessUtxo: { script: sourceScript, value: opts.inputValue },
+  });
+  // Output 0: vault deposit.
+  psbt.addOutput({
+    address: opts.vault ?? VAULT_ADDR,
+    value: opts.vaultValue,
+  });
+  // Output 1: OP_RETURN memo.
+  const memoEmbed = bitcoinjsForFixtures.payments.embed({ data: [opts.memoBytes] });
+  psbt.addOutput({ script: memoEmbed.output, value: 0 });
+  // Output 2: change.
+  psbt.addOutput({
+    address: opts.changeAddress ?? opts.source,
+    value: opts.changeValue,
+  });
+  // Output 3 (optional): LiFi fee.
+  if (opts.feeOutputAddress && opts.feeOutputValue !== undefined) {
+    psbt.addOutput({
+      address: opts.feeOutputAddress,
+      value: opts.feeOutputValue,
+    });
+  }
+  // Optional second OP_RETURN — used for the multi-memo refusal test.
+  if (opts.extraOpReturnBytes) {
+    const extra = bitcoinjsForFixtures.payments.embed({
+      data: [opts.extraOpReturnBytes],
+    });
+    psbt.addOutput({ script: extra.output, value: 0 });
+  }
+  return psbt.toHex();
+}
+
+const fetchBitcoinQuoteMock = vi.fn();
+vi.mock("../src/modules/swap/lifi.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/modules/swap/lifi.js")>();
+  return {
+    ...actual,
+    fetchBitcoinQuote: (...args: unknown[]) => fetchBitcoinQuoteMock(...args),
+  };
+});
+
+const getTxHexMock = vi.fn();
+vi.mock("../src/modules/btc/indexer.ts", () => ({
+  getBitcoinIndexer: () => ({ getTxHex: getTxHexMock }),
+  resetBitcoinIndexer: () => {},
+}));
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(pjoin(tmpdir(), "vaultpilot-btc-lifi-"));
+  setConfigDirForTesting(tmpHome);
+  fetchBitcoinQuoteMock.mockReset();
+  getTxHexMock.mockReset();
+  getTxHexMock.mockImplementation(async (txid: string) => {
+    // Default: return a prev-tx hex paying 100_000 sats to SEGWIT_ADDR
+    // at vout=0. Each test that varies inputs sets the value via the
+    // synthetic PSBT, so the prev-tx output value just needs to be
+    // >= the witnessUtxo value. We size it generously.
+    if (txid !== FAKE_TXID) {
+      throw new Error(
+        `Test setup error: getTxHex(${txid}) called but only FAKE_TXID is registered.`,
+      );
+    }
+    return buildPrevTxHex(1_000_000, SEGWIT_ADDR, 0);
+  });
+  const { clearPairedBtcAddresses, setPairedBtcAddress } = await import(
+    "../src/signing/btc-usb-signer.js"
+  );
+  const { __clearBitcoinTxStore } = await import(
+    "../src/signing/btc-tx-store.js"
+  );
+  clearPairedBtcAddresses();
+  __clearBitcoinTxStore();
+  setPairedBtcAddress({
+    address: SEGWIT_ADDR,
+    publicKey: SEGWIT_PUBKEY,
+    path: "84'/0'/0'/0/0",
+    appVersion: "2.4.6",
+    addressType: "segwit",
+    accountIndex: 0,
+    chain: 0,
+    addressIndex: 0,
+  });
+});
+
+afterEach(() => {
+  setConfigDirForTesting(null);
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+/**
+ * Synthesize a LiFi quote object that matches the SDK shape closely enough
+ * for the builder. Only the fields the builder actually reads are
+ * populated.
+ */
+function makeLifiQuote(opts: {
+  psbtHex: string;
+  vault: string;
+  fromAmountSats: number;
+  toToken: { address: string; symbol: string; decimals: number };
+  toAmount: string;
+  toAmountMin: string;
+  tool?: string;
+}): unknown {
+  return {
+    tool: opts.tool ?? "near",
+    transactionRequest: {
+      to: opts.vault,
+      data: opts.psbtHex,
+      value: String(opts.fromAmountSats),
+    },
+    action: {
+      fromToken: { address: "bitcoin", symbol: "BTC", decimals: 8 },
+      toToken: opts.toToken,
+      fromAmount: String(opts.fromAmountSats),
+    },
+    estimate: {
+      toAmount: opts.toAmount,
+      toAmountMin: opts.toAmountMin,
+      executionDuration: 1312,
+    },
+  };
+}
+
+describe("buildBitcoinLifiSwap", () => {
+  it("decodes vault + OP_RETURN + change, hydrates nonWitnessUtxo, and projects the verification block", async () => {
+    const memoBytes = Buffer.from("3d7c6c6966698048cfc093", "hex"); // "=|lifi" + binary
+    const psbtHex = buildLifiShapedPsbtHex({
+      source: SEGWIT_ADDR,
+      inputValue: 887_578,
+      vaultValue: 499_262,
+      memoBytes,
+      changeValue: 386_519,
+      feeOutputAddress: LIFI_FEE_ADDR,
+      feeOutputValue: 1_250,
+    });
+    fetchBitcoinQuoteMock.mockResolvedValueOnce(
+      makeLifiQuote({
+        psbtHex,
+        vault: VAULT_ADDR,
+        fromAmountSats: 500_000,
+        toToken: {
+          address: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+        },
+        toAmount: "166995621559815435",
+        toAmountMin: "166494634695135988",
+      }),
+    );
+
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    const tx = await buildBitcoinLifiSwap({
+      wallet: SEGWIT_ADDR,
+      toChain: "ethereum",
+      toToken: "native",
+      toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      amount: "0.005",
+      slippageBps: 50,
+    });
+
+    // Header invariants.
+    expect(tx.chain).toBe("bitcoin");
+    expect(tx.action).toBe("native_send");
+    expect(tx.from).toBe(SEGWIT_ADDR);
+    expect(tx.addressFormat).toBe("bech32");
+    expect(tx.accountPath).toBe("84'/0'/0'");
+    expect(tx.handle).toBeDefined();
+
+    // Verification block — vault, memo hex, route tool, expected/min out.
+    expect(tx.decoded.functionName).toBe("bitcoin.lifi_swap");
+    expect(tx.decoded.args.vault).toBe(VAULT_ADDR);
+    expect(tx.decoded.args.opReturnHex).toBe(memoBytes.toString("hex"));
+    expect(tx.decoded.args.opReturnAscii).toBe("=|lifi"); // printable prefix
+    expect(tx.decoded.args.route).toBe("near");
+    expect(tx.decoded.args.toChain).toBe("ethereum");
+    expect(tx.decoded.args.toAddress).toBe(
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    );
+    expect(tx.decoded.args.expectedOut).toContain("ETH");
+    expect(tx.decoded.args.minOut).toContain("ETH");
+    expect(tx.decoded.args.slippageBps).toBe("50");
+
+    // Outputs decoded — should be 4 (vault, OP_RETURN, change, LiFi fee).
+    expect(tx.decoded.outputs).toHaveLength(4);
+    const vaultOut = tx.decoded.outputs.find((o) => o.address === VAULT_ADDR);
+    expect(vaultOut).toBeDefined();
+    expect(vaultOut?.amountSats).toBe("499262");
+    expect(vaultOut?.isChange).toBe(false);
+
+    const opReturnOut = tx.decoded.outputs.find((o) => o.address === "OP_RETURN");
+    expect(opReturnOut).toBeDefined();
+    expect(opReturnOut?.amountSats).toBe("0");
+
+    const changeOut = tx.decoded.outputs.find(
+      (o) => o.address === SEGWIT_ADDR && o.isChange,
+    );
+    expect(changeOut).toBeDefined();
+    expect(changeOut?.amountSats).toBe("386519");
+    expect(changeOut?.changePath).toBe("84'/0'/0'/0/0");
+
+    const feeOut = tx.decoded.outputs.find(
+      (o) => o.address === LIFI_FEE_ADDR,
+    );
+    expect(feeOut).toBeDefined();
+    expect(feeOut?.amountSats).toBe("1250");
+    expect(feeOut?.isChange).toBe(false);
+
+    // Sources — single source, single input.
+    expect(tx.sources).toEqual([
+      { address: SEGWIT_ADDR, path: "84'/0'/0'/0/0", publicKey: SEGWIT_PUBKEY },
+    ]);
+    expect(tx.inputSources).toEqual([SEGWIT_ADDR]);
+    expect(tx.decoded.sources).toEqual([
+      {
+        address: SEGWIT_ADDR,
+        pulledSats: "887578",
+        pulledBtc: "0.00887578",
+        inputCount: 1,
+      },
+    ]);
+
+    // Fee = inputs - outputs = 887578 - (499262 + 0 + 386519 + 1250) = 547.
+    expect(tx.decoded.feeSats).toBe("547");
+    expect(tx.decoded.rbfEligible).toBe(false);
+
+    // Hydration check — nonWitnessUtxo must now be set on every input.
+    expect(getTxHexMock).toHaveBeenCalledOnce();
+    const hydrated = bitcoinjsForFixtures.Psbt.fromBase64(tx.psbtBase64);
+    expect(hydrated.data.inputs).toHaveLength(1);
+    expect(hydrated.data.inputs[0].nonWitnessUtxo).toBeInstanceOf(Buffer);
+  });
+
+  it("refuses inputs from a different scriptPubKey than the source address", async () => {
+    // Build a PSBT whose input claims a witnessUtxo from a DIFFERENT
+    // address (synthetically — we re-encode another address's script).
+    // Real-world tampering would manifest the same way: aggregator
+    // returns a PSBT with foreign inputs.
+    const otherAddr = "bc1q539etcvmjsvm3wtltwdkkj6tfd95kj6ttxc3zu";
+    const psbt = new bitcoinjsForFixtures.Psbt({ network: NETWORK });
+    psbt.addInput({
+      hash: FAKE_TXID,
+      index: 0,
+      sequence: 0xfffffffd,
+      witnessUtxo: {
+        script: bitcoinjsForFixtures.address.toOutputScript(otherAddr, NETWORK),
+        value: 887_578,
+      },
+    });
+    psbt.addOutput({ address: VAULT_ADDR, value: 499_262 });
+    psbt.addOutput({
+      script: bitcoinjsForFixtures.payments.embed({
+        data: [Buffer.from("memo", "ascii")],
+      }).output,
+      value: 0,
+    });
+    psbt.addOutput({ address: SEGWIT_ADDR, value: 386_519 });
+
+    fetchBitcoinQuoteMock.mockResolvedValueOnce(
+      makeLifiQuote({
+        psbtHex: psbt.toHex(),
+        vault: VAULT_ADDR,
+        fromAmountSats: 500_000,
+        toToken: {
+          address: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+        },
+        toAmount: "1",
+        toAmountMin: "1",
+      }),
+    );
+
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/different scriptPubKey/);
+  });
+
+  it("refuses when the PSBT has no OP_RETURN memo output", async () => {
+    const psbt = new bitcoinjsForFixtures.Psbt({ network: NETWORK });
+    psbt.addInput({
+      hash: FAKE_TXID,
+      index: 0,
+      sequence: 0xfffffffd,
+      witnessUtxo: {
+        script: bitcoinjsForFixtures.address.toOutputScript(SEGWIT_ADDR, NETWORK),
+        value: 887_578,
+      },
+    });
+    // No OP_RETURN — only deposit + change.
+    psbt.addOutput({ address: VAULT_ADDR, value: 499_262 });
+    psbt.addOutput({ address: SEGWIT_ADDR, value: 386_519 });
+
+    fetchBitcoinQuoteMock.mockResolvedValueOnce(
+      makeLifiQuote({
+        psbtHex: psbt.toHex(),
+        vault: VAULT_ADDR,
+        fromAmountSats: 500_000,
+        toToken: {
+          address: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+        },
+        toAmount: "1",
+        toAmountMin: "1",
+      }),
+    );
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/no OP_RETURN memo/);
+  });
+
+  it("refuses when the PSBT has multiple OP_RETURN outputs", async () => {
+    const psbtHex = buildLifiShapedPsbtHex({
+      source: SEGWIT_ADDR,
+      inputValue: 887_578,
+      vaultValue: 499_262,
+      memoBytes: Buffer.from("memo1", "ascii"),
+      changeValue: 386_519,
+      extraOpReturnBytes: Buffer.from("memo2", "ascii"),
+    });
+    fetchBitcoinQuoteMock.mockResolvedValueOnce(
+      makeLifiQuote({
+        psbtHex,
+        vault: VAULT_ADDR,
+        fromAmountSats: 500_000,
+        toToken: {
+          address: "0x0000000000000000000000000000000000000000",
+          symbol: "ETH",
+          decimals: 18,
+        },
+        toAmount: "1",
+        toAmountMin: "1",
+      }),
+    );
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/multiple OP_RETURN/);
+  });
+
+  it("refuses Solana destinations with an EVM-shaped toAddress", async () => {
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "solana",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/not a valid Solana base58 address/);
+    expect(fetchBitcoinQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses EVM destinations with a Solana-shaped toAddress", async () => {
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/not a valid EVM address/);
+    expect(fetchBitcoinQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the wallet is not paired", async () => {
+    const { clearPairedBtcAddresses } = await import(
+      "../src/signing/btc-usb-signer.js"
+    );
+    clearPairedBtcAddresses();
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+      }),
+    ).rejects.toThrow(/not paired/);
+    expect(fetchBitcoinQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses high slippage without explicit acknowledgement", async () => {
+    const { buildBitcoinLifiSwap } = await import(
+      "../src/modules/btc/lifi-swap.ts"
+    );
+    await expect(
+      buildBitcoinLifiSwap({
+        wallet: SEGWIT_ADDR,
+        toChain: "ethereum",
+        toToken: "native",
+        toAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        amount: "0.005",
+        slippageBps: 200,
+      }),
+    ).rejects.toThrow(/slippage/i);
+    expect(fetchBitcoinQuoteMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #397.

## Summary
- New `prepare_btc_lifi_swap` tool: native BTC → token-on-EVM-or-Solana via LiFi's aggregator. LiFi auctions the route across intent solvers (NEAR Intents, Garden, Thorswap, Chainflip, Symbiosis) and returns a PSBT depositing to the chosen solver's vault with an OP_RETURN memo committing to the cross-chain destination.
- Source-side scope (Phase 1, mirrors `prepare_btc_send`): native segwit + taproot only. Destination scope: every EVM chain in `SupportedChain` plus Solana — TRON rejected up-front (no LiFi route from BTC, empirically verified).
- LTC source NOT included: LiFi's API only exposes BTC from the Bitcoin-fork family even though NEAR Intents protocol-level supports LTC/DOGE/BCH/ZEC. Tracked as separate primitive (would need direct THORChain or NEAR Intents integration).

## Why LiFi over THORChain (initial scope direction)
Empirical research against [`https://li.quest/v1/quote`](https://li.quest/v1/quote) confirmed LiFi's NEAR Intents integration covers BTC ↔ {ETH, Polygon, Arbitrum, Solana} as **single-hop** bridges from native BTC. Original issue #397 assumed THORChain for BTC → SOL, but THORChain has no Solana support — would have been 2-hop. LiFi-via-NEAR-Intents collapses it to one tx, fits the existing `prepare_swap` / `prepare_solana_lifi_swap` integration shape, and reuses the existing Ledger BTC sign path.

## Implementation notes
- **PSBT hydration**: LiFi's response carries `witnessUtxo` only on each input. Ledger BTC app 2.x rejects segwit/taproot inputs without `nonWitnessUtxo` (issue #213). The builder re-fetches each prev-tx hex from our Esplora indexer and attaches.
- **Pre-forward checks**: every input's prevout script must equal the source address's scriptPubKey; exactly one OP_RETURN output; deposit output address matches LiFi's advertised vault. Refuses with clear error on mismatch.
- **Verification block**: surfaces the vault address, OP_RETURN bytes (hex + printable-ASCII prefix), expected/min output on destination, slippage, chosen solver, execution duration estimate.
- **Change handling**: LiFi sends change back to source address (chain=0) — same simplification as existing `prepare_btc_send` Phase 1; trips Ledger's "unusual change path" notice but funds return to user (consistent with existing UX, project memory `project_btc_ltc_change_path_phase1`).

## Test plan
- [x] Unit tests cover: golden path (vault + memo + change + LiFi fee decoded, nonWitnessUtxo hydrated), refusal of foreign-input scripts, missing OP_RETURN, multi-OP_RETURN, EVM/Solana address-format mismatches, unpaired wallet, high-slippage without ack
- [x] Full test suite green locally (1931 tests)
- [x] Typecheck + build clean
- [ ] Live BTC → ETH route (paired Ledger BTC + small testnet/mainnet amount) — deferred to user-side validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)