### PR TITLE
feat(swap): protocol routing filter + routedVia surfacing (#411)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2056,18 +2056,20 @@ async function main() {
       description:
         "Get a LiFi aggregator quote for a token swap (same-chain) or bridge (cross-chain). Returns expected output, fees, execution time, and the underlying tool selected. Default is exact-in (`amount` = fromToken); set `amountSide: \"to\"` for exact-out quotes (`amount` = target toToken output). " +
         "Source chain is always EVM. Destination can be any EVM chain, Solana, or TRON — pass `toChain: \"solana\"` / `toChain: \"tron\"` + an explicit `toAddress` (Solana base58 / TRON T-prefixed base58); the bridge protocol delivers tokens on the destination chain after the EVM source tx confirms (typically 1-15 min). Exact-out is not supported for cross-chain bridges to Solana or TRON. For Solana-source swaps and bridges (the reverse direction) use `prepare_solana_lifi_swap`. TRON-source LiFi is not yet wired. " +
+        "PROTOCOL ROUTING (issue #411): without `exchanges` / `bridges`, LiFi picks the best-output route across all aggregators (Sushi, Uniswap, 1inch, Paraswap, etc.). When the user names a specific DEX (\"swap on 1inch\"), pass `exchanges: [\"1inch\"]` so LiFi only routes via that DEX — without the filter, the prepare receipt would silently use a different protocol. The response's `routedVia.tool` is the actually-resolved route; surface it to the user before they sign. " +
         "No transaction is built by this tool.",
       inputSchema: getSwapQuoteInput.shape,
     },
     handler(getSwapQuote)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "prepare_swap",
     {
       description:
         "Prepare an unsigned swap or bridge transaction via LiFi aggregator. Same-chain swaps use the best DEX route; cross-chain swaps use a bridge + DEX combo. Default is exact-in (`amount` = fromToken); set `amountSide: \"to\"` for exact-out (`amount` = target toToken output, e.g. \"I want 100 USDC out\"). " +
         "Source chain is always EVM. Destination can be any EVM chain, Solana, or TRON. For non-EVM destinations pass `toChain: \"solana\"` / `\"tron\"` + an explicit `toAddress` in the destination chain's format; the user signs an EVM tx and the bridge protocol delivers tokens to the destination after confirmation. The destination-side decimals cross-check is dropped for non-EVM destinations (we can't read SPL/TRC-20 via EVM RPC); LiFi's reported decimals are the source of truth there. Exact-out is not supported for cross-chain-to-non-EVM. For Solana-source swaps and bridges use `prepare_solana_lifi_swap`. TRON-source LiFi is not yet wired. " +
+        "PROTOCOL ROUTING (issue #411): without `exchanges` / `bridges`, LiFi picks the best-output route across all aggregators. When the user explicitly names a DEX (\"swap on 1inch\", \"use Sushi\"), pass `exchanges: [\"1inch\"]` (or the named protocol) — without the filter LiFi may silently route via a different DEX. If no route satisfies the filter the call errors with a clear message; the agent can offer to retry without the filter. The unsigned tx's `description` includes \"via <tool>\" and notes whether the resolved tool matched the filter. " +
         "DECODING DEFENSE: every cross-chain bridge calldata is parsed into its `BridgeData` tuple and the encoded `destinationChainId` + `receiver` are cross-checked against what the user requested — refuses on mismatch. Catches a compromised MCP that returns calldata routing to a different chain or recipient than the prepare receipt advertises. " +
         "INTERMEDIATE-CHAIN BRIDGES: NEAR Intents (notably for ETH→TRON USDT routes) settles on NEAR and releases on the final chain via an off-chain relayer, so its on-chain `destinationChainId` is NEAR's pseudo-id (1885080386571452) rather than the user's requested chain. The defense allows this ONLY for an explicit hardcoded (bridge name, intermediate chain ID) pair held as a source-code constant — not loaded from env / config / LiFi response — so a compromised aggregator can't claim arbitrary chains as 'intermediate'. Receiver-side checks (non-EVM sentinel, etc.) still apply unchanged. " +
         "The returned tx can be sent via `send_transaction`.",

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -307,6 +307,50 @@ async function readOnchainDecimals(
 }
 
 /**
+ * Issue #411 — when an `exchanges` / `bridges` filter is set and LiFi
+ * can't satisfy it, the SDK throws a generic "No available routes"
+ * error that doesn't tell the user the filter was the cause. Wrap
+ * the original error with context naming the filter so the agent can
+ * relay an actionable message ("no route via 1inch — retry without
+ * the filter to use the best-output route").
+ *
+ * Pass-through unchanged when no filter was set.
+ */
+function rephraseLifiNoRouteError(
+  err: unknown,
+  args: { exchanges?: string[]; bridges?: string[] },
+): Error {
+  const baseErr = err instanceof Error ? err : new Error(String(err));
+  const noFilter =
+    (!args.exchanges || args.exchanges.length === 0) &&
+    (!args.bridges || args.bridges.length === 0);
+  if (noFilter) return baseErr;
+  // LiFi's no-route errors carry messages like "No available routes" /
+  // "NotFoundError". Match liberally — false positives just add a hint
+  // to the message, no harm.
+  const msg = baseErr.message.toLowerCase();
+  const looksLikeNoRoute =
+    msg.includes("no available") ||
+    msg.includes("notfound") ||
+    msg.includes("no route") ||
+    msg.includes("not found");
+  if (!looksLikeNoRoute) return baseErr;
+  const filterParts: string[] = [];
+  if (args.exchanges && args.exchanges.length > 0) {
+    filterParts.push(`exchanges=[${args.exchanges.join(", ")}]`);
+  }
+  if (args.bridges && args.bridges.length > 0) {
+    filterParts.push(`bridges=[${args.bridges.join(", ")}]`);
+  }
+  return new Error(
+    `LiFi found no route satisfying ${filterParts.join(" + ")}. ` +
+      `Original LiFi error: ${baseErr.message}. ` +
+      `Try without the filter to use the best-output route across all ` +
+      `aggregators, or pick a different exchange/bridge.`,
+  );
+}
+
+/**
  * Reject slippage configurations that are almost certainly user/agent error.
  * The schema already caps at 500 bps (5%); this adds a soft-cap at 100 bps
  * (1%) that requires an explicit ack. MEV sandwich bots target open-slippage
@@ -365,10 +409,18 @@ export async function getSwapQuote(args: GetSwapQuoteArgs) {
     ...(args.toAddress !== undefined ? { toAddress: args.toAddress } : {}),
     slippage: args.slippageBps !== undefined ? args.slippageBps / 10_000 : undefined,
     ...(isExactOut ? { toAmount: amountWei } : { fromAmount: amountWei }),
+    ...(args.exchanges && args.exchanges.length > 0
+      ? { allowExchanges: args.exchanges }
+      : {}),
+    ...(args.bridges && args.bridges.length > 0
+      ? { allowBridges: args.bridges }
+      : {}),
   } as Parameters<typeof fetchQuote>[0];
 
   const [quote, oneInchRaw] = await Promise.all([
-    fetchQuote(lifiReq),
+    fetchQuote(lifiReq).catch((err: unknown) => {
+      throw rephraseLifiNoRouteError(err, args);
+    }),
     oneInchApiKey
       ? fetchOneInchQuote({
           chain,
@@ -471,6 +523,23 @@ export async function getSwapQuote(args: GetSwapQuoteArgs) {
     }
   }
 
+  // Issue #411 — top-level `routedVia` makes the actual route prominent
+  // in the response so an agent can compare against the user's stated
+  // protocol preference before relaying. `requestedExchanges` /
+  // `requestedBridges` echo the filter that was applied so the
+  // structured shape carries both intent + result.
+  const routedVia = {
+    tool: quote.tool,
+    requestedExchanges: args.exchanges,
+    requestedBridges: args.bridges,
+    matchedRequestedExchanges:
+      args.exchanges && args.exchanges.length > 0
+        ? args.exchanges.some(
+            (e) => e.toLowerCase() === quote.tool.toLowerCase(),
+          )
+        : undefined,
+  };
+
   return {
     fromChain: args.fromChain,
     toChain: args.toChain,
@@ -482,6 +551,7 @@ export async function getSwapQuote(args: GetSwapQuoteArgs) {
     fromAmountUsd,
     toAmountUsd,
     tool: quote.tool,
+    routedVia,
     executionDurationSeconds: quote.estimate.executionDuration,
     feeCostsUsd: sumLifiCostsUsd(quote.estimate.feeCosts),
     gasCostsUsd: sumLifiCostsUsd(quote.estimate.gasCosts),
@@ -525,8 +595,16 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
     ...(args.toAddress !== undefined ? { toAddress: args.toAddress } : {}),
     slippage: args.slippageBps !== undefined ? args.slippageBps / 10_000 : undefined,
     ...(isExactOut ? { toAmount: amountWei } : { fromAmount: amountWei }),
+    ...(args.exchanges && args.exchanges.length > 0
+      ? { allowExchanges: args.exchanges }
+      : {}),
+    ...(args.bridges && args.bridges.length > 0
+      ? { allowBridges: args.bridges }
+      : {}),
   } as Parameters<typeof fetchQuote>[0];
-  const quote = await fetchQuote(lifiReq);
+  const quote = await fetchQuote(lifiReq).catch((err: unknown) => {
+    throw rephraseLifiNoRouteError(err, args);
+  });
 
   const txRequest = quote.transactionRequest;
   if (!txRequest || !txRequest.to || !txRequest.data) {
@@ -647,9 +725,24 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
   );
   const fromDisplay = isExactOut ? `~${quotedFromAmount}` : args.amount;
   const toDisplay = isExactOut ? args.amount : `~${quotedToAmount}`;
+  // Issue #411 — when the agent passed an `exchanges` filter and the
+  // route matches, surface it so the receipt confirms the preference
+  // was honoured. When the filter was set but the resolved tool
+  // differs (LiFi sometimes exposes a tool name aliased differently
+  // from the filter input — e.g. "1inch" vs "oneinch"), the prepare
+  // receipt notes the mismatch even though no error was raised.
+  const exchangeFilterApplied = args.exchanges && args.exchanges.length > 0;
+  const matchedFilter = exchangeFilterApplied
+    ? args.exchanges!.some((e) => e.toLowerCase() === quote.tool.toLowerCase())
+    : undefined;
+  const routingNote = exchangeFilterApplied
+    ? matchedFilter
+      ? ` (matched requested exchange filter: ${args.exchanges!.join(", ")})`
+      : ` (NOTE: requested exchange filter ${JSON.stringify(args.exchanges)} did not match resolved tool '${quote.tool}' — verify before signing)`
+    : "";
   const description = crossChain
-    ? `Bridge ${fromDisplay} ${fromSym} from ${args.fromChain} to ${toDisplay} ${toSym} on ${args.toChain} via ${quote.tool}`
-    : `Swap ${fromDisplay} ${fromSym} → ${toDisplay} ${toSym} on ${args.fromChain} via ${quote.tool}`;
+    ? `Bridge ${fromDisplay} ${fromSym} from ${args.fromChain} to ${toDisplay} ${toSym} on ${args.toChain} via ${quote.tool}${routingNote}`
+    : `Swap ${fromDisplay} ${fromSym} → ${toDisplay} ${toSym} on ${args.fromChain} via ${quote.tool}${routingNote}`;
 
   const swapTx: UnsignedTx = {
     chain,
@@ -665,6 +758,12 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
         from: `${fromDisplay} ${fromSym}`,
         expectedOut: `${quotedToAmount} ${toSym}`,
         minOut: `${formatUnits(BigInt(quote.estimate.toAmountMin), quote.action.toToken.decimals)} ${toSym}`,
+        ...(exchangeFilterApplied
+          ? {
+              requestedExchanges: args.exchanges!.join(", "),
+              matchedRequestedExchanges: matchedFilter ? "yes" : "no",
+            }
+          : {}),
       },
     },
     gasEstimate: txRequest.gasLimit ? BigInt(txRequest.gasLimit).toString() : undefined,

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -75,6 +75,16 @@ interface LifiQuoteRequestBase {
   toAddress?: string;
   /** Optional slippage override — LiFi default is 0.5% (0.005). */
   slippage?: number;
+  /**
+   * Issue #411 — restrict LiFi routing to a specific set of DEX
+   * aggregators / bridges. When set, LiFi's quote engine refuses to
+   * route through any tool not in the allowlist; if no satisfying
+   * route exists the SDK throws (NotFoundError / similar), surfacing
+   * as a clear error to the caller. When omitted, LiFi picks the
+   * best-output tool unconstrained.
+   */
+  allowExchanges?: string[];
+  allowBridges?: string[];
 }
 
 export type LifiQuoteRequest =
