### PR TITLE
fix: get_health_alerts coverage across Compound V3, Morpho, MarginFi, Kamino (#427)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1847,11 +1847,21 @@ async function main() {
     handler(getLpPositions)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "get_health_alerts",
     {
       description:
-        "Check for Aave V3 lending positions approaching liquidation. Returns positions whose health factor is below the given threshold (default 1.5).",
+        "READ-ONLY — across-protocol liquidation-risk check. Fans out in parallel to Aave V3 / " +
+        "Compound V3 / Morpho Blue (EVM, via `wallet`) and MarginFi / Kamino (Solana, via " +
+        "`solanaWallet`); returns every position whose health factor is below `threshold` " +
+        "(default 1.5). Each row carries `protocol` (discriminator), `chain`, `market` " +
+        "(market addr / marketId / MarginfiAccount / obligation; null for Aave's per-chain " +
+        "aggregation), `healthFactor`, `collateralUsd`, `debtUsd`, and `marginToLiquidation` " +
+        "(% HF would need to drop to hit 1.0). At least one of `wallet` / `solanaWallet` is " +
+        "required. Per-protocol failures (RPC down, MarginFi SDK IDL drift) are captured in " +
+        "the optional `notes[]` field rather than failing the whole call — a partial result " +
+        "still surfaces, and the absence of a protocol from the at-risk list is never " +
+        "silently wrong. Issue #427 (was Aave-V3-only despite generic name).",
       inputSchema: getHealthAlertsInput.shape,
     },
     handler(getHealthAlerts)

--- a/src/modules/digest/index.ts
+++ b/src/modules/digest/index.ts
@@ -205,21 +205,26 @@ async function readHealthAlerts(
   args: GetDailyBriefingArgs,
   notes: string[],
 ): Promise<{ threshold: number; atRisk: HealthAlertRow[] } | null> {
-  // Health alerts are EVM/Aave-only today. Without an EVM wallet,
-  // there's nothing to check — return empty rather than a note (the
-  // user simply has no EVM exposure).
-  if (!args.wallet) {
+  // Issue #427: digest now mirrors the cross-protocol coverage in
+  // `getHealthAlerts` (Aave / Compound V3 / Morpho / MarginFi / Kamino).
+  // Without ANY wallet address (EVM or Solana) there's nothing to check —
+  // return empty rather than a note (the user simply has no exposure).
+  if (!args.wallet && !args.solanaAddress) {
     return { threshold: HEALTH_FACTOR_THRESHOLD, atRisk: [] };
   }
   try {
     const r = await getHealthAlerts({
       wallet: args.wallet,
+      solanaWallet: args.solanaAddress,
       threshold: HEALTH_FACTOR_THRESHOLD,
     });
+    if (r.notes && r.notes.length > 0) notes.push(...r.notes);
     return {
       threshold: r.threshold,
       atRisk: r.atRisk.map((a) => ({
+        protocol: a.protocol,
         chain: a.chain,
+        market: a.market,
         healthFactor: a.healthFactor,
         collateralUsd: a.collateralUsd,
         debtUsd: a.debtUsd,

--- a/src/modules/digest/render.ts
+++ b/src/modules/digest/render.ts
@@ -69,8 +69,9 @@ export function renderBriefingNarrative(briefing: DailyBriefing): string {
         `lending position(s) below health-factor ${briefing.healthAlerts.threshold}:`,
     );
     for (const a of briefing.healthAlerts.atRisk) {
+      const label = formatProtocolLabel(a.protocol, a.chain);
       lines.push(
-        `- Aave on ${a.chain}: HF ${a.healthFactor.toFixed(2)} ` +
+        `- ${label}: HF ${a.healthFactor.toFixed(2)} ` +
           `(collateral ${formatUsd(a.collateralUsd)} / debt ${formatUsd(a.debtUsd)}, ` +
           `${a.marginToLiquidation.toFixed(1)}% margin to liquidation)`,
       );
@@ -143,6 +144,23 @@ function formatPeriod(p: "24h" | "7d" | "30d"): string {
 
 function formatPeriodTail(p: "24h" | "7d" | "30d"): string {
   return p === "24h" ? "last 24h" : p === "7d" ? "past week" : "past month";
+}
+
+function formatProtocolLabel(protocol: string, chain: string): string {
+  switch (protocol) {
+    case "aave-v3":
+      return `Aave V3 on ${chain}`;
+    case "compound-v3":
+      return `Compound V3 on ${chain}`;
+    case "morpho-blue":
+      return `Morpho Blue on ${chain}`;
+    case "marginfi":
+      return "MarginFi on Solana";
+    case "kamino":
+      return "Kamino on Solana";
+    default:
+      return `${protocol} on ${chain}`;
+  }
 }
 
 function formatUsd(n: number): string {

--- a/src/modules/digest/schemas.ts
+++ b/src/modules/digest/schemas.ts
@@ -106,10 +106,16 @@ export interface TopMover {
 /**
  * Lending-position alert row. Mirrors `getHealthAlerts` output one-to-one
  * — re-exporting the shape here so digest-only callers don't need to
- * import the positions module's types.
+ * import the positions module's types. Issue #427 added the `protocol`
+ * discriminator + `market` handle so the digest line can label the
+ * specific protocol the user is at risk on (Aave / Compound V3 / Morpho /
+ * MarginFi / Kamino) rather than always saying "Aave".
  */
 export interface HealthAlertRow {
+  protocol: "aave-v3" | "compound-v3" | "morpho-blue" | "marginfi" | "kamino";
   chain: string;
+  /** Protocol-specific market handle; null for Aave (per-chain aggregation). */
+  market: string | null;
   healthFactor: number;
   collateralUsd: number;
   debtUsd: number;

--- a/src/modules/positions/index.ts
+++ b/src/modules/positions/index.ts
@@ -3,6 +3,10 @@ import { getUniswapPositions } from "./uniswap.js";
 import { getCompoundPositions } from "../compound/index.js";
 import { getCompoundMarketInfo } from "../compound/market-info.js";
 import { getMorphoPositions } from "../morpho/index.js";
+import {
+  getMarginfiPositions,
+  getKaminoPositions,
+} from "../execution/index.js";
 import type {
   GetLendingPositionsArgs,
   GetLpPositionsArgs,
@@ -36,30 +40,246 @@ export async function getLpPositions(args: GetLpPositionsArgs): Promise<{
   return { wallet, positions: perChain.flat() };
 }
 
+/**
+ * Health-factor row for one at-risk lending position. The discriminator
+ * is `protocol`; `chain` is "solana" for MarginFi / Kamino and an EVM
+ * chain otherwise; `market` is the protocol-specific position handle —
+ * Comet address for Compound V3, marketId bytes32 for Morpho Blue,
+ * MarginfiAccount for MarginFi, obligation for Kamino, and `null` for
+ * Aave V3 (Aave aggregates per-chain, not per-market).
+ */
+export interface HealthAlertRow {
+  protocol: "aave-v3" | "compound-v3" | "morpho-blue" | "marginfi" | "kamino";
+  chain: SupportedChain | "solana";
+  market: string | null;
+  healthFactor: number;
+  collateralUsd: number;
+  debtUsd: number;
+  /** % HF would need to drop by to hit 1.0. */
+  marginToLiquidation: number;
+}
+
+function marginPct(hf: number): number {
+  if (!Number.isFinite(hf) || hf <= 0) return 0;
+  return Math.max(0, Math.round(((hf - 1) / hf) * 10000) / 100);
+}
+
+/**
+ * Across-protocol liquidation-risk reader. Issue #427: until this rewrite
+ * the function only scanned Aave V3 reserves — a user with no Aave borrows
+ * but active borrows on Compound V3 / Morpho Blue / MarginFi / Kamino got
+ * `atRisk: []` back from a generically-named tool, which is false safety
+ * reassurance, not just a UX gap.
+ *
+ * Now fans out to all five readers in parallel and computes a unified
+ * health factor per position:
+ *   - Aave V3, MarginFi, Kamino expose `healthFactor` directly on the
+ *     position type → use as-is.
+ *   - Compound V3 needs per-market `liquidateCollateralFactor` to compute
+ *     `Σ(collat_i × CF_i) / debt`. We fetch one `getCompoundMarketInfo`
+ *     per market the user has positions in (most users have ≤ 2).
+ *   - Morpho Blue exposes `lltv` on the position; `(collat × lltv) / debt`
+ *     reproduces Morpho's liquidation rule.
+ *
+ * EVM and Solana inputs are independent: the user passes whichever
+ * address(es) they have. Schema validation requires at least one.
+ *
+ * Per-protocol failures (RPC down, MarginFi SDK IDL drift, etc.) DO NOT
+ * fail the whole call — each reader is wrapped so a partial result still
+ * reaches the user. The optional `notes[]` field flags any reader that
+ * couldn't run so a "no liquidation risk" answer is never silently wrong.
+ */
 export async function getHealthAlerts(args: GetHealthAlertsArgs): Promise<{
-  wallet: string;
+  wallet: string | null;
+  solanaWallet: string | null;
   threshold: number;
-  atRisk: Array<{
-    chain: SupportedChain;
-    healthFactor: number;
-    collateralUsd: number;
-    debtUsd: number;
-    marginToLiquidation: number;
-  }>;
+  atRisk: HealthAlertRow[];
+  notes?: string[];
 }> {
+  if (!args.wallet && !args.solanaWallet) {
+    throw new Error(
+      "get_health_alerts requires at least one of `wallet` (EVM) or " +
+        "`solanaWallet` (Solana base58).",
+    );
+  }
   const threshold = args.threshold ?? 1.5;
-  const { positions, wallet } = await getLendingPositions({ wallet: args.wallet, chains: undefined });
-  const atRisk = positions
+  const notes: string[] = [];
+
+  type ProtocolJob =
+    | { kind: "skip" }
+    | { kind: "rows"; rows: HealthAlertRow[] };
+  async function run(
+    label: string,
+    fn: () => Promise<HealthAlertRow[]>,
+  ): Promise<ProtocolJob> {
+    try {
+      return { kind: "rows", rows: await fn() };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      notes.push(`${label} health check failed: ${msg}`);
+      return { kind: "skip" };
+    }
+  }
+
+  const evmJobs = args.wallet
+    ? [
+        run("Aave V3", () => readAaveAtRisk(args.wallet!, threshold)),
+        run("Compound V3", () => readCompoundAtRisk(args.wallet!, threshold)),
+        run("Morpho Blue", () => readMorphoAtRisk(args.wallet!, threshold)),
+      ]
+    : [];
+  const solanaJobs = args.solanaWallet
+    ? [
+        run("MarginFi", () => readMarginfiAtRisk(args.solanaWallet!, threshold)),
+        run("Kamino", () => readKaminoAtRisk(args.solanaWallet!, threshold)),
+      ]
+    : [];
+
+  const results = await Promise.all([...evmJobs, ...solanaJobs]);
+  const atRisk = results.flatMap((r) => (r.kind === "rows" ? r.rows : []));
+  return {
+    wallet: args.wallet ?? null,
+    solanaWallet: args.solanaWallet ?? null,
+    threshold,
+    atRisk,
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}
+
+async function readAaveAtRisk(
+  wallet: string,
+  threshold: number,
+): Promise<HealthAlertRow[]> {
+  const { positions } = await getLendingPositions({ wallet, chains: undefined });
+  return positions
     .filter((p) => p.healthFactor < threshold && p.totalDebtUsd > 0)
     .map((p) => ({
+      protocol: "aave-v3" as const,
       chain: p.chain,
+      market: null,
       healthFactor: p.healthFactor,
       collateralUsd: p.totalCollateralUsd,
       debtUsd: p.totalDebtUsd,
-      // Margin is the % HF would need to drop by to hit 1.0.
-      marginToLiquidation: Math.max(0, Math.round(((p.healthFactor - 1) / p.healthFactor) * 10000) / 100),
+      marginToLiquidation: marginPct(p.healthFactor),
     }));
-  return { wallet, threshold, atRisk };
+}
+
+async function readCompoundAtRisk(
+  wallet: string,
+  threshold: number,
+): Promise<HealthAlertRow[]> {
+  const { positions } = await getCompoundPositions({ wallet, chains: undefined });
+  const borrowing = positions.filter((p) => p.totalDebtUsd > 0);
+  if (borrowing.length === 0) return [];
+  // Comet's liquidation rule: Σ(collateral_i × liquidateCF_i) ≥ borrowed.
+  // CF lives on the market info — fetch one per (chain, market).
+  const infos = await Promise.all(
+    borrowing.map((p) =>
+      getCompoundMarketInfo({ chain: p.chain, market: p.marketAddress }),
+    ),
+  );
+  const rows: HealthAlertRow[] = [];
+  for (let i = 0; i < borrowing.length; i++) {
+    const pos = borrowing[i];
+    const info = infos[i];
+    const cfByAsset = new Map<string, number>();
+    for (const c of info.collateralAssets) {
+      cfByAsset.set(
+        c.asset.toLowerCase(),
+        Number(c.liquidateCollateralFactor) / 1e18,
+      );
+    }
+    const liquidationCollateralUsd = pos.collateral.reduce((sum, t) => {
+      const cf = cfByAsset.get(t.token.toLowerCase()) ?? 0;
+      return sum + (t.valueUsd ?? 0) * cf;
+    }, 0);
+    const hf = liquidationCollateralUsd / pos.totalDebtUsd;
+    if (hf >= threshold) continue;
+    rows.push({
+      protocol: "compound-v3",
+      chain: pos.chain,
+      market: pos.marketAddress,
+      healthFactor: Math.round(hf * 10000) / 10000,
+      collateralUsd: pos.totalCollateralUsd,
+      debtUsd: pos.totalDebtUsd,
+      marginToLiquidation: marginPct(hf),
+    });
+  }
+  return rows;
+}
+
+async function readMorphoAtRisk(
+  wallet: string,
+  threshold: number,
+): Promise<HealthAlertRow[]> {
+  // Morpho Blue is Ethereum-only today; discovery is opt-in via
+  // VAULTPILOT_MORPHO_DISCOVERY=1 (without it, getMorphoPositions returns
+  // an empty list with `discoverySkipped: true`). The discoverySkipped
+  // case is a pre-existing limitation — surfacing it as a `notes` line
+  // here so the user at least sees that Morpho coverage was inactive.
+  const { positions, discoverySkipped } = await getMorphoPositions({
+    wallet,
+    chain: "ethereum",
+  });
+  if (discoverySkipped) {
+    throw new Error(
+      "Morpho discovery is opt-in (set VAULTPILOT_MORPHO_DISCOVERY=1) — " +
+        "this run did not scan Morpho positions.",
+    );
+  }
+  const rows: HealthAlertRow[] = [];
+  for (const pos of positions) {
+    if (pos.totalDebtUsd <= 0) continue;
+    const lltvFraction = Number(pos.lltv) / 1e18;
+    const hf = (pos.totalCollateralUsd * lltvFraction) / pos.totalDebtUsd;
+    if (hf >= threshold) continue;
+    rows.push({
+      protocol: "morpho-blue",
+      chain: pos.chain,
+      market: pos.marketId,
+      healthFactor: Math.round(hf * 10000) / 10000,
+      collateralUsd: pos.totalCollateralUsd,
+      debtUsd: pos.totalDebtUsd,
+      marginToLiquidation: marginPct(hf),
+    });
+  }
+  return rows;
+}
+
+async function readMarginfiAtRisk(
+  solanaWallet: string,
+  threshold: number,
+): Promise<HealthAlertRow[]> {
+  const { positions } = await getMarginfiPositions({ wallet: solanaWallet });
+  return positions
+    .filter((p) => p.totalBorrowedUsd > 0 && p.healthFactor < threshold)
+    .map((p) => ({
+      protocol: "marginfi" as const,
+      chain: "solana" as const,
+      market: p.marginfiAccount,
+      healthFactor: p.healthFactor,
+      collateralUsd: p.totalSuppliedUsd,
+      debtUsd: p.totalBorrowedUsd,
+      marginToLiquidation: marginPct(p.healthFactor),
+    }));
+}
+
+async function readKaminoAtRisk(
+  solanaWallet: string,
+  threshold: number,
+): Promise<HealthAlertRow[]> {
+  const { positions } = await getKaminoPositions({ wallet: solanaWallet });
+  return positions
+    .filter((p) => p.totalBorrowedUsd > 0 && p.healthFactor < threshold)
+    .map((p) => ({
+      protocol: "kamino" as const,
+      chain: "solana" as const,
+      market: p.obligation,
+      healthFactor: p.healthFactor,
+      collateralUsd: p.totalSuppliedUsd,
+      debtUsd: p.totalBorrowedUsd,
+      marginToLiquidation: marginPct(p.healthFactor),
+    }));
 }
 
 export async function simulatePositionChange(args: SimulatePositionChangeArgs): Promise<{

--- a/src/modules/positions/schemas.ts
+++ b/src/modules/positions/schemas.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 import { SUPPORTED_CHAINS } from "../../types/index.js";
-import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+import { EVM_ADDRESS, SOLANA_ADDRESS } from "../../shared/address-patterns.js";
 
 const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
 const walletSchema = z.string().regex(EVM_ADDRESS, "must be a 0x-prefixed EVM address");
+const solanaWalletSchema = z
+  .string()
+  .regex(SOLANA_ADDRESS, "must be a base58 Solana address (43–44 chars)");
 
 export const getLendingPositionsInput = z.object({
   wallet: walletSchema,
@@ -16,7 +19,17 @@ export const getLpPositionsInput = z.object({
 });
 
 export const getHealthAlertsInput = z.object({
-  wallet: walletSchema,
+  /**
+   * EVM wallet (Aave V3 / Compound V3 / Morpho Blue coverage). Optional
+   * since a user may hold lending positions only on Solana — but at least
+   * one of `wallet` / `solanaWallet` MUST be provided.
+   */
+  wallet: walletSchema.optional(),
+  /**
+   * Solana wallet (MarginFi + Kamino coverage). Optional but mirrors the
+   * EVM wallet rule: at least one address must be supplied.
+   */
+  solanaWallet: solanaWalletSchema.optional(),
   threshold: z.number().min(1).max(10).optional().default(1.5),
 });
 

--- a/test/health-alerts-multi-protocol.test.ts
+++ b/test/health-alerts-multi-protocol.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Issue #427: `get_health_alerts` was Aave-V3-only despite the generic
+ * name — a wallet with no Aave borrows but active borrows on Compound V3
+ * / Morpho Blue / MarginFi / Kamino got `atRisk: []` back, which is
+ * false safety reassurance.
+ *
+ * These tests lock the across-protocol coverage by mocking each
+ * underlying reader and asserting the unified `atRisk[]` shape +
+ * per-protocol HF math:
+ *   - Aave V3: passes through `position.healthFactor`.
+ *   - Compound V3: computes `Σ(collat_i × CF_i) / debt` from the
+ *     market-info collateral table.
+ *   - Morpho Blue: computes `(collat × lltv) / debt` from the position's
+ *     `lltv` field.
+ *   - MarginFi / Kamino: pass through `position.healthFactor`.
+ *
+ * Also locks the partial-failure shape (one reader throws → the others
+ * still return rows + a `notes[]` line so a "no liquidation risk" answer
+ * is never silently wrong).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const EVM_WALLET = "0x8F9dE85C01070D2762d29A6Dd7ffEcC965b34361";
+const SOLANA_WALLET = "8axowbY3iTotwSMr1iHsdxLArm6oNB4mhpYJyHrohYf3";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockAave(positions: unknown[]) {
+  vi.doMock("../src/modules/positions/aave.js", () => ({
+    getAaveLendingPosition: vi.fn(async (_w: string, chain: string) => {
+      const match = (positions as Array<{ chain: string }>).find(
+        (p) => p.chain === chain,
+      );
+      return match ?? null;
+    }),
+    simulateHealthFactorChange: vi.fn(),
+  }));
+}
+
+function mockCompound(positions: unknown[], marketInfos: Record<string, unknown>) {
+  vi.doMock("../src/modules/compound/index.js", () => ({
+    getCompoundPositions: vi.fn(async () => ({ positions })),
+  }));
+  vi.doMock("../src/modules/compound/market-info.js", () => ({
+    getCompoundMarketInfo: vi.fn(async ({ market }: { market: string }) => {
+      const info = marketInfos[market.toLowerCase()];
+      if (!info) throw new Error(`no mock market info for ${market}`);
+      return info;
+    }),
+  }));
+}
+
+function mockMorpho(positions: unknown[]) {
+  vi.doMock("../src/modules/morpho/index.js", () => ({
+    getMorphoPositions: vi.fn(async () => ({
+      wallet: EVM_WALLET,
+      positions,
+    })),
+  }));
+}
+
+function mockSolana(marginfi: unknown[], kamino: unknown[]) {
+  // readMarginfiAtRisk + readKaminoAtRisk dynamic-import this module.
+  vi.doMock("../src/modules/execution/index.js", () => ({
+    getMarginfiPositions: vi.fn(async () => ({ positions: marginfi })),
+    getKaminoPositions: vi.fn(async () => ({ positions: kamino })),
+  }));
+}
+
+describe("getHealthAlerts — multi-protocol coverage (#427)", () => {
+  it("returns an Aave row when the position's healthFactor is below threshold", async () => {
+    mockAave([
+      {
+        protocol: "aave-v3",
+        chain: "ethereum",
+        healthFactor: 1.2,
+        totalCollateralUsd: 5000,
+        totalDebtUsd: 4000,
+      },
+    ]);
+    mockCompound([], {});
+    mockMorpho([]);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({ wallet: EVM_WALLET, threshold: 1.5 });
+    expect(r.atRisk).toHaveLength(1);
+    expect(r.atRisk[0]).toMatchObject({
+      protocol: "aave-v3",
+      chain: "ethereum",
+      market: null,
+      healthFactor: 1.2,
+      collateralUsd: 5000,
+      debtUsd: 4000,
+    });
+    expect(r.atRisk[0].marginToLiquidation).toBeCloseTo(16.67, 1);
+  });
+
+  it("computes a Compound V3 health factor from the market info CF table", async () => {
+    // Single collateral asset, CF = 0.85 (1e18-scaled = 8.5e17). Collateral
+    // $1000 → liquidationCollateralUsd $850. Debt $700 → HF 850/700 ≈ 1.214.
+    const market = "0xc3d688b66703497daa19211eedff47f25384cdc3";
+    mockAave([]);
+    mockCompound(
+      [
+        {
+          protocol: "compound-v3",
+          chain: "ethereum",
+          marketAddress: market,
+          collateral: [{ token: "0xWETH", valueUsd: 1000 }],
+          totalCollateralUsd: 1000,
+          totalDebtUsd: 700,
+        },
+      ],
+      {
+        [market.toLowerCase()]: {
+          collateralAssets: [
+            {
+              asset: "0xWETH",
+              liquidateCollateralFactor: (BigInt(85) * 10n ** 16n).toString(),
+            },
+          ],
+        },
+      },
+    );
+    mockMorpho([]);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({ wallet: EVM_WALLET, threshold: 1.5 });
+    expect(r.atRisk).toHaveLength(1);
+    expect(r.atRisk[0].protocol).toBe("compound-v3");
+    expect(r.atRisk[0].market).toBe(market);
+    expect(r.atRisk[0].healthFactor).toBeCloseTo(1.2143, 3);
+  });
+
+  it("computes a Morpho Blue health factor from lltv on the position", async () => {
+    // lltv 0.86 (86% of 1e18). Collateral $2000 × 0.86 = $1720. Debt $1500
+    // → HF ≈ 1.1467. Below 1.5 threshold.
+    mockAave([]);
+    mockCompound([], {});
+    mockMorpho([
+      {
+        protocol: "morpho-blue",
+        chain: "ethereum",
+        marketId: "0xabc123",
+        lltv: (BigInt(86) * 10n ** 16n).toString(),
+        totalCollateralUsd: 2000,
+        totalDebtUsd: 1500,
+      },
+    ]);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({ wallet: EVM_WALLET, threshold: 1.5 });
+    expect(r.atRisk).toHaveLength(1);
+    expect(r.atRisk[0].protocol).toBe("morpho-blue");
+    expect(r.atRisk[0].market).toBe("0xabc123");
+    expect(r.atRisk[0].healthFactor).toBeCloseTo(1.1467, 3);
+  });
+
+  it("returns MarginFi + Kamino rows from the precomputed healthFactor", async () => {
+    mockSolana(
+      [
+        {
+          protocol: "marginfi",
+          chain: "solana",
+          marginfiAccount: "Mfi1Account",
+          totalSuppliedUsd: 1500,
+          totalBorrowedUsd: 1100,
+          healthFactor: 1.1,
+        },
+      ],
+      [
+        {
+          protocol: "kamino",
+          chain: "solana",
+          obligation: "KamObligationXyz",
+          totalSuppliedUsd: 800,
+          totalBorrowedUsd: 600,
+          healthFactor: 1.05,
+        },
+      ],
+    );
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({
+      solanaWallet: SOLANA_WALLET,
+      threshold: 1.5,
+    });
+    expect(r.atRisk.map((a) => a.protocol).sort()).toEqual(["kamino", "marginfi"]);
+    const mfi = r.atRisk.find((a) => a.protocol === "marginfi")!;
+    expect(mfi).toMatchObject({
+      chain: "solana",
+      market: "Mfi1Account",
+      healthFactor: 1.1,
+      collateralUsd: 1500,
+      debtUsd: 1100,
+    });
+  });
+
+  it("filters out positions at or above the threshold", async () => {
+    mockAave([
+      {
+        protocol: "aave-v3",
+        chain: "ethereum",
+        healthFactor: 2.5, // safe
+        totalCollateralUsd: 10_000,
+        totalDebtUsd: 1000,
+      },
+    ]);
+    mockCompound([], {});
+    mockMorpho([]);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({ wallet: EVM_WALLET, threshold: 1.5 });
+    expect(r.atRisk).toEqual([]);
+  });
+
+  it("captures partial-reader failures in notes[] without dropping other protocols", async () => {
+    mockAave([
+      {
+        protocol: "aave-v3",
+        chain: "ethereum",
+        healthFactor: 1.2,
+        totalCollateralUsd: 5000,
+        totalDebtUsd: 4000,
+      },
+    ]);
+    // Compound reader throws — should not fail the whole call.
+    vi.doMock("../src/modules/compound/index.js", () => ({
+      getCompoundPositions: vi.fn(async () => {
+        throw new Error("RPC down");
+      }),
+    }));
+    vi.doMock("../src/modules/compound/market-info.js", () => ({
+      getCompoundMarketInfo: vi.fn(),
+    }));
+    mockMorpho([]);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    const r = await getHealthAlerts({ wallet: EVM_WALLET, threshold: 1.5 });
+    expect(r.atRisk).toHaveLength(1);
+    expect(r.atRisk[0].protocol).toBe("aave-v3");
+    expect(r.notes).toBeDefined();
+    expect(r.notes!.some((n) => /Compound V3/.test(n) && /RPC down/.test(n))).toBe(true);
+  });
+
+  it("rejects calls that supply neither wallet nor solanaWallet", async () => {
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    await expect(getHealthAlerts({ threshold: 1.5 })).rejects.toThrow(
+      /at least one of/i,
+    );
+  });
+
+  it("does not call EVM readers when only solanaWallet is provided", async () => {
+    const aaveSpy = vi.fn();
+    vi.doMock("../src/modules/positions/aave.js", () => ({
+      getAaveLendingPosition: aaveSpy,
+      simulateHealthFactorChange: vi.fn(),
+    }));
+    const compoundSpy = vi.fn();
+    vi.doMock("../src/modules/compound/index.js", () => ({
+      getCompoundPositions: compoundSpy,
+    }));
+    vi.doMock("../src/modules/compound/market-info.js", () => ({
+      getCompoundMarketInfo: vi.fn(),
+    }));
+    const morphoSpy = vi.fn();
+    vi.doMock("../src/modules/morpho/index.js", () => ({
+      getMorphoPositions: morphoSpy,
+    }));
+    mockSolana([], []);
+    const { getHealthAlerts } = await import("../src/modules/positions/index.js");
+    await getHealthAlerts({ solanaWallet: SOLANA_WALLET });
+    expect(aaveSpy).not.toHaveBeenCalled();
+    expect(compoundSpy).not.toHaveBeenCalled();
+    expect(morphoSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #427. `get_health_alerts` was Aave-V3-only despite the generic name — a wallet borrowing on Compound V3 / Morpho Blue / MarginFi / Kamino got back `atRisk: []`, which is false safety reassurance against liquidation, not just a UX gap.
- Rewrites the tool to fan out to all five protocol readers in parallel. Output `atRisk[]` rows carry a `protocol` discriminator (`aave-v3` / `compound-v3` / `morpho-blue` / `marginfi` / `kamino`) + protocol-specific `market` handle.
- Adds optional `solanaWallet` arg for MarginFi + Kamino coverage; at least one of `wallet` / `solanaWallet` is required. Schema rejects empty calls.
- Per-protocol failures captured in `notes[]` rather than failing the whole call — a partial result still surfaces, and a "no liquidation risk" answer is never silently wrong (e.g. RPC down or MarginFi SDK IDL drift).
- Daily-briefing renderer now labels each row by protocol (`Aave V3 on ethereum`, `Kamino on Solana`, …) instead of always saying `Aave on …`.

## HF math
- Aave V3 / MarginFi / Kamino → use the position's `healthFactor` field.
- Compound V3 → one `getCompoundMarketInfo` per market, compute `Σ(collat_i × CF_i) / debt`.
- Morpho Blue → `(collat × lltv) / debt` from `position.lltv`.

## Test plan
- [x] `vitest run test/health-alerts-multi-protocol.test.ts` — 8/8 pass (Aave passthrough, Compound CF math, Morpho lltv math, MarginFi+Kamino passthrough, threshold filtering, partial-failure note capture, no-wallet rejection, EVM-readers-skipped-on-Solana-only).
- [x] Full suite — 2108/2108 pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual: against the smoke-test wallet `0x8EB8…ab28` from issue #427's repro (scripts 075/116), confirm Compound V3 / MarginFi / Kamino positions surface in `atRisk[]` when their HF is below the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)