### PR TITLE
fix(skill-pin): bump to v6 for Inv #13 multi-step BTC flows (closes #463)

### DIFF
--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "e48d5c0cdeb85be7b3a431a678d1cf2ff40aa52a69259567bb575779af75007a";
+  "83195093d98367ad8000164caa396e855a213d9de64018ba148d03be566772df";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v5_";
-export const EXPECTED_SKILL_SENTINEL_C = "9c4a2e7f3d816b50";
+export const EXPECTED_SKILL_SENTINEL_B = "_v6_";
+export const EXPECTED_SKILL_SENTINEL_C = "8682084ac4984982";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =


### PR DESCRIPTION
## Summary

Coordinated MCP-side pin bump for [vaultpilot-security-skill#17](https://github.com/szhygulin/vaultpilot-security-skill/pull/17) which adds **Invariant #13: Multi-step BTC flows**.

Bumps three constants in `src/diagnostics/skill-pin-drift.ts`:

| Constant | Before | After |
|---|---|---|
| `EXPECTED_SKILL_SHA256` | `e48d5c0c…007a` | `83195093…72df` |
| `EXPECTED_SKILL_SENTINEL_B` | `_v5_` | `_v6_` |
| `EXPECTED_SKILL_SENTINEL_C` | `9c4a2e7f3d816b50` | `8682084ac4984982` |

## ⚠️ Merge ordering

**This PR is DRAFT** until the skill PR merges, because:

1. The runtime diagnostic in `skill-pin-drift.ts` fetches `SKILL.md` from the skill repo's `master` and compares the hash to `EXPECTED_SKILL_SHA256`.
2. If this MCP PR lands FIRST, master is still v5 → expected is v6 → every signing flow halts with `vaultpilot-preflight skill integrity check FAILED`.
3. Right order: merge [skill#17](https://github.com/szhygulin/vaultpilot-security-skill/pull/17) → mark this draft ready → merge.

## Test plan

- [x] Full vitest suite green (2100/2100)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] `skill-pin-drift.test.ts` 17/17 pass against new constants
- [ ] After skill#17 merges: end-to-end signing flow passes Step 0 integrity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)