### PR TITLE
fix(skill-pin): bump to v7 for Inv #2 framing (closes #462)

### DIFF
--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "83195093d98367ad8000164caa396e855a213d9de64018ba148d03be566772df";
+  "b70085dfad5d22658372f034dea5dfd6b82d0acee8cdb32da980093bb01f0799";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v6_";
-export const EXPECTED_SKILL_SENTINEL_C = "8682084ac4984982";
+export const EXPECTED_SKILL_SENTINEL_B = "_v7_";
+export const EXPECTED_SKILL_SENTINEL_C = "8e252312c08c415b";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =


### PR DESCRIPTION
## Summary

Coordinated MCP-side pin bump for [vaultpilot-security-skill#18](https://github.com/szhygulin/vaultpilot-security-skill/pull/18) which reframes §Invariant 2 as **corroborating, not load-bearing** in the rogue-MCP threat model.

| Constant | Before | After |
|---|---|---|
| `EXPECTED_SKILL_SHA256` | `83195093…72df` | `b70085df…0799` |
| `EXPECTED_SKILL_SENTINEL_B` | `_v6_` | `_v7_` |
| `EXPECTED_SKILL_SENTINEL_C` | `8682084ac4984982` | `8e252312c08c415b` |

## ⚠️ Merge ordering

**DRAFT** until the skill PR merges. If this lands first, every signing flow halts with `vaultpilot-preflight skill integrity check FAILED` until skill#18 ships.

## Test plan

- [x] `skill-pin-drift.test.ts` 17/17 pass against new constants
- [x] Typecheck clean
- [ ] After skill#18 merges: end-to-end signing flow passes Step 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)