### PR TITLE
feat(btc): add feePriority preset enum to prepare_btc_send (#435)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2884,11 +2884,17 @@ async function main() {
         "BTC app clear-signs every output (address + amount) + fee on-screen, so there " +
         "is NO blind-sign hash to pre-match in chat. The verification block surfaces " +
         "every output's address, amount in BTC, isChange flag, fee (BTC + sat/vB), " +
-        "and RBF flag. Coin-selection runs branch-and-bound + accumulative fallback " +
-        "via the `coinselect` library; a fee-cap guard refuses any tx whose fee " +
-        "exceeds `max(10 × feeRate × vbytes, 2% of total output value)` unless " +
-        "`allowHighFee: true` is passed. RBF is enabled by default (sequence " +
-        "0xFFFFFFFD); pass `rbf: false` to mark final.",
+        "and RBF flag. " +
+        "Fee selection: pass `feeRateSatPerVb` for an explicit sat/vB number, OR " +
+        "`feePriority` for a fuzzy preset (`fastestFee` / `halfHourFee` / `hourFee` / " +
+        "`economyFee` / `minimumFee` — issue #435) that resolves to mempool.space's " +
+        "named buckets at prepare time. Default (neither set) is `halfHourFee`. " +
+        "The resolved sat/vB always appears in the response under `feeRateSatPerVb` so " +
+        "the user sees what was picked. Coin-selection runs branch-and-bound + " +
+        "accumulative fallback via the `coinselect` library; a fee-cap guard refuses " +
+        "any tx whose fee exceeds `max(10 × feeRate × vbytes, 2% of total output " +
+        "value)` unless `allowHighFee: true` is passed. RBF is enabled by default " +
+        "(sequence 0xFFFFFFFD); pass `rbf: false` to mark final.",
       inputSchema: prepareBitcoinNativeSendInput.shape,
     },
     handler(prepareBitcoinNativeSend, { toolName: "prepare_btc_send" })

