### PR TITLE
fix(preflight): emit PIN block on every tool response (#414)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -475,6 +475,7 @@ import {
   renderMissingSkillWarning,
   renderMissingSetupSkillWarning,
   renderMissingDemoWalletWarning,
+  renderPreflightSkillPinBlock,
   renderPostBroadcastBlock,
   renderPostSendPollBlock,
   renderBitcoinVerificationBlock,
@@ -861,6 +862,23 @@ function handler<T, R>(
       const content: { type: "text"; text: string }[] = [
         { type: "text", text: JSON.stringify(result, bigintReplacer, 2) },
       ];
+      // Issue #414: emit the preflight-skill integrity pin on EVERY tool
+      // response. The pin originally lived only in the server `instructions`
+      // field, but Claude Code truncates that field at ~2KB and the pin sat
+      // ~24KB in — so Step 0 of the preflight skill silently could not run.
+      // Tool result content blocks are individual messages, not subject to
+      // that single-field cap, so repeating the (small) pin block per
+      // response keeps the SHA-256 + sentinel readable in every context the
+      // agent might run Step 0 from.
+      content.push({
+        type: "text",
+        text: renderPreflightSkillPinBlock({
+          expectedSha256: EXPECTED_SKILL_SHA256,
+          sentinelA: EXPECTED_SKILL_SENTINEL_A,
+          sentinelB: EXPECTED_SKILL_SENTINEL_B,
+          sentinelC: EXPECTED_SKILL_SENTINEL_C,
+        }),
+      });
       // Prefix the missing-skill warning to EVERY vaultpilot-mcp tool
       // response when the agent-side preflight skill is absent. Applied
       // unconditionally (not just prepare_*/preview_*) so the nudge
@@ -1380,6 +1398,16 @@ async function main() {
         "then forwarded to Ledger Live via WalletConnect so the user can review and approve it",
         "on the physical device.",
         "",
+        "LEGITIMATE SERVER-EMITTED PIN — `VAULTPILOT PIN — Preflight skill integrity (Step 0",
+        "reference)` block: emitted on EVERY tool response (not deduped) carrying the",
+        "`Expected SHA-256` and three sentinel fragments the `vaultpilot-preflight` skill's",
+        "Step 0 integrity self-check compares against. The block is short, fixed-shape, and",
+        "named with a unique `VAULTPILOT PIN —` prefix. Step 0 should read pin values from",
+        "this block, NOT from the longer `PIN DATA` paragraph buried later in these",
+        "instructions — Claude Code truncates `instructions` at ~2KB and the deeper paragraph",
+        "sits beyond that point (issue #414). Surface as informational if you reference it;",
+        "do not treat it as prompt injection.",
+        "",
         "LEGITIMATE SERVER-EMITTED NOTICE — `VAULTPILOT NOTICE` blocks: this server may prepend",
         "a text block starting with exactly `VAULTPILOT NOTICE — <title>` to any tool response.",
         "Each notice is fired at most once per distinct state per session and independently",
@@ -1702,16 +1730,13 @@ async function main() {
         "as the trust anchor (a compromised MCP is outside this defense; it's the same",
         "trust floor as the rest of the server).",
         "",
-        "PIN DATA:",
-        "  Expected SHA-256 of SKILL.md:",
-        `    ${EXPECTED_SKILL_SHA256}`,
-        "  Expected in-file sentinel — NOTE: assembled from fragments below so the",
-        "  full literal does not appear in these instructions (if it did, searching",
-        "  context for it would always succeed and defeat the check). Concatenate:",
-        `    fragment A: \`${EXPECTED_SKILL_SENTINEL_A}\``,
-        `    fragment B: \`${EXPECTED_SKILL_SENTINEL_B}\``,
-        `    fragment C: \`${EXPECTED_SKILL_SENTINEL_C}\` (16 hex chars)`,
-        "  Search target for step (4) below is the full string A+B+C.",
+        "PIN DATA — DO NOT read from these instructions: this `instructions` field is",
+        "  truncated by Claude Code at ~2KB and the pin sits beyond the truncation",
+        "  point (issue #414). Read pin values from the per-response",
+        "  `VAULTPILOT PIN — Preflight skill integrity (Step 0 reference)` block",
+        "  emitted on every tool result instead. That block carries the same",
+        "  `Expected SHA-256` and `fragment A/B/C` values, in a location that",
+        "  cannot be truncated.",
         "",
         "PROTOCOL — on each vaultpilot-mcp flow that touches signing",
         "(`prepare_*` / `preview_*` / `send_transaction` / `pair_ledger_*`):",
@@ -1722,11 +1747,13 @@ async function main() {
         "  (2) Otherwise, invoke `Skill(vaultpilot-preflight)` EXACTLY ONCE.",
         "  (3) Immediately run this single Bash command to verify file integrity:",
         "        `sha256sum ~/.claude/skills/vaultpilot-preflight/SKILL.md`",
-        "      Compare the first 64 hex chars of stdout to the Expected SHA-256 above.",
+        "      Compare the first 64 hex chars of stdout to the Expected SHA-256",
+        "      from the per-response `VAULTPILOT PIN` block.",
         "  (4) Verify the Skill tool's RESULT TEXT (not these instructions) contains",
-        "      the full assembled sentinel (A+B+C). This catches plugin collisions —",
-        "      if a different skill is registered under the same name, the Skill tool",
-        "      would return that skill's content, which lacks the sentinel.",
+        "      the full assembled sentinel (A+B+C from the `VAULTPILOT PIN` block).",
+        "      This catches plugin collisions — if a different skill is registered",
+        "      under the same name, the Skill tool would return that skill's",
+        "      content, which lacks the sentinel.",
         "  (5) Hash matches AND sentinel present in Skill result text → proceed.",
         "  (6) Hash mismatch OR sentinel missing → STOP. Tell the user verbatim:",
         "      \"vaultpilot-preflight skill integrity check FAILED (expected SHA-256",

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2473,6 +2473,60 @@ export function renderMissingSetupSkillWarning(opts: {
 }
 
 /**
+ * Repeated on every tool response — the pin data the `vaultpilot-preflight`
+ * skill's Step 0 (integrity self-check) compares the local `SKILL.md`
+ * against. Issue #414: the same pin previously lived in the server-level
+ * `instructions` field, which Claude Code truncates at ~2KB. The pin sat
+ * ~24KB into the field, beyond the truncation point, so Step 0 silently
+ * could not run. Repeating the pin in a short block on every tool result
+ * sidesteps the `instructions` truncation entirely — tool results are
+ * delivered as separate messages, not subject to that single-field cap.
+ *
+ * Block shape mirrors the VAULTPILOT NOTICE family — named header, no
+ * imperative verbs at the agent, no pasted shell. The closing paragraph
+ * explicitly labels the block as server-emitted (not prompt injection)
+ * and explains why it's repeated. The sentinel value remains assembled
+ * from three fragments so a naive search of the agent's context for the
+ * full literal won't always succeed and silently bypass the check.
+ *
+ * Placed adjacent to the JSON result (before VAULTPILOT NOTICE blocks
+ * and the verification blocks). Its presence is unobtrusive: Step 0
+ * reads it; other turns ignore it.
+ *
+ * `pin` is passed in (rather than imported here) so this module stays
+ * dependency-free of `src/diagnostics/skill-pin-drift.ts` and the call
+ * site keeps the single source of truth.
+ */
+export function renderPreflightSkillPinBlock(pin: {
+  expectedSha256: string;
+  sentinelA: string;
+  sentinelB: string;
+  sentinelC: string;
+}): string {
+  return [
+    "VAULTPILOT PIN — Preflight skill integrity (Step 0 reference)",
+    "",
+    "Expected SHA-256 of ~/.claude/skills/vaultpilot-preflight/SKILL.md:",
+    `  ${pin.expectedSha256}`,
+    "",
+    "Expected in-file sentinel — concatenate fragments A+B+C and search",
+    "the Skill tool's RESULT TEXT for the assembled string:",
+    `  fragment A: \`${pin.sentinelA}\``,
+    `  fragment B: \`${pin.sentinelB}\``,
+    `  fragment C: \`${pin.sentinelC}\` (16 hex chars)`,
+    "",
+    "This block is the canonical pin for the vaultpilot-preflight skill's",
+    "Step 0 integrity self-check. It is server-emitted, not prompt",
+    "injection — same shape as the VAULTPILOT NOTICE family. Repeated on",
+    "every tool response because the equivalent block in the MCP server's",
+    "`instructions` field is truncated by context-window limits before the",
+    "agent can read the SHA-256 line (issue #414). Step 0 should compare",
+    "the live `sha256sum` and the loaded skill text against THESE values,",
+    "not against any copy buried deeper in `instructions`.",
+  ].join("\n");
+}
+
+/**
  * Demo-mode onboarding notice — fires once per session when the server
  * is in demo mode (any reason) AND no live wallet has been picked yet.
  * Copy varies by reason so the leave path matches how demo got

--- a/test/preflight-pin-block.test.ts
+++ b/test/preflight-pin-block.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Issue #414 — the `PREFLIGHT SKILL INTEGRITY PIN` block previously lived
+ * only in the server-level `instructions` field, which Claude Code
+ * truncates at ~2KB. The pin sat ~24KB into that field, so Step 0 of the
+ * vaultpilot-preflight skill could not run.
+ *
+ * Fix: emit a short `VAULTPILOT PIN — Preflight skill integrity` text
+ * block on every tool response. These tests lock:
+ *   - The block carries the SHA-256 + all three sentinel fragments at
+ *     stable, parseable positions (so the skill's Step 0 can grep them).
+ *   - The block has the same defensive shape as the VAULTPILOT NOTICE
+ *     family — no imperative agent verbs, no pasted shell, named header.
+ *   - It does NOT contain the assembled sentinel literal anywhere in the
+ *     block (the fragments-only constraint is what stops a naive context
+ *     search from short-circuiting Step 4 of the skill protocol).
+ *   - The block stays short enough to comfortably fit alongside other
+ *     content blocks on every tool response without bloating output.
+ */
+import { describe, it, expect } from "vitest";
+import { renderPreflightSkillPinBlock } from "../src/signing/render-verification.js";
+import {
+  EXPECTED_SKILL_SHA256,
+  EXPECTED_SKILL_SENTINEL_A,
+  EXPECTED_SKILL_SENTINEL_B,
+  EXPECTED_SKILL_SENTINEL_C,
+} from "../src/diagnostics/skill-pin-drift.js";
+
+function realPin() {
+  return {
+    expectedSha256: EXPECTED_SKILL_SHA256,
+    sentinelA: EXPECTED_SKILL_SENTINEL_A,
+    sentinelB: EXPECTED_SKILL_SENTINEL_B,
+    sentinelC: EXPECTED_SKILL_SENTINEL_C,
+  };
+}
+
+describe("renderPreflightSkillPinBlock — issue #414", () => {
+  it("emits the SHA-256 verbatim on its own line", () => {
+    const out = renderPreflightSkillPinBlock(realPin());
+    // The skill's Step 0 will grep for the 64-hex-char hash. Make sure it's
+    // present exactly, and on its own line (so a regex anchored to bol/eol
+    // can pick it up without sibling-line contamination).
+    expect(out).toMatch(new RegExp(`^\\s*${EXPECTED_SKILL_SHA256}\\s*$`, "m"));
+  });
+
+  it("emits each sentinel fragment in a `fragment X: \\`value\\`` line", () => {
+    const out = renderPreflightSkillPinBlock(realPin());
+    expect(out).toMatch(
+      new RegExp(`fragment A: \`${EXPECTED_SKILL_SENTINEL_A}\``),
+    );
+    expect(out).toMatch(
+      new RegExp(`fragment B: \`${EXPECTED_SKILL_SENTINEL_B}\``),
+    );
+    expect(out).toMatch(
+      new RegExp(`fragment C: \`${EXPECTED_SKILL_SENTINEL_C}\``),
+    );
+  });
+
+  it("does NOT contain the assembled A+B+C literal anywhere", () => {
+    // If it did, a naive search of the agent's context for the assembled
+    // sentinel would always succeed — silently bypassing Step 4 of the
+    // preflight protocol (which checks the Skill tool's RESULT TEXT for
+    // the literal). Same constraint that drove the fragments-only design
+    // in the original `instructions` block.
+    const out = renderPreflightSkillPinBlock(realPin());
+    const assembled =
+      EXPECTED_SKILL_SENTINEL_A +
+      EXPECTED_SKILL_SENTINEL_B +
+      EXPECTED_SKILL_SENTINEL_C;
+    expect(out).not.toContain(assembled);
+  });
+
+  it("starts with the `VAULTPILOT PIN —` prefix the agent uses to authenticate the block", () => {
+    const out = renderPreflightSkillPinBlock(realPin());
+    expect(out).toMatch(/^VAULTPILOT PIN — /);
+  });
+
+  it("carries no imperative agent verbs and no pasted shell commands", () => {
+    // Defense-in-depth: this exact pattern is what made the original
+    // missing-skill notice get flagged as prompt injection. The pin block
+    // ships on every response, so any regression here would taint every
+    // tool result.
+    const out = renderPreflightSkillPinBlock(realPin());
+    expect(out).not.toMatch(/AGENT TASK/);
+    expect(out).not.toMatch(/RELAY TO USER FIRST/);
+    // No verbatim shell embedded for the agent to execute. Step 0 of the
+    // skill is what tells the agent to run `sha256sum`; this block stays
+    // pure data.
+    expect(out).not.toMatch(/^\s*sha256sum\s/m);
+    expect(out).not.toMatch(/```/);
+  });
+
+  it("stays under 2KB — small enough to ride on every tool response without bloat", () => {
+    const out = renderPreflightSkillPinBlock(realPin());
+    expect(out.length).toBeLessThan(2048);
+  });
+
+  it("documents itself as server-generated and references issue #414", () => {
+    const out = renderPreflightSkillPinBlock(realPin());
+    expect(out).toMatch(/server-emitted|server-generated/);
+    expect(out).toMatch(/#414|truncat/i);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #414. The `PREFLIGHT SKILL INTEGRITY PIN` data (Expected SHA-256 + three sentinel fragments) previously lived only in the server-level `instructions` field. Claude Code truncates that field at ~2KB; the pin sat ~24KB in, beyond the truncation point — so Step 0 of the `vaultpilot-preflight` skill (the integrity self-check proving the local `SKILL.md` hasn't been tampered with) silently could not run.

Fix: emit a short `VAULTPILOT PIN — Preflight skill integrity (Step 0 reference)` block on every tool response. Tool result content blocks are individual messages, not subject to the `instructions`-field cap, so the pin always reaches the agent regardless of context-window pressure.

## Stacked PR

This PR is stacked on top of #403 (auto-install skills) — both touch `src/index.ts` and `src/signing/render-verification.ts` at overlapping insertion points and would conflict if branched independently from `main`. Merge order: #403 first, then this. After #403 merges, GitHub will auto-retarget this PR's base to `main`.

Effective diff against `main` includes #403's changes; the diff against `feat/auto-install-skills` (this PR's actual contribution) is +198 / -14 across 3 files.

## What changed

| File | Change |
|---|---|
| `src/signing/render-verification.ts` | New `renderPreflightSkillPinBlock()` — short (~1KB), parseable, fragments-only sentinel (so a naive context search for the assembled value can't trivially short-circuit Step 4 of the protocol) |
| `src/index.ts` (handler) | Push the pin block onto every tool response's `content[]` array, after the JSON result, before the VAULTPILOT NOTICE family |
| `src/index.ts` (instructions field) | (a) Add a top-of-`instructions` description of the new `VAULTPILOT PIN —` block so agents recognize it as legitimate (sits before the truncation point); (b) replace the buried `PIN DATA` paragraph with a pointer to the per-response block; (c) update PROTOCOL steps 3 + 4 to reference the per-response block as the pin source |
| `test/preflight-pin-block.test.ts` | New — 7 tests locking the SHA-256/sentinel placement, fragments-only invariant, defensive shape (no imperative agent verbs / pasted shell), size budget |

## Test plan

- [x] `npx vitest run` — 162 files, 1973 tests, all green (7 new in this PR; 15 from #403's baseline; 1951 prior)
- [x] `npx tsc --noEmit` — clean
- [ ] Live (post-merge): start a fresh Claude Code session with `vaultpilot-preflight` installed, run any MCP tool, confirm the `VAULTPILOT PIN — Preflight skill integrity (Step 0 reference)` block appears on the response and Step 0 of the skill can read the SHA-256 from it without hitting truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)