### PR TITLE
fix: add_contact + listContacts work without paired Ledger (#428, partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 
 - **Server-integrated second-agent verification** — MCP calls an independent LLM directly on high-value sends and blocks on disagreement. Structurally closes the coordinated-agent gap that today's copy-paste `get_verification_artifact` flow only narrows.
 - **PreToolUse hook for mechanical hash enforcement** — host-side code that recomputes the pre-sign hash and blocks the MCP tool call on divergence, making the check mechanical rather than prose-based. Ships as a separate `vaultpilot-hook` repo.
+- **Contacts unsigned/verified state machine** (follow-up to [#428](https://github.com/szhygulin/vaultpilot-mcp/issues/428)) — persistent on-disk unsigned entries + `promote_unsigned_contacts` sign-on-pair upgrade flow + tamper-aware merge between signed and unsigned overlays. Today's #428 fix covers the user-visible "first-run users can label addresses without a Ledger" gap with a process-local in-memory store; the deferred state machine adds restart-survivable persistence and the upgrade-on-pair semantics. ([plan](./claude-work/plan-contacts-unsigned-state-machine.md))
 
 **Recently shipped** (previously on this list)
 

--- a/src/contacts/index.ts
+++ b/src/contacts/index.ts
@@ -109,6 +109,25 @@ async function pickAnchorForChain(
   return pickEvmAnchor();
 }
 
+/**
+ * Issue #428 — variant that returns `null` instead of throwing when no
+ * Ledger is paired, so write paths can fall through to the unsigned
+ * in-memory store. Other failures (BTC anchor present but taproot-only,
+ * etc.) still throw so the user sees the real error rather than a
+ * silent demotion to unsigned.
+ */
+async function tryPickAnchorForChain(
+  chain: "btc" | "evm",
+): Promise<BtcAnchor | EvmAnchor | null> {
+  try {
+    return await pickAnchorForChain(chain);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.startsWith(ContactsError.LedgerNotPaired)) return null;
+    throw e;
+  }
+}
+
 async function signBlobForChain(args: {
   chain: "btc" | "evm";
   preimage: string;
@@ -195,6 +214,14 @@ export async function addContact(args: AddContactArgs): Promise<{
   address: string;
   version: number;
   anchorAddress: string;
+  /**
+   * `true` when the contact was stored unsigned (demo mode OR non-demo
+   * with no paired Ledger — issue #428). Persistence is process-local
+   * in both cases; the agent should surface "(unsigned)" alongside the
+   * label so the user knows the address is not anchored to a hardware
+   * key. Pair a Ledger and re-add the contact to upgrade to signed.
+   */
+  unsigned?: boolean;
 }> {
   // Demo mode: route to the in-memory store, no Ledger interaction.
   // `version` and `anchorAddress` are placeholders so the response shape
@@ -214,6 +241,7 @@ export async function addContact(args: AddContactArgs): Promise<{
       address: args.address,
       version: 0,
       anchorAddress: "DEMO_ANCHOR",
+      unsigned: true,
     };
   }
   rejectIfNotV1(args.chain);
@@ -224,6 +252,32 @@ export async function addContact(args: AddContactArgs): Promise<{
       `${ContactsError.AddressFormatMismatch}: address "${args.address}" does not ` +
         `match the expected format for chain "${args.chain}".`,
     );
+  }
+
+  // Issue #428 — when no Ledger is paired, fall through to the same
+  // in-memory store demo mode uses, return `unsigned: true`. Lets first-
+  // run / accountant-share users label addresses without entering demo
+  // mode (which intercepts broadcasts) or pairing a Ledger they don't
+  // own. Persistence is process-local; the deferred state machine in
+  // `claude-work/plan-contacts-unsigned-state-machine.md` adds disk
+  // persistence + sign-on-pair upgrade.
+  const anchor = await tryPickAnchorForChain(chain);
+  if (anchor === null) {
+    addDemoContact({
+      chain: args.chain,
+      label: args.label,
+      address: args.address,
+      ...(args.notes !== undefined ? { notes: args.notes } : {}),
+      ...(args.tags !== undefined ? { tags: args.tags } : {}),
+    });
+    return {
+      chain: args.chain,
+      label: args.label,
+      address: args.address,
+      version: 0,
+      anchorAddress: "UNSIGNED_NO_LEDGER",
+      unsigned: true,
+    };
   }
 
   const file = readContactsFile();
@@ -247,7 +301,6 @@ export async function addContact(args: AddContactArgs): Promise<{
     }
   }
 
-  const anchor = await pickAnchorForChain(chain);
   // Build the new entries: replace if same label, append otherwise.
   const oldEntries: SignedContactEntry[] = existingBlob?.entries ?? [];
   const filtered = oldEntries.filter((e) => e.label !== args.label);
@@ -313,7 +366,12 @@ export async function addContact(args: AddContactArgs): Promise<{
 }
 
 export async function removeContact(args: RemoveContactArgs): Promise<{
-  removed: Array<{ chain: ContactChain; address: string; version: number }>;
+  removed: Array<{
+    chain: ContactChain;
+    address: string;
+    version: number;
+    unsigned?: boolean;
+  }>;
 }> {
   if (isDemoMode()) {
     const removed = removeDemoContact({
@@ -326,14 +384,28 @@ export async function removeContact(args: RemoveContactArgs): Promise<{
           `on ${args.chain ? `chain ${args.chain}` : "any chain"}.`,
       );
     }
-    return { removed: removed.map((r) => ({ ...r, version: 0 })) };
+    return {
+      removed: removed.map((r) => ({ ...r, version: 0, unsigned: true })),
+    };
   }
+  // Issue #428 — also clear matching entries from the in-memory unsigned
+  // store. Unsigned removals don't need a Ledger; signed removals still
+  // do, and fall through to the existing path below.
+  const unsignedRemoved = removeDemoContact({
+    label: args.label,
+    ...(args.chain !== undefined ? { chain: args.chain } : {}),
+  });
   const file = readContactsFile();
   const chains: Array<"btc" | "evm"> = args.chain
     ? (rejectIfNotV1(args.chain), [args.chain as "btc" | "evm"])
     : ["btc", "evm"];
 
-  const removed: Array<{ chain: ContactChain; address: string; version: number }> = [];
+  const removed: Array<{
+    chain: ContactChain;
+    address: string;
+    version: number;
+    unsigned?: boolean;
+  }> = unsignedRemoved.map((r) => ({ ...r, version: 0, unsigned: true }));
   let next = file;
   for (const chain of chains) {
     const blob = next.chains[chain];
@@ -387,7 +459,10 @@ export async function removeContact(args: RemoveContactArgs): Promise<{
         `on ${args.chain ? `chain ${args.chain}` : "any chain"}.`,
     );
   }
-  writeContactsFile(next);
+  // Only persist if signed removals actually changed the disk file.
+  // Pure unsigned removals (issue #428) leave the on-disk blob untouched.
+  const signedRemovals = removed.some((r) => !r.unsigned);
+  if (signedRemovals) writeContactsFile(next);
   return { removed };
 }
 
@@ -399,7 +474,8 @@ export async function listContacts(
       ...(args.chain !== undefined ? { chain: args.chain } : {}),
       ...(args.label !== undefined ? { label: args.label } : {}),
     });
-    // Join by label across chains — same shape as production.
+    // Join by label across chains — same shape as production. Every
+    // demo entry is unsigned; flag accordingly.
     const byLabel = new Map<string, ListedContact>();
     for (const row of rows) {
       const existing = byLabel.get(row.label);
@@ -419,6 +495,7 @@ export async function listContacts(
             ? { tags: existing.tags }
             : {}),
         addedAt: earlierAddedAt,
+        unsigned: true,
       });
     }
     const contacts = Array.from(byLabel.values()).sort((a, b) =>
@@ -464,6 +541,49 @@ export async function listContacts(
         addedAt: earlierAddedAt,
       });
     }