@@ -122,6 +132,18 @@ export async function fetchQuote(req: LifiQuoteRequest) {
           : NATIVE
       : req.toToken;
 
+  // LiFi's `getQuote` accepts `allowExchanges`/`allowBridges` as
+  // optional filters; spread them in only when set so the default
+  // (full routing graph) is preserved.
+  const filterFields = {
+    ...(req.allowExchanges && req.allowExchanges.length > 0
+      ? { allowExchanges: req.allowExchanges }
+      : {}),
+    ...(req.allowBridges && req.allowBridges.length > 0
+      ? { allowBridges: req.allowBridges }
+      : {}),
+  };
+
   if (req.toAmount !== undefined) {
     return getQuote({
       fromChain: fromChain as LifiChainId,
@@ -132,6 +154,7 @@ export async function fetchQuote(req: LifiQuoteRequest) {
       fromAddress: req.fromAddress,
       ...(req.toAddress !== undefined ? { toAddress: req.toAddress } : {}),
       slippage: req.slippage,
+      ...filterFields,
     });
   }
   return getQuote({
@@ -143,6 +166,7 @@ export async function fetchQuote(req: LifiQuoteRequest) {
     fromAddress: req.fromAddress,
     ...(req.toAddress !== undefined ? { toAddress: req.toAddress } : {}),
     slippage: req.slippage,
+    ...filterFields,
   });
 }
 

--- a/src/modules/swap/schemas.ts
+++ b/src/modules/swap/schemas.ts
@@ -113,6 +113,36 @@ const baseSwapSchema = z.object({
         "that an unusually-high slippage is intentional — the default rejects the tx " +
         "to protect the user from MEV sandwich attacks."
     ),
+  // Issue #411 — explicit DEX / bridge routing preferences. Without
+  // these, LiFi picks whatever pool gives the best output (Sushi,
+  // Uniswap, 1inch, KyberSwap, Paraswap, etc.). When the user names a
+  // protocol — "swap on 1inch" — the agent should pass
+  // `exchanges: ["1inch"]` so LiFi only considers that DEX. Filter
+  // is hard: LiFi returns NO_ROUTE if the named DEX can't satisfy the
+  // request, surfacing as a clear error rather than silent fallback.
+  exchanges: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      "Restrict LiFi routing to a specific set of DEX/exchange aggregators. Common " +
+        'values: "1inch", "sushiswap", "uniswap", "paraswap", "0x", "kyberswap", ' +
+        '"odos", "openocean". When the user explicitly names a DEX ("swap on 1inch"), ' +
+        "pass it here — without a filter, LiFi silently picks the best-output route " +
+        "regardless of what the user asked for. Multiple entries OR'd. If no route " +
+        "exists via the requested exchange(s) the call errors clearly; agent should " +
+        "offer to retry without the filter.",
+    ),
+  bridges: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      "Restrict cross-chain routing to a specific set of bridge protocols. Common " +
+        'values: "across", "stargate", "hop", "cbridge", "amarok", "polygon", ' +
+        '"arbitrum-bridge". Mirrors `exchanges` but for bridge selection. Only ' +
+        "applies to cross-chain routes; ignored for intra-chain swaps.",
+    ),
 });
 
 export const getSwapQuoteInput = baseSwapSchema;

