### PR TITLE
feat(demo): unsigned in-memory address book in demo mode

### DIFF
--- a/src/contacts/demo-store.ts
+++ b/src/contacts/demo-store.ts
@@ -1,0 +1,207 @@
+/**
+ * Process-local demo-mode address book. Mirrors `live-mode.ts`'s
+ * pattern — in-memory only, never persisted, lost on process restart.
+ *
+ * Why a separate store rather than reusing the production
+ * `~/.vaultpilot-mcp/contacts.json`:
+ *   1. Production contacts are signature-verified by the user's
+ *      hardware wallet on every read. Demo mode has no Ledger, so
+ *      the same code path can't be exercised (the existing
+ *      `pickAnchorForChain` throws when no pairing exists).
+ *   2. Persisting unsigned demo entries to the same disk file as the
+ *      production blob would erode the file's invariant ("every entry
+ *      was authorized by the device the user controls"). A separate
+ *      in-memory store keeps the trust boundary crisp: the demo book
+ *      exists in this process only, the signed book persists on disk.
+ *   3. Latching demo state in-memory matches `live-mode.ts`'s persona
+ *      selection — neither survives restart, both are deliberate try-
+ *      before-install scaffolding.
+ *
+ * Trust note (less-secure-by-design): a compromised MCP can mutate
+ * the demo store without the user's hardware key. That's acceptable
+ * because demo mode intercepts `send_transaction` and returns
+ * simulation envelopes — nothing actually goes on-chain. Address-
+ * poisoning protection in demo mode is "the agent shows you the
+ * resolved address" + "the prepare receipt is a simulation that
+ * never broadcasts," not the cryptographic signature chain
+ * production gets.
+ */
+
+import type { ContactChain } from "./schemas.js";
+import { CONTACT_ADDRESS_PATTERNS } from "./schemas.js";
+
+/**
+ * Per-entry record. `addedAt` is captured at insertion time so the
+ * `list_contacts` ordering / display matches the production shape.
+ */
+interface DemoContactEntry {
+  address: string;
+  addedAt: string;
+  notes?: string;
+  tags?: string[];
+}
+
+/**
+ * Per-chain map keyed by label. Same chain set as production
+ * `ContactChain` (btc/evm/solana/tron) — demo mode has no signer
+ * constraint so all four are usable from day one. Litecoin is not in
+ * `ContactChain` and therefore not addressable here either.
+ */
+const store: Record<ContactChain, Map<string, DemoContactEntry>> = {
+  btc: new Map(),
+  evm: new Map(),
+  solana: new Map(),
+  tron: new Map(),
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Add (or replace) a demo contact. Adding the same `label` REPLACES
+ * the existing entry on that chain, mirroring the production semantics
+ * (one label → one address per chain). Duplicate-address detection
+ * across labels: refuses if `address` is already saved under a
+ * different label, same as production. Address-format validation
+ * reuses the production regex table.
+ */
+export function addDemoContact(args: {
+  chain: ContactChain;
+  label: string;
+  address: string;
+  notes?: string;
+  tags?: string[];
+}): { entry: DemoContactEntry; replacedExisting: boolean } {
+  if (!CONTACT_ADDRESS_PATTERNS[args.chain].test(args.address)) {
+    throw new Error(
+      `CONTACTS_ADDRESS_FORMAT_MISMATCH: address "${args.address}" does not ` +
+        `match the expected format for chain "${args.chain}".`,
+    );
+  }
+  const chainStore = store[args.chain];
+  for (const [existingLabel, existingEntry] of chainStore.entries()) {
+    if (
+      existingLabel !== args.label &&
+      existingEntry.address === args.address
+    ) {
+      throw new Error(
+        `CONTACTS_DUPLICATE_ADDRESS: address ${args.address} is already ` +
+          `saved as "${existingLabel}" on ${args.chain}. Remove the existing ` +
+          `entry first if you want to rename, or pick a different address.`,
+      );
+    }
+  }
+  const existing = chainStore.get(args.label);
+  const entry: DemoContactEntry = {
+    address: args.address,
+    addedAt: existing?.addedAt ?? nowIso(),
+    ...(args.notes !== undefined ? { notes: args.notes } : {}),
+    ...(args.tags !== undefined ? { tags: args.tags } : {}),
+  };
+  chainStore.set(args.label, entry);
+  return { entry, replacedExisting: existing !== undefined };
+}
+
+/**
+ * Remove a label from one chain (when `chain` is set) or every chain
+ * that has it (when omitted). Matches the production tool's two-mode
+ * behavior. Returns the list of chains the label was found on.
+ */
+export function removeDemoContact(args: {
+  label: string;
+  chain?: ContactChain;
+}): Array<{ chain: ContactChain; address: string }> {
+  const chains: ContactChain[] = args.chain
+    ? [args.chain]
+    : (Object.keys(store) as ContactChain[]);
+  const removed: Array<{ chain: ContactChain; address: string }> = [];
+  for (const chain of chains) {
+    const entry = store[chain].get(args.label);
+    if (entry) {
+      removed.push({ chain, address: entry.address });
+      store[chain].delete(args.label);
+    }
+  }
+  return removed;
+}
+
+/**
+ * Read view: all entries flattened to one row per (chain, label),
+ * already address-format-valid by construction (write path checks).
+ * Resolver + listContacts both consume this.
+ */
+export function listDemoContacts(args?: {
+  chain?: ContactChain;
+  label?: string;
+}): Array<{
+  chain: ContactChain;
+  label: string;
+  address: string;
+  addedAt: string;
+  notes?: string;
+  tags?: string[];
+}> {
+  const chains: ContactChain[] = args?.chain
+    ? [args.chain]
+    : (Object.keys(store) as ContactChain[]);
+  const out: Array<{
+    chain: ContactChain;
+    label: string;
+    address: string;
+    addedAt: string;
+    notes?: string;
+    tags?: string[];
+  }> = [];
+  for (const chain of chains) {
+    for (const [label, entry] of store[chain].entries()) {
+      if (args?.label && label !== args.label) continue;
+      out.push({
+        chain,
+        label,
+        address: entry.address,
+        addedAt: entry.addedAt,
+        ...(entry.notes !== undefined ? { notes: entry.notes } : {}),
+        ...(entry.tags !== undefined ? { tags: entry.tags } : {}),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Forward lookup for the resolver — `(chain, label) → address?`.
+ * Returns null when no entry exists. Demo-only: the resolver consults
+ * this BEFORE the production (signed) lookup when in demo mode.
+ */
+export function findDemoContactByLabel(
+  chain: ContactChain,
+  label: string,
+): string | null {
+  const entry = store[chain].get(label);
+  return entry?.address ?? null;
+}
+
+/**
+ * Reverse lookup for the resolver — `(chain, address) → label?`.
+ * For EVM addresses the comparison is case-insensitive. Returns null
+ * when no entry matches.
+ */
+export function findDemoContactByAddress(
+  chain: ContactChain,
+  address: string,
+): string | null {
+  const target = chain === "evm" ? address.toLowerCase() : address;
+  for (const [label, entry] of store[chain].entries()) {
+    const candidate = chain === "evm" ? entry.address.toLowerCase() : entry.address;
+    if (candidate === target) return label;
+  }
+  return null;
+}
+
+/** Test-only: reset the in-memory store. */
+export function _resetDemoContactsForTests(): void {
+  for (const chain of Object.keys(store) as ContactChain[]) {
+    store[chain].clear();
+  }
+}

--- a/src/contacts/index.ts
+++ b/src/contacts/index.ts
@@ -20,6 +20,12 @@ import {
   writeContactsFile,
 } from "./storage.js";
 import {
+  addDemoContact,
+  removeDemoContact,
+  listDemoContacts,
+} from "./demo-store.js";
+import { isDemoMode } from "../demo/index.js";
+import {
   type ContactsFile,
   type ChainBlob,
   type ListedContact,
@@ -190,6 +196,26 @@ export async function addContact(args: AddContactArgs): Promise<{
   version: number;
   anchorAddress: string;
 }> {
+  // Demo mode: route to the in-memory store, no Ledger interaction.
+  // `version` and `anchorAddress` are placeholders so the response shape
+  // matches the production tool — agents that branch on those fields
+  // see a sentinel ("DEMO_ANCHOR") rather than a missing key.
+  if (isDemoMode()) {
+    addDemoContact({
+      chain: args.chain,
+      label: args.label,
+      address: args.address,
+      ...(args.notes !== undefined ? { notes: args.notes } : {}),
+      ...(args.tags !== undefined ? { tags: args.tags } : {}),
+    });
+    return {
+      chain: args.chain,
+      label: args.label,
+      address: args.address,
+      version: 0,
+      anchorAddress: "DEMO_ANCHOR",
+    };
+  }
   rejectIfNotV1(args.chain);
   const chain = args.chain as "btc" | "evm";
   // Address format validation up front.
@@ -289,6 +315,19 @@ export async function addContact(args: AddContactArgs): Promise<{
 export async function removeContact(args: RemoveContactArgs): Promise<{
   removed: Array<{ chain: ContactChain; address: string; version: number }>;
 }> {
+  if (isDemoMode()) {
+    const removed = removeDemoContact({
+      label: args.label,
+      ...(args.chain !== undefined ? { chain: args.chain } : {}),
+    });
+    if (removed.length === 0) {
+      throw new Error(
+        `${ContactsError.LabelNotFound}: no contact with label "${args.label}" found ` +
+          `on ${args.chain ? `chain ${args.chain}` : "any chain"}.`,
+      );
+    }
+    return { removed: removed.map((r) => ({ ...r, version: 0 })) };
+  }
   const file = readContactsFile();
   const chains: Array<"btc" | "evm"> = args.chain
     ? (rejectIfNotV1(args.chain), [args.chain as "btc" | "evm"])
@@ -355,6 +394,38 @@ export async function removeContact(args: RemoveContactArgs): Promise<{
 export async function listContacts(
   args: ListContactsArgs,
 ): Promise<{ contacts: ListedContact[] }> {
+  if (isDemoMode()) {
+    const rows = listDemoContacts({
+      ...(args.chain !== undefined ? { chain: args.chain } : {}),
+      ...(args.label !== undefined ? { label: args.label } : {}),
+    });
+    // Join by label across chains — same shape as production.
+    const byLabel = new Map<string, ListedContact>();
+    for (const row of rows) {
+      const existing = byLabel.get(row.label);
+      const earlierAddedAt =
+        existing && existing.addedAt < row.addedAt ? existing.addedAt : row.addedAt;
+      byLabel.set(row.label, {
+        label: row.label,
+        addresses: { ...(existing?.addresses ?? {}), [row.chain]: row.address },
+        ...(row.notes !== undefined
+          ? { notes: row.notes }
+          : existing?.notes !== undefined
+            ? { notes: existing.notes }
+            : {}),
+        ...(row.tags !== undefined
+          ? { tags: row.tags }
+          : existing?.tags !== undefined
+            ? { tags: existing.tags }
+            : {}),
+        addedAt: earlierAddedAt,
+      });
+    }
+    const contacts = Array.from(byLabel.values()).sort((a, b) =>
+      a.label < b.label ? -1 : a.label > b.label ? 1 : 0,
+    );
+    return { contacts };
+  }
   const file = readContactsStrict();
   const targets: Array<"btc" | "evm"> = args.chain
     ? (rejectIfNotV1(args.chain), [args.chain as "btc" | "evm"])
@@ -404,6 +475,34 @@ export async function listContacts(
 export async function verifyContacts(
   args: VerifyContactsArgs,
 ): Promise<{ results: VerifyResult[] }> {
+  if (isDemoMode()) {
+    // Demo store is unsigned by design; "verification" reduces to a
+    // count of how many entries are present per requested chain. The
+    // `anchorAddress: "DEMO_ANCHOR"` sentinel tells callers the result
+    // is from the demo path so they don't conflate it with a signed
+    // verification.
+    const chains: ContactChain[] = args.chain
+      ? [args.chain]
+      : (["btc", "evm", "solana", "tron"] as ContactChain[]);
+    const rows = listDemoContacts();
+    const byChain = new Map<ContactChain, number>();
+    for (const r of rows) byChain.set(r.chain, (byChain.get(r.chain) ?? 0) + 1);
+    return {
+      results: chains.map((chain) => {
+        const count = byChain.get(chain) ?? 0;
+        if (count === 0) {
+          return { chain, ok: false, reason: "no entries on this chain" };
+        }
+        return {
+          chain,
+          ok: true,
+          anchorAddress: "DEMO_ANCHOR",
+          version: 0,
+          entryCount: count,
+        };
+      }),
+    };
+  }
   let file: ContactsFile;
   try {
     file = readContactsStrict();

--- a/src/contacts/resolver.ts
+++ b/src/contacts/resolver.ts
@@ -31,6 +31,11 @@ import {
   CONTACT_ADDRESS_PATTERNS,
   type ContactChain,
 } from "./schemas.js";
+import {
+  findDemoContactByLabel,
+  findDemoContactByAddress,
+} from "./demo-store.js";
+import { isDemoMode } from "../demo/index.js";
 
 export type ResolutionSource =
   | "literal"
@@ -156,6 +161,48 @@ export async function resolveRecipient(
   // Chains the contacts module doesn't index (LTC) → literal-only.
   if (!cc) {
     return { address: input, source: "literal", warnings: [] };
+  }
+
+  // Demo mode: lookups go against the in-memory demo store. There's
+  // no signed blob so no tamper path — every match is a clean
+  // resolution (or a no-match → fall through to literal/ENS). The
+  // demo store covers all four chains (btc/evm/solana/tron) by
+  // design, vs. production v1's btc+evm-only resolver.
+  if (isDemoMode()) {
+    if (looksLikeLiteralAddress(input, cc)) {
+      const label = findDemoContactByAddress(cc, input);
+      return label
+        ? { address: input, source: "literal", label, warnings: [] }
+        : { address: input, source: "literal", warnings: [] };
+    }
+    const labelHit = findDemoContactByLabel(cc, input);
+    if (labelHit) {
+      return {
+        address: labelHit,
+        source: "contact",
+        label: input,
+        warnings: [],
+      };
+    }
+    // Fall through to ENS for EVM (.eth lookups still work in demo
+    // since they hit mainnet RPC, which is real-mode-equivalent).
+    if (cc === "evm" && input.includes(".") && /\.[a-z0-9]+$/.test(input)) {
+      try {
+        const ens = await resolveName({ name: input });
+        if (ens.address) {
+          const reverseLabel = findDemoContactByAddress("evm", ens.address);
+          return {
+            address: ens.address,
+            source: "ens",
+            ...(reverseLabel ? { label: reverseLabel } : {}),
+            warnings: [],
+          };
+        }
+      } catch {
+        // Fall through to "unknown".
+      }
+    }
+    return { address: input, source: "unknown", warnings: [] };
   }
 
   const warnings: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3782,9 +3782,11 @@ async function main() {
     "add_contact",
     {
       description:
-        "Save a label → address binding to the on-disk address book. The blob is signed with the user's paired Ledger key on that chain (BIP-137 for BTC, EIP-191 for EVM in v1.0; Solana / TRON support deferred to v1.5). " +
-        "v1.0 chains: `btc` + `evm`. `solana` / `tron` return CONTACTS_CHAIN_NOT_YET_SUPPORTED. The `notes` and `tags` fields update the unsigned metadata sidecar (joined across chains by label) so editing them doesn't require a fresh device signature. " +
-        "Sends like `prepare_native_send({ to: \"Mom\" })` then resolve `Mom` against the verified blob automatically — no separate lookup tool. Adding the same label twice on the same chain replaces the address (with a fresh signature). Adding a different label that maps to an already-saved address rejects with CONTACTS_DUPLICATE_ADDRESS.",
+        "Save a label → address binding to the address book. " +
+        "**Production mode**: blob is signed with the user's paired Ledger key on that chain (BIP-137 for BTC, EIP-191 for EVM in v1.0; Solana / TRON support deferred to v1.5). " +
+        "v1.0 production chains: `btc` + `evm`. `solana` / `tron` return CONTACTS_CHAIN_NOT_YET_SUPPORTED. The `notes` and `tags` fields update the unsigned metadata sidecar (joined across chains by label) so editing them doesn't require a fresh device signature. " +
+        "**Demo mode** (`VAULTPILOT_DEMO=true`): writes to a process-local in-memory store (lost on restart, never persisted to disk). No Ledger interaction. All four chains usable from day one (btc/evm/solana/tron). Less secure by design — there's no signature chain to detect tamper — but matches demo mode's broader trade-off where `send_transaction` is intercepted as a simulation. " +
+        "Sends like `prepare_native_send({ to: \"Mom\" })` then resolve `Mom` against the verified blob (or, in demo mode, the in-memory store) automatically — no separate lookup tool. Adding the same label twice on the same chain replaces the address (with a fresh signature in production). Adding a different label that maps to an already-saved address rejects with CONTACTS_DUPLICATE_ADDRESS.",
       inputSchema: addContactInput.shape,
     },
     handler(addContact)
@@ -3794,7 +3796,7 @@ async function main() {
     "remove_contact",
     {
       description:
-        "Remove a labeled contact. Without `chain`, removes the label from EVERY chain that has it (one device interaction per chain). With `chain`, removes only that chain's entry — the label can survive on other chains. The unsigned metadata row (notes / tags) is dropped only when no chain still references the label. Issues CONTACTS_LABEL_NOT_FOUND if no chain has the label.",
+        "Remove a labeled contact. Without `chain`, removes the label from EVERY chain that has it (one device interaction per chain in production; no device in demo). With `chain`, removes only that chain's entry — the label can survive on other chains. The unsigned metadata row (notes / tags) is dropped only when no chain still references the label. Issues CONTACTS_LABEL_NOT_FOUND if no chain has the label. In demo mode, removal is from the in-memory store with no signing.",
       inputSchema: removeContactInput.shape,
     },
     handler(removeContact)
@@ -3805,7 +3807,8 @@ async function main() {
     {
       description:
         "Verify + return the joined per-label view across chains. Each row contains the label, addresses keyed by chain, optional notes / tags, and the earliest `addedAt` across the joined entries. " +
-        "Strict-fail on tamper: any signature failure / anchor mismatch / version rollback throws immediately (CONTACTS_TAMPERED / CONTACTS_ANCHOR_MISMATCH / CONTACTS_VERSION_ROLLBACK) rather than silently dropping rows — agents must surface the failure to the user.",
+        "Strict-fail on tamper (production): any signature failure / anchor mismatch / version rollback throws immediately (CONTACTS_TAMPERED / CONTACTS_ANCHOR_MISMATCH / CONTACTS_VERSION_ROLLBACK) rather than silently dropping rows — agents must surface the failure to the user. " +
+        "In demo mode, the demo in-memory store is read directly (no signature path); all four chains supported.",
       inputSchema: listContactsInput.shape,
     },
     handler(listContacts)
@@ -3815,7 +3818,7 @@ async function main() {
     "verify_contacts",
     {
       description:
-        "Explicit re-verify. Returns one row per requested chain: `{ chain, ok, anchorAddress?, version?, entryCount?, reason? }`. Useful for periodic integrity checks or after a suspected tamper event. Does NOT throw on per-chain failure — caller inspects the `results` array.",
+        "Explicit re-verify. Returns one row per requested chain: `{ chain, ok, anchorAddress?, version?, entryCount?, reason? }`. Useful for periodic integrity checks or after a suspected tamper event. Does NOT throw on per-chain failure — caller inspects the `results` array. In demo mode, returns a count of in-memory entries per chain (no signature path) with `anchorAddress: \"DEMO_ANCHOR\"` so callers can distinguish the demo result.",
       inputSchema: verifyContactsInput.shape,
     },
     handler(verifyContacts)

--- a/test/contacts-demo-mode.test.ts
+++ b/test/contacts-demo-mode.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+/**
+ * Demo-mode address book — `add_contact` / `remove_contact` /
+ * `list_contacts` / `verify_contacts` route to an in-memory demo
+ * store when `VAULTPILOT_DEMO=true`. Unsigned by design (no Ledger
+ * available in demo mode). Lost on process restart.
+ *
+ * Pinned invariants:
+ *   - addContact in demo writes to the in-memory store, no signing,
+ *     no disk write
+ *   - all four chains (btc/evm/solana/tron) addressable from day one
+ *     in demo (vs. production v1's btc+evm-only)
+ *   - addContact rejects malformed addresses up-front
+ *   - addContact rejects duplicate-address-different-label
+ *   - removeContact removes from one chain or all (matches production)
+ *   - listContacts joins by label across chains (matches production
+ *     shape)
+ *   - verifyContacts in demo returns a count + the DEMO_ANCHOR
+ *     sentinel so callers can distinguish from a signed verify
+ *   - resolveRecipient label-lookup hits the demo store
+ *   - resolveRecipient reverse-lookup decorates literal addresses with
+ *     the demo label
+ *   - exiting demo mode (unsetting the env var) makes the production
+ *     path fire again (demo store is invisible from real mode)
+ */
+
+beforeEach(async () => {
+  // Re-import a fresh copy of the contacts module + demo store for
+  // every test so the in-memory `store` is clean.
+  const { _resetDemoContactsForTests } = await import(
+    "../src/contacts/demo-store.js"
+  );
+  _resetDemoContactsForTests();
+  process.env.VAULTPILOT_DEMO = "true";
+});
+
+afterEach(() => {
+  delete process.env.VAULTPILOT_DEMO;
+});
+
+describe("demo-mode address book — addContact", () => {
+  it("writes to the in-memory store with no signing required", async () => {
+    const { addContact, listContacts } = await import("../src/contacts/index.js");
+    const result = await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    expect(result.label).toBe("Mom");
+    expect(result.address).toBe("0xabcdef0123456789ABCDEF0123456789aBcDeF01");
+    expect(result.anchorAddress).toBe("DEMO_ANCHOR");
+    expect(result.version).toBe(0);
+
+    const list = await listContacts({});
+    expect(list.contacts).toHaveLength(1);
+    expect(list.contacts[0].label).toBe("Mom");
+    expect(list.contacts[0].addresses.evm).toBe(
+      "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    );
+  });
+
+  it("supports all four chains in demo (btc/evm/solana/tron)", async () => {
+    const { addContact, listContacts } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "btc",
+      label: "Alice",
+      address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    });
+    await addContact({
+      chain: "evm",
+      label: "Alice",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    await addContact({
+      chain: "solana",
+      label: "Alice",
+      address: "DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1",
+    });
+    await addContact({
+      chain: "tron",
+      label: "Alice",
+      address: "TLPpXqMWoyLgQqGv1J7jVmzAMQVYQ8XQVy",
+    });
+    const list = await listContacts({ label: "Alice" });
+    expect(list.contacts).toHaveLength(1);
+    const alice = list.contacts[0];
+    expect(alice.addresses.btc).toBeDefined();
+    expect(alice.addresses.evm).toBeDefined();
+    expect(alice.addresses.solana).toBeDefined();
+    expect(alice.addresses.tron).toBeDefined();
+  });
+
+  it("rejects malformed addresses up-front", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await expect(
+      addContact({
+        chain: "evm",
+        label: "Bob",
+        address: "definitely-not-an-address",
+      }),
+    ).rejects.toThrow(/CONTACTS_ADDRESS_FORMAT_MISMATCH/);
+  });
+
+  it("rejects a different label mapping to an already-saved address (duplicate-address)", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    await expect(
+      addContact({
+        chain: "evm",
+        label: "Dad",
+        address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+      }),
+    ).rejects.toThrow(/CONTACTS_DUPLICATE_ADDRESS/);
+  });
+
+  it("replaces (not duplicates) when the same label is added twice on the same chain", async () => {
+    const { addContact, listContacts } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0x1111111111111111111111111111111111111111",
+    });
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0x2222222222222222222222222222222222222222",
+    });
+    const list = await listContacts({});
+    expect(list.contacts).toHaveLength(1);
+    expect(list.contacts[0].addresses.evm).toBe(
+      "0x2222222222222222222222222222222222222222",
+    );
+  });
+});
+
+describe("demo-mode address book — removeContact", () => {
+  it("removes a label from one chain when chain is specified", async () => {
+    const { addContact, removeContact, listContacts } = await import(
+      "../src/contacts/index.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    await addContact({
+      chain: "btc",
+      label: "Mom",
+      address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    });
+    const result = await removeContact({ label: "Mom", chain: "evm" });
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0].chain).toBe("evm");
+
+    const list = await listContacts({});
+    expect(list.contacts[0].addresses.evm).toBeUndefined();
+    expect(list.contacts[0].addresses.btc).toBeDefined();
+  });
+
+  it("removes a label from every chain when chain is omitted", async () => {
+    const { addContact, removeContact, listContacts } = await import(
+      "../src/contacts/index.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    await addContact({
+      chain: "btc",
+      label: "Mom",
+      address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    });
+    const result = await removeContact({ label: "Mom" });
+    expect(result.removed.length).toBeGreaterThanOrEqual(2);
+    const list = await listContacts({});
+    expect(list.contacts).toHaveLength(0);
+  });
+
+  it("throws CONTACTS_LABEL_NOT_FOUND when no chain has the label", async () => {
+    const { removeContact } = await import("../src/contacts/index.js");
+    await expect(
+      removeContact({ label: "Nobody" }),
+    ).rejects.toThrow(/CONTACTS_LABEL_NOT_FOUND/);
+  });
+});
+
+describe("demo-mode address book — verifyContacts", () => {
+  it("returns the DEMO_ANCHOR sentinel + a count per populated chain", async () => {
+    const { addContact, verifyContacts } = await import(
+      "../src/contacts/index.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    const v = await verifyContacts({});
+    const evmRow = v.results.find((r) => r.chain === "evm");
+    expect(evmRow?.ok).toBe(true);
+    expect(evmRow?.anchorAddress).toBe("DEMO_ANCHOR");
+    expect(evmRow?.entryCount).toBe(1);
+    // Empty chains report ok=false with the human reason.
+    const btcRow = v.results.find((r) => r.chain === "btc");
+    expect(btcRow?.ok).toBe(false);
+    expect(btcRow?.reason).toMatch(/no entries/);
+  });
+});
+
+describe("demo-mode address book — resolveRecipient", () => {
+  it("resolves a demo label to the stored address (forward lookup)", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    const { resolveRecipient } = await import(
+      "../src/contacts/resolver.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    const r = await resolveRecipient("Mom", "ethereum");
+    expect(r.address).toBe("0xabcdef0123456789ABCDEF0123456789aBcDeF01");
+    expect(r.source).toBe("contact");
+    expect(r.label).toBe("Mom");
+  });
+
+  it("decorates a literal address with the matching demo label (reverse lookup)", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    const { resolveRecipient } = await import(
+      "../src/contacts/resolver.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    const r = await resolveRecipient(
+      "0xABCDEF0123456789ABCDEF0123456789ABCDEF01", // upper-case input
+      "ethereum",
+    );
+    expect(r.address).toBe("0xABCDEF0123456789ABCDEF0123456789ABCDEF01");
+    expect(r.source).toBe("literal");
+    expect(r.label).toBe("Mom");
+  });
+
+  it("supports Solana label resolution in demo (production v1 doesn't)", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    const { resolveRecipient } = await import(
+      "../src/contacts/resolver.js"
+    );
+    await addContact({
+      chain: "solana",
+      label: "Alice",
+      address: "DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1",
+    });
+    const r = await resolveRecipient("Alice", "solana");
+    expect(r.address).toBe("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
+    expect(r.source).toBe("contact");
+  });
+
+  it("returns source=unknown when the label has no match", async () => {
+    const { resolveRecipient } = await import(
+      "../src/contacts/resolver.js"
+    );
+    const r = await resolveRecipient("Nobody", "ethereum");
+    expect(r.source).toBe("unknown");
+  });
+});
+
+describe("demo store isolation from production", () => {
+  it("does NOT touch disk — demo entries don't appear in the production-mode list", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "DemoMom",
+      address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+    });
+    // Switch out of demo mode and try the production reader. The
+    // production path reads from disk via `readContactsStrict`; the
+    // demo-only entry was never written there, so it should be absent.
+    delete process.env.VAULTPILOT_DEMO;
+    const { listContacts } = await import("../src/contacts/index.js");
+    // Production path will throw on no-file or return an empty list
+    // depending on storage state. Either way, "DemoMom" must NOT be
+    // present.
+    try {
+      const list = await listContacts({});
+      const labels = list.contacts.map((c) => c.label);
+      expect(labels).not.toContain("DemoMom");
+    } catch (err) {
+      // Production-mode read may throw because no contacts file exists
+      // in the test environment — that's also a valid "demo entry not
+      // leaked" outcome.
+      expect((err as Error).message).not.toContain("DemoMom");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a process-local in-memory contacts store (`src/contacts/demo-store.ts`, mirrors `live-mode.ts` — never persisted, lost on restart)
- `add_contact` / `remove_contact` / `list_contacts` / `verify_contacts` route to the demo store when `VAULTPILOT_DEMO=true`, skipping all Ledger interaction
- Demo-mode coverage spans all four chains (btc/evm/solana/tron) since the signer constraint is gone — useful because demo personas have multi-chain wallets
- `resolveRecipient` consults the demo store on label / reverse-decoration lookups, so `prepare_native_send({ to: "Mom" })` works end-to-end in demo without a device

## Why this matters
Demo mode was supposed to be try-before-install, but the address book was unreachable: every `add_contact` call hit `pickAnchorForChain` which throws when no Ledger is paired. Users couldn't even practice the label flow. This PR closes that gap with the smallest possible change — production path is untouched (still requires signing for btc+evm, still throws CONTACTS_CHAIN_NOT_YET_SUPPORTED for solana/tron in v1).

## Trust trade-off (less secure by design)
- No signature chain → a compromised MCP can mutate the demo store unobserved
- Acceptable because demo mode intercepts `send_transaction` and returns a simulation envelope, so nothing actually broadcasts. Address-poisoning protection in demo is "the agent shows you the resolved address" + "the prepare receipt is a simulation," not the cryptographic chain production gets
- Verify path returns `anchorAddress: \"DEMO_ANCHOR\"` so callers can distinguish a demo verify from a signed verify

## Test plan
- [x] 14 new unit tests cover: addContact persists in-memory + supports all 4 chains, address-format and duplicate-address refusal, replace-on-same-label, removeContact one-chain vs all-chains, label-not-found, verifyContacts shape, resolver forward + reverse + Solana label lookup + unknown fallback, demo-store-isolation-from-disk
- [x] Full test suite (1989 tests) green locally
- [x] Typecheck + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)