### PR TITLE
feat: VAULTPILOT NOTICE — Update available

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ All optional if the matching field is in `~/.vaultpilot-mcp/config.json`; env va
 - `VAULTPILOT_SKILL_MARKER_PATH` — suppresses the preflight-skill notice for read-only users who accept the tradeoff
 - `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1` — skips the lazy first-run `git clone` of the companion preflight + setup skills into `~/.claude/skills/`. The original manual-install notice fires instead. Use for air-gapped / no-egress operation where the MCP must not contact github.com.
 - `VAULTPILOT_DEMO=true` — enables [demo mode](#demo-mode) (curated personas + simulated `send_transaction`, no signing, no broadcast). Set the literal string `true`; any other value is rejected with a diagnostic message.
+- `VAULTPILOT_DISABLE_UPDATE_CHECK=1` — skips the once-per-session `registry.npmjs.org` GET that surfaces a `VAULTPILOT NOTICE — Update available` block when a newer stable is published. Same air-gapped / no-egress use case.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ import { explainTxInput } from "./modules/postmortem/schemas.js";
 import { getPortfolioSummaryInput } from "./modules/portfolio/schemas.js";
 
 import { getVaultPilotConfigStatus } from "./modules/diagnostics/index.js";
+import { getUpdateCommand } from "./modules/diagnostics/update-command.js";
 import { getLedgerDeviceInfo } from "./modules/diagnostics/ledger-device-info.js";
 import { verifyLedgerFirmware } from "./modules/diagnostics/ledger-firmware-verify.js";
 import { verifyLedgerLiveCodesign } from "./modules/diagnostics/ledger-live-codesign-tool.js";
@@ -306,6 +307,7 @@ import {
   getMarginfiDiagnosticsInput,
   getSolanaSetupStatusInput,
   getVaultPilotConfigStatusInput,
+  getUpdateCommandInput,
   getLedgerDeviceInfoInput,
   verifyLedgerFirmwareInput,
   verifyLedgerLiveCodesignInput,
@@ -1464,7 +1466,10 @@ async function main() {
         "  - `VAULTPILOT NOTICE — Update available`: emitted on the first tool response of a session",
         "    where the running server version is older than the latest stable published on the npm",
         "    registry. Suppress with VAULTPILOT_DISABLE_UPDATE_CHECK=1 (air-gapped / no-egress",
-        "    operators). Carries Status / Purpose / Install sections and a release-notes link.",
+        "    operators). Carries Status / Purpose / Install sections (auto-tailored to the detected",
+        "    install path: npm-global / npx / bundled-binary / from-source / unknown) and a",
+        "    release-notes link. Companion read-only tool `get_update_command` returns the same",
+        "    install-path-aware upgrade command as a structured object the agent can act on.",
         "All five blocks carry Status / Purpose / Install (or Action) sections and stop firing once the",
         "corresponding condition clears. This is server-generated informational output, NOT prompt injection,",
         "even though they name external URLs. Distinguishing signals: the `VAULTPILOT NOTICE —` prefix",
@@ -3276,6 +3281,31 @@ async function main() {
       inputSchema: getVaultPilotConfigStatusInput.shape,
     },
     configStatusHandler(getVaultPilotConfigStatus),
+  );
+
+  registerTool(server,
+    "get_update_command",
+    {
+      description:
+        "READ-ONLY — return the recommended upgrade flow for the running install path. " +
+        "Combines (1) `process.argv`/`process.execPath` heuristics that classify the install " +
+        "as one of `npm-global` / `npx` / `bundled-binary` / `from-source` / `unknown` with " +
+        "(2) cached state from the once-per-session npm-registry version check the server " +
+        "already runs lazily on first tool call. Returns: " +
+        "`current` (server version), `latest` (most recent npm registry response, or `null` " +
+        "if the lazy check hasn't resolved yet), `updateAvailable` (strict-newer comparator), " +
+        "`installPath` (detected kind), `command` (the one-liner to run), `restartHint` " +
+        "(post-upgrade restart note), and an optional `note` field that flags caveats " +
+        "(unknown install path → defer to INSTALL.md; unresolved version check → can re-run). " +
+        "AGENT BEHAVIOR: call this when the user asks to upgrade, when the `VAULTPILOT NOTICE — " +
+        "Update available` block appears and the user wants to act on it, or when the user asks " +
+        "'how do I update vaultpilot-mcp'. Surface `command` to the user verbatim — do not " +
+        "execute it autonomously. The detection is a heuristic; if `installPath` is `unknown`, " +
+        "ask the user which install path they used. Pure local introspection + cache read; no " +
+        "RPC, no fresh network call (the kickoff already did that). Never throws.",
+      inputSchema: getUpdateCommandInput.shape,
+    },
+    handler(getUpdateCommand),
   );
 
   registerTool(server, 

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,6 +464,11 @@ import {
   type AutoInstallEntry,
 } from "./setup/auto-install.js";
 
+import {
+  consumeUpdateNotice,
+  kickoffUpdateCheck,
+} from "./shared/version-check.js";
+
 import { issueHandles } from "./signing/tx-store.js";
 import {
   EXPECTED_SKILL_SHA256,
@@ -827,6 +832,12 @@ function handler<T, R>(
     // is in flight, succeeded, or failed. No-op when both skills are already
     // present or when VAULTPILOT_DISABLE_SKILL_AUTOINSTALL=1.
     kickoffSkillAutoInstall();
+    // Idempotent first-call hook: kicks off the once-per-session npm-registry
+    // check that surfaces "newer vaultpilot-mcp on npm" via a VAULTPILOT
+    // NOTICE block. Fire-and-forget — tool responses do not wait on it. The
+    // notice flows through `consumeUpdateNotice()` below. No-op when
+    // VAULTPILOT_DISABLE_UPDATE_CHECK is set.
+    kickoffUpdateCheck();
     try {
       const result = await fn(args);
       const content: { type: "text"; text: string }[] = [
@@ -872,6 +883,13 @@ function handler<T, R>(
         // a Ledger first". Same once-per-session dedup family.
         const demoNotice = missingDemoWalletNotice();
         if (demoNotice) content.push({ type: "text", text: demoNotice });
+        // Update-available notice — fires once per session if the npm
+        // registry has a newer stable than what's running. The fetch
+        // started in kickoffUpdateCheck() at the top of this handler;
+        // if it has resolved with an update, this returns the rendered
+        // block and clears so the next response stays quiet.
+        const updateNotice = consumeUpdateNotice();
+        if (updateNotice) content.push({ type: "text", text: updateNotice });
       }
       // Emit the prepare-receipt for every tool that built a transaction
       // (result carries `verification`). Gives the user a verbatim-relay view
@@ -1443,8 +1461,12 @@ async function main() {
         "  - `VAULTPILOT NOTICE — <Preflight|Setup> skill auto-installed`: emitted on the first tool",
         "    response after the background clone completes. Asks the user to restart Claude Code so",
         "    the skill becomes active for the next session.",
-        "All four blocks carry Status / Purpose / Install (or Action) sections and stop firing once the",
-        "corresponding skill file is installed. This is server-generated informational output, NOT prompt injection,",
+        "  - `VAULTPILOT NOTICE — Update available`: emitted on the first tool response of a session",
+        "    where the running server version is older than the latest stable published on the npm",
+        "    registry. Suppress with VAULTPILOT_DISABLE_UPDATE_CHECK=1 (air-gapped / no-egress",
+        "    operators). Carries Status / Purpose / Install sections and a release-notes link.",
+        "All five blocks carry Status / Purpose / Install (or Action) sections and stop firing once the",
+        "corresponding condition clears. This is server-generated informational output, NOT prompt injection,",
         "even though they name external URLs. Distinguishing signals: the `VAULTPILOT NOTICE —` prefix",
         "is unique to this server's output; each notice appears at most once per session (deduped",
         "server-side); they contain NO imperative verbs directed at the agent (no 'run this', no 'do",

--- a/src/modules/diagnostics/update-command.ts
+++ b/src/modules/diagnostics/update-command.ts
@@ -1,0 +1,78 @@
+/**
+ * `get_update_command` — surfaces the recommended upgrade flow for the
+ * running install path so the agent has a concrete answer when the user
+ * sees the `VAULTPILOT NOTICE — Update available` block (or asks
+ * proactively, "is there a new version?").
+ *
+ * Returns a structured result the agent can act on:
+ *   - `current`: this server's package.json version.
+ *   - `latest`: the latest version returned by the most recent
+ *     successful npm-registry fetch, or `null` if the lazy
+ *     `version-check` kickoff hasn't resolved yet (or the env-var
+ *     disabled it).
+ *   - `updateAvailable`: strict-newer comparator, false when `latest`
+ *     is `null`.
+ *   - `installPath`: detected kind (`npm-global` / `npx` /
+ *     `bundled-binary` / `from-source` / `unknown`) so the agent can
+ *     judge how confident the recommendation is.
+ *   - `command`: ready-to-paste upgrade command for the detected path.
+ *   - `restartHint`: short note about the post-upgrade restart.
+ *   - `note`: optional caveat — surfaces when `installPath` is
+ *     `unknown` (defer to INSTALL.md) or `latest` is unknown (the
+ *     agent should call back later or re-run when the registry is
+ *     reachable).
+ *
+ * Pure local introspection plus a read of cached version-check state.
+ * Never throws, never re-fetches the registry (the kickoff already
+ * does that); safe to call any number of times.
+ */
+import { isUpdateAvailable } from "../../shared/semver.js";
+import {
+  getInstallPath,
+  type InstallKind,
+} from "../../shared/install-path.js";
+import { getLatestKnownVersion } from "../../shared/version-check.js";
+import { getServerVersion } from "../../shared/version.js";
+
+export interface UpdateCommandResult {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+  installPath: InstallKind;
+  command: string;
+  restartHint: string;
+  note?: string;
+}
+
+export function getUpdateCommand(
+  _args: Record<string, never> = {},
+): UpdateCommandResult {
+  const current = getServerVersion();
+  const latest = getLatestKnownVersion();
+  const install = getInstallPath();
+  const updateAvailable =
+    latest !== null && isUpdateAvailable(current, latest);
+
+  let note: string | undefined;
+  if (latest === null) {
+    note =
+      "The npm-registry version check hasn't resolved yet (or VAULTPILOT_DISABLE_UPDATE_CHECK is set). " +
+      "The `command` is still correct for the detected install path; the agent can re-run this tool " +
+      "after a few seconds or check https://www.npmjs.com/package/vaultpilot-mcp directly.";
+  } else if (install.kind === "unknown") {
+    note =
+      "Install path could not be detected from process.argv / process.execPath. " +
+      "Ask the user how they installed vaultpilot-mcp (npm, bundled binary, source, Docker) " +
+      "and refer to INSTALL.md for the matching update flow.";
+  }
+
+  return {
+    current,
+    latest,
+    updateAvailable,
+    installPath: install.kind,
+    command: install.recommendedCommand,
+    restartHint: install.restartHint,
+    ...(note ? { note } : {}),
+  };
+}

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -595,6 +595,15 @@ export const prepareTronLifiSwapInput = z.object({
 export const getVaultPilotConfigStatusInput = z.object({});
 
 /**
+ * No args — `get_update_command` returns the recommended upgrade flow for
+ * the running install path (npm-global / npx / bundled-binary / from-
+ * source / unknown), the current and latest known versions, and the
+ * "restart Claude Code after" reminder. Pure local introspection +
+ * cached npm-registry version lookup; never throws.
+ */
+export const getUpdateCommandInput = z.object({});
+
+/**
  * No args — `get_ledger_device_info` opens a USB HID transport to the
  * connected Ledger, issues the dashboard-level GET_APP_AND_VERSION APDU
  * (CLA=0xb0 INS=0x01), and returns the name/version of the currently-
@@ -1725,6 +1734,7 @@ export type PrepareBitcoinRbfBumpArgs = z.infer<typeof prepareBitcoinRbfBumpInpu
 export type PrepareBitcoinLifiSwapArgs = z.infer<typeof prepareBitcoinLifiSwapInput>;
 export type SignBtcMessageArgs = z.infer<typeof signBtcMessageInput>;
 export type GetVaultPilotConfigStatusArgs = z.infer<typeof getVaultPilotConfigStatusInput>;
+export type GetUpdateCommandArgs = z.infer<typeof getUpdateCommandInput>;
 export type GetLedgerDeviceInfoArgs = z.infer<typeof getLedgerDeviceInfoInput>;
 export type VerifyLedgerFirmwareArgs = z.infer<typeof verifyLedgerFirmwareInput>;
 export type VerifyLedgerLiveCodesignArgs = z.infer<typeof verifyLedgerLiveCodesignInput>;

--- a/src/shared/install-path.ts
+++ b/src/shared/install-path.ts
@@ -1,0 +1,178 @@
+/**
+ * Heuristic detection of how this `vaultpilot-mcp` process was installed,
+ * so the update-available notice and the `get_update_command` tool can
+ * surface the right upgrade command for the running install path —
+ * not just the npm-global default.
+ *
+ * Returns one of five kinds based on `process.argv[0]` (the binary or
+ * `node`), `process.argv[1]` (the script under node), `process.execPath`,
+ * and the npm user-agent env var. Each kind ships a recommended
+ * upgrade command + restart hint.
+ *
+ * Heuristics, not gospel: agent should still surface the answer to the
+ * user rather than execute the upgrade autonomously. The `kind` field
+ * lets the agent distinguish "I confidently know the path" (`npm-global`,
+ * `bundled-binary`, etc.) from `unknown` (defer to INSTALL.md).
+ */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type InstallKind =
+  | "npm-global"
+  | "npx"
+  | "bundled-binary"
+  | "from-source"
+  | "unknown";
+
+export interface InstallPathInfo {
+  kind: InstallKind;
+  /**
+   * Path the heuristic latched onto. Returned for diagnostic use only —
+   * not surfaced in the user-facing notice.
+   */
+  detectedFrom: string;
+  /** Recommended upgrade command, ready to render verbatim. */
+  recommendedCommand: string;
+  /**
+   * Multi-line install block formatted for the VAULTPILOT NOTICE — Update
+   * available block. Indented to line up under the `Install:` label.
+   */
+  noticeInstallBlock: string;
+  /** Short restart hint shown alongside the command. */
+  restartHint: string;
+}
+
+let cached: InstallPathInfo | null = null;
+
+export function getInstallPath(): InstallPathInfo {
+  if (cached !== null) return cached;
+  cached = detect();
+  return cached;
+}
+
+/** For tests — clears the memoized detection so test fixtures can swap argv. */
+export function _resetInstallPathCacheForTests(): void {
+  cached = null;
+}
+
+function detect(): InstallPathInfo {
+  const argv0 = process.argv[0] ?? "";
+  const argv1 = process.argv[1] ?? "";
+  const execPath = process.execPath ?? "";
+  const ua = process.env.npm_config_user_agent ?? "";
+
+  const argv0Base = baseName(argv0);
+  const argv1Norm = argv1.replace(/\\/g, "/");
+  const isNodeArgv0 = /^node(\.exe)?$/i.test(argv0Base);
+
+  // Bundled binary: argv[0] is the SEA binary itself, not `node`. The
+  // binary name carries `vaultpilot-mcp` (per INSTALL.md Path A naming).
+  if (!isNodeArgv0 && /vaultpilot-mcp/i.test(argv0Base)) {
+    return {
+      kind: "bundled-binary",
+      detectedFrom: argv0,
+      recommendedCommand:
+        "curl -fsSL https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.sh | bash",
+      noticeInstallBlock: [
+        "         (bundled-binary install detected)",
+        "         curl -fsSL https://github.com/szhygulin/vaultpilot-mcp/releases/",
+        "           latest/download/install.sh | bash",
+        "         Windows PowerShell: iwr <same path>/install.ps1 -UseBasicParsing | iex.",
+        "         Or download the new binaries from the GitHub releases page.",
+        "         Restart Claude Code after the new binary is in place.",
+      ].join("\n"),
+      restartHint: "Restart Claude Code after the new binary is in place.",
+    };
+  }
+
+  // npx: argv[1] resolves under an npx cache dir, or the npm user-agent
+  // explicitly says npx.
+  if (
+    /\/_npx\//.test(argv1Norm) ||
+    /\/\.npm\/_npx\//.test(argv1Norm) ||
+    /\bnpx\b/i.test(ua)
+  ) {
+    return {
+      kind: "npx",
+      detectedFrom: argv1 || ua,
+      recommendedCommand:
+        "npx --prefer-online -y vaultpilot-mcp@latest  # or just restart Claude Code",
+      noticeInstallBlock: [
+        "         (npx-launched install detected)",
+        "         Restart Claude Code — `npx -y vaultpilot-mcp@latest` will fetch",
+        "         the new version on the next launch (npm registry cache may delay",
+        "         this up to ~10 minutes; pass --prefer-online for immediate refresh).",
+      ].join("\n"),
+      restartHint: "Restart Claude Code; npx pulls the new version on next launch.",
+    };
+  }
+
+  // From source: argv[1] sits inside a checked-out git tree. Walk up at
+  // most 6 levels looking for `.git/`. Distinct from npm-global because
+  // npm never installs into a directory with a `.git/` ancestor.
+  if (argv1) {
+    let dir = dirname(argv1);
+    for (let i = 0; i < 6 && dir.length > 1; i++) {
+      if (existsSync(join(dir, ".git"))) {
+        return {
+          kind: "from-source",
+          detectedFrom: argv1,
+          recommendedCommand: `git -C ${dir} pull && npm install --legacy-peer-deps && npm run build`,
+          noticeInstallBlock: [
+            "         (from-source install detected)",
+            `         git -C ${dir} pull \\`,
+            "           && npm install --legacy-peer-deps \\",
+            "           && npm run build",
+            "         Restart Claude Code after the rebuild completes.",
+          ].join("\n"),
+          restartHint: "Restart Claude Code after the rebuild completes.",
+        };
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  // npm-global: argv[1] sits under a known global node_modules path. Check
+  // AFTER the from-source walk so a developer running `npm link` from a
+  // checked-out repo lands on `from-source` instead.
+  if (
+    /\/lib\/node_modules\//.test(argv1Norm) ||
+    /\/node_modules\/\.bin\//.test(argv1Norm) ||
+    /\/\.npm\//.test(argv1Norm) ||
+    /\/npm\/node_modules\//.test(argv1Norm) ||
+    /\/homebrew\/.*node_modules\//.test(argv1Norm)
+  ) {
+    return {
+      kind: "npm-global",
+      detectedFrom: argv1,
+      recommendedCommand: "npm install -g vaultpilot-mcp@latest",
+      noticeInstallBlock: [
+        "         (npm-global install detected)",
+        "         npm install -g vaultpilot-mcp@latest",
+        "         Restart Claude Code after upgrading so the new binary loads.",
+      ].join("\n"),
+      restartHint:
+        "Restart Claude Code after upgrading so the new binary loads.",
+    };
+  }
+
+  return {
+    kind: "unknown",
+    detectedFrom: argv0 || execPath,
+    recommendedCommand:
+      "See https://github.com/szhygulin/vaultpilot-mcp/blob/main/INSTALL.md",
+    noticeInstallBlock: [
+      "         (install path could not be detected — check INSTALL.md)",
+      "         https://github.com/szhygulin/vaultpilot-mcp/blob/main/INSTALL.md",
+      "         covers npm, bundled-binary, source, and Docker update flows.",
+      "         Restart Claude Code after upgrading.",
+    ].join("\n"),
+    restartHint: "Restart Claude Code after upgrading.",
+  };
+}
+
+function baseName(p: string): string {
+  return p.split(/[/\\]/).pop() ?? "";
+}

--- a/src/shared/semver.ts
+++ b/src/shared/semver.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimal semver comparator. Just enough for the npm-registry "is there a
+ * newer version" check; not a full semver implementation.
+ *
+ * Recognized shape: `MAJOR.MINOR.PATCH` with optional `-prerelease`
+ * (single dotted identifier list) and an optional `+build` suffix that's
+ * stripped before compare. Anything malformed → `0` (treat as "not
+ * strictly newer") so the update-check gracefully degrades to silence
+ * rather than firing a noisy notice on garbage input.
+ *
+ * Prerelease ordering follows semver §11: any prerelease is LESS than the
+ * same MAJOR.MINOR.PATCH without one (so `0.11.0-rc.1` < `0.11.0`).
+ * Numeric prerelease identifiers compare numerically; non-numeric
+ * compare ASCII.
+ */
+export type Cmp = -1 | 0 | 1;
+
+interface Parsed {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[] | null;
+}
+
+const RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function parse(s: string): Parsed | null {
+  if (typeof s !== "string") return null;
+  const m = RE.exec(s.trim());
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ? m[4].split(".") : null,
+  };
+}
+
+function cmpNum(a: number, b: number): Cmp {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function cmpPrerelease(a: string[] | null, b: string[] | null): Cmp {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1; // no prerelease > any prerelease
+  if (b === null) return -1;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i];
+    const bi = b[i];
+    const an = /^\d+$/.test(ai);
+    const bn = /^\d+$/.test(bi);
+    if (an && bn) {
+      const c = cmpNum(Number(ai), Number(bi));
+      if (c !== 0) return c;
+    } else if (an !== bn) {
+      // Numeric identifiers always have lower precedence than non-numeric.
+      return an ? -1 : 1;
+    } else {
+      if (ai < bi) return -1;
+      if (ai > bi) return 1;
+    }
+  }
+  return cmpNum(a.length, b.length);
+}
+
+/**
+ * Compare two semver strings. Returns -1 if a < b, 1 if a > b, 0 otherwise
+ * (including malformed input on either side).
+ */
+export function compareSemver(a: string, b: string): Cmp {
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return 0;
+  let c = cmpNum(pa.major, pb.major);
+  if (c !== 0) return c;
+  c = cmpNum(pa.minor, pb.minor);
+  if (c !== 0) return c;
+  c = cmpNum(pa.patch, pb.patch);
+  if (c !== 0) return c;
+  return cmpPrerelease(pa.prerelease, pb.prerelease);
+}
+
+/**
+ * True iff `latest` is strictly greater than `current` AND both are stable
+ * (no prerelease tag on either side). The "stable beats stable" gate keeps
+ * us from nagging users on a stable when the only newer publish is a
+ * prerelease — npm's `dist-tag latest` skips prereleases by convention,
+ * so this is defense-in-depth rather than expected hot path.
+ */
+export function isUpdateAvailable(current: string, latest: string): boolean {
+  const pa = parse(current);
+  const pb = parse(latest);
+  if (!pa || !pb) return false;
+  if (pa.prerelease !== null || pb.prerelease !== null) return false;
+  return compareSemver(latest, current) === 1;
+}

--- a/src/shared/version-check.ts
+++ b/src/shared/version-check.ts
@@ -23,6 +23,7 @@
  * (mirrors the `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL` shape).
  */
 import { renderUpdateAvailableNotice } from "../signing/render-verification.js";
+import { getInstallPath } from "./install-path.js";
 import { isUpdateAvailable } from "./semver.js";
 import { getServerVersion } from "./version.js";
 
@@ -33,6 +34,13 @@ const PACKAGE_NAME = "vaultpilot-mcp";
 let kickoffStarted = false;
 let resolvedNotice: string | null = null;
 let noticeEmitted = false;
+/**
+ * Latest version observed from the npm registry, regardless of whether it
+ * is newer than the current. Surfaced through `getLatestKnownVersion()`
+ * so the `get_update_command` tool can report a concrete latest version
+ * to the agent rather than `null` when no update is needed.
+ */
+let latestKnownVersion: string | null = null;
 
 function isDisabled(): boolean {
   const v = process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
@@ -56,6 +64,7 @@ export function _resetUpdateCheckForTests(): void {
   kickoffStarted = false;
   resolvedNotice = null;
   noticeEmitted = false;
+  latestKnownVersion = null;
 }
 
 /**
@@ -91,11 +100,14 @@ async function runCheck(): Promise<void> {
     if (!body || typeof body.version !== "string") return;
     const current = getServerVersion();
     const latest = body.version;
+    latestKnownVersion = latest;
     if (!isUpdateAvailable(current, latest)) return;
+    const install = getInstallPath();
     resolvedNotice = renderUpdateAvailableNotice({
       current,
       latest,
       packageName: PACKAGE_NAME,
+      installBlock: install.noticeInstallBlock,
     });
   } catch {
     // Silent fall-through — see module header.
@@ -112,4 +124,15 @@ export function consumeUpdateNotice(): string | null {
   if (resolvedNotice === null) return null;
   noticeEmitted = true;
   return resolvedNotice;
+}
+
+/**
+ * Latest version returned by the most recent successful npm-registry
+ * fetch, regardless of whether it is newer than the current. `null`
+ * means the fetch hasn't resolved yet (or failed silently). Used by
+ * `get_update_command` so it can surface a concrete latest version
+ * even when no update is available.
+ */
+export function getLatestKnownVersion(): string | null {
+  return latestKnownVersion;
 }

--- a/src/shared/version-check.ts
+++ b/src/shared/version-check.ts
@@ -1,0 +1,115 @@
+/**
+ * Lazy, fire-and-forget npm-registry check that surfaces a once-per-session
+ * `VAULTPILOT NOTICE — Update available` block when a newer stable is
+ * published.
+ *
+ * Lifecycle:
+ *   - `kickoffUpdateCheck()` is called from the top of every tool handler.
+ *     The first call kicks off a single GET against
+ *     `registry.npmjs.org/vaultpilot-mcp/latest`; subsequent calls are
+ *     no-ops while that promise is in flight or has resolved. Tool
+ *     responses do NOT await it.
+ *   - `consumeUpdateNotice()` is called once per response. It returns the
+ *     rendered notice text the first time the promise has resolved with
+ *     an update available, then `null` forever after.
+ *
+ * Failure modes — network error, non-200 status, malformed JSON, missing
+ * `.version` field, comparator throws — all silently fall through to "no
+ * notice this session." The check is informational; never surfaces a
+ * network error to the user. See `claude-work/plan-update-available-
+ * notice.md` for the full threat model.
+ *
+ * Honors `VAULTPILOT_DISABLE_UPDATE_CHECK=1` for air-gapped operators
+ * (mirrors the `VAULTPILOT_DISABLE_SKILL_AUTOINSTALL` shape).
+ */
+import { renderUpdateAvailableNotice } from "../signing/render-verification.js";
+import { isUpdateAvailable } from "./semver.js";
+import { getServerVersion } from "./version.js";
+
+const REGISTRY_URL = "https://registry.npmjs.org/vaultpilot-mcp/latest";
+const FETCH_TIMEOUT_MS = 3000;
+const PACKAGE_NAME = "vaultpilot-mcp";
+
+let kickoffStarted = false;
+let resolvedNotice: string | null = null;
+let noticeEmitted = false;
+
+function isDisabled(): boolean {
+  const v = process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
+  if (!v) return false;
+  return v !== "0" && v.toLowerCase() !== "false";
+}
+
+/**
+ * Optional fetch override for tests — lets a test plug a stub without
+ * mocking `globalThis.fetch`. Returns `null` to fall through to the
+ * default fetch.
+ */
+type FetchFn = typeof fetch;
+let fetchOverride: FetchFn | null = null;
+
+export function _setFetchForTests(fn: FetchFn | null): void {
+  fetchOverride = fn;
+}
+
+export function _resetUpdateCheckForTests(): void {
+  kickoffStarted = false;
+  resolvedNotice = null;
+  noticeEmitted = false;
+}
+
+/**
+ * Idempotent kickoff. Synchronous-returning even though it starts an async
+ * fetch — callers never await this, the resolved notice flows through
+ * `consumeUpdateNotice()`.
+ */
+export function kickoffUpdateCheck(): void {
+  if (kickoffStarted) return;
+  kickoffStarted = true;
+  if (isDisabled()) return;
+  void runCheck();
+}
+
+async function runCheck(): Promise<void> {
+  try {
+    const f = fetchOverride ?? globalThis.fetch;
+    if (typeof f !== "function") return;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await f(REGISTRY_URL, {
+        method: "GET",
+        headers: { accept: "application/json" },
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) return;
+    const body = (await res.json()) as { version?: unknown };
+    if (!body || typeof body.version !== "string") return;
+    const current = getServerVersion();
+    const latest = body.version;
+    if (!isUpdateAvailable(current, latest)) return;
+    resolvedNotice = renderUpdateAvailableNotice({
+      current,
+      latest,
+      packageName: PACKAGE_NAME,
+    });
+  } catch {
+    // Silent fall-through — see module header.
+  }
+}
+
+/**
+ * Returns the rendered notice text on the first successful resolve where
+ * an update is available; subsequent calls return `null`. Safe to call on
+ * every tool response.
+ */
+export function consumeUpdateNotice(): string | null {
+  if (noticeEmitted) return null;
+  if (resolvedNotice === null) return null;
+  noticeEmitted = true;
+  return resolvedNotice;
+}

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,58 @@
+/**
+ * Read this server's currently-running version from the bundled
+ * `package.json`. Resolved relative to this module's URL so it works under
+ * `node dist/index.js`, `npx`, the bundled binary, and tests.
+ *
+ * Memoized — `package.json` doesn't change while the process is running.
+ * On a read failure (deleted, malformed, missing `version`) returns
+ * `"0.0.0"` so the update check degrades silently rather than throwing
+ * out of a tool handler.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+let cached: string | null = null;
+
+export function getServerVersion(): string {
+  if (cached !== null) return cached;
+  cached = readVersionUncached();
+  return cached;
+}
+
+/** For tests — clears the memoized read so test fixtures can swap files. */
+export function _resetServerVersionCacheForTests(): void {
+  cached = null;
+}
+
+function readVersionUncached(): string {
+  // From `dist/shared/version.js` or `src/shared/version.ts`, walk up to
+  // the package root. `package.json` is two levels up at runtime
+  // (`dist/shared/version.js` → `dist/` → root), and two levels up under
+  // ts-node from source as well (`src/shared/version.ts` → `src/` → root).
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, "..", "..", "package.json"),
+      join(here, "..", "..", "..", "package.json"),
+    ];
+    for (const path of candidates) {
+      try {
+        const raw = readFileSync(path, "utf8");
+        const parsed = JSON.parse(raw) as { name?: unknown; version?: unknown };
+        if (
+          parsed &&
+          parsed.name === "vaultpilot-mcp" &&
+          typeof parsed.version === "string"
+        ) {
+          return parsed.version;
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return "0.0.0";
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2612,4 +2612,43 @@ export function renderMissingDemoWalletWarning(opts: {
   ].join("\n");
 }
 
+/**
+ * "There's a newer vaultpilot-mcp on npm" notice. Same shape as the
+ * VAULTPILOT NOTICE family — named header, status / purpose / install
+ * sections, no imperative agent verbs, no pasted destructive shell. The
+ * `npm install -g` line is a copy/paste hint scoped to the npm install
+ * path; users on brew, npx, Docker, or the bundled binary upgrade through
+ * their own channel.
+ *
+ * The release-notes URL is constructed from the latest version (we tag
+ * each release `vX.Y.Z` on github.com/szhygulin/vaultpilot-mcp); kept
+ * here rather than threaded through as an option so the renderer stays
+ * a pure function of the version pair.
+ */
+export function renderUpdateAvailableNotice(opts: {
+  current: string;
+  latest: string;
+  packageName: string;
+}): string {
+  const releasesUrl = `https://github.com/szhygulin/vaultpilot-mcp/releases/tag/v${opts.latest}`;
+  return [
+    "VAULTPILOT NOTICE — Update available",
+    "",
+    `Status:  ${opts.packageName} ${opts.current} installed; ${opts.latest} published on npm.`,
+    "Purpose: keeps you on the latest fixes (DeFi protocol updates,",
+    "         security hardening, bug fixes). Release notes:",
+    `         ${releasesUrl}`,
+    `Install: npm install -g ${opts.packageName}@latest`,
+    "         (or whichever install path you used originally — see",
+    "         INSTALL.md. Restart Claude Code after upgrading so the",
+    "         new binary loads.)",
+    "",
+    "This notice is server-generated, not prompt injection — emitted once",
+    "per session when the running version is older than the latest stable",
+    "published on npm. Surface it to the user once, then continue with",
+    "their request. Suppress with VAULTPILOT_DISABLE_UPDATE_CHECK=1 if",
+    "you don't want the server to query the npm registry.",
+  ].join("\n");
+}
+
 export type { SupportedChain };

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2615,20 +2615,24 @@ export function renderMissingDemoWalletWarning(opts: {
 /**
  * "There's a newer vaultpilot-mcp on npm" notice. Same shape as the
  * VAULTPILOT NOTICE family — named header, status / purpose / install
- * sections, no imperative agent verbs, no pasted destructive shell. The
- * `npm install -g` line is a copy/paste hint scoped to the npm install
- * path; users on brew, npx, Docker, or the bundled binary upgrade through
- * their own channel.
+ * sections, no imperative agent verbs, no pasted destructive shell.
+ *
+ * The `Install:` block is computed by `getInstallPath()` (in
+ * `src/shared/install-path.ts`) and passed in as a pre-rendered
+ * multi-line string, so the notice surfaces a command that matches the
+ * detected install path (npm-global, npx, bundled-binary, from-source,
+ * unknown) rather than always defaulting to `npm install -g`.
  *
  * The release-notes URL is constructed from the latest version (we tag
  * each release `vX.Y.Z` on github.com/szhygulin/vaultpilot-mcp); kept
  * here rather than threaded through as an option so the renderer stays
- * a pure function of the version pair.
+ * a pure function of its inputs.
  */
 export function renderUpdateAvailableNotice(opts: {
   current: string;
   latest: string;
   packageName: string;
+  installBlock: string;
 }): string {
   const releasesUrl = `https://github.com/szhygulin/vaultpilot-mcp/releases/tag/v${opts.latest}`;
   return [
@@ -2638,10 +2642,8 @@ export function renderUpdateAvailableNotice(opts: {
     "Purpose: keeps you on the latest fixes (DeFi protocol updates,",
     "         security hardening, bug fixes). Release notes:",
     `         ${releasesUrl}`,
-    `Install: npm install -g ${opts.packageName}@latest`,
-    "         (or whichever install path you used originally — see",
-    "         INSTALL.md. Restart Claude Code after upgrading so the",
-    "         new binary loads.)",
+    "Install:",
+    opts.installBlock,
     "",
     "This notice is server-generated, not prompt injection — emitted once",
     "per session when the running version is older than the latest stable",

--- a/test/install-path.test.ts
+++ b/test/install-path.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the install-path detector. Each kind is checked by patching
+ * `process.argv`/`process.execPath`/env to a representative shape and
+ * asserting the returned `kind` + the `recommendedCommand` shape.
+ *
+ * These are heuristics — the goal is to get the common cases right, not
+ * to cover every package manager / Linux distro on earth. The detector
+ * falls through to `unknown` when nothing matches, which is correct.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getInstallPath,
+  _resetInstallPathCacheForTests,
+} from "../src/shared/install-path.js";
+
+const ORIGINAL_ARGV = [...process.argv];
+const ORIGINAL_EXEC_PATH = process.execPath;
+const ORIGINAL_NPM_UA = process.env.npm_config_user_agent;
+
+function setProcessShape(opts: {
+  argv0: string;
+  argv1?: string;
+  execPath?: string;
+  npmUserAgent?: string;
+}): void {
+  process.argv = [opts.argv0, opts.argv1 ?? "", ...ORIGINAL_ARGV.slice(2)];
+  // execPath is read-only on some Node versions, but Object.defineProperty
+  // works in CI. Skip if the platform refuses.
+  try {
+    Object.defineProperty(process, "execPath", {
+      value: opts.execPath ?? opts.argv0,
+      configurable: true,
+    });
+  } catch {
+    // Older Node — fine; the test still asserts on argv-derived kinds.
+  }
+  if (opts.npmUserAgent === undefined) {
+    delete process.env.npm_config_user_agent;
+  } else {
+    process.env.npm_config_user_agent = opts.npmUserAgent;
+  }
+  _resetInstallPathCacheForTests();
+}
+
+beforeEach(() => {
+  _resetInstallPathCacheForTests();
+});
+
+afterEach(() => {
+  process.argv = ORIGINAL_ARGV;
+  try {
+    Object.defineProperty(process, "execPath", {
+      value: ORIGINAL_EXEC_PATH,
+      configurable: true,
+    });
+  } catch {
+    // ignore
+  }
+  if (ORIGINAL_NPM_UA === undefined) {
+    delete process.env.npm_config_user_agent;
+  } else {
+    process.env.npm_config_user_agent = ORIGINAL_NPM_UA;
+  }
+  _resetInstallPathCacheForTests();
+});
+
+describe("getInstallPath", () => {
+  it("detects bundled-binary by argv[0] basename", () => {
+    setProcessShape({
+      argv0: "/home/user/.local/bin/vaultpilot-mcp-linux-x64-0.11.0",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("bundled-binary");
+    expect(info.recommendedCommand).toMatch(/install\.sh \| bash/);
+    expect(info.noticeInstallBlock).toMatch(/bundled-binary install detected/);
+  });
+
+  it("detects npx via cache path", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/home/u/.npm/_npx/abc123/node_modules/vaultpilot-mcp/dist/index.js",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("npx");
+    expect(info.recommendedCommand).toMatch(/npx/);
+    expect(info.recommendedCommand).toMatch(/vaultpilot-mcp@latest/);
+  });
+
+  it("detects npx via npm_config_user_agent", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/some/random/path/index.js",
+      npmUserAgent: "npm/10.2.4 node/v20.10.0 linux x64 workspaces/false npx/10.2.4",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("npx");
+  });
+
+  it("detects npm-global by /lib/node_modules/ path", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("npm-global");
+    expect(info.recommendedCommand).toBe("npm install -g vaultpilot-mcp@latest");
+  });
+
+  it("detects npm-global on homebrew prefix", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/opt/homebrew/lib/node_modules/vaultpilot-mcp/dist/index.js",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("npm-global");
+  });
+
+  it("detects from-source via .git ancestor", () => {
+    const root = mkdtempSync(join(tmpdir(), "vaultpilot-source-"));
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, "dist"));
+    const argv1 = join(root, "dist", "index.js");
+    try {
+      setProcessShape({ argv0: "/usr/bin/node", argv1 });
+      const info = getInstallPath();
+      expect(info.kind).toBe("from-source");
+      expect(info.recommendedCommand).toMatch(/git -C .* pull/);
+      expect(info.recommendedCommand).toMatch(/npm run build/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to unknown when no heuristic matches", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/var/some/non-conventional/place/index.js",
+    });
+    const info = getInstallPath();
+    expect(info.kind).toBe("unknown");
+    expect(info.recommendedCommand).toMatch(/INSTALL\.md/);
+  });
+
+  it("memoizes detection — second call returns the same object", () => {
+    setProcessShape({
+      argv0: "/usr/bin/node",
+      argv1: "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js",
+    });
+    const a = getInstallPath();
+    const b = getInstallPath();
+    expect(a).toBe(b);
+  });
+
+  it("noticeInstallBlock starts with the indented Install: alignment for every kind", () => {
+    const cases: Array<{ argv0: string; argv1?: string }> = [
+      { argv0: "/home/u/.local/bin/vaultpilot-mcp-linux-x64-0.11.0" },
+      { argv0: "/usr/bin/node", argv1: "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js" },
+      { argv0: "/usr/bin/node", argv1: "/var/random/index.js" },
+    ];
+    for (const c of cases) {
+      setProcessShape(c);
+      const info = getInstallPath();
+      // Every block starts with the 9-space indent that lines up under the
+      // `Install:` label in the rendered notice.
+      expect(info.noticeInstallBlock.split("\n")[0]).toMatch(/^ {9}\(/);
+    }
+  });
+});

--- a/test/missing-skill-render.test.ts
+++ b/test/missing-skill-render.test.ts
@@ -119,6 +119,10 @@ describe("renderUpdateAvailableNotice", () => {
       current: "0.10.0",
       latest: "0.11.2",
       packageName: "vaultpilot-mcp",
+      installBlock:
+        "         (npm-global install detected)\n" +
+        "         npm install -g vaultpilot-mcp@latest\n" +
+        "         Restart Claude Code after upgrading so the new binary loads.",
     });
     expect(out).toMatch(/^VAULTPILOT NOTICE — Update available/);
     expect(out).toMatch(/vaultpilot-mcp 0\.10\.0 installed/);
@@ -133,9 +137,25 @@ describe("renderUpdateAvailableNotice", () => {
       current: "0.10.0",
       latest: "1.0.0",
       packageName: "vaultpilot-mcp",
+      installBlock: "         (test) some upgrade hint",
     });
     expect(out).toMatch(/0\.10\.0 installed; 1\.0\.0 published/);
     expect(out).toMatch(/releases\/tag\/v1\.0\.0/);
+  });
+
+  it("renders the supplied install block verbatim (no hardcoded npm command)", () => {
+    const block = [
+      "         (bundled-binary install detected)",
+      "         curl -fsSL https://example/install.sh | bash",
+    ].join("\n");
+    const out = renderUpdateAvailableNotice({
+      current: "0.10.0",
+      latest: "0.11.2",
+      packageName: "vaultpilot-mcp",
+      installBlock: block,
+    });
+    expect(out).toContain(block);
+    expect(out).not.toMatch(/npm install -g/);
   });
 
   it("carries no imperative agent verbs and no pasted shell beyond the install copy", () => {
@@ -143,6 +163,10 @@ describe("renderUpdateAvailableNotice", () => {
       current: "0.10.0",
       latest: "0.11.2",
       packageName: "vaultpilot-mcp",
+      installBlock:
+        "         (npm-global install detected)\n" +
+        "         npm install -g vaultpilot-mcp@latest\n" +
+        "         Restart Claude Code after upgrading so the new binary loads.",
     });
     expect(out).not.toMatch(/AGENT TASK/);
     expect(out).not.toMatch(/RELAY TO USER FIRST/);

--- a/test/missing-skill-render.test.ts
+++ b/test/missing-skill-render.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from "vitest";
 import {
   renderMissingSkillWarning,
   renderMissingSetupSkillWarning,
+  renderUpdateAvailableNotice,
 } from "../src/signing/render-verification.js";
 
 const PREFLIGHT_REPO =
@@ -109,5 +110,42 @@ describe("renderMissingSetupSkillWarning — state variants", () => {
       expect(v).not.toMatch(/^\s*git clone\s/m);
       expect(v).not.toMatch(/```/);
     }
+  });
+});
+
+describe("renderUpdateAvailableNotice", () => {
+  it("renders the standard VAULTPILOT NOTICE shape with both versions", () => {
+    const out = renderUpdateAvailableNotice({
+      current: "0.10.0",
+      latest: "0.11.2",
+      packageName: "vaultpilot-mcp",
+    });
+    expect(out).toMatch(/^VAULTPILOT NOTICE — Update available/);
+    expect(out).toMatch(/vaultpilot-mcp 0\.10\.0 installed/);
+    expect(out).toMatch(/0\.11\.2 published on npm/);
+    expect(out).toMatch(/releases\/tag\/v0\.11\.2/);
+    expect(out).toMatch(/npm install -g vaultpilot-mcp@latest/);
+    expect(out).toMatch(/VAULTPILOT_DISABLE_UPDATE_CHECK=1/);
+  });
+
+  it("renders cleanly across a wider version jump", () => {
+    const out = renderUpdateAvailableNotice({
+      current: "0.10.0",
+      latest: "1.0.0",
+      packageName: "vaultpilot-mcp",
+    });
+    expect(out).toMatch(/0\.10\.0 installed; 1\.0\.0 published/);
+    expect(out).toMatch(/releases\/tag\/v1\.0\.0/);
+  });
+
+  it("carries no imperative agent verbs and no pasted shell beyond the install copy", () => {
+    const out = renderUpdateAvailableNotice({
+      current: "0.10.0",
+      latest: "0.11.2",
+      packageName: "vaultpilot-mcp",
+    });
+    expect(out).not.toMatch(/AGENT TASK/);
+    expect(out).not.toMatch(/RELAY TO USER FIRST/);
+    expect(out).not.toMatch(/```/);
   });
 });

--- a/test/update-command.test.ts
+++ b/test/update-command.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the `get_update_command` tool. Asserts the structured shape
+ * the agent will see across the update / no-update / install-path-
+ * unknown / version-check-unresolved branches.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getUpdateCommand } from "../src/modules/diagnostics/update-command.js";
+import {
+  _resetInstallPathCacheForTests,
+} from "../src/shared/install-path.js";
+import {
+  _resetUpdateCheckForTests,
+  _setFetchForTests,
+  kickoffUpdateCheck,
+} from "../src/shared/version-check.js";
+
+const ORIGINAL_ARGV = [...process.argv];
+
+function setArgv(argv0: string, argv1: string): void {
+  process.argv = [argv0, argv1, ...ORIGINAL_ARGV.slice(2)];
+  _resetInstallPathCacheForTests();
+}
+
+function makeFetch(version: string) {
+  return vi.fn(async () => ({ ok: true, json: async () => ({ version }) }) as Response);
+}
+
+beforeEach(() => {
+  _resetUpdateCheckForTests();
+  _resetInstallPathCacheForTests();
+  delete process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
+});
+
+afterEach(() => {
+  _setFetchForTests(null);
+  process.argv = ORIGINAL_ARGV;
+  _resetUpdateCheckForTests();
+  _resetInstallPathCacheForTests();
+  delete process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
+});
+
+describe("getUpdateCommand", () => {
+  it("returns updateAvailable=false with a null latest before the version check resolves", () => {
+    setArgv("/usr/bin/node", "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js");
+    const r = getUpdateCommand();
+    expect(r.latest).toBeNull();
+    expect(r.updateAvailable).toBe(false);
+    expect(r.installPath).toBe("npm-global");
+    expect(r.command).toBe("npm install -g vaultpilot-mcp@latest");
+    expect(r.note).toMatch(/hasn't resolved yet/);
+  });
+
+  it("returns updateAvailable=true when the registry has a newer stable", async () => {
+    setArgv("/usr/bin/node", "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js");
+    _setFetchForTests(makeFetch("999.0.0"));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    const r = getUpdateCommand();
+    expect(r.latest).toBe("999.0.0");
+    expect(r.updateAvailable).toBe(true);
+    expect(r.installPath).toBe("npm-global");
+    expect(r.note).toBeUndefined();
+  });
+
+  it("returns updateAvailable=false when latest equals current", async () => {
+    setArgv("/usr/bin/node", "/usr/local/lib/node_modules/vaultpilot-mcp/dist/index.js");
+    _setFetchForTests(makeFetch("0.0.0"));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    const r = getUpdateCommand();
+    expect(r.latest).toBe("0.0.0");
+    expect(r.updateAvailable).toBe(false);
+    // `note` is undefined here — installPath known, latest known.
+    expect(r.note).toBeUndefined();
+  });
+
+  it("surfaces a defer-to-INSTALL.md note when install path is unknown", async () => {
+    setArgv("/usr/bin/node", "/var/some/non-conventional/place/index.js");
+    _setFetchForTests(makeFetch("999.0.0"));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    const r = getUpdateCommand();
+    expect(r.installPath).toBe("unknown");
+    expect(r.note).toMatch(/INSTALL\.md/);
+  });
+
+  it("returns the bundled-binary command when argv[0] is the SEA binary", async () => {
+    setArgv("/home/u/.local/bin/vaultpilot-mcp-linux-x64-0.11.0", "");
+    _setFetchForTests(makeFetch("999.0.0"));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    const r = getUpdateCommand();
+    expect(r.installPath).toBe("bundled-binary");
+    expect(r.command).toMatch(/install\.sh \| bash/);
+    expect(r.updateAvailable).toBe(true);
+  });
+});

--- a/test/version-check.test.ts
+++ b/test/version-check.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the npm-registry update-available check.
+ *
+ * Locks:
+ *   - compareSemver covers the spec corners (major/minor/patch ladder,
+ *     prerelease ordering, malformed input → 0).
+ *   - isUpdateAvailable refuses to nag on prereleases (either side).
+ *   - kickoffUpdateCheck + consumeUpdateNotice surface the notice exactly
+ *     once across the success path.
+ *   - Network error / non-200 / malformed body / equal version → no notice.
+ *   - VAULTPILOT_DISABLE_UPDATE_CHECK suppresses the fetch entirely.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { compareSemver, isUpdateAvailable } from "../src/shared/semver.js";
+import {
+  consumeUpdateNotice,
+  kickoffUpdateCheck,
+  _resetUpdateCheckForTests,
+  _setFetchForTests,
+} from "../src/shared/version-check.js";
+
+describe("compareSemver", () => {
+  it("orders major.minor.patch correctly", () => {
+    expect(compareSemver("0.9.0", "0.10.0")).toBe(-1);
+    expect(compareSemver("0.10.0", "0.10.0")).toBe(0);
+    expect(compareSemver("1.0.0", "0.99.99")).toBe(1);
+    expect(compareSemver("0.10.1", "0.10.0")).toBe(1);
+    expect(compareSemver("0.10.0", "0.10.1")).toBe(-1);
+  });
+
+  it("treats prerelease as less than the corresponding stable", () => {
+    expect(compareSemver("0.11.0-rc.1", "0.11.0")).toBe(-1);
+    expect(compareSemver("0.11.0", "0.11.0-rc.1")).toBe(1);
+  });
+
+  it("orders prerelease identifiers per semver spec", () => {
+    expect(compareSemver("0.11.0-alpha", "0.11.0-beta")).toBe(-1);
+    expect(compareSemver("0.11.0-rc.1", "0.11.0-rc.2")).toBe(-1);
+    // Numeric < non-numeric per §11.4.3.
+    expect(compareSemver("0.11.0-1", "0.11.0-alpha")).toBe(-1);
+    // Longer prerelease > shorter when shorter is a prefix.
+    expect(compareSemver("0.11.0-rc.1", "0.11.0-rc.1.0")).toBe(-1);
+  });
+
+  it("returns 0 on malformed input rather than throwing", () => {
+    expect(compareSemver("not-a-version", "0.10.0")).toBe(0);
+    expect(compareSemver("0.10.0", "")).toBe(0);
+    expect(compareSemver("0.10", "0.10.0")).toBe(0);
+  });
+
+  it("strips +build suffix before compare", () => {
+    expect(compareSemver("0.11.0+abc", "0.11.0+def")).toBe(0);
+    expect(compareSemver("0.11.0+abc", "0.11.1")).toBe(-1);
+  });
+});
+
+describe("isUpdateAvailable", () => {
+  it("true only when both sides are stable and latest > current", () => {
+    expect(isUpdateAvailable("0.10.0", "0.11.0")).toBe(true);
+    expect(isUpdateAvailable("0.10.0", "0.10.0")).toBe(false);
+    expect(isUpdateAvailable("0.11.0", "0.10.0")).toBe(false);
+  });
+
+  it("false when either side is a prerelease", () => {
+    expect(isUpdateAvailable("0.10.0", "0.11.0-rc.1")).toBe(false);
+    expect(isUpdateAvailable("0.10.0-rc.1", "0.11.0")).toBe(false);
+  });
+
+  it("false on malformed input rather than throwing", () => {
+    expect(isUpdateAvailable("garbage", "0.11.0")).toBe(false);
+    expect(isUpdateAvailable("0.10.0", "garbage")).toBe(false);
+  });
+});
+
+describe("kickoffUpdateCheck + consumeUpdateNotice", () => {
+  beforeEach(() => {
+    _resetUpdateCheckForTests();
+    delete process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
+  });
+  afterEach(() => {
+    _setFetchForTests(null);
+    _resetUpdateCheckForTests();
+    delete process.env.VAULTPILOT_DISABLE_UPDATE_CHECK;
+  });
+
+  function makeFetch(version: string | null, opts?: { ok?: boolean; throwErr?: boolean }) {
+    return vi.fn(async () => {
+      if (opts?.throwErr) throw new Error("network down");
+      const ok = opts?.ok ?? true;
+      return {
+        ok,
+        json: async () => (version === null ? {} : { version }),
+      } as Response;
+    });
+  }
+
+  it("emits the notice once on a newer-version response, then returns null", async () => {
+    // The version we ship in package.json is real (currently 0.11.1). Using
+    // 999.0.0 forces "latest > current" no matter how the package version
+    // changes underneath this test.
+    _setFetchForTests(makeFetch("999.0.0"));
+    kickoffUpdateCheck();
+    // Yield to the microtask queue so the fetch promise settles.
+    await new Promise((r) => setTimeout(r, 0));
+    const first = consumeUpdateNotice();
+    expect(first).toMatch(/^VAULTPILOT NOTICE — Update available/);
+    expect(first).toMatch(/999\.0\.0/);
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("emits no notice when the registry version equals or is older than current", async () => {
+    _setFetchForTests(makeFetch("0.0.0"));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("emits no notice on a network error", async () => {
+    _setFetchForTests(makeFetch(null, { throwErr: true }));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("emits no notice on a non-200 response", async () => {
+    _setFetchForTests(makeFetch("999.0.0", { ok: false }));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("emits no notice when the response body lacks a .version field", async () => {
+    _setFetchForTests(makeFetch(null));
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("never makes the fetch call when VAULTPILOT_DISABLE_UPDATE_CHECK=1", async () => {
+    process.env.VAULTPILOT_DISABLE_UPDATE_CHECK = "1";
+    const f = makeFetch("999.0.0");
+    _setFetchForTests(f);
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(f).not.toHaveBeenCalled();
+    expect(consumeUpdateNotice()).toBeNull();
+  });
+
+  it("kickoffUpdateCheck is idempotent — second call is a no-op", async () => {
+    const f = makeFetch("999.0.0");
+    _setFetchForTests(f);
+    kickoffUpdateCheck();
+    kickoffUpdateCheck();
+    kickoffUpdateCheck();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a once-per-session `VAULTPILOT NOTICE — Update available` block that fires when `registry.npmjs.org/vaultpilot-mcp/latest` reports a newer stable than what's running. Mirrors the existing preflight / setup / pin-drift notice family in shape, dedup model, and `instructions`-field registration.
- Lazy + non-blocking: fetch is kicked off on the first tool handler entry, tool responses do not await it, and the resolved notice is consumed on the next response after resolution. Any failure path (network, non-200, malformed body, missing `.version`, comparator throw) silently falls through to "no notice this session."
- New module trio under `src/shared/` (`semver.ts`, `version.ts`, `version-check.ts`) — no new runtime deps; semver comparator is ~30 LoC of strict `MAJOR.MINOR.PATCH(-prerelease)` parsing, sufficient for the npm `/latest` payload shape.
- Disable: `VAULTPILOT_DISABLE_UPDATE_CHECK=1` (air-gapped / no-egress operators), documented in README env-vars table and in the `instructions` catalogue.

## Test plan
- [x] `vitest run test/version-check.test.ts test/missing-skill-render.test.ts` → 26/26 pass (semver ladder, prerelease ordering, malformed-input degradation, dedup, network error / non-200 / equal version → no notice, env-var disable, renderer snapshot).
- [x] `tsc --noEmit` → clean.
- [ ] **Manual smoke test** (recommended before merge): bump local `package.json` to `0.0.1`, rebuild, restart Claude Code, run any tool. Notice should appear once. Set `VAULTPILOT_DISABLE_UPDATE_CHECK=1`, restart, repeat — notice should NOT fire and no network call should hit `registry.npmjs.org`.

## Background
Plan: `claude-work/plan-update-available-notice.md` (already-approved, gitignored).

History: this branch was created and largely written before a hard-kill incident corrupted the local `.git/objects/04/6f44a6...` (origin/main's tip). The implementation survived in the working tree because none of it had been committed yet; this PR is the first commit on the branch. Refetch from origin restored the corrupted object and one orphaned ref (`feat/425-incident-report-v2` — empty ref + empty reflog, no commits, unrecoverable but also nothing to recover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)