--- a/test/swap-protocol-routing.test.ts
+++ b/test/swap-protocol-routing.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Issue #411 — protocol-routing preference on `prepare_swap` /
+ * `get_swap_quote`. The user said "swap on 1inch", LiFi silently
+ * routed via SushiSwap, and the prepare receipt didn't surface that
+ * the named protocol was not honoured.
+ *
+ * Coverage:
+ *   - `exchanges` filter is forwarded to LiFi as `allowExchanges`.
+ *   - `bridges` filter is forwarded as `allowBridges`.
+ *   - Filter omitted ⇒ LiFi receives no allowExchanges/allowBridges
+ *     fields (default routing).
+ *   - Response carries a `routedVia` field naming the resolved tool +
+ *     whether it matched the requested filter.
+ *   - Prepare-tx description includes a routing note when the filter
+ *     matched, and a clear MISMATCH note when it didn't.
+ *   - LiFi NotFound errors get rephrased to mention the filter so
+ *     the agent can offer to retry without it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseUnits } from "viem";
+
+const fetchQuoteMock = vi.fn();
+vi.mock("../src/modules/swap/lifi.js", () => ({
+  fetchQuote: (...args: unknown[]) => fetchQuoteMock(...args),
+  fetchStatus: vi.fn(),
+  initLifi: () => {},
+  LIFI_SOLANA_CHAIN_ID: 1151111081099710,
+  fetchSolanaQuote: vi.fn(),
+}));
+
+const fetchOneInchMock = vi.fn();
+vi.mock("../src/modules/swap/oneinch.js", () => ({
+  fetchOneInchQuote: (...args: unknown[]) => fetchOneInchMock(...args),
+}));
+
+const evmClientStub = {
+  readContract: vi.fn(),
+  multicall: vi.fn(),
+};
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => evmClientStub,
+  resetClients: () => {},
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/config/user-config.js", () => ({
+  readUserConfig: () => ({}),
+  resolveOneInchApiKey: () => undefined,
+}));
+
+const EVM_WALLET = "0x1111111111111111111111111111111111111111";
+const ETH_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const ETH_WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const LIFI_DIAMOND = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
+
+function makeIntraChainQuote(tool: string) {
+  return {
+    action: {
+      fromToken: {
+        address: ETH_USDC,
+        symbol: "USDC",
+        decimals: 6,
+        priceUSD: "1",
+      },
+      toToken: {
+        address: ETH_WETH,
+        symbol: "WETH",
+        decimals: 18,
+        priceUSD: "3000",
+      },
+      fromAmount: "100000000", // 100 USDC
+    },
+    estimate: {
+      toAmount: "33000000000000000", // 0.033 WETH
+      toAmountMin: "32700000000000000",
+      executionDuration: 60,
+      feeCosts: [],
+      gasCosts: [],
+      approvalAddress: LIFI_DIAMOND,
+    },
+    transactionRequest: {
+      to: LIFI_DIAMOND,
+      // Intra-chain swap calldata: NOT bridge-shaped, so
+      // `verifyLifiBridgeIntent` returns silently. Any non-bridge
+      // bytes work as long as the prefix isn't accidentally a
+      // valid LiFi bridge selector.
+      data: ("0xfeedface" + "00".repeat(36)) as `0x${string}`,
+      value: "0",
+      gasLimit: "200000",
+    },
+    tool,
+  };
+}
+
+beforeEach(() => {
+  fetchQuoteMock.mockReset();
+  fetchOneInchMock.mockReset();
+  evmClientStub.readContract.mockReset();
+  evmClientStub.readContract.mockImplementation(
+    async (req: { functionName: string; address?: string }) => {
+      if (req.functionName === "allowance") return parseUnits("1000", 6);
+      if (req.functionName === "decimals") {
+        // USDC = 6, WETH = 18 — the on-chain decimals cross-check
+        // refuses if these don't match LiFi's reported metadata.
+        return req.address?.toLowerCase() === ETH_WETH.toLowerCase() ? 18 : 6;
+      }
+      return 0;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("issue #411 — exchanges/bridges filter forwarding", () => {
+  it("forwards `exchanges: ['1inch']` to LiFi as allowExchanges", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("1inch"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["1inch"],
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.allowExchanges).toEqual(["1inch"]);
+  });
+
+  it("forwards `bridges` to LiFi as allowBridges", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("across"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      bridges: ["across", "stargate"],
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.allowBridges).toEqual(["across", "stargate"]);
+  });
+
+  it("does NOT set allowExchanges/allowBridges when filter is omitted (default routing preserved)", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("sushiswap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.allowExchanges).toBeUndefined();
+    expect(lifiCall.allowBridges).toBeUndefined();
+  });
+});
+
+describe("issue #411 — routedVia surfacing in getSwapQuote", () => {
+  it("response carries `routedVia.tool` matching LiFi's resolved tool", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("sushiswap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    const out = await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+    });
+    expect(out.routedVia.tool).toBe("sushiswap");
+    expect(out.routedVia.matchedRequestedExchanges).toBeUndefined();
+  });
+
+  it("when filter matches, routedVia.matchedRequestedExchanges = true", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("1inch"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    const out = await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["1inch"],
+    });
+    expect(out.routedVia.tool).toBe("1inch");
+    expect(out.routedVia.matchedRequestedExchanges).toBe(true);
+    expect(out.routedVia.requestedExchanges).toEqual(["1inch"]);
+  });
+
+  it("when filter set but resolved tool is aliased differently, matchedRequestedExchanges = false", async () => {
+    // LiFi sometimes exposes a tool name aliased differently from the
+    // filter input. Filter forwarding still narrows the routing graph;
+    // this just records the post-resolution mismatch so the receipt
+    // can flag it.
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("oneinch"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    const out = await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["1inch"],
+    });
+    expect(out.routedVia.tool).toBe("oneinch");
+    expect(out.routedVia.matchedRequestedExchanges).toBe(false);
+  });
+});
+
+describe("issue #411 — prepareSwap description carries the routing note", () => {
+  it("description includes 'via <tool>' even with no filter", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("sushiswap"));
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+    });
+    expect(tx.description).toContain("via sushiswap");
+  });
+
+  it("filter matches: description appends '(matched requested exchange filter: ...)'", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("1inch"));
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["1inch"],
+    });
+    expect(tx.description).toContain("via 1inch");
+    expect(tx.description).toMatch(/matched requested exchange filter/);
+  });
+
+  it("filter set but resolved tool different: description carries an explicit MISMATCH note", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("oneinch"));
+    const { prepareSwap } = await import("../src/modules/swap/index.js");
+    const tx = await prepareSwap({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["1inch"],
+    });
+    expect(tx.description).toContain("via oneinch");
+    expect(tx.description).toContain("did not match");
+    // Decoded args also carry the mismatch flag for structured consumers.
+    expect(tx.decoded?.args.matchedRequestedExchanges).toBe("no");
+    expect(tx.decoded?.args.requestedExchanges).toBe("1inch");
+  });
+});
+
+describe("issue #411 — LiFi no-route error gets rephrased to name the filter", () => {
+  it("when filter is set, NotFound error is wrapped with filter context", async () => {
+    fetchQuoteMock.mockRejectedValue(new Error("No available routes for the requested swap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: ETH_USDC,
+        toToken: ETH_WETH,
+        amount: "100",
+        exchanges: ["1inch"],
+      }),
+    ).rejects.toThrow(/no route satisfying exchanges=\[1inch\]/);
+  });
+
+  it("when filter is omitted, LiFi error is passed through unchanged", async () => {
+    fetchQuoteMock.mockRejectedValue(new Error("No available routes for the requested swap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: ETH_USDC,
+        toToken: ETH_WETH,
+        amount: "100",
+      }),
+    ).rejects.toThrow(/No available routes/);
+  });
+
+  it("non-no-route LiFi errors pass through even when filter is set (don't mis-rephrase)", async () => {
+    fetchQuoteMock.mockRejectedValue(new Error("rate limit exceeded"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await expect(
+      getSwapQuote({
+        wallet: EVM_WALLET,
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        fromToken: ETH_USDC,
+        toToken: ETH_WETH,
+        amount: "100",
+        exchanges: ["1inch"],
+      }),
+    ).rejects.toThrow(/rate limit exceeded/);
+  });
+});


