### PR TITLE
Demo saga followups: items #3–#7 from plan parking lot

### DIFF
--- a/.github/workflows/verify-personas.yml
+++ b/.github/workflows/verify-personas.yml
@@ -1,0 +1,48 @@
+name: Verify demo personas
+
+# Out-of-tree watcher for src/demo/personas.ts cell drift. Personas
+# point at real public wallets that may go quiet or rotate over time;
+# this workflow runs cheap liveness checks via public chain APIs and
+# exits non-zero (failing the run) if any cell looks dead.
+#
+# Trigger: workflow_dispatch (manual) + weekly cron. Not blocking on
+# PRs — drift is caught after the fact, not at PR time. The intent is
+# that a maintainer reviews the failing run, refreshes the offending
+# cell in src/demo/personas.ts, and bumps verifiedAt.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Mondays 06:00 UTC. Picked off-peak so a flaky public-RPC
+    # response doesn't drown out CI alerts on weekday work hours.
+    - cron: "0 6 * * 1"
+
+jobs:
+  verify:
+    name: Liveness check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install
+        run: npm ci --legacy-peer-deps
+
+      - name: Build (provides dist/demo/personas.js)
+        run: npm run build
+
+      - name: Verify personas
+        id: verify
+        run: node scripts/verify-personas.mjs | tee verify-personas.report.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-personas-report
+          path: verify-personas.report.md
+          retention-days: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,22 @@ If you genuinely want to contribute on a tracking issue, demonstrate it by:
 1. Opening a small, focused PR against an actual bug or already-scoped task first, so we have signal that you understand the codebase.
 2. Asking a specific clarifying question that shows you read the issue and the linked code — pick one of the open decisions in the issue and propose a defensible answer with reasoning.
 
+## Testing demo mode locally
+
+Demo mode runs the server without RPC keys, Ledger pairing, or a config file:
+
+```bash
+VAULTPILOT_DEMO=true node dist/index.js
+```
+
+Or wire it into a local Claude Code session:
+
+```bash
+claude mcp add vaultpilot-mcp-dev --env VAULTPILOT_DEMO=true -- node /absolute/path/to/vaultpilot-mcp/dist/index.js
+```
+
+Useful when changing `src/demo/`, the `prepare_*` refusal/simulation paths, or `buildSimulationEnvelope` — unit tests cover contract correctness, but the agent-UX class of regressions (persona drift, simulation envelope readability, nudge timing) only surface in a live walkthrough.
+
 ## Reporting security issues
 
 Do **not** open a public issue for vulnerabilities. See [SECURITY.md](./SECURITY.md) for the disclosure process.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,39 @@ npm run setup
 
 Environment variables always override the config file.
 
