### PR TITLE
ci: auto-triage agent for newly opened issues

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -1,0 +1,166 @@
+name: Issue triage agent
+
+# Auto-triage every newly opened issue with Claude. The agent reads the
+# issue body + recent merged-PR history + house style, classifies the
+# issue, and:
+#
+#   SMALL   — implements the fix, opens a DRAFT PR
+#   LARGE   — writes a plan, comments it on the issue, no PR
+#   DISCUSS — same as LARGE but for issues needing design input
+#   MIXED   — opens a DRAFT PR for the small parts AND comments a
+#             plan covering the deferred large parts on the issue
+#   SKIP    — comments the reason, no PR (spam, off-topic,
+#             tracking-issue, drive-by bounty pattern)
+#
+# === Setup (one-time) ===
+#   1. Repo Settings → Secrets and variables → Actions → New secret:
+#        Name:  ANTHROPIC_API_KEY
+#        Value: <your Anthropic API key>
+#   2. Repo Settings → Actions → General → Workflow permissions:
+#        verify "Read and write permissions" is allowed for the
+#        repo, OR rely on the per-job `permissions:` block below
+#        (preferred — least privilege).
+#
+# === Per-issue overrides ===
+#   - `no-triage` label set BEFORE opening: skip auto-triage entirely
+#     (use an issue-template default if you want opt-in, not opt-out).
+#   - `retriage` label added AFTER opening: re-run with refreshed
+#     context (e.g. after the maintainer adds clarifying info).
+#   - `@claude` mention in the issue body or any comment: also
+#     triggers via the action's default `trigger_phrase`.
+#
+# === Cost notes ===
+# Each fired run uses the Anthropic API. If issue volume spikes:
+#   - Switch the trigger to `[labeled]`-only and require an explicit
+#     `triage` label before firing (changes default from auto-on to
+#     auto-off).
+#   - Or tighten `--max-turns` in `claude_args` (already capped below).
+
+on:
+  issues:
+    types: [opened, labeled]
+
+# Workflow-level permissions = none. Job-level explicitly grants the
+# minimum needed. Keeps a leaked GITHUB_TOKEN scope-bounded.
+permissions: {}
+
+jobs:
+  triage:
+    if: |
+      (github.event.action == 'opened' && !contains(github.event.issue.labels.*.name, 'no-triage'))
+      || (github.event.action == 'labeled' && github.event.label.name == 'retriage')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # push branches for SMALL implementations
+      pull-requests: write  # open draft PRs
+      issues: write         # post the triage verdict comment
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so the agent can read PR precedent
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        # --legacy-peer-deps for the same Kamino kit-version split
+        # documented in ci.yml.
+        run: npm ci --legacy-peer-deps
+
+      - name: Run triage agent
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # One rolling comment per issue rather than a new comment
+          # per re-trigger; keeps the issue thread readable.
+          use_sticky_comment: true
+          # Cap turns so a confused agent can't run away with API
+          # spend. 30 is enough for a SMALL fix-and-PR loop.
+          claude_args: |
+            --max-turns 30
+          prompt: |
+            You are the issue-triage agent for the **szhygulin/vaultpilot-mcp** repo.
+            Issue **#${{ github.event.issue.number }}** — `${{ github.event.issue.title }}` —
+            was opened by `@${{ github.event.issue.user.login }}`.
+
+            ## Read first (in this order)
+
+            - `CLAUDE.md` — house style, worktree-per-feature rule, PR workflow, push-back discipline
+            - `CONTRIBUTING.md` — what PRs land + the off-topic / drive-by bounty pattern to filter on
+            - `README.md` — what the project does
+            - `gh issue view ${{ github.event.issue.number }}` — full issue body + comments
+            - `gh pr list --state merged --limit 20` — recent precedent for scope + tone
+            - `gh issue list --state closed --limit 20` — recent triage decisions
+
+            ## Classify into ONE of
+
+            - **SKIP** — spam, duplicate of a still-open or recently-closed issue, off-topic,
+              drive-by bounty pattern (per CONTRIBUTING.md), or a discussion / tracking issue
+              with no actionable scope. Comment the verdict + reason briefly. Stop.
+
+            - **SMALL** — well-scoped enough to auto-implement. ALL must hold:
+              * Single file OR very narrow multi-file change
+              * ≤ 50 LoC diff (tests included)
+              * No new npm dependencies
+              * NOT touching: tool registration in `src/index.ts`, signing flow
+                (`src/signing/`), tx serialization, demo-mode gates (`src/demo/`),
+                preflight skill integrity
+              * Fix pattern is already-known (typo, copy update, off-by-one, missing
+                field on a JSON response, README link rot)
+              * Tests can be added in the same PR
+
+              Implement per CLAUDE.md: create a worktree under
+              `.claude/worktrees/<short-name>`, branch
+              `fix/issue-${{ github.event.issue.number }}-<slug>` off `origin/main`,
+              fix it, run `npm test` AND `npx tsc --noEmit`, commit, push, open a
+              **DRAFT** PR with `Closes #${{ github.event.issue.number }}` in the body.
+              Comment on the issue linking the PR.
+
+            - **LARGE** — implementable but the diff would exceed SMALL. Write a plan,
+              comment it on the issue. No PR.
+
+            - **DISCUSS** — legitimate but needs design input from the maintainer
+              before any code (architecture trade-offs, SDK choice, breaking-change
+              scope). Plan + comment, no PR.
+
+            - **MIXED** — issue contains BOTH small parts that can be auto-PR'd AND
+              larger / design parts. Implement the small parts as a DRAFT PR with
+              "Partially addresses #${{ github.event.issue.number }}" in the body
+              (NOT `Closes`), AND comment the plan for the deferred parts on the issue.
+
+            ## Plan format (LARGE / DISCUSS / MIXED-deferred)
+
+            Under 800 words. Sections:
+            - **Verdict** — one sentence: recommend / defer / out-of-scope, with the why.
+            - **Scope** — concrete files + functions that would change.
+            - **Open decisions** — explicit list of design questions for the maintainer.
+              For each: 2-3 options + your recommendation. This is the part you NEED
+              maintainer input on before code can land.
+            - **Effort** — rough LoC + test surface estimate.
+            - **Risks** — security, dependency tree, breaking-change reach, cross-PR
+              collision with in-flight work.
+
+            ## Hard constraints
+
+            - NEVER push to `main`. NEVER `--no-verify`. NEVER force-push or amend.
+            - Always open PRs as **DRAFT**. The maintainer marks ready after review.
+            - If `npm test` OR `npx tsc --noEmit` fails on a SMALL implementation:
+              **downgrade to LARGE** — delete the branch, write a plan instead,
+              explain what went wrong.
+            - When in doubt about classification, default to **LARGE**. False-positive
+              plans are cheap; false-positive auto-PRs aren't.
+            - Apply the "Smallest-Solution Discipline" from CLAUDE.md: propose the
+              minimum change that solves the stated problem; don't bundle "while I'm
+              here" refactors, don't add caching/persistence/abstractions for one-shot
+              cases, don't generalize for hypothetical future callers.
+            - Always comment on the issue with the verdict + brief reasoning, even on SKIP.
+            - Use `gh` to read issue content — don't guess.
+
+            ## Auth + identity
+
+            `gh` is pre-configured with `GITHUB_TOKEN`. Git is configured with the
+            `claude[bot]` identity by the action. You do not need to set either up.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ claude mcp add vaultpilot-mcp-dev --env VAULTPILOT_DEMO=true -- node /absolute/p
 
 Useful when changing `src/demo/`, the `prepare_*` refusal/simulation paths, or `buildSimulationEnvelope` — unit tests cover contract correctness, but the agent-UX class of regressions (persona drift, simulation envelope readability, nudge timing) only surface in a live walkthrough.
 
