### PR TITLE
docs(roadmap): Aptos + Sui chain support (refs #444)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 
 - **Bitcoin** via Ledger USB HID — native segwit + taproot sends, portfolio integration, mempool.space fee estimation, BIP-125 RBF by default. ([plan](./claude-work/plan-bitcoin-ledger-phase1.md))
 - **Hyperliquid L1** — full parity (perps + spot + vaults + staking + TWAP). Ledger-per-trade blind-sign signing; no API-wallet shortcut. ([plan](./claude-work/plan-hyperliquid-full-parity.md))
+- **Aptos + Sui** (Move-VM) — read first (balance + staking + Sui objects), then Ledger USB HID pair + native send + stake delegate per chain. WalletConnect doesn't carry Move namespaces, so signing follows the TRON / Solana USB precedent. Phase 1 (Aptos read-only) is the smallest unit. ([plan](./claude-work/plan-aptos-sui-chain-support.md))
 
 **More Solana protocols**
 


### PR DESCRIPTION
## Summary
Adds a deferred roadmap entry for Aptos + Sui (Move-VM) chain support under \`New chains\`, pointing at the new plan in \`claude-work/plan-aptos-sui-chain-support.md\`.

## Why deferred (not implemented now)
Issue [#444](https://github.com/szhygulin/vaultpilot-mcp/issues/444) bundles two non-EVM chain integrations (Aptos and Sui) into one ask. Each is ~4–6 weeks on the scale of existing Solana / TRON / BTC phases — different SDKs, different signing surface (Ledger USB HID per chain since WalletConnect doesn't carry Move namespaces, mirroring TRON / Solana precedent), and Sui's object-based state model doesn't map onto our existing account-based readers.

Plan splits into four phases starting with Aptos read-only (~400 LoC, single PR) so the first picked-up unit is well-scoped when work resumes.

## Test plan
- [x] No code change. README link target exists at \`./claude-work/plan-aptos-sui-chain-support.md\` (gitignored — intentional, matches the precedent of every other roadmap plan link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)