### PR TITLE
feat(lido): add prepare_lido_wrap / prepare_lido_unwrap (closes #442)

### DIFF
--- a/src/abis/lido.ts
+++ b/src/abis/lido.ts
@@ -45,6 +45,20 @@ export const wstETHAbi = [
     inputs: [{ name: "wstETHAmount", type: "uint256" }],
     outputs: [{ type: "uint256" }],
   },
+  {
+    type: "function",
+    name: "wrap",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "_stETHAmount", type: "uint256" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "unwrap",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "_wstETHAmount", type: "uint256" }],
+    outputs: [{ type: "uint256" }],
+  },
 ] as const;
 
 export const lidoWithdrawalQueueAbi = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,8 @@ import {
   prepareUniswapV3Rebalance,
   prepareLidoStake,
   prepareLidoUnstake,
+  prepareLidoWrap,
+  prepareLidoUnwrap,
   prepareEigenLayerDeposit,
   prepareNativeSend,
   prepareWethUnwrap,
@@ -325,6 +327,8 @@ import {
   prepareUniswapV3RebalanceInput,
   prepareLidoStakeInput,
   prepareLidoUnstakeInput,
+  prepareLidoWrapInput,
+  prepareLidoUnwrapInput,
   prepareEigenLayerDepositInput,
   prepareNativeSendInput,
   prepareWethUnwrapInput,
@@ -3611,7 +3615,7 @@ async function main() {
     txHandler("prepare_lido_stake", prepareLidoStake)
   );
 
-  registerTool(server, 
+  registerTool(server,
     "prepare_lido_unstake",
     {
       description:
@@ -3621,7 +3625,27 @@ async function main() {
     txHandler("prepare_lido_unstake", prepareLidoUnstake)
   );
 
-  registerTool(server, 
+  registerTool(server,
+    "prepare_lido_wrap",
+    {
+      description:
+        "Build an unsigned wstETH.wrap transaction that converts stETH (rebasing) into wstETH (non-rebasing). 1:1 by share count, no DEX fee. Includes an stETH approve step to the wstETH contract if needed.",
+      inputSchema: prepareLidoWrapInput.shape,
+    },
+    txHandler("prepare_lido_wrap", prepareLidoWrap)
+  );
+
+  registerTool(server,
+    "prepare_lido_unwrap",
+    {
+      description:
+        "Build an unsigned wstETH.unwrap transaction that converts wstETH (non-rebasing) back into stETH (rebasing). No approval needed — burns wstETH from the caller's balance.",
+      inputSchema: prepareLidoUnwrapInput.shape,
+    },
+    txHandler("prepare_lido_unwrap", prepareLidoUnwrap)
+  );
+
+  registerTool(server,
     "prepare_eigenlayer_deposit",
     {
       description:

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -105,6 +105,8 @@ import {
 import {
   buildLidoStake,
   buildLidoUnstake,
+  buildLidoWrap,
+  buildLidoUnwrap,
   buildEigenLayerDeposit,
 } from "../staking/actions.js";
 import { buildWethUnwrap } from "../weth/actions.js";
@@ -125,6 +127,8 @@ import type {
   PrepareUniswapV3RebalanceArgs,
   PrepareLidoStakeArgs,
   PrepareLidoUnstakeArgs,
+  PrepareLidoWrapArgs,
+  PrepareLidoUnwrapArgs,
   PrepareEigenLayerDepositArgs,
   PrepareNativeSendArgs,
   PrepareWethUnwrapArgs,
@@ -2395,6 +2399,25 @@ export async function prepareLidoUnstake(args: PrepareLidoUnstakeArgs): Promise<
       wallet: args.wallet as `0x${string}`,
       amountStETH: args.amountStETH,
       approvalCap: args.approvalCap,
+    })
+  );
+}
+
+export async function prepareLidoWrap(args: PrepareLidoWrapArgs): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildLidoWrap({
+      wallet: args.wallet as `0x${string}`,
+      amountStETH: args.amountStETH,
+      approvalCap: args.approvalCap,
+    })
+  );
+}
+
+export async function prepareLidoUnwrap(args: PrepareLidoUnwrapArgs): Promise<UnsignedTx> {
+  return enrichTx(
+    buildLidoUnwrap({
+      wallet: args.wallet as `0x${string}`,
+      amountWstETH: args.amountWstETH,
     })
   );
 }

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -723,6 +723,25 @@ export const prepareLidoUnstakeInput = z.object({
     ),
   approvalCap: approvalCapSchema,
 });
+export const prepareLidoWrapInput = z.object({
+  wallet: walletSchema,
+  amountStETH: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable stETH amount to wrap into wstETH, NOT raw wei. Example: "0.5" for 0.5 stETH (18 decimals).'
+    ),
+  approvalCap: approvalCapSchema,
+});
+export const prepareLidoUnwrapInput = z.object({
+  wallet: walletSchema,
+  amountWstETH: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable wstETH amount to unwrap into stETH, NOT raw wei. Example: "0.5" for 0.5 wstETH (18 decimals).'
+    ),
+});
 
 export const prepareEigenLayerDepositInput = z.object({
   wallet: walletSchema,
@@ -992,6 +1011,8 @@ export type PrepareAaveBorrowArgs = z.infer<typeof prepareAaveBorrowInput>;
 export type PrepareAaveRepayArgs = z.infer<typeof prepareAaveRepayInput>;
 export type PrepareLidoStakeArgs = z.infer<typeof prepareLidoStakeInput>;
 export type PrepareLidoUnstakeArgs = z.infer<typeof prepareLidoUnstakeInput>;
+export type PrepareLidoWrapArgs = z.infer<typeof prepareLidoWrapInput>;
+export type PrepareLidoUnwrapArgs = z.infer<typeof prepareLidoUnwrapInput>;
 export type PrepareEigenLayerDepositArgs = z.infer<typeof prepareEigenLayerDepositInput>;
 export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
 export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;

--- a/src/modules/staking/actions.ts
+++ b/src/modules/staking/actions.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, parseEther, parseUnits, zeroAddress } from "viem";
-import { stETHAbi, lidoWithdrawalQueueAbi } from "../../abis/lido.js";
+import { stETHAbi, wstETHAbi, lidoWithdrawalQueueAbi } from "../../abis/lido.js";
 import { eigenStrategyManagerAbi } from "../../abis/eigenlayer-strategy-manager.js";
 import { CONTRACTS } from "../../config/contracts.js";
 import { buildApprovalTx, chainApproval, resolveApprovalCap } from "../shared/approval.js";
@@ -66,6 +66,70 @@ export async function buildLidoUnstake(p: LidoUnstakeParams): Promise<UnsignedTx
   };
 
   return chainApproval(approve, unstakeTx);
+}
+
+export interface LidoWrapParams {
+  wallet: `0x${string}`;
+  amountStETH: string;
+  approvalCap?: string;
+}
+
+export async function buildLidoWrap(p: LidoWrapParams): Promise<UnsignedTx> {
+  const amountWei = parseEther(p.amountStETH);
+  const stETH = CONTRACTS.ethereum.lido.stETH as `0x${string}`;
+  const wstETH = CONTRACTS.ethereum.lido.wstETH as `0x${string}`;
+
+  const { approvalAmount, display } = resolveApprovalCap(p.approvalCap, amountWei, 18);
+  const approve = await buildApprovalTx({
+    chain: "ethereum",
+    wallet: p.wallet,
+    asset: stETH,
+    spender: wstETH,
+    amountWei,
+    approvalAmount,
+    approvalDisplay: display,
+    symbol: "stETH",
+    spenderLabel: "Lido wstETH",
+  });
+
+  const wrapTx: UnsignedTx = {
+    chain: "ethereum",
+    to: wstETH,
+    data: encodeFunctionData({
+      abi: wstETHAbi,
+      functionName: "wrap",
+      args: [amountWei],
+    }),
+    value: "0",
+    from: p.wallet,
+    description: `Wrap ${p.amountStETH} stETH into wstETH`,
+    decoded: { functionName: "wrap", args: { amount: p.amountStETH + " stETH" } },
+  };
+
+  return chainApproval(approve, wrapTx);
+}
+
+export interface LidoUnwrapParams {
+  wallet: `0x${string}`;
+  amountWstETH: string;
+}
+
+export function buildLidoUnwrap(p: LidoUnwrapParams): UnsignedTx {
+  const amountWei = parseEther(p.amountWstETH);
+  const wstETH = CONTRACTS.ethereum.lido.wstETH as `0x${string}`;
+  return {
+    chain: "ethereum",
+    to: wstETH,
+    data: encodeFunctionData({
+      abi: wstETHAbi,
+      functionName: "unwrap",
+      args: [amountWei],
+    }),
+    value: "0",
+    from: p.wallet,
+    description: `Unwrap ${p.amountWstETH} wstETH into stETH`,
+    decoded: { functionName: "unwrap", args: { amount: p.amountWstETH + " wstETH" } },
+  };
 }
 
 export interface EigenDepositParams {

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { parseEther, toFunctionSelector, zeroAddress } from "viem";
-import { buildLidoStake } from "../src/modules/staking/actions.js";
+import {
+  buildLidoStake,
+  buildLidoUnwrap,
+} from "../src/modules/staking/actions.js";
 import { CONTRACTS } from "../src/config/contracts.js";
 
 describe("buildLidoStake", () => {
@@ -34,5 +37,34 @@ describe("buildLidoStake", () => {
     expect(tx.decoded?.functionName).toBe("submit");
     expect(tx.decoded?.args.value).toBe("2.25 ETH");
     expect(tx.description).toContain("2.25 ETH");
+  });
+});
+
+describe("buildLidoUnwrap", () => {
+  const wallet = "0x2222222222222222222222222222222222222222" as `0x${string}`;
+
+  it("returns a single tx to the wstETH contract with no approve step", () => {
+    const tx = buildLidoUnwrap({ wallet, amountWstETH: "1.5" });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to.toLowerCase()).toBe(CONTRACTS.ethereum.lido.wstETH.toLowerCase());
+    expect(tx.from).toBe(wallet);
+    expect(tx.value).toBe("0");
+    expect(tx.next).toBeUndefined();
+  });
+
+  it("calldata starts with the unwrap(uint256) selector and encodes amount in wei", () => {
+    const tx = buildLidoUnwrap({ wallet, amountWstETH: "0.25" });
+    const selector = toFunctionSelector("unwrap(uint256)");
+    expect(tx.data.toLowerCase().startsWith(selector.toLowerCase())).toBe(true);
+    expect(tx.data.length).toBe(2 + 8 + 64);
+    const argHex = tx.data.slice(2 + 8);
+    expect(BigInt("0x" + argHex)).toBe(parseEther("0.25"));
+  });
+
+  it("decoded metadata preserves user-facing amount", () => {
+    const tx = buildLidoUnwrap({ wallet, amountWstETH: "2" });
+    expect(tx.decoded?.functionName).toBe("unwrap");
+    expect(tx.decoded?.args.amount).toBe("2 wstETH");
+    expect(tx.description).toContain("2 wstETH");
   });
 });


