### PR TITLE
feat(security): wire INV_1A canonical-dispatch check into prepare_* handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -478,6 +478,7 @@ import {
 } from "./shared/version-check.js";
 
 import { issueHandles } from "./signing/tx-store.js";
+import { assertCanonicalDispatchOnTxChain } from "./security/canonical-dispatch.js";
 import {
   EXPECTED_SKILL_SHA256,
   EXPECTED_SKILL_SENTINEL_A,
@@ -974,11 +975,22 @@ function handler<T, R>(
  * never passes raw calldata to the signing path — it calls send_transaction
  * with a handle, which closes the prompt-injection → arbitrary-calldata window.
  *
+ * Before issuing handles, the action leg's `to` is checked against the
+ * canonical-target allowlist (Invariant #1.a, MCP-side mirror). The action
+ * leg is the tail of the `next` chain — approval legs target the ERC-20
+ * token contract (never canonical) and live ahead of it. Tools outside the
+ * allowlist (sends, LiFi-routed swaps, Curve, Safe ops) hit a no-op in the
+ * helper, so the wiring is safe to apply uniformly here.
+ *
  * `toolName` is the registered MCP tool name; it's threaded through so the
  * prepare-receipt block can label which tool was called with which args.
  */
 function txHandler<T>(toolName: string, fn: (args: T) => Promise<UnsignedTx> | UnsignedTx) {
-  return handler(async (args: T) => issueHandles(await fn(args)), { toolName });
+  return handler(async (args: T) => {
+    const tx = await fn(args);
+    assertCanonicalDispatchOnTxChain(toolName, tx);
+    return issueHandles(tx);
+  }, { toolName });
 }
 
 /**

--- a/src/security/canonical-dispatch.ts
+++ b/src/security/canonical-dispatch.ts
@@ -27,7 +27,7 @@
  */
 
 import { CONTRACTS } from "../config/contracts.js";
-import type { SupportedChain } from "../types/index.js";
+import type { SupportedChain, UnsignedTx } from "../types/index.js";
 
 /**
  * Tool families with canonical-target enforcement. Keyed by the
@@ -138,6 +138,25 @@ export function assertCanonicalDispatchTarget(
       `[INV_1A] ✗ DISPATCH-TARGET MISMATCH for ${toolName} on ${chain}: builder produced to=${to}, but the canonical target(s) for this tool family are: ${allowed}. Refusing to issue handle.`,
     );
   }
+}
+
+/**
+ * Walk to the action leg of a prepared `UnsignedTx` chain and assert its
+ * dispatch target against the canonical-target allowlist for `toolName`.
+ *
+ * Approval legs sit ahead of the action and target the ERC-20 token
+ * contract (never in the allowlist) — the canonical-target check applies
+ * to the protocol action at the tail of the chain. Wired into `txHandler`
+ * (src/index.ts) so every prepare_* handler runs through this guard
+ * before handles are issued.
+ */
+export function assertCanonicalDispatchOnTxChain(
+  toolName: string,
+  tx: UnsignedTx,
+): void {
+  let tail: UnsignedTx = tx;
+  while (tail.next) tail = tail.next;
+  assertCanonicalDispatchTarget(toolName, tail.chain, tail.to);
 }
 
 /**

--- a/test/canonical-dispatch.test.ts
+++ b/test/canonical-dispatch.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
   assertCanonicalDispatchTarget,
+  assertCanonicalDispatchOnTxChain,
   _enumerateAllowlistForTests,
 } from "../src/security/canonical-dispatch.js";
 import { CONTRACTS } from "../src/config/contracts.js";
+import type { UnsignedTx } from "../src/types/index.js";
 
 /**
  * These tests pin the MCP-side mirror of skill v8's Invariant #1.a.
@@ -164,6 +166,132 @@ describe("canonical-dispatch — Invariant #1.a MCP-side mirror", () => {
     ).not.toThrow();
     expect(() =>
       assertCanonicalDispatchTarget("prepare_solana_native_send", "ethereum", arbitrary),
+    ).not.toThrow();
+  });
+});
+
+describe("assertCanonicalDispatchOnTxChain — txHandler wiring shape (issue #483)", () => {
+  // The wiring inside `txHandler` (src/index.ts) walks the `next` chain to
+  // its tail, then calls `assertCanonicalDispatchTarget` against the tail's
+  // chain + to. These tests pin that contract end-to-end, exercising the
+  // exact helper `txHandler` calls — so a refactor that breaks the
+  // walk-to-tail step (or skips the assertion) fails here.
+
+  const aavePool = CONTRACTS.ethereum.aave.pool as `0x${string}`;
+  const usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as `0x${string}`;
+  const stETH = CONTRACTS.ethereum.lido.stETH as `0x${string}`;
+  const npm = CONTRACTS.ethereum.uniswap.positionManager as `0x${string}`;
+  const swapRouter = CONTRACTS.ethereum.uniswap.swapRouter02 as `0x${string}`;
+  const cUSDCv3 = CONTRACTS.ethereum.compound.cUSDCv3 as `0x${string}`;
+  const morphoBlue = CONTRACTS.ethereum.morpho.blue as `0x${string}`;
+  const eigenSM = CONTRACTS.ethereum.eigenlayer.strategyManager as `0x${string}`;
+  const bogus = "0x000000000000000000000000000000000000dead" as `0x${string}`;
+
+  function leg(to: `0x${string}`, next?: UnsignedTx): UnsignedTx {
+    return {
+      chain: "ethereum",
+      to,
+      data: "0x",
+      value: "0",
+      description: "",
+      ...(next ? { next } : {}),
+    };
+  }
+
+  it("approve→action chain: tail-leg `to` outside allowlist throws INV_1A (Aave supply)", () => {
+    const chain = leg(usdc, leg(bogus));
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_aave_supply", chain)).toThrow(
+      /INV_1A.*DISPATCH-TARGET MISMATCH/,
+    );
+  });
+
+  it("approve→action chain: canonical tail-leg `to` passes (token contract at head is ignored)", () => {
+    // Approval to USDC sits ahead of an Aave Pool action. The walk-to-tail
+    // skips the approval leg (token contract is never canonical) and
+    // checks the action leg against the allowlist.
+    const chain = leg(usdc, leg(aavePool));
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_aave_supply", chain)).not.toThrow();
+  });
+
+  it("single-tx flows (no approval): canonical `to` passes, bogus throws (Lido stake)", () => {
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_lido_stake", leg(stETH))).not.toThrow();
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_lido_stake", leg(bogus))).toThrow(
+      /INV_1A/,
+    );
+  });
+
+  it("Compound supply chain: builder substituting an off-allowlist Comet at the tail throws", () => {
+    const chain = leg(usdc, leg(bogus));
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_compound_supply", chain)).toThrow(
+      /INV_1A.*DISPATCH-TARGET MISMATCH/,
+    );
+    // Canonical Comet on the tail passes.
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_compound_supply", leg(usdc, leg(cUSDCv3))),
+    ).not.toThrow();
+  });
+
+  it("Morpho supply chain: bogus tail throws, Morpho Blue tail passes", () => {
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_morpho_supply", leg(usdc, leg(bogus))),
+    ).toThrow(/INV_1A/);
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_morpho_supply", leg(usdc, leg(morphoBlue))),
+    ).not.toThrow();
+  });
+
+  it("Uniswap swap chain (approve→swap): bogus router-substitute throws, SwapRouter02 passes", () => {
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_uniswap_swap", leg(usdc, leg(bogus))),
+    ).toThrow(/INV_1A/);
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_uniswap_swap", leg(usdc, leg(swapRouter))),
+    ).not.toThrow();
+  });
+
+  it("Uniswap V3 mint chain (approve→approve→mint): two-deep tail walk hits the NPM leg", () => {
+    const wbtc = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" as `0x${string}`;
+    // Two approvals (token0, token1) precede the NPM mint.
+    expect(() =>
+      assertCanonicalDispatchOnTxChain(
+        "prepare_uniswap_v3_mint",
+        leg(usdc, leg(wbtc, leg(npm))),
+      ),
+    ).not.toThrow();
+    // Substituted final leg is caught.
+    expect(() =>
+      assertCanonicalDispatchOnTxChain(
+        "prepare_uniswap_v3_mint",
+        leg(usdc, leg(wbtc, leg(bogus))),
+      ),
+    ).toThrow(/INV_1A/);
+  });
+
+  it("EigenLayer deposit (approve→deposit): bogus tail throws, StrategyManager passes", () => {
+    expect(() =>
+      assertCanonicalDispatchOnTxChain(
+        "prepare_eigenlayer_deposit",
+        leg(usdc, leg(bogus)),
+      ),
+    ).toThrow(/INV_1A/);
+    expect(() =>
+      assertCanonicalDispatchOnTxChain(
+        "prepare_eigenlayer_deposit",
+        leg(usdc, leg(eigenSM)),
+      ),
+    ).not.toThrow();
+  });
+
+  it("non-guarded prepare_* (sends, LiFi swap): wiring is a no-op even with arbitrary `to`", () => {
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_native_send", leg(bogus)),
+    ).not.toThrow();
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_token_send", leg(usdc, leg(bogus))),
+    ).not.toThrow();
+    // prepare_swap (LiFi) is not in the allowlist either — the helper short-circuits.
+    expect(() =>
+      assertCanonicalDispatchOnTxChain("prepare_swap", leg(bogus)),
     ).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #483.

## Summary
- Adds `assertCanonicalDispatchOnTxChain(toolName, tx)` to `src/security/canonical-dispatch.ts` — walks the `next` chain to its tail and runs the existing per-(family, chain) allowlist assertion against the action leg.
- Wires the helper into `txHandler` (`src/index.ts`) so every `prepare_*` returning `UnsignedTx` is guarded before handles are issued. Approval legs at the head of the chain target ERC-20 contracts (never canonical) and are skipped automatically by the tail walk; unguarded tools (sends, LiFi swap, Curve, Safe ops) hit the existing short-circuit.

## Defense layering
- Skill-side Inv #1.a (skill v8 §1.a) is the load-bearing defense against the rogue-MCP threat (smoke-test b117).
- This MCP-side wiring is defense-in-depth: catches an internal bug or supply-chain tamper that substitutes the target inside a `build*` function. Mirrors the skill's `[INV_1A] ✗ DISPATCH-TARGET MISMATCH` prose so an operator reading either side gets the same diagnostic.

## Test plan
- [x] `npx vitest run test/canonical-dispatch.test.ts` — 19/19 pass (10 existing + 9 new wiring-shape tests covering approve→action, single-tx, three-leg approve→approve→mint, and no-op flows).
- [x] `npx vitest run` — full suite 2167/2167 pass.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)