--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -181,9 +181,22 @@ export interface BuildBitcoinNativeSendArgs {
   amount: string;
   /**
    * Fee rate in sat/vB. Optional — when omitted, uses the indexer's
-   * `halfHourFee` recommendation (~3-block target).
+   * `halfHourFee` recommendation (~3-block target). Mutually exclusive
+   * with `feePriority`; the schema rejects both-set at the call site.
    */
   feeRateSatPerVb?: number;
+  /**
+   * Issue #435 — preset that resolves to one of mempool.space's named
+   * fee buckets. Resolved via `getFeeEstimates()` once; the resolved
+   * sat/vB flows through `feeRateSatPerVb` semantics for the rest of
+   * the build. When neither is set, defaults to `halfHourFee`.
+   */
+  feePriority?:
+    | "fastestFee"
+    | "halfHourFee"
+    | "hourFee"
+    | "economyFee"
+    | "minimumFee";
   /**
    * BIP-125 RBF. Default true → sequence `0xFFFFFFFD` (replaceable).
    */
@@ -289,13 +302,27 @@ export async function buildBitcoinNativeSend(
 
   const indexer = getBitcoinIndexer();
 
-  // 2. Resolve fee rate.
+  // 2. Resolve fee rate. Both `feeRateSatPerVb` (raw) and `feePriority`
+  //    (preset, issue #435) are optional. When neither is supplied the
+  //    default is the indexer's `halfHourFee` (~3-block target) — same
+  //    behavior as before #435 added the preset enum.
+  if (
+    args.feeRateSatPerVb !== undefined &&
+    args.feePriority !== undefined
+  ) {
+    throw new Error(
+      "Pass either `feeRateSatPerVb` (raw sat/vB) or `feePriority` (preset), " +
+        "not both. The preset resolves to a sat/vB at prepare time so passing " +
+        "both is ambiguous.",
+    );
+  }
   let feeRate: number;
   if (args.feeRateSatPerVb !== undefined) {
     feeRate = args.feeRateSatPerVb;
   } else {
     const fees = await indexer.getFeeEstimates();
-    feeRate = fees.halfHourFee;
+    const bucket = args.feePriority ?? "halfHourFee";
+    feeRate = fees[bucket];
   }
   if (!Number.isFinite(feeRate) || feeRate <= 0) {
     throw new Error(

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -1239,6 +1239,9 @@ export async function prepareBitcoinNativeSend(
     ...(args.feeRateSatPerVb !== undefined
       ? { feeRateSatPerVb: args.feeRateSatPerVb }
       : {}),
+    ...(args.feePriority !== undefined
+      ? { feePriority: args.feePriority }
+      : {}),
     ...(args.rbf !== undefined ? { rbf: args.rbf } : {}),
     ...(args.allowHighFee !== undefined ? { allowHighFee: args.allowHighFee } : {}),
   });

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1327,7 +1327,26 @@ export const prepareBitcoinNativeSendInput = z.object({
     .describe(
       "Fee rate in sat/vB. Optional — when omitted, uses mempool.space's " +
         "`halfHourFee` recommendation (~3-block confirm target). Override for " +
-        "priority sends through congestion. Capped at 10000 sat/vB for safety."
+        "priority sends through congestion. Capped at 10000 sat/vB for safety. " +
+        "Mutually exclusive with `feePriority`."
+    ),
+  feePriority: z
+    .enum([
+      "fastestFee",
+      "halfHourFee",
+      "hourFee",
+      "economyFee",
+      "minimumFee",
+    ])
+    .optional()
+    .describe(
+      "Issue #435 — fuzzy-fee preset that resolves to mempool.space's named " +
+        "buckets (`fastestFee` ~next-block, `halfHourFee` ~3-block, `hourFee` " +
+        "~6-block, `economyFee` lowest still-included, `minimumFee` floor). " +
+        "Resolves at prepare time via `getFeeEstimates()`; the resolved sat/vB " +
+        "appears in the response so the user sees what was picked. Default " +
+        "(neither preset nor `feeRateSatPerVb` supplied) is `halfHourFee`. " +
+        "Mutually exclusive with `feeRateSatPerVb`."
     ),
   rbf: z
     .boolean()

--- a/test/btc-pr3-send.test.ts
+++ b/test/btc-pr3-send.test.ts
@@ -283,6 +283,93 @@ describe("buildBitcoinNativeSend", () => {
     expect(getFeeEstimatesMock).not.toHaveBeenCalled();
   });
 
+  it("issue #435: resolves feePriority preset to the indexer bucket", async () => {
+    getUtxosMock.mockResolvedValueOnce([
+      { txid: FAKE_TXID, vout: 0, value: 100_000, unconfirmed: false },
+    ]);
+    getFeeEstimatesMock.mockResolvedValueOnce({
+      fastestFee: 50,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: SEGWIT_ADDR,
+      to: RECIPIENT,
+      amount: "0.0005",
+      feePriority: "fastestFee",
+    });
+    expect(tx.decoded.feeRateSatPerVb).toBe(50);
+    expect(getFeeEstimatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("issue #435: resolves the economyFee preset", async () => {
+    getUtxosMock.mockResolvedValueOnce([
+      { txid: FAKE_TXID, vout: 0, value: 100_000, unconfirmed: false },
+    ]);
+    getFeeEstimatesMock.mockResolvedValueOnce({
+      fastestFee: 50,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: SEGWIT_ADDR,
+      to: RECIPIENT,
+      amount: "0.0005",
+      feePriority: "economyFee",
+    });
+    expect(tx.decoded.feeRateSatPerVb).toBe(2);
+  });
+
+  it("issue #435: rejects when both feeRateSatPerVb and feePriority are set", async () => {
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    await expect(
+      buildBitcoinNativeSend({
+        wallet: SEGWIT_ADDR,
+        to: RECIPIENT,
+        amount: "0.0005",
+        feeRateSatPerVb: 25,
+        feePriority: "fastestFee",
+      }),
+    ).rejects.toThrow(/not both/i);
+    // Indexer must NOT be hit when the args are ambiguous — the guard
+    // runs before any network work.
+    expect(getFeeEstimatesMock).not.toHaveBeenCalled();
+  });
+
+  it("issue #435: default behavior unchanged — neither set falls back to halfHourFee", async () => {
+    getUtxosMock.mockResolvedValueOnce([
+      { txid: FAKE_TXID, vout: 0, value: 100_000, unconfirmed: false },
+    ]);
+    getFeeEstimatesMock.mockResolvedValueOnce({
+      fastestFee: 50,
+      halfHourFee: 10,
+      hourFee: 5,
+      economyFee: 2,
+      minimumFee: 1,
+    });
+    const { buildBitcoinNativeSend } = await import(
+      "../src/modules/btc/actions.ts"
+    );
+    const tx = await buildBitcoinNativeSend({
+      wallet: SEGWIT_ADDR,
+      to: RECIPIENT,
+      amount: "0.0005",
+    });
+    expect(tx.decoded.feeRateSatPerVb).toBe(10);
+  });
+
   it("rejects unpaired source addresses", async () => {
     const { buildBitcoinNativeSend } = await import(
       "../src/modules/btc/actions.ts"


### PR DESCRIPTION
## Summary
- Closes [#435](https://github.com/szhygulin/vaultpilot-mcp/issues/435). `prepare_btc_send` now accepts a fuzzy-fee preset alongside the existing raw `feeRateSatPerVb`. Five presets — `fastestFee` / `halfHourFee` / `hourFee` / `economyFee` / `minimumFee` — match mempool.space's `/v1/fees/recommended` bucket names so users see familiar terminology.
- Mutually exclusive with `feeRateSatPerVb` (both-set throws before any network work). Default (neither set) is unchanged — `halfHourFee`.
- The resolved sat/vB always appears in the response under `decoded.feeRateSatPerVb` (existing field), so the user sees what the preset resolved to.

## Test plan
- [x] 4 new cases in `test/btc-pr3-send.test.ts` (fastestFee preset, economyFee preset, both-set rejection, default unchanged); 29/29 BTC send tests pass.
- [x] Full suite — 2124/2124 pass.
- [x] `tsc --noEmit` clean.

## Out of scope
- Preset support for `prepare_btc_multisig_send` / `prepare_btc_lifi_swap` — separate code paths, separate fee-resolution sites. File a follow-up if useful.
- The bonus `feeCapWillTripWith: <preset>` hint mentioned in the issue — defer to a follow-up if users want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)