### PR DESCRIPTION
## Summary
When the user said \"swap on 1inch\", LiFi silently routed via SushiSwap and the prepare receipt didn't surface the mismatch — the user only discovered it by reading decoded calldata. Three changes address this from different angles, picking up all three of #411's expected-behaviour bullet points:

1. **Filter knobs** — new optional \`exchanges?: string[]\` and \`bridges?: string[]\` on \`prepare_swap\` / \`get_swap_quote\` map to LiFi's \`allowExchanges\` / \`allowBridges\`. When the user names a DEX, the agent passes \`exchanges: [\"1inch\"]\` and LiFi only considers that DEX. No filter ⇒ default best-output routing (existing behavior preserved). 
2. **\`routedVia\` surfacing** — top-level \`routedVia\` record on the response carries \`{ tool, requestedExchanges?, requestedBridges?, matchedRequestedExchanges? }\`, and the prepare-tx \`description\` appends \"(matched requested exchange filter: ...)\" when honoured or an explicit \"(NOTE: requested exchange filter ... did not match resolved tool '...' — verify before signing)\" when LiFi resolves to an aliased name. Receipts make the actual route obvious instead of burying it in calldata.
3. **No-route error rephrasing** — when a filter is set and LiFi throws \"No available routes\" / NotFoundError, wrap the error to name the offending filter so the agent can offer to retry without it. Errors with filter omitted pass through unchanged. Non-no-route errors (rate-limit etc.) also pass through verbatim.

Tool descriptions updated so an agent knows to use \`exchanges\` / \`bridges\` when the user names a protocol, and that without a filter LiFi may pick a different DEX than what the user said.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 2001/2001 pass. New \`test/swap-protocol-routing.test.ts\` covers filter forwarding (exchanges + bridges + omitted), \`routedVia\` population (matched + aliased-mismatch + no-filter), prepare-tx description routing note, and no-route-error rephrasing (with-filter rephrased, without-filter passthrough, non-no-route passthrough).
- [ ] Manual: \`prepare_swap({ wallet, fromChain, toChain, fromToken, toToken, amount, exchanges: [\"1inch\"] })\` returns a tx whose description names 1inch and \`routedVia.matchedRequestedExchanges = true\`. Same call with no liquid 1inch route returns a clear filter-mention error.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)