### PR TITLE
fix: actionable EtherscanApiKeyMissingError message (#413)

### DIFF
--- a/src/data/apis/etherscan-v2.ts
+++ b/src/data/apis/etherscan-v2.ts
@@ -29,11 +29,24 @@ interface EtherscanEnvelope<T> {
 
 export class EtherscanApiKeyMissingError extends Error {
   constructor() {
+    // Issue #413 — surface the fastest fix (the runtime `set_etherscan_api_key`
+    // tool, no restart needed) FIRST, then the persistent options. Names the
+    // tools that need the key so the user knows what they unblock by
+    // setting it. The previous copy pointed at a wrong signup URL
+    // (etherscan.io/apis → 404; correct is etherscan.io/myapikey) and a
+    // wrong config path (~/.vaultpilot/ → ~/.vaultpilot-mcp/), and didn't
+    // mention the runtime tool at all.
     super(
-      "ETHERSCAN_API_KEY is not set. Etherscan V2 requires an API key — " +
-        "get a free one at https://etherscan.io/apis and set ETHERSCAN_API_KEY " +
-        "in the MCP server env, or run `vaultpilot-mcp-setup` to store it in " +
-        "~/.vaultpilot/config.json."
+      "ETHERSCAN_API_KEY is not set — required for `get_transaction_history`, " +
+        "`get_token_allowances`, `explain_tx`, and address-poisoning checks " +
+        "(Etherscan V2 refuses unauthed multi-chain calls). " +
+        "Fastest fix (no restart): get a free key at https://etherscan.io/myapikey " +
+        "(~60 sec; free tier covers personal use across Ethereum / Arbitrum / " +
+        "Polygon / Base / Optimism), then call " +
+        "`set_etherscan_api_key({ apiKey: \"<paste>\" })` to set it for this " +
+        "session. To persist across restarts, set ETHERSCAN_API_KEY in the MCP " +
+        "server env or run `vaultpilot-mcp-setup` to save it to " +
+        "~/.vaultpilot-mcp/config.json."
     );
     this.name = "EtherscanApiKeyMissingError";
   }


### PR DESCRIPTION
## Summary
The \`EtherscanApiKeyMissingError\` thrown by \`etherscanV2Fetch\` (in \`src/data/apis/etherscan-v2.ts\`) is the underlying signal that propagated as an opaque \"ETHERSCAN_API_KEY is not set\" failure on \`get_token_allowances\` (and on \`get_transaction_history\`, \`explain_tx\`, address-poisoning checks — all the same code path). The previous message pointed at env-var setup + restart but never mentioned the existing runtime \`set_etherscan_api_key\` tool, which is the fastest fix and doesn't require restart.

New message:
- Names the dependent tools so the user knows what's unblocked by setting the key.
- Leads with \`set_etherscan_api_key({ apiKey: \"...\" })\` as the fastest fix.
- Keeps env var + \`vaultpilot-mcp-setup\` as persistent alternatives.
- Fixes two stale strings in the previous copy: signup link (\`etherscan.io/apis\` → 404, correct is \`etherscan.io/myapikey\`) and config path (\`~/.vaultpilot/\` → \`~/.vaultpilot-mcp/\`).

Improving the global error rather than wrapping at the allowances handler because the same opacity affects every Etherscan-dependent tool — single fix, broader benefit. Closes #413.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 1989/1989 pass. Existing test in \`test/history.test.ts\` (\`/ETHERSCAN_API_KEY/\` regex) still matches.
- [ ] Manual: in demo mode without an Etherscan key, call \`get_token_allowances\` for any wallet → error names \`set_etherscan_api_key\` as the fastest fix; agent can paste a key from \`etherscan.io/myapikey\` and continue without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)