### PR TITLE
chore(release): bump to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
Patch release covering everything that landed since 0.11.0 (~9 PRs).

## Highlights

- **Demo / first-contact UX** — actionable Etherscan-key error message (#413), preflight skill PIN block on every tool response so Step 0 actually runs (#414), agent-loop trap closer + Solana handle fix in broadcastSimulationDispatch (#409), proactive Helius nudge + broader public-RPC throttle detection (#410), in-memory address book in demo mode, persona enrichment (rehearsableFlows / flowGaps), AGENTS.md decoupling restart from demo framing (#408).
- **Swap routing** — \`exchanges\` / \`bridges\` filter on \`prepare_swap\` + \`get_swap_quote\` with \`routedVia\` surfacing so receipts make the actual route obvious (#411).
- **Aave UX** — symbol + alternatives in frozen/paused market errors (#412).
- **CI** — drop binary-smoke-test PR job; release-binaries.yml still covers it.
- **Repo discipline** — CLAUDE.md: branch every PR off main, drop stacking pattern.

## Included PRs

- #422 fix(demo): state-precondition hint on prepare_* failures (#409)
- #423 fix(solana): proactive Helius nudge (#410)
- #421 feat(swap): protocol routing filter + routedVia (#411)
- #420 feat(demo): rehearsableFlows + flowGaps per persona cell
- #419 fix(aave): symbol + alternatives in frozen/paused error (#412)
- #418 chore(claude): always branch from main
- #417 fix(preflight): emit PIN block on every tool response (#414)
- #416 fix: actionable EtherscanApiKeyMissingError (#413)
- #415 docs(agents): decouple restart from demo framing (#408)
- #407 ci: drop binary-smoke-test
- #406 feat(demo): in-memory address book

## Deliberately deferred

- **Demo state overlay (Options A/C of #409).** Loop-trap closed via the cheap advisory hint (Option B); virtual state overlay across every protocol and pre-warmed persona fixtures stay deferred — heavier ops cost, low-traffic benefit until the basic demo flows are exercised in the wild more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)