### PR TITLE
docs(roadmap): canonical L1↔L2 / L2↔L2 bridges (refs #443)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 - **Curve + Convex + Pendle + GMX V2** — stable-LP / yield-trading / perps. Direct ABI integration for Curve / Convex / GMX; `@pendle/sdk-v2` for Pendle. ([plan](./claude-work/plan-defi-expansion-roadmap.md))
 - **Balancer V2 + V3 + Aura** — Vault-centric LP + V3 Hooks pools + Aura boost. ([plan](./claude-work/plan-balancer-v2-v3-aura.md))
 - **DEX liquidity verb set** — Uniswap V3 `mint` / `collect` / `decrease_liquidity` / `burn` / `rebalance` (reads already shipped), Curve LP, Balancer LP. ([plan](./claude-work/plan-dex-liquidity-provision.md))
+- **Canonical L1↔L2 / L2↔L2 bridges** — Optimism / Base (Bedrock, shared ABI), Arbitrum, Polygon PoS. Trust-minimized alternative to LiFi: slow (7-day proof window for OP-Stack rollups, ~30 min – 3 h for Polygon PoS exit) but L1-anchored. Phased per-bridge; Phase 1 (OP+Base) is the smallest unit. ([plan](./claude-work/plan-canonical-bridges.md))
 
 **New chains**
 


### PR DESCRIPTION
## Summary
Adds a deferred roadmap entry for canonical bridges (Optimism / Base / Arbitrum / Polygon PoS) under \`New protocols (EVM)\`, pointing at the new plan in \`claude-work/plan-canonical-bridges.md\`.

## Why deferred (not implemented now)
Issue [#443](https://github.com/szhygulin/vaultpilot-mcp/issues/443) bundles 4 distinct bridge protocols and overlooks that L2→L1 withdrawals on optimistic rollups (Arbitrum / OP / Base) are 2-step flows separated by a 7-day proof window — the proposed \`prepare_*_l2_withdraw\` tools as written would build only the L2-side initiate, leaving funds unclaimable without a separate \`finalize\` tool. Picking it up properly is ~3 weeks of phased work that doesn't currently outrank the queued items above it on the roadmap.

The plan splits into 4 phases starting with Optimism Bedrock (single ABI pass yields both OP and Base via the shared \`OptimismPortal\` + \`L2StandardBridge\` contracts) so the smallest meaningful first PR is well-defined when the work resumes.

## Test plan
- [x] No code change. README link target exists at \`./claude-work/plan-canonical-bridges.md\` (gitignored — intentional, matches the precedent of every other roadmap plan link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)