### PR TITLE
chore(release): bump to 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.12.0";
+const SERVER_VERSION = "0.12.1";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
## Summary

Patch release covering the unified-binary refactor that landed after v0.12.0:

- **#487 — unified server + setup wizard into one binary** via the `setup` subcommand. Halves binary count per release (8 → 4), drops the macos-x64-setup flake leg, preserves backward compat on both binary path (`*-server` asset name unchanged) and npm path (`vaultpilot-mcp-setup` shim still works). Test suite: 2158/2158 pass (+7 new for argv routing).

## Merge ordering

After merge:
1. Tag `v0.12.1` on the merge commit
2. Push tag
3. `gh release create v0.12.1` → fires `publish.yml` (npm + MCP Registry) and `release-binaries.yml` (now produces 4 binaries instead of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)