+  }
+
+  // Issue #428 — also fold in any unsigned entries from the in-memory
+  // store so a non-demo user who added contacts before pairing a Ledger
+  // can still see them. A label that has BOTH signed and unsigned
+  // entries gets `unsigned: true` so the agent surfaces "(unsigned)"
+  // in the verification block — the safety property is "never claim
+  // a label is verified when any chain is unsigned."
+  const unsignedRows = listDemoContacts({
+    ...(args.chain !== undefined ? { chain: args.chain } : {}),
+    ...(args.label !== undefined ? { label: args.label } : {}),
+  });
+  for (const row of unsignedRows) {
+    const existing = byLabel.get(row.label);
+    const earlierAddedAt =
+      existing && existing.addedAt < row.addedAt
+        ? existing.addedAt
+        : row.addedAt;
+    const newAddresses = {
+      ...(existing?.addresses ?? {}),
+      // In-memory wins ONLY for chains the disk doesn't already cover —
+      // signed disk entries are the source of truth for any chain they
+      // populate. The unsigned overlay just fills gaps.
+      ...(existing?.addresses && existing.addresses[row.chain]
+        ? {}
+        : { [row.chain]: row.address }),
+    };
+    byLabel.set(row.label, {
+      label: row.label,
+      addresses: newAddresses,
+      ...(row.notes !== undefined
+        ? { notes: row.notes }
+        : existing?.notes !== undefined
+          ? { notes: existing.notes }
+          : {}),
+      ...(row.tags !== undefined
+        ? { tags: row.tags }
+        : existing?.tags !== undefined
+          ? { tags: existing.tags }
+          : {}),
+      addedAt: earlierAddedAt,
+      unsigned: true,
+    });
   }
 
   const contacts = Array.from(byLabel.values()).sort((a, b) =>
@@ -524,11 +644,29 @@ export async function verifyContacts(
   const targets: Array<"btc" | "evm"> = args.chain
     ? (rejectIfNotV1(args.chain), [args.chain as "btc" | "evm"])
     : ["btc", "evm"];
+  // Issue #428 — count unsigned in-memory entries per chain so each
+  // VerifyResult can carry `unsignedEntryCount`. A chain with NO signed
+  // blob but ≥1 unsigned entry returns `ok: false, reason: "no signed
+  // entries on this chain", unsignedEntryCount: N` so the agent
+  // surfaces the unsigned overlay rather than silently dropping it.
+  const unsignedCounts = new Map<ContactChain, number>();
+  for (const r of listDemoContacts()) {
+    unsignedCounts.set(r.chain, (unsignedCounts.get(r.chain) ?? 0) + 1);
+  }
   const results: VerifyResult[] = [];
   for (const chain of targets) {
+    const unsignedN = unsignedCounts.get(chain) ?? 0;
     const blob = file.chains[chain];
     if (!blob) {
-      results.push({ chain, ok: false, reason: "no entries on this chain" });
+      results.push({
+        chain,
+        ok: false,
+        reason:
+          unsignedN > 0
+            ? "no signed entries on this chain (unsigned-only)"
+            : "no entries on this chain",
+        ...(unsignedN > 0 ? { unsignedEntryCount: unsignedN } : {}),
+      });
       continue;
     }
     try {
@@ -539,12 +677,18 @@ export async function verifyContacts(
         anchorAddress: blob.anchorAddress,
         version: blob.version,
         entryCount: blob.entries.length,
+        ...(unsignedN > 0 ? { unsignedEntryCount: unsignedN } : {}),
       });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       // Surface the matching CONTACTS_* error code.
       const code = msg.split(":")[0];
-      results.push({ chain, ok: false, reason: code });
+      results.push({
+        chain,
+        ok: false,
+        reason: code,
+        ...(unsignedN > 0 ? { unsignedEntryCount: unsignedN } : {}),
+      });
     }
   }
   return { results };

--- a/src/contacts/resolver.ts
+++ b/src/contacts/resolver.ts
@@ -208,7 +208,10 @@ export async function resolveRecipient(
   const warnings: string[] = [];
 
   // (1) Literal address: pass through, optionally decorated with a
-  // reverse-lookup label.
+  // reverse-lookup label. Issue #428 — fall back to the in-memory
+  // unsigned store when the signed blob has no match (or no blob),
+  // and warn that the label is unsigned so Invariant #7 keeps
+  // working in degraded form.
   if (looksLikeLiteralAddress(input, cc)) {
     if (cc === "btc" || cc === "evm") {
       const r = await reverseLookup(cc, input);
@@ -224,17 +227,45 @@ export async function resolveRecipient(
         warnings.push(
           "contacts file failed verification — recipient label not checked",
         );
+      } else {
+        const unsignedLabel = findDemoContactByAddress(cc, input);
+        if (unsignedLabel) {
+          warnings.push(
+            `contact "${unsignedLabel}" matched from the in-memory unsigned ` +
+              `store — pair a Ledger to anchor this label cryptographically.`,
+          );
+          return {
+            address: input,
+            source: "literal",
+            label: unsignedLabel,
+            warnings,
+          };
+        }
       }
     }
     return { address: input, source: "literal", warnings };
   }
 
-  // (2) Contact label match. STRICT verify — tamper aborts.
+  // (2) Contact label match. STRICT verify — tamper aborts. Falls back
+  // to the unsigned in-memory store on no signed hit (#428).
   if (cc === "btc" || cc === "evm") {
     const labelHit = await forwardLookup(cc, input);
     if (labelHit) {
       return {
         address: labelHit,
+        source: "contact",
+        label: input,
+        warnings,
+      };
+    }
+    const unsignedHit = findDemoContactByLabel(cc, input);
+    if (unsignedHit) {
+      warnings.push(
+        `contact "${input}" resolved from the in-memory unsigned store — ` +
+          `pair a Ledger to anchor this label cryptographically.`,
+      );
+      return {
+        address: unsignedHit,
         source: "contact",
         label: input,
         warnings,
@@ -249,7 +280,7 @@ export async function resolveRecipient(
       if (ens.address) {
         // Reverse-decorate the ENS hit if a contact matches the same
         // address (contact-wins precedence rule, but only when
-        // contacts verify cleanly).
+        // contacts verify cleanly). Falls back to unsigned (#428).
         const r = await reverseLookup("evm", ens.address);
         let label: string | undefined;
         if (r.state === "match") label = r.label;
@@ -257,6 +288,15 @@ export async function resolveRecipient(
           warnings.push(
             "contacts file failed verification — ENS reverse-decoration skipped",
           );
+        } else {
+          const unsignedLabel = findDemoContactByAddress("evm", ens.address);
+          if (unsignedLabel) {
+            label = unsignedLabel;
+            warnings.push(
+              `ENS hit decorated with unsigned label "${unsignedLabel}" — ` +
+                `pair a Ledger to anchor cryptographically.`,
+            );
+          }
         }
         return {
           address: ens.address,

--- a/src/contacts/schemas.ts
+++ b/src/contacts/schemas.ts
@@ -195,8 +195,11 @@ export type VerifyContactsArgs = z.infer<typeof verifyContactsInput>;
 
 /**
  * One row returned by `list_contacts` — a single label joined across
- * chains, with addresses keyed by chain. Every address has been
- * signature-verified before this row is built.
+ * chains, with addresses keyed by chain. Issue #428: `unsigned` rows
+ * exist when the user added a contact without a paired Ledger (the
+ * in-memory fall-through path). Signed rows are signature-verified
+ * before this row is built; unsigned rows have only address-format
+ * validation and process-local persistence.
  */
 export interface ListedContact {
   label: string;
@@ -210,6 +213,13 @@ export interface ListedContact {
   tags?: string[];
   /** Earliest `addedAt` across the joined chain entries. */
   addedAt: string;
+  /**
+   * `true` when at least one of the joined chain entries is unsigned
+   * (in-memory only, no Ledger signature). Implies process-local
+   * persistence (lost on restart) until #428's deferred state machine
+   * lands a sign-on-pair upgrade flow.
+   */
+  unsigned?: boolean;
 }
 
 export interface VerifyResult {
@@ -223,6 +233,13 @@ export interface VerifyResult {
   entryCount?: number;
   /** Reason for ok=false. Filled with the matching CONTACTS_* error code. */
   reason?: string;
+  /**
+   * Issue #428 — count of unsigned (in-memory) entries on this chain
+   * that exist alongside (or instead of) the signed blob. Surfaced
+   * separately so the agent can label them as not-anchored even when
+   * the signed blob is empty or absent. Omitted when zero.
+   */
+  unsignedEntryCount?: number;
 }
 
 /** Stable error codes. Mirror the plan's named error symbols. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3888,10 +3888,11 @@ async function main() {
     {
       description:
         "Save a label → address binding to the address book. " +
-        "**Production mode**: blob is signed with the user's paired Ledger key on that chain (BIP-137 for BTC, EIP-191 for EVM in v1.0; Solana / TRON support deferred to v1.5). " +
+        "**Production mode + Ledger paired**: blob is signed with the user's paired Ledger key on that chain (BIP-137 for BTC, EIP-191 for EVM in v1.0; Solana / TRON support deferred to v1.5). Persisted to `~/.vaultpilot-mcp/contacts.json` and verified on every read. " +
+        "**Production mode + no Ledger paired (issue #428)**: writes to a process-local in-memory store and returns `unsigned: true` + `anchorAddress: \"UNSIGNED_NO_LEDGER\"` so first-run / accountant-share users can label addresses without entering demo mode (which intercepts broadcasts). The label is process-local — lost on restart — and resolves with a `(unsigned)` warning in send-flow verification blocks. Pair a Ledger and re-add to upgrade to a signed entry. " +
+        "**Demo mode** (`VAULTPILOT_DEMO=true`): same in-memory store, returns `unsigned: true` + `anchorAddress: \"DEMO_ANCHOR\"`. All four chains usable from day one (btc/evm/solana/tron). " +
         "v1.0 production chains: `btc` + `evm`. `solana` / `tron` return CONTACTS_CHAIN_NOT_YET_SUPPORTED. The `notes` and `tags` fields update the unsigned metadata sidecar (joined across chains by label) so editing them doesn't require a fresh device signature. " +
-        "**Demo mode** (`VAULTPILOT_DEMO=true`): writes to a process-local in-memory store (lost on restart, never persisted to disk). No Ledger interaction. All four chains usable from day one (btc/evm/solana/tron). Less secure by design — there's no signature chain to detect tamper — but matches demo mode's broader trade-off where `send_transaction` is intercepted as a simulation. " +
-        "Sends like `prepare_native_send({ to: \"Mom\" })` then resolve `Mom` against the verified blob (or, in demo mode, the in-memory store) automatically — no separate lookup tool. Adding the same label twice on the same chain replaces the address (with a fresh signature in production). Adding a different label that maps to an already-saved address rejects with CONTACTS_DUPLICATE_ADDRESS.",
+        "Sends like `prepare_native_send({ to: \"Mom\" })` resolve `Mom` against the signed blob first, then fall through to the unsigned overlay with a warning. Adding the same label twice on the same chain replaces the address (with a fresh signature in production-signed mode). Adding a different label that maps to an already-saved address rejects with CONTACTS_DUPLICATE_ADDRESS.",
       inputSchema: addContactInput.shape,
     },
     handler(addContact)
@@ -3901,7 +3902,7 @@ async function main() {
     "remove_contact",
     {
       description:
-        "Remove a labeled contact. Without `chain`, removes the label from EVERY chain that has it (one device interaction per chain in production; no device in demo). With `chain`, removes only that chain's entry — the label can survive on other chains. The unsigned metadata row (notes / tags) is dropped only when no chain still references the label. Issues CONTACTS_LABEL_NOT_FOUND if no chain has the label. In demo mode, removal is from the in-memory store with no signing.",
+        "Remove a labeled contact. Without `chain`, removes the label from EVERY chain that has it (one device interaction per chain when removing a signed entry). With `chain`, removes only that chain's entry — the label can survive on other chains. The unsigned metadata row (notes / tags) is dropped only when no chain still references the label. Issues CONTACTS_LABEL_NOT_FOUND if neither the signed disk nor the unsigned in-memory store has the label. Issue #428: unsigned-only removals never need a Ledger; mixed labels (signed entry on one chain + unsigned on another) require pairing only for the signed-entry chain.",
       inputSchema: removeContactInput.shape,
     },
     handler(removeContact)
@@ -3911,9 +3912,9 @@ async function main() {
     "list_contacts",
     {
       description:
-        "Verify + return the joined per-label view across chains. Each row contains the label, addresses keyed by chain, optional notes / tags, and the earliest `addedAt` across the joined entries. " +
-        "Strict-fail on tamper (production): any signature failure / anchor mismatch / version rollback throws immediately (CONTACTS_TAMPERED / CONTACTS_ANCHOR_MISMATCH / CONTACTS_VERSION_ROLLBACK) rather than silently dropping rows — agents must surface the failure to the user. " +
-        "In demo mode, the demo in-memory store is read directly (no signature path); all four chains supported.",
+        "Return the joined per-label view across chains. Each row contains the label, addresses keyed by chain, optional notes / tags, the earliest `addedAt` across the joined entries, and an optional `unsigned: true` flag (issue #428) when at least one chain entry is unsigned (in-memory only). " +
+        "Strict-fail on tamper (signed disk blobs): any signature failure / anchor mismatch / version rollback throws immediately (CONTACTS_TAMPERED / CONTACTS_ANCHOR_MISMATCH / CONTACTS_VERSION_ROLLBACK) rather than silently dropping rows — agents must surface the failure to the user. Unsigned in-memory entries are merged on top of the verified signed view; signed entries always win on a per-(label, chain) basis. " +
+        "In demo mode, the demo in-memory store is read directly (no signature path); all four chains supported, every row is `unsigned: true`.",
       inputSchema: listContactsInput.shape,
     },
     handler(listContacts)
@@ -3923,7 +3924,9 @@ async function main() {
     "verify_contacts",
     {
       description:
-        "Explicit re-verify. Returns one row per requested chain: `{ chain, ok, anchorAddress?, version?, entryCount?, reason? }`. Useful for periodic integrity checks or after a suspected tamper event. Does NOT throw on per-chain failure — caller inspects the `results` array. In demo mode, returns a count of in-memory entries per chain (no signature path) with `anchorAddress: \"DEMO_ANCHOR\"` so callers can distinguish the demo result.",
+        "Explicit re-verify. Returns one row per requested chain: `{ chain, ok, anchorAddress?, version?, entryCount?, reason?, unsignedEntryCount? }`. Useful for periodic integrity checks or after a suspected tamper event. Does NOT throw on per-chain failure — caller inspects the `results` array. " +
+        "Issue #428: `unsignedEntryCount` is the count of in-memory unsigned entries on this chain (omitted when zero). When a chain has only unsigned entries, `ok: false, reason: \"no signed entries on this chain (unsigned-only)\", unsignedEntryCount: N` so the agent surfaces the unsigned overlay rather than silently dropping it. " +
+        "In demo mode, returns a count of in-memory entries per chain with `anchorAddress: \"DEMO_ANCHOR\"`.",
       inputSchema: verifyContactsInput.shape,
     },
     handler(verifyContacts)

--- a/test/contacts-demo-mode.test.ts
+++ b/test/contacts-demo-mode.test.ts
@@ -272,31 +272,49 @@ describe("demo-mode address book — resolveRecipient", () => {
   });
 });
 
-describe("demo store isolation from production", () => {
-  it("does NOT touch disk — demo entries don't appear in the production-mode list", async () => {
+describe("demo store / in-memory overlay across modes", () => {
+  it("does NOT touch disk — demo entries are never written to ~/.vaultpilot-mcp/contacts.json", async () => {
     const { addContact } = await import("../src/contacts/index.js");
     await addContact({
       chain: "evm",
       label: "DemoMom",
       address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
     });
-    // Switch out of demo mode and try the production reader. The
-    // production path reads from disk via `readContactsStrict`; the
-    // demo-only entry was never written there, so it should be absent.
-    delete process.env.VAULTPILOT_DEMO;
-    const { listContacts } = await import("../src/contacts/index.js");
-    // Production path will throw on no-file or return an empty list
-    // depending on storage state. Either way, "DemoMom" must NOT be
-    // present.
-    try {
-      const list = await listContacts({});
-      const labels = list.contacts.map((c) => c.label);
-      expect(labels).not.toContain("DemoMom");
-    } catch (err) {
-      // Production-mode read may throw because no contacts file exists
-      // in the test environment — that's also a valid "demo entry not
-      // leaked" outcome.
-      expect((err as Error).message).not.toContain("DemoMom");
-    }
+    // Disk surface — readContactsStrict only sees what was persisted.
+    // Demo-mode adds never touch disk, so the strict read must not
+    // know about DemoMom regardless of subsequent mode.
+    const { readContactsStrict } = await import(
+      "../src/contacts/storage.js"
+    );
+    const file = readContactsStrict();
+    const entries = file.chains.evm?.entries ?? [];
+    expect(entries.some((e) => e.label === "DemoMom")).toBe(false);
   });
+
+  it(
+    "issue #428: demo entries surface in non-demo listContacts as the unsigned " +
+      "overlay (process-local, never persisted) — flagged unsigned: true",
+    async () => {
+      const { addContact } = await import("../src/contacts/index.js");
+      await addContact({
+        chain: "evm",
+        label: "DemoMom",
+        address: "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+      });
+      // Drop demo mode and read again. Pre-#428 the in-memory store was
+      // demo-mode-only and DemoMom would have been invisible. Post-#428
+      // the same store backs the unsigned overlay used by non-demo no-
+      // Ledger users — DemoMom appears with `unsigned: true` so the
+      // agent surfaces "(unsigned)" in the verification block.
+      delete process.env.VAULTPILOT_DEMO;
+      const { listContacts } = await import("../src/contacts/index.js");
+      const list = await listContacts({});
+      const demoMom = list.contacts.find((c) => c.label === "DemoMom");
+      expect(demoMom).toBeDefined();
+      expect(demoMom?.unsigned).toBe(true);
+      expect(demoMom?.addresses.evm).toBe(
+        "0xabcdef0123456789ABCDEF0123456789aBcDeF01",
+      );
+    },
+  );
 });

--- a/test/contacts-no-ledger-unsigned.test.ts
+++ b/test/contacts-no-ledger-unsigned.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Issue #428: `add_contact` was hard-gated on Ledger pairing — first-run
+ * / accountant-share users in production mode (not demo) saw
+ * CONTACTS_LEDGER_NOT_PAIRED and couldn't label addresses without
+ * either pairing a Ledger they don't own or entering demo mode (which
+ * intercepts broadcasts).
+ *
+ * These tests pin the smallest fix: when `pickEvmAnchor` /
+ * `assertBtcAnchorAvailable` throws CONTACTS_LEDGER_NOT_PAIRED in
+ * non-demo mode, fall through to the same in-memory store demo mode
+ * uses, return `unsigned: true` + `anchorAddress: "UNSIGNED_NO_LEDGER"`.
+ * Listing surfaces the entry with `unsigned: true`. Removing works
+ * without a Ledger. The resolver decorates literal addresses + forward-
+ * resolves labels from the unsigned store with a "(unsigned)" warning
+ * so Invariant #7 keeps working in degraded form.
+ *
+ * Persistence-across-restart and sign-on-pair upgrade are NOT covered
+ * here — those are deferred per
+ * `claude-work/plan-contacts-unsigned-state-machine.md`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Force production mode (not demo) so the new fall-through path is the
+// one under test. Demo coverage lives in contacts-demo-mode.test.ts.
+beforeEach(() => {
+  delete process.env.VAULTPILOT_DEMO;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+/**
+ * Mock the EVM signer to behave as if no Ledger Live WC session is
+ * open — `pickEvmAnchor` throws CONTACTS_LEDGER_NOT_PAIRED, the
+ * runtime signal `addContact` falls through on. `signContactsBlobEvm`
+ * is also mocked so a misrouted call would surface visibly. The mock
+ * MUST be installed before the first import of `contacts/index.js` —
+ * call `vi.resetModules()` between this and the imports if the module
+ * cache might already hold the real signer.
+ */
+function mockEvmSignerNoLedger(): void {
+  vi.doMock("../src/signers/contacts/evm.js", () => ({
+    pickEvmAnchor: vi.fn(async () => {
+      throw new Error(
+        "CONTACTS_LEDGER_NOT_PAIRED: no active WalletConnect session.",
+      );
+    }),
+    signContactsBlobEvm: vi.fn(async () => {
+      throw new Error("signContactsBlobEvm should not be called when unsigned");
+    }),
+  }));
+}
+
+/**
+ * Boilerplate every test runs: reset module cache, install the no-
+ * Ledger mock, reset the in-memory + anchor state, and re-import the
+ * fresh contacts module. Ordering matters — module-cache reset has
+ * to come before the import so the mock is consulted.
+ */
+async function freshContactsModule(): Promise<typeof import("../src/contacts/index.js")> {
+  vi.resetModules();
+  mockEvmSignerNoLedger();
+  const { _resetDemoContactsForTests } = await import(
+    "../src/contacts/demo-store.js"
+  );
+  _resetDemoContactsForTests();
+  const mod = await import("../src/contacts/index.js");
+  mod._resetContactsAnchorStateForTests();
+  return mod;
+}
+
+const EVM_ADDR_MOM = "0xabcdef0123456789ABCDEF0123456789aBcDeF01";
+const EVM_ADDR_DAD = "0x1234567890123456789012345678901234567890";
+
+describe("addContact — fall-through to in-memory store when no Ledger paired", () => {
+  it("returns unsigned: true + UNSIGNED_NO_LEDGER instead of throwing", async () => {
+    const { addContact } = await freshContactsModule();
+    const r = await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: EVM_ADDR_MOM,
+    });
+    expect(r.unsigned).toBe(true);
+    expect(r.anchorAddress).toBe("UNSIGNED_NO_LEDGER");
+    expect(r.version).toBe(0);
+    expect(r.label).toBe("Mom");
+    expect(r.address).toBe(EVM_ADDR_MOM);
+  });
+
+  it("surfaces unsigned entries via listContacts with unsigned: true flag", async () => {
+    const { addContact, listContacts } = await freshContactsModule();
+    await addContact({ chain: "evm", label: "Mom", address: EVM_ADDR_MOM });
+    const r = await listContacts({});
+    expect(r.contacts).toHaveLength(1);
+    expect(r.contacts[0]).toMatchObject({
+      label: "Mom",
+      addresses: { evm: EVM_ADDR_MOM },
+      unsigned: true,
+    });
+  });
+
+  it("rejects address-format mismatches the same way the signed path does", async () => {
+    const { addContact } = await freshContactsModule();
+    await expect(
+      addContact({
+        chain: "evm",
+        label: "Garbage",
+        address: "definitely-not-an-evm-address",
+      }),
+    ).rejects.toThrow(/CONTACTS_ADDRESS_FORMAT_MISMATCH/);
+  });
+});
+
+describe("removeContact — works on unsigned entries without a Ledger", () => {
+  it("removes the unsigned entry and reports unsigned: true on the row", async () => {
+    const { addContact, removeContact, listContacts } = await freshContactsModule();
+    await addContact({ chain: "evm", label: "Mom", address: EVM_ADDR_MOM });
+    const r = await removeContact({ label: "Mom" });
+    expect(r.removed).toHaveLength(1);
+    expect(r.removed[0]).toMatchObject({
+      chain: "evm",
+      address: EVM_ADDR_MOM,
+      unsigned: true,
+    });
+    const list = await listContacts({});
+    expect(list.contacts).toEqual([]);
+  });
+
+  it("throws CONTACTS_LABEL_NOT_FOUND when neither signed nor unsigned has the label", async () => {
+    const { removeContact } = await freshContactsModule();
+    await expect(removeContact({ label: "Ghost" })).rejects.toThrow(
+      /CONTACTS_LABEL_NOT_FOUND/,
+    );
+  });
+});
+
+describe("verifyContacts — surfaces unsignedEntryCount alongside signed counts", () => {
+  it("reports `unsigned-only` when only the in-memory store has entries", async () => {
+    const { addContact, verifyContacts } = await freshContactsModule();
+    await addContact({ chain: "evm", label: "Mom", address: EVM_ADDR_MOM });
+    await addContact({ chain: "evm", label: "Dad", address: EVM_ADDR_DAD });
+    const r = await verifyContacts({ chain: "evm" });
+    expect(r.results).toHaveLength(1);
+    expect(r.results[0]).toMatchObject({
+      chain: "evm",
+      ok: false,
+      unsignedEntryCount: 2,
+    });
+    expect(r.results[0].reason).toMatch(/unsigned-only/);
+  });
+});
+
+describe("resolveRecipient — degraded reverse-decoration via unsigned store", () => {
+  it("decorates a literal address with the unsigned label + warning", async () => {
+    const { addContact } = await freshContactsModule();
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    await addContact({ chain: "evm", label: "Mom", address: EVM_ADDR_MOM });
+    const r = await resolveRecipient(EVM_ADDR_MOM, "ethereum");
+    expect(r.address).toBe(EVM_ADDR_MOM);
+    expect(r.label).toBe("Mom");
+    expect(r.warnings.some((w) => /unsigned/i.test(w))).toBe(true);
+  });
+
+  it("forward-resolves an unsigned label with a warning", async () => {
+    const { addContact } = await freshContactsModule();
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    await addContact({ chain: "evm", label: "Mom", address: EVM_ADDR_MOM });
+    const r = await resolveRecipient("Mom", "ethereum");
+    expect(r.source).toBe("contact");
+    expect(r.address).toBe(EVM_ADDR_MOM);
+    expect(r.label).toBe("Mom");
+    expect(r.warnings.some((w) => /unsigned/i.test(w))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes [#428](https://github.com/szhygulin/vaultpilot-mcp/issues/428) **partially** (user-visible gap). The full state machine (persistent unsigned entries + sign-on-pair upgrade + Solana/TRON support) is intentionally deferred — see "Deferred" below.
- `add_contact` no longer hard-fails with `CONTACTS_LEDGER_NOT_PAIRED` in non-demo mode. When no Ledger is paired, the call falls through to the same in-memory store demo mode uses, returns `unsigned: true` + `anchorAddress: "UNSIGNED_NO_LEDGER"`. Persistence is process-local (lost on restart) until the deferred state machine ships.
- `list_contacts` merges the unsigned overlay on top of the verified signed view; signed entries always win per (label, chain). Each row carries `unsigned: true` when at least one chain entry is unsigned.
- `remove_contact` works on unsigned entries with no Ledger interaction. Mixed labels (signed on one chain + unsigned on another) only require pairing for the signed-entry chain.
- `verify_contacts` reports `unsignedEntryCount` per chain. A chain with only unsigned entries returns `ok: false, reason: "no signed entries on this chain (unsigned-only)", unsignedEntryCount: N` so the agent surfaces the unsigned overlay rather than silently dropping it.
- Resolver decorates literal addresses + forward-resolves unsigned labels with a `(unsigned)` warning. Invariant #7 keeps working in degraded form — the user is told the label isn't anchored cryptographically, so the on-device clear-sign of the literal address remains the trust root.

## Trust model
The unsigned overlay does **not** carry the same safety guarantees as the signed blob. A compromised MCP can inject entries into the in-memory store and the resolver will surface them with a warning. The Ledger device's clear-sign of the literal address remains the safety net — the warning tag exists so users with read-only / accountant-share use cases can opt into the weaker guarantee explicitly.

## Test plan
- [x] `vitest run test/contacts-no-ledger-unsigned.test.ts` — 8 new cases pass.
- [x] `vitest run test/contacts-demo-mode.test.ts test/contacts.test.ts` — 35 existing pass; updated the "demo store isolation" test to reflect the new shared-unsigned-overlay contract.
- [x] Full suite — 2117/2117 pass.
- [x] `tsc --noEmit` clean.

## Deferred (not in this PR)
Documented in [`claude-work/plan-contacts-unsigned-state-machine.md`](./claude-work/plan-contacts-unsigned-state-machine.md) and surfaced in the README roadmap:

- Persistent on-disk unsigned entries (today's fix is process-local)
- `promote_unsigned_contacts` sign-on-pair upgrade flow
- Tamper-aware merge with signed/unsigned label disagreement
- Solana / TRON unsigned support

When this PR lands, close #428 as **partially fixed, partially deferred** with a link to the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)