+## Issue triage
+
+New issues are auto-triaged by an agent ([`.github/workflows/triage-issue.yml`](./.github/workflows/triage-issue.yml)) that reads the issue, classifies it, and either:
+
+- Implements small / well-scoped fixes as a draft PR (typo, copy update, missing field, single-file off-by-one).
+- Comments a written plan for issues needing maintainer design input — that's the cue to discuss before code lands.
+- Skips spam / off-topic / discussion-only issues with a brief reason.
+
+To opt out per-issue: open with the `no-triage` label set. To re-trigger after editing: add the `retriage` label.
+
 ## Reporting security issues
 
 Do **not** open a public issue for vulnerabilities. See [SECURITY.md](./SECURITY.md) for the disclosure process.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-triages every newly opened issue with Claude (via the official [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action)).

The agent reads the issue + recent merged-PR precedent + house style (CLAUDE.md / CONTRIBUTING.md / README.md) and classifies into ONE of:

| Bucket | What the agent does |
|---|---|
| **SMALL** | Implements the fix in a fresh worktree, runs tests + typecheck, opens a **DRAFT** PR with `Closes #N` |
| **LARGE** | Writes a plan, comments it on the issue. No code pushed. |
| **DISCUSS** | Same as LARGE but for issues needing maintainer design input first. |
| **MIXED** | Auto-PRs the small parts AND comments a plan for the deferred design parts on the same issue. |
| **SKIP** | Brief comment with the reason (spam / off-topic / tracking-issue / drive-by bounty pattern). |

## Plan format the agent uses (LARGE / DISCUSS / MIXED-deferred)

Under 800 words, with explicit **Open decisions** sections — each design question gets 2-3 options + a recommendation. That's the cue for maintainer input before code lands.

## Guardrails baked into the prompt

- Always **DRAFT** PRs — maintainer marks ready after review.
- Failed `npm test` or `npx tsc --noEmit` on a SMALL implementation ⇒ downgrade to LARGE, no PR.
- Default to LARGE under classification uncertainty (false-positive plans are cheap; false-positive auto-PRs aren't).
- Apply CLAUDE.md's smallest-solution discipline.
- Hard NOT-touching list: tool registration, signing flow, tx serialization, demo-mode gates, preflight skill integrity.
- Workflow-level `permissions: {}`; job-level least privilege (`contents/pull-requests/issues: write` only).
- `claude_args: --max-turns 30` caps per-run API spend.

## Setup needed once

1. Add `ANTHROPIC_API_KEY` to repo secrets.
2. (Optional) Verify Settings → Actions → Workflow permissions allows the per-job grants.

## Per-issue overrides

- `no-triage` label set BEFORE opening → skip auto-triage entirely.
- `retriage` label added AFTER opening → re-run with refreshed context.
- `@claude` mention in body or comment also triggers the action's default `trigger_phrase`.

## Test plan

- [ ] Merge → secret set → open a deliberately spammy test issue, confirm SKIP path.
- [ ] Open a typo-fix issue, confirm SMALL → DRAFT PR path.
- [ ] Open a roadmap-shaped issue, confirm LARGE → plan-comment path.
- [ ] Verify `no-triage` label suppresses, `retriage` re-fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)