### PR TITLE
chore(release): bump to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.11.1";
+const SERVER_VERSION = "0.12.0";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
## Summary

Release 0.12.0 — covers the v8 skill-companion batch + the orphan 0.11.1 work that was bumped locally but never tagged/published. npm registry currently at 0.11.0; this jumps to 0.12.0 (per `publish-npm-release` skill guidance — don't ship a stale version, jump forward).

## What ships under 0.12.0

- **Skill v8 companion** (#480): `EXPECTED_SKILL_SHA256` / sentinel pin bump v7→v8, `[SET-LEVEL ENUMERATION]` block on `get_token_allowances`, `assertCanonicalDispatchTarget` helper (`src/security/canonical-dispatch.ts`).
- **Earlier-merged work that was bumped to 0.11.1 locally but never released**: every PR that merged after 0.11.0 hit npm. Notable ones: `request_capability` rate-limit fallback, MarginFi guard hardening, demo-mode followups (#449), persona rotation watcher, `--demo` CLI alias, smarter refusal messages, BTC RBF + LTC support pieces, NFT portfolio Solana, health-alerts multi-protocol, smoke-test results bundle, prior skill-pin bumps (v6 / v7 for #463 + #462), README + SECURITY rewrite for v0.6.0 invariants (#485).

## Merge ordering

After merging this PR, I'll:
1. Tag the merge commit `v0.12.0`
2. Push the tag
3. Create the GitHub Release (fires `publish.yml` → npm + MCP Registry; `release-binaries.yml` → linux/macos/windows binaries)

## Test plan

- [x] `npm run build` clean (`tsc --noEmit` covered)
- [x] Full vitest suite: 2151/2151 pass
- [x] Stale `0.11.1` references swept (only test fixtures + comment remain — non-pinning)
- [ ] After merge + release: `npm view vaultpilot-mcp version` returns `0.12.0`, MCP Registry shows the new version, three release binaries land

🤖 Generated with [Claude Code](https://claude.com/claude-code)