### PR TITLE
fix(solana): proactive Helius nudge + broaden public-RPC throttle detection (#410)

### DIFF
--- a/src/data/runtime-rpc-overrides.ts
+++ b/src/data/runtime-rpc-overrides.ts
@@ -42,7 +42,13 @@ interface ServiceConfig {
   buildResolvedValue: (apiKey: string) => string;
   /** Signup URL surfaced in the nudge text. */
   signupUrl: string;
-  /** Build the nudge block (markdown) given the current error count. */
+  /**
+   * Build the nudge block (markdown). `errorCount` is 0 for proactive
+   * nudges (fired before the user has hit any rate-limit error) and >0
+   * for reactive nudges (fired by `recordPublicError`). Implementations
+   * branch on the count to swap the lead-in copy: "you'll likely hit
+   * throttling shortly" vs "you've already hit N rate-limit errors".
+   */
   renderNudge: (errorCount: number) => string;
 }
 
@@ -67,17 +73,33 @@ const SERVICE_CONFIGS: Record<ServiceId, ServiceConfig> = {
     buildResolvedValue: (apiKey) =>
       `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
     signupUrl: "https://dashboard.helius.dev/",
-    renderNudge: (errorCount) =>
-      `[VAULTPILOT_DEMO — Helius setup nudge]\n\n` +
-      `Public Solana RPC has hit ${errorCount} rate-limit error${errorCount === 1 ? "" : "s"} this session. ` +
-      `Public Solana endpoints throttle aggressively under any real walkthrough.\n\n` +
-      `Free Helius API key takes 60 seconds:\n` +
-      `  1. Open [Helius dashboard](https://dashboard.helius.dev/) — sign in with GitHub or email.\n` +
-      `  2. Dashboard auto-creates a default API key on first login. Copy it (UUID format: 8-4-4-4-12 hex).\n` +
-      `  3. Paste the key into chat. The agent will call \`set_helius_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
-      `The key is held in process memory only — survives until the MCP server restarts. ` +
-      `To persist across restarts, exit demo mode (unset VAULTPILOT_DEMO + restart) and run ` +
-      `\`vaultpilot-mcp-setup\` to save the key to ~/.vaultpilot-mcp/config.json.`,
+    renderNudge: (errorCount) => {
+      const leadIn =
+        errorCount === 0
+          ? // Proactive: fired on first Solana RPC use when public fallback
+            // is in play. Wording aimed at "before you hit errors" — surfaces
+            // the fix path during the user's first read tool, not after they
+            // see 9 confusing rate-limit failures (issue #410).
+            `Solana RPC is using the public mainnet endpoint (api.mainnet-beta.solana.com). ` +
+            `That endpoint throttles aggressively under any real walkthrough — portfolio reads, ` +
+            `staking lookups, and swap quotes typically trip 429s within the first few calls.`
+          : // Reactive: fires on first error of the session and every multiple
+            // of 10 thereafter (10, 20, 30, ...). Phrased as a count so the
+            // user knows how bad it's already gotten.
+            `Public Solana RPC has hit ${errorCount} rate-limit error${errorCount === 1 ? "" : "s"} this session. ` +
+            `Public Solana endpoints throttle aggressively under any real walkthrough.`;
+      return (
+        `[VAULTPILOT_DEMO — Helius setup nudge]\n\n` +
+        `${leadIn}\n\n` +
+        `Free Helius API key takes 60 seconds:\n` +
+        `  1. Open [Helius dashboard](https://dashboard.helius.dev/) — sign in with GitHub or email.\n` +
+        `  2. Dashboard auto-creates a default API key on first login. Copy it (UUID format: 8-4-4-4-12 hex).\n` +
+        `  3. Paste the key into chat. The agent will call \`set_helius_api_key({ apiKey: "<paste>" })\` for you.\n\n` +
+        `The key is held in process memory only — survives until the MCP server restarts. ` +
+        `To persist across restarts, exit demo mode (unset VAULTPILOT_DEMO + restart) and run ` +
+        `\`vaultpilot-mcp-setup\` to save the key to ~/.vaultpilot-mcp/config.json.`
+      );
+    },
   },
   etherscan: {
     id: "etherscan",
@@ -114,6 +136,15 @@ const errorCounts = new Map<ServiceId, number>();
 const pendingNudges = new Set<ServiceId>();
 
 /**
+ * Once-per-session flag: which services have already had their
+ * proactive nudge queued (independent of the reactive error-count
+ * cadence). Without this, every cached-Connection rebuild would
+ * re-queue the proactive nudge. Cleared on `setRuntimeOverride` (the
+ * user has acted) and on test reset.
+ */
+const proactiveNudgesFired = new Set<ServiceId>();
+
+/**
  * Validate + store an API key for the given service. Throws on
  * malformed input rather than storing garbage. Side effects: resets
  * the per-service error counter + clears any pending nudge for this
@@ -148,6 +179,11 @@ export function setRuntimeOverride(
   overrides.set(service, { apiKey, resolvedValue, setAt });
   errorCounts.set(service, 0);
   pendingNudges.delete(service);
+  // The user has acted; don't re-queue the proactive notice if a future
+  // call somehow flips back to the public fallback (override cleared, key
+  // expired, etc.). Cleared in `clearRuntimeOverride` so a deliberate
+  // reset DOES re-arm it.
+  proactiveNudgesFired.add(service);
   return { resolvedValue, setAt, apiKeySuffix: apiKey.slice(-4) };
 }
 
@@ -174,6 +210,10 @@ export function getRuntimeOverrideStatus(service: ServiceId): {
 /** Clears the runtime override for one service. */
 export function clearRuntimeOverride(service: ServiceId): void {
   overrides.delete(service);
+  // Re-arm the proactive nudge so a deliberate clear (e.g. a test
+  // tearing down state, or a future tool that lets the user revoke an
+  // override) gets the heads-up again on the next public-fallback use.
+  proactiveNudgesFired.delete(service);
 }
 
 /**
@@ -199,6 +239,32 @@ export function recordPublicError(service: ServiceId): void {
 /** Read-only counter accessor for tests + diagnostic surfaces. */
 export function getPublicErrorCount(service: ServiceId): number {
   return errorCounts.get(service) ?? 0;
+}
+
+/**
+ * Issue #410 — fired the FIRST time the public-fallback path is used for
+ * a service, BEFORE any rate-limit error. Queues the proactive variant of
+ * the setup nudge so the user gets a heads-up during their first read
+ * tool, not after they've seen 9 confusing rate-limit failures.
+ *
+ * No-op when:
+ *   - An override is already set (the user has a key; nothing to nudge).
+ *   - The proactive nudge has already fired this session (every cached-
+ *     `Connection` rebuild calls this; we want one notice, not many).
+ *   - A reactive nudge is already pending for this service (a real error
+ *     count is more useful than the speculative "you'll likely hit
+ *     throttling" wording — let the reactive one win).
+ *
+ * Doesn't bump `errorCounts` — that stays tied to actual errors, so the
+ * proactive notice renders with `errorCount === 0` and the reactive
+ * variants pick up from 1 normally.
+ */
+export function recordProactivePublicAccess(service: ServiceId): void {
+  if (overrides.has(service)) return;
+  if (proactiveNudgesFired.has(service)) return;
+  if (pendingNudges.has(service)) return;
+  proactiveNudgesFired.add(service);
+  pendingNudges.add(service);
 }
 
 /**
@@ -281,4 +347,5 @@ export function _resetRuntimeRpcOverridesForTests(): void {
   overrides.clear();
   errorCounts.clear();
   pendingNudges.clear();
+  proactiveNudgesFired.clear();
 }

--- a/src/modules/solana/rpc.ts
+++ b/src/modules/solana/rpc.ts
@@ -4,8 +4,18 @@ import { readUserConfig } from "../../config/user-config.js";
 import { recordRateLimit } from "../../data/rate-limit-tracker.js";
 import {
   getRuntimeSolanaRpc,
+  recordProactivePublicAccess,
   recordSolanaPublicError,
 } from "../../data/runtime-rpc-overrides.js";
+
+/**
+ * Canonical public Solana mainnet endpoint. Hardcoded here (mirrors the
+ * `SOLANA_PUBLIC_MAINNET` constant in `src/config/chains.ts`) so this
+ * module can detect the public-fallback path locally without re-importing
+ * the chain config. Kept in sync by hand — both must change together if
+ * the public endpoint URL ever shifts.
+ */
+const SOLANA_PUBLIC_MAINNET_URL = "https://api.mainnet-beta.solana.com";
 
 /**
  * Cached `Connection` for Solana mainnet. Lazy-initialized on first use.
@@ -35,19 +45,84 @@ async function fetchWithRateLimitDetect(
   init?: Parameters<typeof fetch>[1],
 ): Promise<Response> {
   const res = await fetch(input, init);
-  if (res.status === 429) {
+  // HTTP-status side: api.mainnet-beta.solana.com returns 429 most often,
+  // but occasionally surfaces 410 (Gone — restricted method on the public
+  // endpoint) and 503 (overloaded) for the same throttling reason. Issue
+  // #410: counting only 429 silently dropped a real-session 9-error
+  // streak so the nudge never fired.
+  let throttled = res.status === 429 || res.status === 410 || res.status === 503;
+  // JSON-RPC-body side: some Solana public-endpoint operators return HTTP
+  // 200 with a JSON-RPC error body carrying a rate-limit code. Peek via
+  // res.clone() so the original response stays unconsumed for the caller.
+  // Fail-open on any parse error — counting fewer events is preferable to
+  // serving a corrupted body to the SDK.
+  if (!throttled) {
+    try {
+      const cloned = res.clone();
+      const ctype = cloned.headers.get("content-type") ?? "";
+      if (ctype.includes("application/json")) {
+        const body = (await cloned.json()) as
+          | { error?: { code?: number; message?: string } }
+          | undefined;
+        const code = body?.error?.code;
+        const message = body?.error?.message ?? "";
+        // -32429: custom Solana rate-limit code (some public proxies use it).
+        // -32005: Alchemy-style "rate limit exceeded" — mirrors the same code
+        // the EVM tracker watches for.
+        // Substring match guards against operators that pick a different
+        // numeric code but still send a recognizable message.
+        if (code === -32429 || code === -32005) {
+          throttled = true;
+        } else if (
+          /rate.?limit|too many requests|quota|throttl/i.test(message)
+        ) {
+          throttled = true;
+        }
+      }
+    } catch {
+      // body wasn't JSON, or already consumed elsewhere — leave throttled false.
+    }
+  }
+  if (throttled) {
     recordRateLimit({ kind: "solana" });
     // Increment the demo-mode Helius nudge counter — only counts when no
     // runtime override is set, so the nudge doesn't fire after the user
-    // adds a key. Every 10th error trips a `pendingHeliusNudge` flag the
-    // registerTool wrapper picks up on the next response.
+    // adds a key. First error of the session AND every multiple of 10
+    // thereafter trip the pending-nudge flag the registerTool wrapper
+    // picks up on the next response.
     recordSolanaPublicError();
   }
   return res;
 }
 
+/**
+ * Test-only export. The fetch shim is otherwise hidden behind the
+ * cached `Connection` constructor, but issue #410's broadened detection
+ * (HTTP 410 / 503 / JSON-RPC body codes) needs unit-level coverage that
+ * doesn't go through web3.js's Connection internals. Calling this is the
+ * cheapest way to assert "given a Response shaped like X, did the
+ * Helius error counter increment by 1?"
+ */
+export function _fetchWithRateLimitDetectForTests(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): Promise<Response> {
+  return fetchWithRateLimitDetect(input, init);
+}
+
 export function getSolanaConnection(): Connection {
   const url = resolveSolanaRpcUrl(readUserConfig());
+  // Issue #410: when the resolved URL is the public-fallback mainnet
+  // endpoint (no override, no env, no config), proactively queue the
+  // Helius setup nudge so the user gets a heads-up on their first read
+  // tool — instead of after 9 confusing rate-limit errors. No-op when an
+  // override is set or the proactive notice has already fired this
+  // session. Done at connection-resolve time (not at fetch time) so the
+  // nudge fires on the first tool that touches Solana RPC, regardless of
+  // whether that tool happens to trip a 429 immediately.
+  if (url === SOLANA_PUBLIC_MAINNET_URL) {
+    recordProactivePublicAccess("helius");
+  }
   // Issue #371 follow-up: when `set_helius_api_key` flips the runtime
   // override, the resolved URL changes mid-process. Rebuild the cached
   // Connection if the URL no longer matches what we built it against —

--- a/test/runtime-rpc-overrides.test.ts
+++ b/test/runtime-rpc-overrides.test.ts
@@ -322,3 +322,174 @@ describe("classifySolanaRpcSource integration — runtime-override wins", () => 
     delete process.env.SOLANA_RPC_URL;
   });
 });
+
+describe("recordProactivePublicAccess — issue #410", () => {
+  it("queues a Helius nudge with proactive copy (no error count) on first call", async () => {
+    const { recordProactivePublicAccess, consumePendingNudge } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    recordProactivePublicAccess("helius");
+    const nudge = consumePendingNudge("helius");
+    expect(nudge).not.toBeNull();
+    // Proactive variant: lead-in talks about likely-future throttling, not
+    // a count of past errors. Reactive variant carries "rate-limit error(s)
+    // this session" — must NOT appear here.
+    expect(nudge!).toMatch(/throttle|throttling|throttles/i);
+    expect(nudge!).not.toMatch(/has hit \d+ rate-limit/);
+    // Still carries the actionable bits — signup URL, set_helius_api_key.
+    expect(nudge!).toContain("set_helius_api_key");
+    expect(nudge!).toContain("dashboard.helius.dev");
+  });
+
+  it("does NOT bump the error counter (counts stay tied to actual errors)", async () => {
+    const {
+      recordProactivePublicAccess,
+      getSolanaPublicErrorCount,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    recordProactivePublicAccess("helius");
+    expect(getSolanaPublicErrorCount()).toBe(0);
+  });
+
+  it("is idempotent — second call does not re-queue (stays once-per-session)", async () => {
+    const { recordProactivePublicAccess, consumePendingNudge } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    recordProactivePublicAccess("helius");
+    consumePendingNudge("helius");
+    // Second call after consumption: should NOT re-queue. The user has
+    // already seen the heads-up; further re-queues would be noise.
+    recordProactivePublicAccess("helius");
+    expect(consumePendingNudge("helius")).toBeNull();
+  });
+
+  it("does NOT queue a nudge when an override is already active", async () => {
+    const { recordProactivePublicAccess, consumePendingNudge } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    setHeliusApiKey(VALID_KEY);
+    recordProactivePublicAccess("helius");
+    expect(consumePendingNudge("helius")).toBeNull();
+  });
+
+  it("yields to a reactive nudge that's already pending (real error count beats speculative)", async () => {
+    const { recordProactivePublicAccess, consumePendingNudge } = await import(
+      "../src/data/runtime-rpc-overrides.js"
+    );
+    // Simulate an error tripping the reactive nudge first.
+    recordSolanaPublicError();
+    // Then the proactive trigger fires (e.g. another tool resolved the
+    // public URL between the error happening and the nudge being consumed).
+    recordProactivePublicAccess("helius");
+    const nudge = consumePendingNudge("helius");
+    // Reactive variant wins — has the real error count.
+    expect(nudge!).toMatch(/has hit 1 rate-limit error this session/);
+  });
+
+  it("re-arms after clearRuntimeOverride so a future re-trigger fires the heads-up again", async () => {
+    const {
+      recordProactivePublicAccess,
+      clearRuntimeOverride,
+      consumePendingNudge,
+    } = await import("../src/data/runtime-rpc-overrides.js");
+    setHeliusApiKey(VALID_KEY); // marks proactive as fired (user has acted)
+    clearRuntimeOverride("helius"); // user explicitly removes the key
+    recordProactivePublicAccess("helius");
+    expect(consumePendingNudge("helius")).not.toBeNull();
+  });
+});
+
+describe("fetchWithRateLimitDetect — broadened detection (issue #410)", () => {
+  // Helper: build a Response shaped like what fetch returns, then run it
+  // through the same gate the production fetch shim uses. Re-imports the
+  // module each test so reset is honored.
+  async function detectThrottle(opts: {
+    status: number;
+    contentType?: string;
+    body?: unknown;
+  }): Promise<{ throttled: boolean; errorCount: number }> {
+    const fakeResponse = new Response(
+      opts.body !== undefined ? JSON.stringify(opts.body) : null,
+      {
+        status: opts.status,
+        headers: opts.contentType ? { "content-type": opts.contentType } : {},
+      },
+    );
+    // Mock global.fetch for the shim's single call.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => fakeResponse.clone();
+    try {
+      const { _fetchWithRateLimitDetectForTests } = await import(
+        "../src/modules/solana/rpc.js"
+      );
+      // Drain the response body in the shim path; production calls .clone()
+      // first, so the original is still readable to the caller. We just
+      // care whether recordSolanaPublicError got called.
+      _resetRuntimeRpcOverridesForTests();
+      const before = getSolanaPublicErrorCount();
+      await _fetchWithRateLimitDetectForTests("https://api.mainnet-beta.solana.com");
+      const after = getSolanaPublicErrorCount();
+      return { throttled: after > before, errorCount: after };
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  it("HTTP 429 → counted (existing behavior, lock-in)", async () => {
+    expect((await detectThrottle({ status: 429 })).throttled).toBe(true);
+  });
+
+  it("HTTP 410 → counted (Solana public sometimes returns 410 for throttled methods)", async () => {
+    expect((await detectThrottle({ status: 410 })).throttled).toBe(true);
+  });
+
+  it("HTTP 503 → counted (overloaded public node)", async () => {
+    expect((await detectThrottle({ status: 503 })).throttled).toBe(true);
+  });
+
+  it("HTTP 200 + JSON-RPC error code -32429 → counted", async () => {
+    const res = await detectThrottle({
+      status: 200,
+      contentType: "application/json",
+      body: { jsonrpc: "2.0", id: 1, error: { code: -32429, message: "Too Many Requests" } },
+    });
+    expect(res.throttled).toBe(true);
+  });
+
+  it("HTTP 200 + JSON-RPC error code -32005 → counted (Alchemy-style rate limit)", async () => {
+    const res = await detectThrottle({
+      status: 200,
+      contentType: "application/json",
+      body: { jsonrpc: "2.0", id: 1, error: { code: -32005, message: "rate limit exceeded" } },
+    });
+    expect(res.throttled).toBe(true);
+  });
+
+  it("HTTP 200 + JSON-RPC error message matching /rate.?limit|too many|throttl|quota/ → counted", async () => {
+    // Custom error code but recognizable message — covers operators that
+    // pick a different numeric code while still surfacing the limit.
+    const res = await detectThrottle({
+      status: 200,
+      contentType: "application/json",
+      body: { jsonrpc: "2.0", id: 1, error: { code: -1, message: "RPC quota exceeded for this IP" } },
+    });
+    expect(res.throttled).toBe(true);
+  });
+
+  it("HTTP 200 with success body → NOT counted (don't treat normal responses as throttling)", async () => {
+    const res = await detectThrottle({
+      status: 200,
+      contentType: "application/json",
+      body: { jsonrpc: "2.0", id: 1, result: { context: { slot: 100 }, value: 42 } },
+    });
+    expect(res.throttled).toBe(false);
+  });
+
+  it("HTTP 200 + non-JSON body → NOT counted (fail-open on parse errors)", async () => {
+    const res = await detectThrottle({
+      status: 200,
+      contentType: "text/plain",
+      body: "OK",
+    });
+    expect(res.throttled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #410. Reporter saw 9-10 Solana rate-limit errors during a normal demo-mode session with no Helius nudge surfacing — two issues were masking it.

### 1. Reactive nudge wasn't catching real-world throttling shapes

`fetchWithRateLimitDetect` (the shim attached to `Connection({ fetch })`) only checked for HTTP 429. `api.mainnet-beta.solana.com` actually surfaces throttling as:

| Shape | Caught before | Caught now |
|---|---|---|
| `HTTP 429` | ✓ | ✓ |
| `HTTP 410 Gone` (restricted method on public endpoint) | ✗ | ✓ |
| `HTTP 503` (overloaded node) | ✗ | ✓ |
| `HTTP 200 + body { error: { code: -32429, ... } }` | ✗ | ✓ |
| `HTTP 200 + body { error: { code: -32005, ... } }` (Alchemy-style) | ✗ | ✓ |
| `HTTP 200 + body { error: { message: "rate limit ..." } }` (custom code) | ✗ | ✓ |

Body parsing uses `res.clone()` so the SDK still gets an unconsumed `Response`. Any parse error is fail-open (don't count, don't break).

### 2. Reactive isn't enough — adds a proactive nudge

Even with reliable detection, the user finds out about `set_helius_api_key` only AFTER hitting an error. Reactive UX.

New `recordProactivePublicAccess("helius")` fires once per session from `getSolanaConnection()` when the resolved URL is the public mainnet endpoint and no override is set. The existing renderer now branches on `errorCount === 0` to swap the reactive "you've hit N errors" prose for a proactive "Solana RPC is using the public endpoint — that throttles aggressively under any real walkthrough; here's how to add a free Helius key in 60 seconds."

The proactive nudge yields to a reactive one if both are pending (a real error count is more useful than speculative wording).

## What changed

| File | Change |
|---|---|
| `src/data/runtime-rpc-overrides.ts` | (a) Helius `renderNudge` branches on `errorCount === 0` for proactive prose; (b) new `recordProactivePublicAccess(service)` fn with once-per-session dedup state; (c) `setRuntimeOverride` marks proactive as fired (user has acted); (d) `clearRuntimeOverride` re-arms it; (e) `_resetRuntimeRpcOverridesForTests` clears the new state too |
| `src/modules/solana/rpc.ts` | (a) Broadened `fetchWithRateLimitDetect` (HTTP 410/503 + JSON-RPC body codes -32429/-32005 + rate-limit-shaped error messages); (b) `getSolanaConnection` calls `recordProactivePublicAccess("helius")` when URL matches the public mainnet endpoint; (c) new `_fetchWithRateLimitDetectForTests` export so unit tests can hit the shim without going through web3.js's `Connection` internals |
| `test/runtime-rpc-overrides.test.ts` | New `describe` blocks: 6 tests for proactive trigger semantics + 8 tests for broadened HTTP/body detection |

## Test plan

- [x] `npx vitest run` — 164 files, 2024 tests, all green (14 new in this PR)
- [x] `npx tsc --noEmit` — clean
- [ ] Live (post-merge): start a fresh demo session with no Helius key, run `get_portfolio_summary` against a Solana-bearing persona, confirm the proactive Helius setup nudge appears in the response BEFORE any rate-limit error
- [ ] Live: continue running Solana tools without adding a key; confirm the reactive "hit N rate-limit errors" nudge fires on what the issue called the "first rate-limit error" (whatever shape — 429, 410, 503, or JSON-RPC body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)