+## Demo mode
+
+For try-before-install exploration without RPC keys, Ledger pairing, or running the wizard, set `VAULTPILOT_DEMO=true`:
+
+```bash
+claude mcp add vaultpilot-mcp --env VAULTPILOT_DEMO=true -- npx -y vaultpilot-mcp
+```
+
+What demo mode does:
+
+- Reads run against real on-chain RPC, but every wallet is one of a curated set of public personas (`whale`, `defi-degen`, `stable-saver`, `staking-maxi`) — no key access, no signing.
+- `send_transaction` is intercepted and returns a [simulation envelope](src/demo/index.ts) — the unsigned tx is `simulate_transaction`'d for revert detection, but nothing is signed and nothing is broadcast.
+- Pairing tools (`pair_ledger_*`), `request_capability`, and on-device signing (`sign_message_*`) are refused outright in demo, since none have an on-chain simulation equivalent.
+
+Picking a persona:
+
+- `get_demo_wallet` lists all personas with their per-chain curated addresses + `rehearsableFlows` (multi-step flows the wallet's existing on-chain state already supports end-to-end).
+- `set_demo_wallet({ persona: "defi-degen" })` activates one. Default mode (no persona) refuses signing-class tools with a structured error pointing at this call.
+- Multi-step flows whose preconditions are themselves state changes (e.g. `prepare_solana_nonce_init` → `marinade_stake`) cannot be rehearsed end-to-end — simulated sends don't mutate chain state. The MCP surfaces a one-shot hint when the agent-loop trap is detected.
+
+API key overrides without restart:
+
+- Solana public RPC throttles within seconds under multi-tool fan-out. Inject a [Helius](https://helius.dev) key at runtime: `set_helius_api_key({ key: "..." })`. The override applies to the next Solana RPC call. Demo mode also nudges proactively every 10 public-RPC throttle errors.
+
+Leaving demo:
+
+- `exit_demo_mode` returns a tailored handoff guide — preflight checks, per-chain RPC recommendations, and the exact `claude mcp add ...` recipe with `VAULTPILOT_DEMO` removed plus a setup-wizard launch step.
+
+Caveats:
+
+- Demo state is process-local and ephemeral; restart loses persona selection.
+- Demo is a scaffold for first-contact, not a sandbox — there is no virtual chain overlay. Permanent setup is what `vaultpilot-mcp-setup` is for.
+
 ## Use with Claude Desktop / Claude Code / Cursor
 
 `vaultpilot-mcp-setup` detects which agent clients you have installed and offers to add a `vaultpilot-mcp` entry to each one's MCP-server config automatically. Each existing config is backed up to `<file>.vaultpilot.bak` before any change. Detected client paths:
@@ -245,6 +278,7 @@ All optional if the matching field is in `~/.vaultpilot-mcp/config.json`; env va
 - `VAULTPILOT_FEEDBACK_ENDPOINT` — optional https proxy for `request_capability` direct POSTs. **The client does not sign or authenticate requests — the proxy MUST enforce its own auth.**
 - `VAULTPILOT_SKILL_MARKER_PATH` — suppresses the preflight-skill notice for read-only users who accept the tradeoff
 - `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` — skips the lazy first-run `git clone` of the companion preflight + setup skills into `~/.claude/skills/`. The original manual-install notice fires instead. Use for air-gapped / no-egress operation where the MCP must not contact github.com.
+- `VAULTPILOT_DEMO=true` — enables [demo mode](#demo-mode) (curated personas + simulated `send_transaction`, no signing, no broadcast). Set the literal string `true`; any other value is rejected with a diagnostic message.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,15 @@ Environment variables always override the config file.
 
 ## Demo mode
 
-For try-before-install exploration without RPC keys, Ledger pairing, or running the wizard, set `VAULTPILOT_DEMO=true`:
+For try-before-install exploration without RPC keys, Ledger pairing, or running the wizard, set `VAULTPILOT_DEMO=true` (or pass `--demo`):
 
 ```bash
 claude mcp add vaultpilot-mcp --env VAULTPILOT_DEMO=true -- npx -y vaultpilot-mcp
+# or, equivalently:
+claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp --demo
 ```
+
+`--demo` is a thin alias that sets `VAULTPILOT_DEMO=true` before initialization. An explicit env value (including `VAULTPILOT_DEMO=false`) wins over the flag — useful when scripted invocations need a deterministic opt-out.
 
 What demo mode does:
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "setup": "node dist/setup.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify-personas": "node scripts/verify-personas.mjs",
     "bundle": "pkg .",
     "prepare": "patch-package"
   },

--- a/scripts/verify-personas.mjs
+++ b/scripts/verify-personas.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Persona address rotation watcher.
+ *
+ * Personas in `src/demo/personas.ts` point at real public wallets that
+ * may drift over time — a "stable-saver" cell could exit all USDC
+ * positions tomorrow, leaving the persona description false. This
+ * script does cheap liveness checks against public RPC / public chain
+ * APIs and prints a markdown report flagging cells that look dead or
+ * drifted. Designed for `workflow_dispatch` (manual + weekly cron) so
+ * a human reviews the report and refreshes the matrix when needed.
+ *
+ * Scope is intentionally minimal: we verify the address still exists
+ * and has a non-zero native balance for the chain. We do NOT try to
+ * verify per-flow rehearsability (e.g. "does this wallet actually
+ * have an Aave V3 supply position?") — that would require per-protocol
+ * SDK setup with API keys, which is out of scope for an out-of-tree
+ * weekly watcher. Liveness is the cheap proxy: a wallet that's gone
+ * from "exchange hot wallet" to zero balance has clearly rotated.
+ *
+ * Usage:
+ *   npm run build                      # produce dist/demo/personas.js
+ *   node scripts/verify-personas.mjs   # prints report, exits 0 / 1
+ */
+import { DEMO_WALLETS } from "../dist/demo/personas.js";
+
+const TIMEOUT_MS = 15_000;
+
+async function fetchWithTimeout(url, init) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function evmNativeBalance(address) {
+  const res = await fetchWithTimeout("https://ethereum-rpc.publicnode.com", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_getBalance",
+      params: [address, "latest"],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(json.error.message);
+  return BigInt(json.result);
+}
+
+async function solanaNativeBalance(address) {
+  const res = await fetchWithTimeout("https://api.mainnet-beta.solana.com", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getBalance",
+      params: [address],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(json.error.message);
+  return BigInt(json.result.value);
+}
+
+async function tronNativeBalance(address) {
+  const res = await fetchWithTimeout(
+    `https://api.trongrid.io/v1/accounts/${address}`,
+  );
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  const account = json.data?.[0];
+  if (!account) return 0n;
+  return BigInt(account.balance ?? 0);
+}
+
+async function btcAddressTxCount(address) {
+  const res = await fetchWithTimeout(
+    `https://mempool.space/api/address/${address}`,
+  );
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  return (json.chain_stats?.tx_count ?? 0) + (json.mempool_stats?.tx_count ?? 0);
+}
+
+function isTransientErr(err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  // Rate-limit / abort / network reset: not drift, just public-API noise.
+  return /HTTP 429|HTTP 5\d\d|aborted|fetch failed|ECONN/i.test(msg);
+}
+
+async function checkCell(chain, type, cell) {
+  try {
+    if (chain === "evm") {
+      const wei = await evmNativeBalance(cell.address);
+      return {
+        status: wei > 0n ? "alive" : "drifted",
+        detail: `${(Number(wei) / 1e18).toFixed(4)} ETH`,
+      };
+    }
+    if (chain === "solana") {
+      const lamports = await solanaNativeBalance(cell.address);
+      return {
+        status: lamports > 0n ? "alive" : "drifted",
+        detail: `${(Number(lamports) / 1e9).toFixed(4)} SOL`,
+      };
+    }
+    if (chain === "tron") {
+      const sun = await tronNativeBalance(cell.address);
+      return {
+        status: sun > 0n ? "alive" : "drifted",
+        detail: `${(Number(sun) / 1e6).toFixed(4)} TRX`,
+      };
+    }
+    if (chain === "bitcoin") {
+      const txCount = await btcAddressTxCount(cell.address);
+      return {
+        status: txCount > 0 ? "alive" : "drifted",
+        detail: `${txCount} txs (lifetime)`,
+      };
+    }
+    return { status: "drifted", detail: `unknown chain: ${chain}` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      status: isTransientErr(err) ? "inconclusive" : "drifted",
+      detail: `error: ${msg}`,
+    };
+  }
+}
+
+async function main() {
+  const lines = [];
+  lines.push("# Persona address rotation report");
+  lines.push("");
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push("");
+  lines.push("| Chain | Type | Address | Status | Detail |");
+  lines.push("|-------|------|---------|--------|--------|");
+
+  let drifted = 0;
+  let inconclusive = 0;
+  let total = 0;
+  for (const [chain, byType] of Object.entries(DEMO_WALLETS)) {
+    for (const [type, cell] of Object.entries(byType)) {
+      if (!cell) continue;
+      total++;
+      const { status, detail } = await checkCell(chain, type, cell);
+      const label =
+        status === "alive" ? "✓ alive" : status === "inconclusive" ? "⚠ inconclusive" : "✗ drifted";
+      if (status === "drifted") drifted++;
+      else if (status === "inconclusive") inconclusive++;
+      const shortAddr = cell.address.slice(0, 8) + "…" + cell.address.slice(-4);
+      lines.push(`| ${chain} | ${type} | \`${shortAddr}\` | ${label} | ${detail} |`);
+    }
+  }
+
+  lines.push("");
+  const alive = total - drifted - inconclusive;
+  lines.push(
+    `**Summary:** ${alive} / ${total} cells alive, ${drifted} drifted, ${inconclusive} inconclusive (transient API errors — re-run later).`,
+  );
+  if (drifted > 0) {
+    lines.push("");
+    lines.push("Drifted cells need attention — refresh the wallet in `src/demo/personas.ts` and bump `verifiedAt`.");
+  }
+
+  const report = lines.join("\n");
+  console.log(report);
+  // Inconclusive results don't fail the workflow — they're rate-limit
+  // noise, not real drift. A genuine drift requires a confirmed
+  // empty-balance / no-activity response.
+  process.exit(drifted > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("verify-personas failed:", err);
+  process.exit(2);
+});

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -468,15 +468,116 @@ export function alwaysGatedRefusalMessage(toolName: string): string {
 }
 
 /**
+ * Map a `prepare_*` tool name to candidate `rehearsableFlows` IDs we
+ * can search the matrix against. The matrix uses chain-agnostic flow
+ * IDs (`native_send`, `aave_supply`, `marinade_stake`); tool names
+ * encode the chain (`prepare_solana_native_send`, `prepare_aave_supply`,
+ * `prepare_marinade_stake`). We strip the `prepare_` prefix and try
+ * the bare form plus chain-prefix-stripped forms so most prepare tools
+ * map cleanly. A miss just falls through to the "no persona matches"
+ * branch in `defaultModeRefusalMessage`.
+ */
+function candidateFlowIds(toolName: string): string[] {
+  if (!toolName.startsWith("prepare_")) return [];
+  const tail = toolName.slice("prepare_".length);
+  const set = new Set<string>([tail]);
+  for (const prefix of ["solana_", "tron_", "btc_", "litecoin_"]) {
+    if (tail.startsWith(prefix)) set.add(tail.slice(prefix.length));
+  }
+  return Array.from(set);
+}
+
+/**
+ * Chain a `prepare_*` tool targets, derived from its name prefix.
+ * EVM tools have no chain prefix (e.g. `prepare_aave_supply`,
+ * `prepare_native_send`) and return null — those should match against
+ * any chain. Returning a chain restricts the matrix search so e.g.
+ * `prepare_solana_native_send` doesn't recommend `staking-maxi`
+ * (which has no Solana cell) just because every EVM cell rehearses
+ * `native_send`.
+ */
+function chainHintForTool(toolName: string): DemoChain | null {
+  if (!toolName.startsWith("prepare_")) return null;
+  const tail = toolName.slice("prepare_".length);
+  if (tail.startsWith("solana_")) return "solana";
+  if (tail.startsWith("tron_")) return "tron";
+  if (tail.startsWith("btc_")) return "bitcoin";
+  return null;
+}
+
+/**
+ * Recommended personas for a given tool. A persona is recommended
+ * when ANY of its curated cells (on the tool's chain, or any chain
+ * if the tool has no chain prefix) lists a `rehearsableFlows` entry
+ * matching one of the candidate flow IDs (exact match, or the cell's
+ * flow starts with `<candidate>_` so `token_send` matches
+ * `token_send_usdc` / `token_send_usdt`).
+ *
+ * The result is sorted by `DEMO_TYPES` order so the message reads
+ * deterministically across runs.
+ */
+function recommendPersonasFor(toolName: string): DemoType[] {
+  const candidates = candidateFlowIds(toolName);
+  if (candidates.length === 0) return [];
+  const chainHint = chainHintForTool(toolName);
+  const chains: readonly DemoChain[] = chainHint ? [chainHint] : DEMO_CHAINS;
+  const matched = new Set<DemoType>();
+  for (const chain of chains) {
+    for (const type of DEMO_TYPES) {
+      const cell = DEMO_WALLETS[chain][type];
+      if (!cell) continue;
+      const hit = cell.rehearsableFlows.some((flow) =>
+        candidates.some((c) => flow === c || flow.startsWith(c + "_")),
+      );
+      if (hit) matched.add(type);
+    }
+  }
+  return DEMO_TYPES.filter((t) => matched.has(t));
+}
+
+/**
  * Structured refusal for conditionally-gated tools when no live wallet
  * is set. Points the user at `set_demo_wallet` so the upgrade path is
  * discoverable from the error itself.
+ *
+ * Message branches on persona-affinity (issue #371 follow-up #7): if
+ * one persona's curated state matches the requested flow, recommend it
+ * specifically rather than dumping the full list. Sourced from the
+ * persona matrix's `rehearsableFlows`, so refreshing the matrix
+ * automatically updates the recommendations — no separate table to
+ * keep in sync.
  */
 export function defaultModeRefusalMessage(toolName: string): string {
+  const recommended = recommendPersonasFor(toolName);
+  const allPersonas = DEMO_TYPES.map((t) => `\`${t}\``).join(", ");
+  let recommendation: string;
+  if (recommended.length === 1) {
+    const others = DEMO_TYPES.filter((t) => t !== recommended[0])
+      .map((t) => `\`${t}\``)
+      .join(", ");
+    recommendation =
+      `Recommended persona: \`${recommended[0]}\` — its curated wallet's on-chain ` +
+      `state already supports this flow end-to-end. ` +
+      `Other personas: ${others}.`;
+  } else if (recommended.length > 1 && recommended.length < DEMO_TYPES.length) {
+    recommendation =
+      `Recommended personas: ${recommended.map((p) => `\`${p}\``).join(", ")}. ` +
+      `Other personas (${DEMO_TYPES.filter((t) => !recommended.includes(t))
+        .map((t) => `\`${t}\``)
+        .join(", ")}) don't have on-chain state for this specific flow.`;
+  } else if (recommended.length === DEMO_TYPES.length) {
+    recommendation = `Available personas: ${allPersonas}.`;
+  } else {
+    recommendation =
+      `Available personas: ${allPersonas}. Note: no persona's curated wallet ` +
+      `currently has on-chain state matching this specific flow, so the prepare ` +
+      `may fail with a state-precondition error. To rehearse this flow end-to-end, ` +
+      `leave demo via \`exit_demo_mode\` and pair a wallet whose state supports it.`;
+  }
   return (
     `[VAULTPILOT_DEMO] '${toolName}' requires an active demo wallet — call ` +
     `\`set_demo_wallet({ persona: "<id>" })\` first to enable the simulated transaction ` +
-    `flow. Available personas: defi-degen, stable-saver, staking-maxi, whale. ` +
+    `flow. ${recommendation} ` +
     `In default demo mode (no live wallet), only read tools and \`set_demo_wallet\` work — ` +
     `signing-class tools refuse to avoid any chance of fake-signing or fake-broadcasting. ` +
     `If you'd rather leave demo entirely and use this tool against your real wallet, call ` +

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -82,6 +82,25 @@ export function initDemoMode(): void {
 }
 
 /**
+ * `--demo` CLI alias. Lets users write `npx vaultpilot-mcp --demo`
+ * instead of `claude mcp add ... --env VAULTPILOT_DEMO=true -- ...`.
+ * MUST be called BEFORE `initDemoMode()` so the env mutation is
+ * visible to `getDemoModeEnvState()`.
+ *
+ * Idempotency rules:
+ *   - If `VAULTPILOT_DEMO` is already set (any value, including
+ *     `"false"`), the explicit env wins. A `--demo` + `VAULTPILOT_DEMO=
+ *     false` combination is ambiguous, so we honor the explicit opt-out
+ *     rather than silently overriding it.
+ *   - If `--demo` is absent, no-op.
+ */
+export function applyDemoCliFlag(argv: readonly string[]): void {
+  if (!argv.includes("--demo")) return;
+  if (process.env.VAULTPILOT_DEMO !== undefined) return;
+  process.env.VAULTPILOT_DEMO = "true";
+}
+
+/**
  * Test-only: reset the latch so different test cases can simulate
  * different boot states. Production code MUST NOT call this.
  */

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -476,23 +476,29 @@ export function defaultModeRefusalMessage(toolName: string): string {
  * unsigned tx and passing the result in — keeping the envelope construction
  * pure makes it easy to test independently of the simulation surface.
  */
+export interface SimulationEnvelope {
+  demo: true;
+  outcome: "simulated";
+  toolName: string;
+  unsignedTxHandle: string;
+  simulatedTxHash: string;
+  simulation: unknown;
+  preview: unknown;
+  message: string;
+}
+
 export function buildSimulationEnvelope(args: {
   toolName: string;
   unsignedTxHandle: string;
   simulationResult: unknown;
   pinnedPreview?: unknown;
-}): {
-  demo: true;
-  outcome: "simulated";
-  simulatedTxHash: string;
-  simulation: unknown;
-  preview: unknown;
-  message: string;
-} {
+}): SimulationEnvelope {
   const simulatedTxHash = makeSimulatedTxHash(args.unsignedTxHandle);
   return {
     demo: true,
     outcome: "simulated",
+    toolName: args.toolName,
+    unsignedTxHandle: args.unsignedTxHandle,
     simulatedTxHash,
     simulation: args.simulationResult,
     preview: args.pinnedPreview ?? null,
@@ -504,6 +510,70 @@ export function buildSimulationEnvelope(args: {
       `any block explorer. To execute for real: unset VAULTPILOT_DEMO, restart the MCP ` +
       `server with a real Ledger paired, then re-run the prepare → preview → send flow.`,
   };
+}
+
+/**
+ * Markdown narrative for the simulation envelope. Mirrors the
+ * `renderVerificationBlock` / `renderPrepareReceiptBlock` pattern used
+ * by the real broadcast path: agents need a verbatim-relayable
+ * paragraph they can show the user without re-decoding the JSON
+ * `simulation` field. Best-effort summary of the simulation outcome —
+ * `simulation` is `unknown` because different chains return different
+ * shapes (viem's `{ status }`, our `{ simulationDeferredToPreview }`
+ * for Solana, our `{ simulationFailed | simulationSkipped, reason }`
+ * for the unhandled-handle paths). The renderer pattern-matches the
+ * shapes we know and falls back to "see `simulation` field" otherwise.
+ */
+export function renderSimulationEnvelopeBlock(envelope: SimulationEnvelope): string {
+  const status = summarizeSimulationStatus(envelope.simulation);
+  const lines: string[] = [];
+  lines.push("**[VAULTPILOT_DEMO] Simulated broadcast — nothing on-chain**");
+  lines.push("");
+  lines.push(`- **Tool:** \`${envelope.toolName}\``);
+  lines.push(`- **Handle:** \`${envelope.unsignedTxHandle}\``);
+  lines.push(
+    `- **Placeholder hash:** \`${envelope.simulatedTxHash}\` (not real — block explorers return "unknown")`,
+  );
+  lines.push(`- **Simulation:** ${status}`);
+  lines.push("");
+  lines.push(
+    "To execute for real: unset `VAULTPILOT_DEMO`, restart the MCP server with a real Ledger paired, then re-run the prepare → preview → send flow.",
+  );
+  return lines.join("\n");
+}
+
+function summarizeSimulationStatus(simulation: unknown): string {
+  if (simulation === null || simulation === undefined) {
+    return "no simulation result attached";
+  }
+  if (typeof simulation !== "object") {
+    return `see \`simulation\` field (raw: ${typeof simulation})`;
+  }
+  const obj = simulation as Record<string, unknown>;
+  if (obj.simulationDeferredToPreview === true) {
+    return "validated at `preview_solana_send` time (Solana pre-sign sim)";
+  }
+  if (obj.simulationFailed === true) {
+    return `failed — ${formatReason(obj.reason)}`;
+  }
+  if (obj.simulationSkipped === true) {
+    return `skipped — ${formatReason(obj.reason)}`;
+  }
+  if (obj.status === "success" || obj.ok === true) {
+    return "would succeed";
+  }
+  if (obj.status === "reverted" || obj.status === "failure") {
+    const reason = obj.revertReason ?? obj.error ?? obj.reason;
+    return `would revert${reason ? ` — ${formatReason(reason)}` : ""}`;
+  }
+  return "see `simulation` field for details";
+}
+
+function formatReason(reason: unknown): string {
+  if (typeof reason === "string") {
+    return reason.length > 200 ? reason.slice(0, 197) + "..." : reason;
+  }
+  return "see `simulation` field";
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   alwaysGatedRefusalMessage,
   defaultModeRefusalMessage,
   buildSimulationEnvelope,
+  renderSimulationEnvelopeBlock,
   buildGetDemoWalletResponse,
   demoStatePreconditionHint,
   getDemoModeReason,
@@ -1126,6 +1127,7 @@ async function broadcastSimulationDispatch(
   });
   return {
     content: [
+      { type: "text" as const, text: renderSimulationEnvelopeBlock(envelope) },
       { type: "text" as const, text: JSON.stringify(envelope, bigintReplacer, 2) },
     ],
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   isConditionallyGatedTool,
   isBroadcastTool,
   alwaysGatedRefusalMessage,
+  applyDemoCliFlag,
   defaultModeRefusalMessage,
   buildSimulationEnvelope,
   renderSimulationEnvelopeBlock,
@@ -1347,6 +1348,12 @@ async function main() {
   // + env-var inspection, no chain reads or transport open. Static import
   // (not dynamic) so the binary path stays compatible — issue #330 noted
   // dynamic imports at startup throw under pkg's snapshot.
+  // `--demo` CLI alias — sets VAULTPILOT_DEMO=true so the env-var
+  // gate fires identically to the `--env VAULTPILOT_DEMO=true` path.
+  // Must run before `parseDoctorFlags` (so `--check` sees demo mode
+  // on) and before `initDemoMode` (which reads the env var).
+  applyDemoCliFlag(process.argv);
+
   const doctorFlags = parseDoctorFlags(process.argv);
   if (doctorFlags.enabled) {
     const report = runDoctor();

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -314,6 +314,44 @@ describe("renderSimulationEnvelopeBlock — markdown narrative", () => {
   });
 });
 
+describe("applyDemoCliFlag — --demo CLI alias", () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env.VAULTPILOT_DEMO;
+    delete process.env.VAULTPILOT_DEMO;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.VAULTPILOT_DEMO;
+    else process.env.VAULTPILOT_DEMO = originalEnv;
+  });
+
+  it("sets VAULTPILOT_DEMO=true when --demo present and env unset", async () => {
+    const { applyDemoCliFlag } = await import("../src/demo/index.js");
+    applyDemoCliFlag(["node", "vaultpilot-mcp", "--demo"]);
+    expect(process.env.VAULTPILOT_DEMO).toBe("true");
+  });
+
+  it("does NOT overwrite an explicit env opt-out (--demo + VAULTPILOT_DEMO=false)", async () => {
+    const { applyDemoCliFlag } = await import("../src/demo/index.js");
+    process.env.VAULTPILOT_DEMO = "false";
+    applyDemoCliFlag(["node", "vaultpilot-mcp", "--demo"]);
+    expect(process.env.VAULTPILOT_DEMO).toBe("false");
+  });
+
+  it("does NOT overwrite an explicit env enable (already true)", async () => {
+    const { applyDemoCliFlag } = await import("../src/demo/index.js");
+    process.env.VAULTPILOT_DEMO = "true";
+    applyDemoCliFlag(["node", "vaultpilot-mcp", "--demo"]);
+    expect(process.env.VAULTPILOT_DEMO).toBe("true");
+  });
+
+  it("is a no-op when --demo absent", async () => {
+    const { applyDemoCliFlag } = await import("../src/demo/index.js");
+    applyDemoCliFlag(["node", "vaultpilot-mcp", "--check"]);
+    expect(process.env.VAULTPILOT_DEMO).toBeUndefined();
+  });
+});
+
 describe("Live-mode state mgmt — persona / custom / clear", () => {
   beforeEach(async () => {
     const { _resetLiveWalletForTests } = await import("../src/demo/live-mode.js");

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -199,6 +199,119 @@ describe("buildSimulationEnvelope — broadcast intercept shape", () => {
     });
     expect(a.simulatedTxHash).not.toBe(b.simulatedTxHash);
   });
+
+  it("envelope echoes toolName + handle so the markdown renderer can use them", async () => {
+    const { buildSimulationEnvelope } = await import("../src/demo/index.js");
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-xyz",
+      simulationResult: null,
+    });
+    expect(env.toolName).toBe("send_transaction");
+    expect(env.unsignedTxHandle).toBe("h-xyz");
+  });
+});
+
+describe("renderSimulationEnvelopeBlock — markdown narrative", () => {
+  it("includes tool, handle, simulated hash, and the not-on-chain caveat", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-abc-123",
+      simulationResult: { ok: true },
+    });
+    const md = renderSimulationEnvelopeBlock(env);
+    expect(md).toContain("[VAULTPILOT_DEMO]");
+    expect(md).toContain("nothing on-chain");
+    expect(md).toContain("`send_transaction`");
+    expect(md).toContain("`h-abc-123`");
+    expect(md).toContain(env.simulatedTxHash);
+    // Action paragraph the agent should relay verbatim.
+    expect(md).toContain("unset `VAULTPILOT_DEMO`");
+  });
+
+  it("summarizes a successful viem-shape simulation as 'would succeed'", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-1",
+      simulationResult: { status: "success" },
+    });
+    expect(renderSimulationEnvelopeBlock(env)).toContain("would succeed");
+  });
+
+  it("summarizes a reverted simulation with the revert reason", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-2",
+      simulationResult: { status: "reverted", revertReason: "insufficient allowance" },
+    });
+    const md = renderSimulationEnvelopeBlock(env);
+    expect(md).toContain("would revert");
+    expect(md).toContain("insufficient allowance");
+  });
+
+  it("summarizes the Solana deferred-to-preview shape", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-sol",
+      simulationResult: { simulationDeferredToPreview: true, chain: "solana" },
+    });
+    expect(renderSimulationEnvelopeBlock(env)).toContain("preview_solana_send");
+  });
+
+  it("summarizes the simulationFailed shape with reason", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-fail",
+      simulationResult: { simulationFailed: true, reason: "RPC timeout" },
+    });
+    const md = renderSimulationEnvelopeBlock(env);
+    expect(md).toContain("failed");
+    expect(md).toContain("RPC timeout");
+  });
+
+  it("summarizes the simulationSkipped shape", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-skip",
+      simulationResult: {
+        simulationSkipped: true,
+        reason: "Handle not found in tx-store",
+      },
+    });
+    const md = renderSimulationEnvelopeBlock(env);
+    expect(md).toContain("skipped");
+    expect(md).toContain("Handle not found");
+  });
+
+  it("falls back to 'see simulation field' for unrecognized shapes", async () => {
+    const { buildSimulationEnvelope, renderSimulationEnvelopeBlock } = await import(
+      "../src/demo/index.js"
+    );
+    const env = buildSimulationEnvelope({
+      toolName: "send_transaction",
+      unsignedTxHandle: "h-unknown",
+      simulationResult: { somethingWeird: 42 },
+    });
+    expect(renderSimulationEnvelopeBlock(env)).toContain("see `simulation` field");
+  });
 });
 
 describe("Live-mode state mgmt — persona / custom / clear", () => {

--- a/test/demo.test.ts
+++ b/test/demo.test.ts
@@ -141,11 +141,54 @@ describe("Refusal messages — stable prefix + actionable content", () => {
     expect(msg).toContain("'prepare_native_send'");
     expect(msg).toContain("set_demo_wallet");
     // Lists the four personas by ID so the agent can offer them to the user
-    // without an extra get_demo_wallet call.
+    // without an extra get_demo_wallet call. native_send is universal
+    // across all persona cells, so the message lands in the
+    // "all personas qualify" branch.
     expect(msg).toContain("defi-degen");
     expect(msg).toContain("stable-saver");
     expect(msg).toContain("staking-maxi");
     expect(msg).toContain("whale");
+  });
+
+  it("defaultModeRefusalMessage recommends a single persona when only one cell rehearses the flow", async () => {
+    // aave_supply is rehearsable on evm/defi-degen and explicitly
+    // gapped on whale + stable-saver. Recommendation should be
+    // defi-degen specifically, with the others mentioned as fallback.
+    const { defaultModeRefusalMessage } = await import("../src/demo/index.js");
+    const msg = defaultModeRefusalMessage("prepare_aave_supply");
+    expect(msg).toContain("Recommended persona: `defi-degen`");
+    expect(msg).toContain("on-chain state already supports this flow end-to-end");
+    // Other personas still get listed for fallback context.
+    expect(msg).toContain("stable-saver");
+    expect(msg).toContain("whale");
+  });
+
+  it("defaultModeRefusalMessage recommends staking-maxi for prepare_lido_stake", async () => {
+    const { defaultModeRefusalMessage } = await import("../src/demo/index.js");
+    const msg = defaultModeRefusalMessage("prepare_lido_stake");
+    expect(msg).toContain("Recommended persona: `staking-maxi`");
+  });
+
+  it("defaultModeRefusalMessage strips the solana_ prefix when matching flow IDs", async () => {
+    // prepare_solana_native_send → native_send candidate. Solana cells
+    // for whale + defi-degen + stable-saver have native_send rehearsable;
+    // staking-maxi is not curated on solana. Expect a multi-persona
+    // recommendation, NOT the all-personas fallback.
+    const { defaultModeRefusalMessage } = await import("../src/demo/index.js");
+    const msg = defaultModeRefusalMessage("prepare_solana_native_send");
+    expect(msg).toContain("Recommended persona");
+    // staking-maxi should appear as "other" since it has no solana cell.
+    expect(msg).toContain("staking-maxi");
+  });
+
+  it("defaultModeRefusalMessage falls back when no persona's curated state matches", async () => {
+    // aave_borrow is in flowGaps for every cell, never rehearsable —
+    // the fallback message should warn about state-precondition fails
+    // and point at exit_demo_mode.
+    const { defaultModeRefusalMessage } = await import("../src/demo/index.js");
+    const msg = defaultModeRefusalMessage("prepare_aave_borrow");
+    expect(msg).toContain("no persona's curated wallet currently has on-chain state");
+    expect(msg).toContain("exit_demo_mode");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements items #3–#7 from [plan-demo-saga-followups.md](claude-work/plan-demo-saga-followups.md). Items #1 (manual smoke test, owner: maintainer) and #2 (Etherscan + Reservoir runtime overrides, blocked by #1) are deliberately deferred.

Five commits, one logical unit each:

- **`#3 feat(demo): markdown-render the simulation envelope`** — adds `renderSimulationEnvelopeBlock(envelope)` that emits a verbatim-relayable markdown block alongside the JSON envelope, mirroring the `renderVerificationBlock` / `renderPrepareReceiptBlock` pattern. Pattern-matches the four simulation shapes (viem `{ status }`, Solana deferred-to-preview, our `simulationFailed` / `simulationSkipped`) with a fallback for unrecognized shapes.
- **`#4 docs(demo): document current demo model in README + CONTRIBUTING`** — new "Demo mode" section between Setup and the MCP-client wiring (env activation, persona list, simulation envelope semantics, `set_demo_wallet` flow, `set_helius_api_key` runtime override, `exit_demo_mode` handoff guide, agent-loop-trap caveat) + `VAULTPILOT_DEMO` in the env-var list. CONTRIBUTING gets a short "Testing demo mode locally" section.
- **`#5 ci(demo): persona address rotation watcher`** — out-of-tree `scripts/verify-personas.mjs` with weekly `workflow_dispatch` + cron trigger. Cheap public-RPC liveness checks; three statuses (alive / drifted / inconclusive — rate-limit transients don't fail the run). Smoke-tested locally: 9/10 cells alive, 1 inconclusive (TRON 429), 0 drifted.
- **`#6 feat(demo): --demo CLI alias`** — `npx vaultpilot-mcp --demo` sets `VAULTPILOT_DEMO=true` before init. Idempotent: an explicit env value (including the opt-out `false`) wins over the flag.
- **`#7 feat(demo): smart per-tool persona recommendations`** — `defaultModeRefusalMessage` now branches on persona-affinity, sourced from the matrix's `rehearsableFlows` so it auto-stays in sync with cell curation. Chain-aware: `prepare_solana_native_send` only searches solana cells.

## Test plan

- [x] Full vitest suite green: 2067/2067 pass
- [x] Typecheck clean (`tsc --noEmit`)
- [x] `scripts/verify-personas.mjs` smoke-tested against live public RPC (9/10 alive, exit 0)
- [ ] Manual demo-mode walkthrough — deferred to plan item #1 (owner: maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)