### PR TITLE
feat(setup): lazy first-run auto-install of companion skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ All optional if the matching field is in `~/.vaultpilot-mcp/config.json`; env va
 - `VAULTPILOT_ALLOW_INSECURE_RPC=1` — opt out of https/private-IP RPC checks (local anvil/hardhat only)
 - `VAULTPILOT_FEEDBACK_ENDPOINT` — optional https proxy for `request_capability` direct POSTs. **The client does not sign or authenticate requests — the proxy MUST enforce its own auth.**
 - `VAULTPILOT_SKILL_MARKER_PATH` — suppresses the preflight-skill notice for read-only users who accept the tradeoff
+- `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` — skips the lazy first-run `git clone` of the companion preflight + setup skills into `~/.claude/skills/`. The original manual-install notice fires instead. Use for air-gapped / no-egress operation where the MCP must not contact github.com.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -452,6 +452,12 @@ import { simulateTransactionInput } from "./modules/simulation/schemas.js";
 
 import { requestCapability, requestCapabilityInput } from "./modules/feedback/index.js";
 
+import {
+  getAutoInstallState,
+  kickoffSkillAutoInstall,
+  type AutoInstallEntry,
+} from "./setup/auto-install.js";
+
 import { issueHandles } from "./signing/tx-store.js";
 import {
   EXPECTED_SKILL_SHA256,
@@ -569,17 +575,30 @@ export function isSetupSkillInstalled(): boolean {
 }
 
 /**
- * Module-level dedup: the missing-skill notice is emitted once per MCP
- * process lifetime (i.e. once per client session, since stdio servers get
- * a fresh process per client connection). Emitting on every tool call
- * created a review-readable nag that competing agent systems began
- * treating as prompt injection. One notice per session, on the first
- * tool call that fires after the skill is absent, is enough.
+ * Per-state dedup: the missing-skill notice is emitted at most once per
+ * distinct auto-install state observed during the session. Without
+ * auto-install (the original behavior) this collapses to once-per-session,
+ * matching the legacy semantics. With auto-install on, the user can see
+ * up to two notices total — the "in progress" one on the first tool call
+ * and a terminal "succeeded" / "failed" one on the call after the clone
+ * completes. Emitting on every tool call created a nag that competing
+ * agent systems began treating as prompt injection.
  *
- * If the user installs the skill mid-session, `isPreflightSkillInstalled`
- * flips to true and resets the flag so that a later removal would retrigger.
+ * Tracks which state (or absence of one) we last surfaced so the renderer
+ * doesn't repeat itself when the auto-install state hasn't changed.
+ *
+ * `null` means "no notice has fired yet this session"; the absence-of-
+ * notice case (skill installed) clears it back to `null` so a mid-session
+ * uninstall would re-trigger.
  */
-let missingSkillNoticeEmitted = false;
+type ShownNoticeKey =
+  | null
+  | "manual"
+  | "in-progress"
+  | "succeeded"
+  | "failed";
+
+let lastShownPreflightNotice: ShownNoticeKey = null;
 
 /**
  * Exported for tests — lets a test reset the dedup state between cases so
@@ -587,14 +606,22 @@ let missingSkillNoticeEmitted = false;
  * asserted independently.
  */
 export function _resetMissingPreflightSkillDedup(): void {
-  missingSkillNoticeEmitted = false;
+  lastShownPreflightNotice = null;
+}
+
+function noticeKeyFor(ai: AutoInstallEntry): ShownNoticeKey {
+  if (ai.state === "in-progress") return "in-progress";
+  if (ai.state === "succeeded") return "succeeded";
+  if (ai.state === "failed") return "failed";
+  return "manual";
 }
 
 /**
  * Render the missing-skill notice block if the skill is NOT installed AND
- * the notice has not yet been emitted in this session; otherwise return
- * `null`. Called by every tool handler so the notice surfaces on whatever
- * is the user's first vaultpilot-mcp call (read-only or signing).
+ * the notice (for the current auto-install state) has not yet been emitted
+ * in this session; otherwise return `null`. Called by every tool handler
+ * so the notice surfaces on whatever is the user's first vaultpilot-mcp
+ * call (read-only or signing).
  *
  * This is a UX nudge, not a security boundary — an actually-compromised
  * MCP would suppress its own notice. The purpose is to catch the
@@ -604,45 +631,56 @@ export function _resetMissingPreflightSkillDedup(): void {
  */
 export function missingPreflightSkillWarning(): string | null {
   if (isPreflightSkillInstalled()) {
-    // Reset dedup flag: if the user installs the skill mid-session, a
-    // subsequent uninstall should re-trigger the notice.
-    missingSkillNoticeEmitted = false;
+    // Reset dedup: if the user uninstalls mid-session, a subsequent removal
+    // should re-trigger the notice from a fresh state.
+    lastShownPreflightNotice = null;
     return null;
   }
-  if (missingSkillNoticeEmitted) return null;
-  missingSkillNoticeEmitted = true;
-  return renderMissingSkillWarning({ skillRepoUrl: SKILL_REPO_URL });
+  const ai = getAutoInstallState("vaultpilot-preflight");
+  const key = noticeKeyFor(ai);
+  if (lastShownPreflightNotice === key) return null;
+  lastShownPreflightNotice = key;
+  return renderMissingSkillWarning({
+    skillRepoUrl: SKILL_REPO_URL,
+    autoInstall: { state: ai.state, installPath: ai.target.installPath, detail: ai.detail },
+  });
 }
 
 /**
- * Independent dedup flag for the setup-skill notice. Separate from
- * `missingSkillNoticeEmitted` so a session can surface both notices
+ * Independent dedup tracker for the setup-skill notice. Separate from
+ * `lastShownPreflightNotice` so a session can surface both notices
  * (preflight + setup) once each — the two skills are independently
  * useful and live at different lifecycle points (every-tool-call vs
  * setup-flow only).
  */
-let missingSetupSkillNoticeEmitted = false;
+let lastShownSetupNotice: ShownNoticeKey = null;
 
 export function _resetMissingSetupSkillDedup(): void {
-  missingSetupSkillNoticeEmitted = false;
+  lastShownSetupNotice = null;
 }
 
 /**
- * Render the setup-skill missing-notice — once per session, only when the
- * skill file is absent. Designed to be invoked from the
- * `get_vaultpilot_config_status` handler (the canonical entry point the
- * setup skill prescribes), so the notice fires exactly when the agent is
- * already in a setup-flow context. Wider invocation would stack two
- * unrelated install notices on every response and dilute the signal.
+ * Render the setup-skill missing-notice — at most once per auto-install
+ * state per session, only when the skill file is absent. Designed to be
+ * invoked from the `get_vaultpilot_config_status` handler (the canonical
+ * entry point the setup skill prescribes), so the notice fires exactly
+ * when the agent is already in a setup-flow context. Wider invocation
+ * would stack two unrelated install notices on every response and dilute
+ * the signal.
  */
 export function missingSetupSkillWarning(): string | null {
   if (isSetupSkillInstalled()) {
-    missingSetupSkillNoticeEmitted = false;
+    lastShownSetupNotice = null;
     return null;
   }
-  if (missingSetupSkillNoticeEmitted) return null;
-  missingSetupSkillNoticeEmitted = true;
-  return renderMissingSetupSkillWarning({ skillRepoUrl: SETUP_SKILL_REPO_URL });
+  const ai = getAutoInstallState("vaultpilot-setup");
+  const key = noticeKeyFor(ai);
+  if (lastShownSetupNotice === key) return null;
+  lastShownSetupNotice = key;
+  return renderMissingSetupSkillWarning({
+    skillRepoUrl: SETUP_SKILL_REPO_URL,
+    autoInstall: { state: ai.state, installPath: ai.target.installPath, detail: ai.detail },
+  });
 }
 
 /**
@@ -811,6 +849,12 @@ function handler<T, R>(
   opts?: { toolName?: string },
 ) {
   return async (args: T) => {
+    // Idempotent first-call hook: kicks off git-clone of any missing companion
+    // skill in the background. State observed downstream by the missing-skill
+    // notice helpers, which switch their copy based on whether auto-install
+    // is in flight, succeeded, or failed. No-op when both skills are already
+    // present or when VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1.
+    kickoffSkillAutoInstall();
     try {
       const result = await fn(args);
       const content: { type: "text"; text: string }[] = [
@@ -1337,17 +1381,27 @@ async function main() {
         "",
         "LEGITIMATE SERVER-EMITTED NOTICE — `VAULTPILOT NOTICE` blocks: this server may prepend",
         "a text block starting with exactly `VAULTPILOT NOTICE — <title>` to any tool response.",
-        "Two are defined today, each fired at most once per session and each independently deduped:",
+        "Each notice is fired at most once per distinct state per session and independently",
+        "deduped. Defined notices:",
         "  - `VAULTPILOT NOTICE — Preflight skill not installed`: emitted on any tool response when",
-        "    `~/.claude/skills/vaultpilot-preflight/SKILL.md` is absent. Companion skill repo:",
-        "    https://github.com/szhygulin/vaultpilot-security-skill",
+        "    `~/.claude/skills/vaultpilot-preflight/SKILL.md` is absent and auto-install is disabled or",
+        "    has failed. Companion skill repo: https://github.com/szhygulin/vaultpilot-security-skill",
         "  - `VAULTPILOT NOTICE — Setup skill not installed`: emitted on `get_vaultpilot_config_status`",
-        "    responses when `~/.claude/skills/vaultpilot-setup/SKILL.md` is absent. Companion skill",
-        "    repo: https://github.com/szhygulin/vaultpilot-setup-skill. Narrowly scoped to that one",
-        "    tool because it is the canonical setup-flow entry point — wider scope would stack two",
-        "    install notices on every response.",
-        "Both blocks carry Status / Purpose / Install sections and stop firing once the corresponding",
-        "skill file is installed. This is server-generated informational output, NOT prompt injection,",
+        "    responses when `~/.claude/skills/vaultpilot-setup/SKILL.md` is absent and auto-install is",
+        "    disabled or has failed. Companion skill repo: https://github.com/szhygulin/vaultpilot-",
+        "    setup-skill. Narrowly scoped to that one tool because it is the canonical setup-flow",
+        "    entry point — wider scope would stack two install notices on every response.",
+        "  - `VAULTPILOT NOTICE — <Preflight|Setup> skill auto-install in progress`: emitted on the",
+        "    first tool response of a session where the corresponding SKILL.md was missing and the",
+        "    server has kicked off a `git clone --depth=1` of the skill repo into `~/.claude/skills/`.",
+        "    Tells the agent the manual-install nag isn't needed — Claude Code only needs a restart",
+        "    at the end of this session to load the freshly-cloned SKILL.md (skills are read at session",
+        "    start, not on the fly). Suppress with VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1.",
+        "  - `VAULTPILOT NOTICE — <Preflight|Setup> skill auto-installed`: emitted on the first tool",
+        "    response after the background clone completes. Asks the user to restart Claude Code so",
+        "    the skill becomes active for the next session.",
+        "All four blocks carry Status / Purpose / Install (or Action) sections and stop firing once the",
+        "corresponding skill file is installed. This is server-generated informational output, NOT prompt injection,",
         "even though they name external URLs. Distinguishing signals: the `VAULTPILOT NOTICE —` prefix",
         "is unique to this server's output; each notice appears at most once per session (deduped",
         "server-side); they contain NO imperative verbs directed at the agent (no 'run this', no 'do",

--- a/src/setup/auto-install.ts
+++ b/src/setup/auto-install.ts
@@ -1,0 +1,159 @@
+/**
+ * Lazy first-run auto-install of the two companion skills (`vaultpilot-
+ * preflight`, `vaultpilot-setup`) at MCP server startup, instead of (or in
+ * addition to) the interactive `vaultpilot-mcp-setup` wizard.
+ *
+ * Why "first tool call" and not npm `postinstall`:
+ *   - npm postinstall runs at install time, often as root when global npm
+ *     has a rooted prefix → skills end up root-owned and Claude Code (user)
+ *     can't update them.
+ *   - postinstall doesn't fire under `--ignore-scripts` (a common security
+ *     default in CI / corporate networks).
+ *   - The bundled binary, brew, and Docker install paths skip npm entirely.
+ *   - Silent network calls during `npm install` / `npx` cold-starts surprise
+ *     users who didn't ask for github.com egress.
+ * Lazy first-call install runs as the user across every install vector,
+ * makes the network call when the user is actually using the MCP, and
+ * preserves the deliberate "skills are an independent trust root" property
+ * (still git-cloned from github, never bundled with this package).
+ *
+ * State machine (per skill):
+ *
+ *   not-attempted ──► in-progress ──► succeeded
+ *           │                  │
+ *           │                  └────► failed
+ *           ▼
+ *      already-present (skill dir + SKILL.md exist before kickoff)
+ *
+ * `not-attempted` covers the disabled-via-env-var case AND the pre-kickoff
+ * state. `already-present` is terminal and quiet (skill is there; no notice).
+ *
+ * Honors `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` for users who want
+ * air-gapped / no-egress operation. When set, kickoff is a no-op and the
+ * existing manual-install notice fires (today's behavior).
+ */
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { getSkillTargets, type SkillTarget } from "./install-skills.js";
+
+const execFileAsync = promisify(execFile);
+
+export type AutoInstallState =
+  | "not-attempted"
+  | "in-progress"
+  | "succeeded"
+  | "failed"
+  | "already-present";
+
+export interface AutoInstallEntry {
+  state: AutoInstallState;
+  target: SkillTarget;
+  /** Populated for `failed`; short message suitable for direct print. */
+  detail?: string;
+}
+
+const states = new Map<string, AutoInstallEntry>();
+let kickoffStarted = false;
+
+function isDisabled(): boolean {
+  const v = process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL;
+  return v === "1" || v === "true";
+}
+
+/**
+ * Idempotent: only the first call does work; subsequent calls are no-ops.
+ * Called from the top of every tool handler so the MCP doesn't need to
+ * pre-compute when the "first tool call" actually is.
+ *
+ * Synchronous-returning even though it kicks off async git-clones — callers
+ * never need to await this, the state map is the only observable surface.
+ */
+export function kickoffSkillAutoInstall(): void {
+  if (kickoffStarted) return;
+  kickoffStarted = true;
+  if (isDisabled()) return;
+  for (const target of getSkillTargets()) {
+    if (existsSync(join(target.installPath, "SKILL.md"))) {
+      states.set(target.name, { state: "already-present", target });
+      continue;
+    }
+    if (existsSync(target.installPath)) {
+      // Dangling dir (half-failed clone left an empty dir, or user interrupted
+      // a prior wizard run). Refuse to clone into it — git would fail anyway,
+      // and we never delete user files. Treat as terminal failed so the
+      // existing manual-install notice fires with a concrete fix.
+      states.set(target.name, {
+        state: "failed",
+        target,
+        detail:
+          `Path exists but has no SKILL.md — left untouched. ` +
+          `Remove it manually, then either re-run vaultpilot-mcp-setup or ` +
+          `git clone ${target.repoUrl} ${target.installPath}.`,
+      });
+      continue;
+    }
+    states.set(target.name, { state: "in-progress", target });
+    void runInstall(target);
+  }
+}
+
+async function runInstall(target: SkillTarget): Promise<void> {
+  try {
+    // mkdir the parent (~/.claude/skills/) so git clone lands somewhere
+    // predictable on a first-ever Claude Code install.
+    mkdirSync(join(target.installPath, ".."), { recursive: true });
+    await execFileAsync(
+      "git",
+      ["clone", "--depth=1", target.repoUrl, target.installPath],
+      { timeout: 30_000 },
+    );
+    states.set(target.name, { state: "succeeded", target });
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { stderr?: string | Buffer };
+    let detail: string;
+    if (err.code === "ENOENT") {
+      detail =
+        `git is not on PATH. Install git, then clone ${target.repoUrl} ` +
+        `to ${target.installPath}.`;
+    } else {
+      const stderr =
+        typeof err.stderr === "string"
+          ? err.stderr.trim()
+          : err.stderr instanceof Buffer
+            ? err.stderr.toString("utf8").trim()
+            : "";
+      const lastLine = stderr ? stderr.split("\n").slice(-1)[0] : "";
+      detail =
+        `git clone failed: ${err.message}` +
+        (lastLine ? ` (${lastLine})` : "");
+    }
+    states.set(target.name, { state: "failed", target, detail });
+  }
+}
+
+/**
+ * Returns the current state for a named skill. Unknown name → `not-attempted`
+ * with a synthesized target (caller is the renderer, which only needs the
+ * state + detail; target is a defensive default).
+ */
+export function getAutoInstallState(skillName: string): AutoInstallEntry {
+  const existing = states.get(skillName);
+  if (existing) return existing;
+  const target = getSkillTargets().find((t) => t.name === skillName);
+  if (!target) {
+    throw new Error(
+      `getAutoInstallState: unknown skill '${skillName}'. ` +
+        `Known: ${getSkillTargets().map((t) => t.name).join(", ")}.`,
+    );
+  }
+  return { state: "not-attempted", target };
+}
+
+/** Test-only: reset the kickoff flag and state map between cases. */
+export function _resetAutoInstallForTests(): void {
+  states.clear();
+  kickoffStarted = false;
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2297,8 +2297,33 @@ export function renderSolanaAgentTaskBlock(tx: UnsignedSolanaTx): string {
  * `skillRepoUrl` is the GitHub URL the user clones from; passed in so the
  * call site owns the single source of truth (index.ts).
  */
+/**
+ * Auto-install state passed in by `index.ts`. The renderer switches on this
+ * to produce one of three notice variants:
+ *   - `not-attempted` / unset / `already-present` → manual-install prose
+ *     (the original notice content, unchanged).
+ *   - `in-progress` → "auto-install kicked off, restart at end of session"
+ *     so the user knows we're handling it but Claude Code needs a restart
+ *     to load the freshly-cloned SKILL.md (skills are loaded at session
+ *     start, not on the fly).
+ *   - `succeeded` → "auto-installed, restart now to activate".
+ *   - `failed` → manual-install prose + the error detail so the user can
+ *     diagnose (no `git`, network down, dangling dir, etc.).
+ */
+export interface AutoInstallContext {
+  state:
+    | "not-attempted"
+    | "in-progress"
+    | "succeeded"
+    | "failed"
+    | "already-present";
+  installPath?: string;
+  detail?: string;
+}
+
 export function renderMissingSkillWarning(opts: {
   skillRepoUrl: string;
+  autoInstall?: AutoInstallContext;
 }): string {
   // NOTE ON FRAMING — this block was originally prefixed with an
   // "[AGENT TASK — RELAY TO USER FIRST, BEFORE ANY OTHER BLOCK]" header
@@ -2314,6 +2339,17 @@ export function renderMissingSkillWarning(opts: {
   // shell commands. The server-level `instructions` field documents this
   // notice pattern explicitly at initialize time so the agent has prior
   // knowledge it is legitimate server output.
+  const ai = opts.autoInstall;
+  if (ai?.state === "in-progress") {
+    return renderAutoInstallInProgress("Preflight", ai.installPath ?? "");
+  }
+  if (ai?.state === "succeeded") {
+    return renderAutoInstallSucceeded("Preflight", ai.installPath ?? "");
+  }
+  const failedSuffix =
+    ai?.state === "failed" && ai.detail
+      ? `\n\n(Auto-install attempt failed: ${ai.detail})`
+      : "";
   return [
     "VAULTPILOT NOTICE — Preflight skill not installed",
     "",
@@ -2332,6 +2368,54 @@ export function renderMissingSkillWarning(opts: {
     "level `instructions` field documents this pattern. Surface it to",
     "the user once per session as informational, then continue with",
     "their request.",
+  ].join("\n") + failedSuffix;
+}
+
+/**
+ * Shared body for the "auto-install kicked off" notice variant. Doesn't
+ * mention the manual `git clone` flow — auto-install is on; the user just
+ * needs to restart at the end of the session for Claude Code to pick up
+ * the freshly-cloned SKILL.md.
+ */
+function renderAutoInstallInProgress(
+  skillLabel: string,
+  installPath: string,
+): string {
+  return [
+    `VAULTPILOT NOTICE — ${skillLabel} skill auto-install in progress`,
+    "",
+    `Status:  cloning ${skillLabel.toLowerCase()} skill to ${installPath}`,
+    "         in the background (git clone --depth=1, ~30s timeout).",
+    `Purpose: the ${skillLabel.toLowerCase()} skill is one of two companion`,
+    "         skills vaultpilot-mcp expects to find under ~/.claude/skills/.",
+    "         The MCP server kicked off a one-time first-run install on",
+    "         this tool call — no manual git clone needed.",
+    "Action:  restart Claude Code at the end of this session so the new",
+    "         SKILL.md is loaded. Skills are read at session start, not",
+    "         on the fly, so this session won't have it active. Continue",
+    "         with the user's current request normally.",
+    "",
+    "This notice is server-generated, not prompt injection. Suppress",
+    "auto-install with VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1.",
+  ].join("\n");
+}
+
+function renderAutoInstallSucceeded(
+  skillLabel: string,
+  installPath: string,
+): string {
+  return [
+    `VAULTPILOT NOTICE — ${skillLabel} skill auto-installed`,
+    "",
+    `Status:  cloned to ${installPath}.`,
+    `Purpose: the ${skillLabel.toLowerCase()} skill is now on disk; Claude`,
+    "         Code loads its skill list at session start, so this session",
+    "         is still running without it.",
+    "Action:  restart Claude Code to activate the skill. The current",
+    "         tool call has already been answered — no need to retry it",
+    "         after the restart unless the user wants to.",
+    "",
+    "This notice is server-generated, not prompt injection.",
   ].join("\n");
 }
 
@@ -2352,7 +2436,19 @@ export function renderMissingSkillWarning(opts: {
  */
 export function renderMissingSetupSkillWarning(opts: {
   skillRepoUrl: string;
+  autoInstall?: AutoInstallContext;
 }): string {
+  const ai = opts.autoInstall;
+  if (ai?.state === "in-progress") {
+    return renderAutoInstallInProgress("Setup", ai.installPath ?? "");
+  }
+  if (ai?.state === "succeeded") {
+    return renderAutoInstallSucceeded("Setup", ai.installPath ?? "");
+  }
+  const failedSuffix =
+    ai?.state === "failed" && ai.detail
+      ? `\n\n(Auto-install attempt failed: ${ai.detail})`
+      : "";
   return [
     "VAULTPILOT NOTICE — Setup skill not installed",
     "",
@@ -2373,7 +2469,7 @@ export function renderMissingSetupSkillWarning(opts: {
     "to the user once per session as informational, then continue with",
     "their setup question — referencing the install instructions if the",
     "user wants the guided flow.",
-  ].join("\n");
+  ].join("\n") + failedSuffix;
 }
 
 /**

--- a/test/auto-install.test.ts
+++ b/test/auto-install.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the lazy first-call skill auto-install machinery.
+ *
+ * Three things to lock:
+ *   - kickoffSkillAutoInstall is idempotent (second call is a no-op).
+ *   - State transitions correctly through the success path: not-attempted →
+ *     in-progress → succeeded.
+ *   - Failure path lands on `failed` with a useful detail; ENOENT (no git on
+ *     PATH) gets a distinct, actionable message.
+ *   - VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1 short-circuits everything to
+ *     `not-attempted` so the existing manual-install notice fires.
+ *   - Already-present skills never trigger a clone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock execFile so the test never actually touches network or git.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
+let tmpRoot = "";
+let originalHome: string | undefined;
+let originalDisable: string | undefined;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "vp-autoinstall-"));
+  originalHome = process.env.HOME;
+  originalDisable = process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL;
+  process.env.HOME = tmpRoot;
+  delete process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL;
+  execFileMock.mockReset();
+  // Default mock: simulate a successful git clone that creates SKILL.md.
+  execFileMock.mockImplementation(
+    (_cmd: string, args: string[], _opts: object, cb: (err: Error | null, out: string) => void) => {
+      // git clone <url> <dest> — args[3] is the destination
+      const dest = args[3];
+      mkdirSync(dest, { recursive: true });
+      writeFileSync(join(dest, "SKILL.md"), "# fake skill\n");
+      cb(null, "");
+    },
+  );
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalDisable === undefined) delete process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL;
+  else process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL = originalDisable;
+  rmSync(tmpRoot, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe("kickoffSkillAutoInstall", () => {
+  it("is idempotent — second call does not trigger a second clone", async () => {
+    const { kickoffSkillAutoInstall, _resetAutoInstallForTests } = await import(
+      "../src/setup/auto-install.js"
+    );
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    kickoffSkillAutoInstall();
+    kickoffSkillAutoInstall();
+
+    // 2 skills × 1 clone each = 2 calls, never more.
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("transitions not-attempted → in-progress → succeeded", async () => {
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    expect(getAutoInstallState("vaultpilot-preflight").state).toBe("not-attempted");
+
+    kickoffSkillAutoInstall();
+    // Synchronously after kickoff, before the awaited execFileAsync resolves,
+    // state is in-progress.
+    expect(getAutoInstallState("vaultpilot-preflight").state).toBe("in-progress");
+
+    // Drain the microtask queue so the awaited callback runs.
+    await new Promise((r) => setImmediate(r));
+
+    expect(getAutoInstallState("vaultpilot-preflight").state).toBe("succeeded");
+    expect(getAutoInstallState("vaultpilot-setup").state).toBe("succeeded");
+  });
+
+  it("marks state=failed with a 'git is not on PATH' detail when execFile throws ENOENT", async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error) => void) => {
+        const err = Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" });
+        cb(err);
+      },
+    );
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    await new Promise((r) => setImmediate(r));
+
+    const entry = getAutoInstallState("vaultpilot-preflight");
+    expect(entry.state).toBe("failed");
+    expect(entry.detail).toMatch(/git is not on PATH/);
+  });
+
+  it("marks state=failed with a generic detail when git clone exits non-zero", async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error & { stderr?: string }) => void) => {
+        const err = Object.assign(new Error("Command failed: git clone ..."), {
+          stderr: "fatal: unable to access 'https://github.com/...': Could not resolve host",
+        });
+        cb(err);
+      },
+    );
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    await new Promise((r) => setImmediate(r));
+
+    const entry = getAutoInstallState("vaultpilot-preflight");
+    expect(entry.state).toBe("failed");
+    expect(entry.detail).toMatch(/git clone failed/);
+    expect(entry.detail).toMatch(/Could not resolve host/);
+  });
+
+  it("VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1 → state stays not-attempted, no clone fires", async () => {
+    process.env.VAULTPILOT_DISABLE_SKILL_AUTOINSTALL = "1";
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    await new Promise((r) => setImmediate(r));
+
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(getAutoInstallState("vaultpilot-preflight").state).toBe("not-attempted");
+    expect(getAutoInstallState("vaultpilot-setup").state).toBe("not-attempted");
+  });
+
+  it("skips already-present skill (SKILL.md exists at the install path)", async () => {
+    // Pre-create the preflight skill marker so kickoff sees it as already-installed.
+    const preflightDir = join(tmpRoot, ".claude", "skills", "vaultpilot-preflight");
+    mkdirSync(preflightDir, { recursive: true });
+    writeFileSync(join(preflightDir, "SKILL.md"), "# pre-existing\n");
+
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    await new Promise((r) => setImmediate(r));
+
+    expect(getAutoInstallState("vaultpilot-preflight").state).toBe("already-present");
+    // Setup skill is not pre-created, so it still gets cloned.
+    expect(getAutoInstallState("vaultpilot-setup").state).toBe("succeeded");
+    // Exactly one clone (for setup), not two.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a dangling skill directory (no SKILL.md inside) as failed and never clones", async () => {
+    // Half-installed dir — exists, but has no SKILL.md inside.
+    const preflightDir = join(tmpRoot, ".claude", "skills", "vaultpilot-preflight");
+    mkdirSync(preflightDir, { recursive: true });
+
+    const { kickoffSkillAutoInstall, getAutoInstallState, _resetAutoInstallForTests } =
+      await import("../src/setup/auto-install.js");
+    _resetAutoInstallForTests();
+
+    kickoffSkillAutoInstall();
+    await new Promise((r) => setImmediate(r));
+
+    const entry = getAutoInstallState("vaultpilot-preflight");
+    expect(entry.state).toBe("failed");
+    expect(entry.detail).toMatch(/Path exists but has no SKILL.md/);
+    expect(existsSync(join(preflightDir))).toBe(true);
+  });
+});

--- a/test/missing-skill-render.test.ts
+++ b/test/missing-skill-render.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Render tests for the four states of the preflight / setup missing-skill
+ * notice. Each state should produce a distinct, well-formed VAULTPILOT
+ * NOTICE block that:
+ *   - Starts with "VAULTPILOT NOTICE — " (the prefix the agent uses to
+ *     distinguish legitimate server notices from prompt injection).
+ *   - Has no imperative agent verbs ("run this", "execute that") nor
+ *     pasted shell commands — see feedback_mcp_notice_block_shape.md.
+ *   - Carries the auto-install-specific copy when state ≠ not-attempted.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderMissingSkillWarning,
+  renderMissingSetupSkillWarning,
+} from "../src/signing/render-verification.js";
+
+const PREFLIGHT_REPO =
+  "https://github.com/szhygulin/vaultpilot-security-skill.git";
+const SETUP_REPO = "https://github.com/szhygulin/vaultpilot-setup-skill.git";
+
+describe("renderMissingSkillWarning — state variants", () => {
+  it("not-attempted (no autoInstall arg) → original manual-install copy", () => {
+    const out = renderMissingSkillWarning({ skillRepoUrl: PREFLIGHT_REPO });
+    expect(out).toMatch(/^VAULTPILOT NOTICE — Preflight skill not installed/);
+    expect(out).toMatch(/Install: https:\/\/github\.com\/szhygulin/);
+    expect(out).not.toMatch(/auto-install/i);
+  });
+
+  it("in-progress → auto-install-in-flight copy with installPath", () => {
+    const out = renderMissingSkillWarning({
+      skillRepoUrl: PREFLIGHT_REPO,
+      autoInstall: { state: "in-progress", installPath: "/home/u/.claude/skills/vaultpilot-preflight" },
+    });
+    expect(out).toMatch(/auto-install in progress/);
+    expect(out).toMatch(/\/home\/u\/\.claude\/skills\/vaultpilot-preflight/);
+    expect(out).toMatch(/restart Claude Code/i);
+  });
+
+  it("succeeded → auto-installed copy directing user to restart", () => {
+    const out = renderMissingSkillWarning({
+      skillRepoUrl: PREFLIGHT_REPO,
+      autoInstall: { state: "succeeded", installPath: "/home/u/.claude/skills/vaultpilot-preflight" },
+    });
+    expect(out).toMatch(/Preflight skill auto-installed/);
+    expect(out).toMatch(/restart Claude Code/i);
+  });
+
+  it("failed → manual-install copy + appended detail line", () => {
+    const out = renderMissingSkillWarning({
+      skillRepoUrl: PREFLIGHT_REPO,
+      autoInstall: { state: "failed", detail: "git is not on PATH." },
+    });
+    // Falls back to the manual-install body…
+    expect(out).toMatch(/^VAULTPILOT NOTICE — Preflight skill not installed/);
+    // …with the failure detail surfaced at the end.
+    expect(out).toMatch(/Auto-install attempt failed: git is not on PATH/);
+  });
+});
+
+describe("renderMissingSetupSkillWarning — state variants", () => {
+  it("not-attempted → original setup-skill manual copy", () => {
+    const out = renderMissingSetupSkillWarning({ skillRepoUrl: SETUP_REPO });
+    expect(out).toMatch(/^VAULTPILOT NOTICE — Setup skill not installed/);
+    expect(out).toMatch(/setup wizard's/);
+    expect(out).not.toMatch(/auto-install in progress/i);
+  });
+
+  it("in-progress → setup-flavored auto-install copy", () => {
+    const out = renderMissingSetupSkillWarning({
+      skillRepoUrl: SETUP_REPO,
+      autoInstall: { state: "in-progress", installPath: "/home/u/.claude/skills/vaultpilot-setup" },
+    });
+    expect(out).toMatch(/Setup skill auto-install in progress/);
+  });
+
+  it("succeeded → setup-flavored auto-installed copy", () => {
+    const out = renderMissingSetupSkillWarning({
+      skillRepoUrl: SETUP_REPO,
+      autoInstall: { state: "succeeded", installPath: "/home/u/.claude/skills/vaultpilot-setup" },
+    });
+    expect(out).toMatch(/Setup skill auto-installed/);
+    expect(out).toMatch(/restart Claude Code/i);
+  });
+
+  it("notice never carries imperative agent verbs or pasted shell commands", () => {
+    // Defense-in-depth: this exact pattern was what made the original notice
+    // get flagged as prompt injection. Test that none of the variants regress.
+    const variants = [
+      renderMissingSkillWarning({ skillRepoUrl: PREFLIGHT_REPO }),
+      renderMissingSkillWarning({
+        skillRepoUrl: PREFLIGHT_REPO,
+        autoInstall: { state: "in-progress", installPath: "/x" },
+      }),
+      renderMissingSkillWarning({
+        skillRepoUrl: PREFLIGHT_REPO,
+        autoInstall: { state: "succeeded", installPath: "/x" },
+      }),
+      renderMissingSetupSkillWarning({ skillRepoUrl: SETUP_REPO }),
+      renderMissingSetupSkillWarning({
+        skillRepoUrl: SETUP_REPO,
+        autoInstall: { state: "in-progress", installPath: "/x" },
+      }),
+    ];
+    for (const v of variants) {
+      // No "[AGENT TASK …]" framing, no "RELAY TO USER FIRST".
+      expect(v).not.toMatch(/AGENT TASK/);
+      expect(v).not.toMatch(/RELAY TO USER FIRST/);
+      // No verbatim shell commands embedded for the agent to execute.
+      expect(v).not.toMatch(/^\s*git clone\s/m);
+      expect(v).not.toMatch(/```/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a lazy first-call auto-install path for the two companion skills (`vaultpilot-preflight`, `vaultpilot-setup`). On the first tool handler invocation of the session, the MCP kicks off background `git clone --depth=1` into `~/.claude/skills/` for any skill whose `SKILL.md` is missing.
- The existing two `VAULTPILOT NOTICE — … skill not installed` blocks now switch their copy to one of three new variants based on auto-install state:
  - **in-progress** — clone running; restart Claude Code at end of session to load
  - **succeeded** — clone done; restart Claude Code to activate (skills are loaded at session start, not on the fly)
  - **failed** — original manual-install notice + appended error detail (no `git`, network down, dangling dir, etc.)
- New env var `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` disables auto-install entirely for air-gapped / no-egress operation; the original manual-install notice fires unchanged in that case.
- Server `instructions` field is updated to document all four notice variants so agents have prior knowledge of the new states (avoids the "looks like prompt injection" trap that bit the original notice — see `feedback_mcp_notice_block_shape.md`).

## Why lazy first-call instead of npm `postinstall`

| Concern | postinstall | Lazy first-call |
|---|---|---|
| Runs as the user | ❌ root when npm prefix is rooted (skills become root-owned) | ✅ |
| Works on every install vector | ❌ npm only; skips bundled binary, brew, Docker | ✅ |
| Doesn't fire under `npm install --ignore-scripts` | ❌ silently skipped | ✅ |
| Preserves "skills are an independent trust root" | ✅ (cloned from github either way) | ✅ |
| No silent network egress at install time | ❌ fires during CI / `npx` cold-starts | ✅ (only when user actually invokes a tool) |

## Files

- `src/setup/auto-install.ts` (new) — state-machine module: `kickoffSkillAutoInstall()`, `getAutoInstallState()`, async git-clone via `child_process.execFile` (not the wizard's blocking `execFileSync`)
- `src/signing/render-verification.ts` — extended `renderMissingSkillWarning` / `renderMissingSetupSkillWarning` to switch on an `autoInstall` arg; new private helpers for the in-progress / succeeded variants
- `src/index.ts` — `kickoffSkillAutoInstall()` called once at the top of every handler entry (idempotent); the missing-skill notice helpers now dedup per state and pass auto-install context to the renderers; server `instructions` field documents all four notice variants
- `test/auto-install.test.ts` (new) — idempotency, state transitions, ENOENT (no git on PATH), generic clone failure, env-var disable, already-present skip, dangling-dir handling
- `test/missing-skill-render.test.ts` (new) — render snapshots for the four states + a defense-in-depth check that no variant carries imperative agent verbs / pasted shell commands
- `README.md` — `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL` documented in env-vars table

## Test plan

- [x] `npx vitest run` — 161 files, 1966 tests, all green (15 new tests in this PR)
- [x] `npx tsc --noEmit` — clean
- [ ] Live smoke (post-merge): wipe `~/.claude/skills/vaultpilot-{preflight,setup}/`, start the MCP, run any read-only tool, confirm the in-progress notice surfaces on the first call and `~/.claude/skills/vaultpilot-preflight/SKILL.md` exists ~3s later
- [ ] Live smoke: with `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` set, confirm no `git clone` fires (verifiable via `tcpdump` or absence of the install path) and the original manual-install notice is the one that surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)