### PR DESCRIPTION
## Summary
- New `prepare_lido_wrap` / `prepare_lido_unwrap` tools for stETH ↔ wstETH conversion. Resolves [#442](https://github.com/szhygulin/vaultpilot-mcp/issues/442).
- Wrap chains an `stETH.approve(wstETH, amount)` (via the shared `buildApprovalTx` helper, honoring `approvalCap`) ahead of `wstETH.wrap(amount)`.
- Unwrap is a single `wstETH.unwrap(amount)` call — no approval needed since the contract burns from `msg.sender`'s own balance.
- Both reuse the existing `buildLidoStake` / `buildLidoUnstake` shape (same `chainApproval` / `enrichTx` plumbing, same schema patterns). No new modules, no new abstractions, no new deps.

## Why not route via LiFi / DEX
Wrapping is share-count-preserving and 1:1 by definition (`wstETH.wrap(x_stETH) → x * (10^18 / stEthPerToken)` wstETH). A DEX swap would charge LP fees and could deviate from that invariant. Same reasoning as the existing ETH↔WETH path that goes through the native wrapper, not LiFi.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] `vitest run test/actions.test.ts test/lido-prefetch-batch.test.ts test/staking-partial-failure.test.ts` → 15/15 pass.
- [x] `buildLidoUnwrap` covered by 3 unit tests (selector + arg encoding + decoded metadata).
- [ ] `buildLidoWrap` follows the same RPC-coupled allowance-read shape as the existing `buildLidoUnstake`, which has no unit tests for the same reason. Live smoke test against mainnet wstETH (`0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0`) recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)