### PR TITLE
chore(release): bump to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -4393,21 +4393,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6444,13 +6429,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7320,21 +7298,6 @@
         "ws": "*"
       }
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7563,25 +7526,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ledger-bitcoin/node_modules/ledger-bitcoin": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
-      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
-      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bitcoinerlab/descriptors": "^1.0.2",
-        "@bitcoinerlab/secp256k1": "^1.0.5",
-        "@ledgerhq/hw-transport": "^6.20.0",
-        "bip32-path": "^0.4.2",
-        "bitcoinjs-lib": "^6.1.3"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -9939,6 +9883,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Highlights

- **Native BTC ↔ EVM/Solana bridging** — `prepare_btc_lifi_swap` opens cross-chain BTC routes via LiFi without leaving the Ledger-signed flow (#401, closes #397).
- **Auto-demo on fresh install** — first-run users get a working demo wallet without configuring `VAULTPILOT_DEMO`. Companion skills (preflight + setup) lazy-install on first signing-class call (#399, #403).
- **2D demo persona matrix** — chain × type cells with per-cell loader, replacing the flat persona list (#404).
- **Solana integrity-check labeling** — agent now surfaces a one-line preface before the `node -e` Bash prompt fires, so the approval modal isn't a surprise mid-send (#400, closes #396).
- **Demo-mode robustness** — `preview_send` no longer requires `WALLETCONNECT_PROJECT_ID` in demo (#398, closes #395); persona enumeration always works regardless of env state (#394, closes #392); `set_demo_wallet` discoverability via `VAULTPILOT NOTICE` (#391).

## Included PRs

- #391 feat(demo): demo-wallet onboarding via VAULTPILOT NOTICE
- #394 fix(demo): always enumerate personas + clearer env-state message
- #398 fix(demo): preview_send no longer requires WALLETCONNECT_PROJECT_ID
- #399 feat(demo): auto-demo mode on fresh install
- #400 fix(verification): label Solana integrity-check block
- #401 feat(btc): native BTC ↔ EVM/Solana bridge via LiFi
- #403 feat(setup): lazy first-run auto-install of companion skills
- #404 feat(demo): 2D chain × type matrix + per-cell loader

## Deliberately deferred

- THORChain memo-PSBT path for #397 — LiFi covers the same UX with broader reach and reuses the existing Ledger flow; THORChain stays a future option if LiFi route quality drops.
- Skill-shipped \`vaultpilot-verify-solana-msg\` bin (#396 fix #2) — companion skills are pure prompt and cannot ship executables. CLAUDE.md rule added to lock this in. The labeling fix in #400 is the full fix for #396.

## Verification
- [x] \`npm run build\` clean
- [x] \`npm test\` → 1975 tests passed (161 files)
- [x] \`package.json\` + \`server.json\` (both top-level and \`packages[0].version\`) bumped to 0.11.0
- [x] \`git grep "0\.10\.1"\` returns nothing outside lockfile/changelog history

🤖 Generated with [Claude Code](https://claude.com/claude-code)