### PR TITLE
fix(demo): state-precondition hint on prepare_* failures (#409)

### DIFF
--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -98,6 +98,68 @@ export function _setAutoDemoLatchForTests(value: boolean | null): void {
 }
 
 /**
+ * Per-session dedup for the demo-mode state-precondition hint
+ * (issue #409). Once an agent has been told a given prepare_* tool's
+ * failure might stem from "demo can't satisfy state-changing
+ * prerequisites", repeating the hint on every retry of the same tool
+ * is noise. The set is keyed by tool name so different prepare_*
+ * tools each get their own one-shot.
+ */
+const statePreconditionHintEmittedFor = new Set<string>();
+
+export function _resetStatePreconditionHintDedup(): void {
+  statePreconditionHintEmittedFor.clear();
+}
+
+/**
+ * Issue #409 — the agent-loop trap. When a prepare_* tool refuses
+ * because of an on-chain state precondition (durable-nonce account
+ * missing, ATA not yet created, allowance still 0 because the prior
+ * approve was simulated, etc.), the agent walks the user through a
+ * "fix" that's itself just another simulation, then re-runs the
+ * original prepare_*, hits the same refusal, and loops.
+ *
+ * Demo mode `simulates` sends but doesn't mutate state — neither real
+ * chain state nor a virtual overlay — so any flow whose preconditions
+ * ARE state changes can't be rehearsed end-to-end. This helper emits
+ * a one-shot advisory note alongside the underlying error so the
+ * agent and user know: the failure might be the demo-mode wall, not
+ * a bug to debug.
+ *
+ * Intentionally advisory (NOT assertive): some prepare_* failures in
+ * demo mode are real (wrong arg, RPC outage, protocol pause). The
+ * agent reads BOTH the original error and this hint and chooses.
+ *
+ * Returns null when:
+ *   - demo mode is OFF (no need to surface),
+ *   - the tool isn't a prepare_* (the loop class is specific to
+ *     state-changing prepare flows),
+ *   - we've already emitted the hint for this tool this session
+ *     (dedup keeps it from being noise on retries).
+ */
+export function demoStatePreconditionHint(toolName: string): string | null {
+  if (!isDemoMode()) return null;
+  if (!toolName.startsWith("prepare_")) return null;
+  if (statePreconditionHintEmittedFor.has(toolName)) return null;
+  statePreconditionHintEmittedFor.add(toolName);
+  return (
+    `[VAULTPILOT_DEMO] If '${toolName}' failed because of an on-chain state ` +
+    `precondition (e.g. durable-nonce account not initialized, ATA not yet ` +
+    `created, allowance still zero because the prior approve was simulated), ` +
+    `note that demo mode CANNOT satisfy state-changing prerequisites — ` +
+    `simulated sends don't mutate real chain state or a virtual demo overlay. ` +
+    `Walking the user through "do step 1 first" would loop because step 1's ` +
+    `simulation also doesn't land on chain. To rehearse this multi-step flow ` +
+    `end-to-end: leave demo (set VAULTPILOT_DEMO=false in the MCP client config ` +
+    `or run \`vaultpilot-mcp-setup\` and restart) and use a wallet whose ` +
+    `precondition is already met on real chain. Demo mode remains useful for ` +
+    `single-step flows (one-shot swap / send / supply on a fresh wallet). ` +
+    `If the error is unrelated (wrong arg, protocol pause, RPC issue), ignore ` +
+    `this hint. Surfaced once per (tool, session).`
+  );
+}
+
+/**
  * Why the server is (or isn't) in demo mode. Drives error-message
  * branching: an `auto-fresh-install` user gets pointed at
  * `vaultpilot-mcp-setup` as the leave path (since they have no env var

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   defaultModeRefusalMessage,
   buildSimulationEnvelope,
   buildGetDemoWalletResponse,
+  demoStatePreconditionHint,
   getDemoModeReason,
   initDemoMode,
   isLiveMode,
@@ -953,6 +954,15 @@ function handler<T, R>(
         for (const { nudge } of consumeAllPendingNudges()) {
           errorContent.push({ type: "text", text: nudge });
         }
+        // Issue #409 — when a prepare_* fails in demo mode, append a
+        // one-shot advisory hint that demo can't satisfy state-changing
+        // preconditions. Closes the agent-loop trap where the agent
+        // walks the user through a "fix" that's itself a simulation,
+        // then re-runs the original prepare and hits the same refusal.
+        if (opts?.toolName) {
+          const stateHint = demoStatePreconditionHint(opts.toolName);
+          if (stateHint) errorContent.push({ type: "text", text: stateHint });
+        }
       }
       return {
         content: errorContent,
@@ -1084,9 +1094,20 @@ async function broadcastSimulationDispatch(
     // `consumeHandle`) so the demo flow doesn't burn the handle — the
     // user can re-run send_transaction in a follow-up turn without a
     // re-prepare. The real broadcast handler is never invoked.
+    //
+    // Issue #409 side-note: handles produced by `prepare_solana_*`
+    // live in a separate Solana draft store, not the EVM tx-store.
+    // The previous code only checked the EVM store and reported
+    // "Handle not found in tx-store" for a perfectly valid Solana
+    // handle that had just been pinned by `preview_solana_send`.
+    // Now we check both stores; if the handle is Solana, treat the
+    // simulation as deferred-to-preview (pre-sign simulation already
+    // ran during preview_solana_send for non-nonce_init actions, so
+    // the broadcast-time simulate is redundant).
     const { hasHandle, consumeHandle, issueHandles } = await import(
       "./signing/tx-store.js"
     );
+    const { hasSolanaDraft } = await import("./signing/solana-tx-store.js");
     const { simulateTransaction } = await import(
       "./modules/simulation/index.js"
     );
@@ -1100,11 +1121,28 @@ async function broadcastSimulationDispatch(
         data: tx.data,
         value: tx.value,
       });
+    } else if (typeof handleArg === "string" && hasSolanaDraft(handleArg)) {
+      // Solana handle recognized — preview_solana_send already ran the
+      // pre-sign simulation against the pinned message bytes during
+      // its handler (see modules/execution/index.ts:previewSolanaSend),
+      // so a redundant broadcast-time simulate would just duplicate
+      // that work. Mark the envelope as "preview-time simulation
+      // already validated this tx" rather than the misleading
+      // "Handle not found" we used to surface.
+      simulationResult = {
+        simulationDeferredToPreview: true,
+        chain: "solana",
+        note:
+          "Solana pre-sign simulation runs at preview_solana_send time, not at " +
+          "broadcast. The pinned message bytes were already simulated for program-" +
+          "level reverts before the user blind-signed.",
+      };
     } else {
       simulationResult = {
         simulationSkipped: true,
         reason:
-          "Handle not found in tx-store. Call a prepare_* tool first to obtain a handle, then pass it to send_transaction.",
+          "Handle not found in tx-store or Solana draft store. Call a prepare_* " +
+          "tool first to obtain a handle, then pass it to send_transaction.",
       };
     }
   } catch (err) {

--- a/src/signing/solana-tx-store.ts
+++ b/src/signing/solana-tx-store.ts
@@ -183,6 +183,17 @@ export function issueSolanaDraftHandle(draft: SolanaTxDraft): { handle: string }
 }
 
 /**
+ * Non-throwing presence check — used by demo-mode's
+ * `broadcastSimulationDispatch` to decide whether the handle lives in
+ * the Solana draft store before falling through to "unknown handle"
+ * (issue #409 side-note). Mirrors the EVM tx-store's `hasHandle`.
+ */
+export function hasSolanaDraft(handle: string): boolean {
+  prune();
+  return store.has(handle);
+}
+
+/**
  * Look up the draft for `handle`. Used by `preview_solana_send` to
  * re-serialize with a fresh blockhash. Throws for unknown / expired
  * handles (same TTL semantics as the pinned path).

--- a/test/demo-state-precondition.test.ts
+++ b/test/demo-state-precondition.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Issue #409 — demo mode can't walk through state-dependent multi-step
+ * flows because simulated sends don't mutate real chain state. The
+ * minimum-viable fix (Option B) is to surface a one-shot advisory
+ * hint when a `prepare_*` fails in demo mode, so the agent doesn't
+ * loop the user through a fix that's itself another simulation.
+ *
+ * Coverage:
+ *   - `demoStatePreconditionHint` returns null outside demo mode.
+ *   - Returns null for non-`prepare_*` tool names (the loop class is
+ *     specific to state-changing prepare flows).
+ *   - Returns a structured `[VAULTPILOT_DEMO]` hint for prepare_* in
+ *     demo mode.
+ *   - Dedups: subsequent calls for the same tool return null.
+ *   - Different prepare_* tools each get their own one-shot.
+ *   - Reset hook clears dedup for test isolation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const ENV_KEY = "VAULTPILOT_DEMO";
+
+describe("issue #409 — demoStatePreconditionHint", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    savedEnv = process.env[ENV_KEY];
+    const {
+      _resetAutoDemoLatchForTests,
+      _resetStatePreconditionHintDedup,
+    } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+    _resetStatePreconditionHintDedup();
+  });
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    const {
+      _resetAutoDemoLatchForTests,
+      _resetStatePreconditionHintDedup,
+    } = await import("../src/demo/index.js");
+    _resetAutoDemoLatchForTests();
+    _resetStatePreconditionHintDedup();
+  });
+
+  it("returns null when demo mode is OFF (env unset, no auto-demo latch)", async () => {
+    delete process.env[ENV_KEY];
+    const { demoStatePreconditionHint } = await import("../src/demo/index.js");
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).toBeNull();
+  });
+
+  it("returns null for non-prepare_* tool names (read tools, signing tools)", async () => {
+    process.env[ENV_KEY] = "true";
+    const {
+      demoStatePreconditionHint,
+      _resetStatePreconditionHintDedup,
+    } = await import("../src/demo/index.js");
+    _resetStatePreconditionHintDedup();
+    expect(demoStatePreconditionHint("get_lending_positions")).toBeNull();
+    expect(demoStatePreconditionHint("send_transaction")).toBeNull();
+    expect(demoStatePreconditionHint("preview_solana_send")).toBeNull();
+    expect(demoStatePreconditionHint("set_demo_wallet")).toBeNull();
+  });
+
+  it("returns the hint for prepare_* in demo mode (explicit env)", async () => {
+    process.env[ENV_KEY] = "true";
+    const { demoStatePreconditionHint } = await import("../src/demo/index.js");
+    const hint = demoStatePreconditionHint("prepare_marinade_stake");
+    expect(hint).not.toBeNull();
+    expect(hint).toMatch(/^\[VAULTPILOT_DEMO\]/);
+    expect(hint).toContain("prepare_marinade_stake");
+    expect(hint).toContain("state-changing prerequisites");
+    // Names the leave path so the agent can offer it to the user.
+    expect(hint).toContain("VAULTPILOT_DEMO=false");
+    expect(hint).toContain("vaultpilot-mcp-setup");
+    // Self-labels as advisory so a defensive agent doesn't treat it
+    // as an authoritative diagnosis.
+    expect(hint).toContain("ignore this hint");
+  });
+
+  it("returns the hint under auto-demo (env unset + latched)", async () => {
+    delete process.env[ENV_KEY];
+    const {
+      demoStatePreconditionHint,
+      _setAutoDemoLatchForTests,
+    } = await import("../src/demo/index.js");
+    _setAutoDemoLatchForTests(true);
+    const hint = demoStatePreconditionHint("prepare_aave_borrow");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("prepare_aave_borrow");
+  });
+
+  it("dedupes per (tool, session) — second call for same tool returns null", async () => {
+    process.env[ENV_KEY] = "true";
+    const { demoStatePreconditionHint } = await import("../src/demo/index.js");
+    const first = demoStatePreconditionHint("prepare_marinade_stake");
+    const second = demoStatePreconditionHint("prepare_marinade_stake");
+    const third = demoStatePreconditionHint("prepare_marinade_stake");
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(third).toBeNull();
+  });
+
+  it("dedup is per-tool, not global — different prepare_* each get one shot", async () => {
+    process.env[ENV_KEY] = "true";
+    const { demoStatePreconditionHint } = await import("../src/demo/index.js");
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).not.toBeNull();
+    // After firing for marinade, a different prepare_* still fires.
+    expect(demoStatePreconditionHint("prepare_aave_borrow")).not.toBeNull();
+    expect(demoStatePreconditionHint("prepare_solana_swap")).not.toBeNull();
+    // But each only fires once.
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).toBeNull();
+    expect(demoStatePreconditionHint("prepare_aave_borrow")).toBeNull();
+  });
+
+  it("reset hook clears dedup so tests can simulate a fresh session", async () => {
+    process.env[ENV_KEY] = "true";
+    const {
+      demoStatePreconditionHint,
+      _resetStatePreconditionHintDedup,
+    } = await import("../src/demo/index.js");
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).not.toBeNull();
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).toBeNull();
+    _resetStatePreconditionHintDedup();
+    expect(demoStatePreconditionHint("prepare_marinade_stake")).not.toBeNull();
+  });
+});
+
+describe("issue #409 side-note — Solana handle in broadcastSimulationDispatch", () => {
+  it("hasSolanaDraft returns false for unknown handles, true after issueSolanaDraftHandle", async () => {
+    const { issueSolanaDraftHandle, hasSolanaDraft } = await import(
+      "../src/signing/solana-tx-store.js"
+    );
+    expect(hasSolanaDraft("nonexistent-handle-xyz")).toBe(false);
+
+    // Minimal draft shape — issueSolanaDraftHandle takes a SolanaTxDraft;
+    // the test just needs the handle to round-trip through the store, not
+    // to be a valid signable draft.
+    const fakeDraft = {
+      action: "nonce_init" as const,
+      wallet: "test-wallet",
+      meta: {},
+      // The draft's other fields are unused by hasSolanaDraft (which
+      // only consults the Map's keys); cast to unknown to skip typing
+      // the full shape.
+    } as unknown as Parameters<typeof issueSolanaDraftHandle>[0];
+    const { handle } = issueSolanaDraftHandle(fakeDraft);
+    expect(hasSolanaDraft(handle)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The agent-loop trap from #409: agent calls \`prepare_marinade_stake\` → \"durable-nonce account not initialized\" → walks user through \`prepare_solana_nonce_init\` → simulated send (no real chain mutation) → re-runs \`prepare_marinade_stake\` → same refusal → loop. Demo mode silently caps every state-dependent multi-step flow at the first state-change boundary because simulated sends don't mutate real chain state or a virtual demo overlay.

This PR implements Option B (the cheap, accurate, sets-correct-expectations path the user explicitly endorsed in the issue): append a one-shot advisory hint when ANY \`prepare_*\` fails in demo mode. The hint:

- Names the demo wall as the likely cause without claiming it's definite (real prepare bugs / wrong args / RPC issues still need debugging).
- Tells the agent demo mode CAN'T satisfy state-changing prerequisites and that walking the user through \"do step 1 first\" would loop because step 1 is also simulated.
- Names the leave path (\`VAULTPILOT_DEMO=false\` or \`vaultpilot-mcp-setup\`) so the agent can offer it.
- Dedups per (tool, session) so retries don't spam.

**Side-note fix from the issue:** \`send_transaction\` in demo mode against a Solana handle was reporting \"Handle not found in tx-store\" because \`broadcastSimulationDispatch\` only checked the EVM tx-store, while \`prepare_solana_*\` / \`preview_solana_send\` route through a separate Solana draft store. Added \`hasSolanaDraft()\`; when the handle is Solana, the envelope now reports \`simulationDeferredToPreview\` with context (preview_solana_send already ran the pre-sign simulation) instead of the misleading not-found message.

**Out of scope** (Options A + C from the issue): virtual state overlay across every protocol, and pre-warmed persona fixtures. Both heavier; this PR ships the loop-trap closer first and leaves higher-fidelity rehearsal for later.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 2018/2018 pass. New \`test/demo-state-precondition.test.ts\` covers env-off → null, non-prepare_* → null, prepare_* in demo → hint with right shape, auto-demo path, dedup per (tool, session), multi-tool dedup independence, reset hook. Plus a Solana draft-store round-trip for \`hasSolanaDraft\`.
- [ ] Manual: in demo mode, call \`prepare_marinade_stake\` against a wallet with no nonce account → response carries the original \"durable-nonce account not initialized\" error AND a \`[VAULTPILOT_DEMO]\` advisory hint pointing the agent at the leave path. Second call to the same prepare doesn't re-emit the hint.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)