### PR TITLE
feat(rocketpool): add prepare_rocketpool_stake + prepare_rocketpool_unstake (closes #429)

### DIFF
--- a/src/abis/rocketpool.ts
+++ b/src/abis/rocketpool.ts
@@ -1,0 +1,73 @@
+// Rocket Pool — RocketDepositPool (deposit) + RocketTokenRETH (burn / read).
+// Minimal functions only: deposit + capacity preflight on the pool, burn +
+// balance + collateral preflight on rETH. RocketStorage lookup is intentionally
+// omitted — addresses are pinned in `config/contracts.ts` and any upgrade is a
+// canonical-dispatch test failure first.
+export const rocketDepositPoolAbi = [
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "payable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "getMaximumDepositAmount",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getBalance",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+export const rocketTokenRETHAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "burn",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "_rethAmount", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "getEthValue",
+    stateMutability: "view",
+    inputs: [{ name: "_rethAmount", type: "uint256" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getRethValue",
+    stateMutability: "view",
+    inputs: [{ name: "_ethAmount", type: "uint256" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getExchangeRate",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getTotalCollateral",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -32,6 +32,22 @@ export const CONTRACTS = {
       // re-validates address checksums and will throw InvalidAddressError otherwise.
       delegationManager: "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
     },
+    /**
+     * Rocket Pool — rETH liquid-staking. Mainnet only; the rETH bridged
+     * representations on L2s (Arbitrum/Optimism/Base/Polygon) are not
+     * deposit-and-mint capable, so stake/unstake live exclusively on L1.
+     * Source: official Rocket Pool docs repo
+     * `docs/en/protocol/contracts-integrations.md`. RocketDepositPool was
+     * upgraded once (v1.0 → v1.1 → v1.2 Atlas); the address below is the
+     * current Atlas deployment. rETH itself has been at the same address
+     * since launch — its upgrade path is via RocketStorage proxy lookup, so
+     * the on-chain address is effectively stable.
+     */
+    rocketpool: {
+      depositPool: "0xDD3f50F8A6CafbE9b31a427582963f465E745AF8",
+      rETH: "0xae78736Cd615f374D3085123A210448E74Fc6393",
+      storage: "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+    },
     // Common ERC-20 tokens used for portfolio summary.
     tokens: {
       USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,8 @@ import {
   prepareLidoWrap,
   prepareLidoUnwrap,
   prepareEigenLayerDeposit,
+  prepareRocketPoolStake,
+  prepareRocketPoolUnstake,
   prepareNativeSend,
   prepareWethUnwrap,
   prepareTokenSend,
@@ -331,6 +333,8 @@ import {
   prepareLidoWrapInput,
   prepareLidoUnwrapInput,
   prepareEigenLayerDepositInput,
+  prepareRocketPoolStakeInput,
+  prepareRocketPoolUnstakeInput,
   prepareNativeSendInput,
   prepareWethUnwrapInput,
   prepareTokenSendInput,
@@ -3731,6 +3735,26 @@ async function main() {
       inputSchema: prepareEigenLayerDepositInput.shape,
     },
     txHandler("prepare_eigenlayer_deposit", prepareEigenLayerDeposit)
+  );
+
+  registerTool(server,
+    "prepare_rocketpool_stake",
+    {
+      description:
+        "Build an unsigned Rocket Pool stake transaction (RocketDepositPool.deposit() payable, mints rETH at the current exchange rate). Ethereum mainnet only — rETH on L2s is bridged and cannot be deposit-and-mint. Preflights `getMaximumDepositAmount()` to refuse if the deposit pool is paused or at capacity.",
+      inputSchema: prepareRocketPoolStakeInput.shape,
+    },
+    txHandler("prepare_rocketpool_stake", prepareRocketPoolStake)
+  );
+
+  registerTool(server,
+    "prepare_rocketpool_unstake",
+    {
+      description:
+        "Build an unsigned Rocket Pool unstake transaction (rETH.burn(uint256), redeems rETH for ETH from on-protocol collateral). No approval needed — burn operates on caller's balance. Preflights wallet rETH balance and rETH contract collateral; if collateral is insufficient, refuses with a hint to unwind via the rETH/ETH Uniswap V3 pool instead.",
+      inputSchema: prepareRocketPoolUnstakeInput.shape,
+    },
+    txHandler("prepare_rocketpool_unstake", prepareRocketPoolUnstake)
   );
 
   registerTool(server, 

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -108,6 +108,8 @@ import {
   buildLidoWrap,
   buildLidoUnwrap,
   buildEigenLayerDeposit,
+  buildRocketPoolStake,
+  buildRocketPoolUnstake,
 } from "../staking/actions.js";
 import { buildWethUnwrap } from "../weth/actions.js";
 import { getTokenPrice } from "../../data/prices.js";
@@ -130,6 +132,8 @@ import type {
   PrepareLidoWrapArgs,
   PrepareLidoUnwrapArgs,
   PrepareEigenLayerDepositArgs,
+  PrepareRocketPoolStakeArgs,
+  PrepareRocketPoolUnstakeArgs,
   PrepareNativeSendArgs,
   PrepareWethUnwrapArgs,
   PrepareTokenSendArgs,
@@ -2436,6 +2440,24 @@ export async function prepareEigenLayerDeposit(args: PrepareEigenLayerDepositArg
       decimals: meta.decimals,
       symbol: meta.symbol,
       approvalCap: args.approvalCap,
+    })
+  );
+}
+
+export async function prepareRocketPoolStake(args: PrepareRocketPoolStakeArgs): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildRocketPoolStake({
+      wallet: args.wallet as `0x${string}`,
+      amountEth: args.amountEth,
+    })
+  );
+}
+
+export async function prepareRocketPoolUnstake(args: PrepareRocketPoolUnstakeArgs): Promise<UnsignedTx> {
+  return enrichTx(
+    await buildRocketPoolUnstake({
+      wallet: args.wallet as `0x${string}`,
+      amountReth: args.amountReth,
     })
   );
 }

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -743,6 +743,26 @@ export const prepareLidoUnwrapInput = z.object({
     ),
 });
 
+export const prepareRocketPoolStakeInput = z.object({
+  wallet: walletSchema,
+  amountEth: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable ETH amount to stake into Rocket Pool (mints rETH), NOT raw wei. Example: "0.5" for 0.5 ETH. Protocol minimum is ~0.01 ETH; the deposit pool also has a per-deposit capacity that we preflight-check.',
+    ),
+});
+
+export const prepareRocketPoolUnstakeInput = z.object({
+  wallet: walletSchema,
+  amountReth: z
+    .string()
+    .max(50)
+    .describe(
+      'Human-readable rETH amount to burn for ETH, NOT raw wei. Example: "0.5" for 0.5 rETH (18 decimals). Burning requires sufficient on-protocol ETH collateral (rETH contract balance + RocketDepositPool excess); if collateral is insufficient, sell rETH on the rETH/ETH Uniswap V3 pool instead via `prepare_uniswap_swap`.',
+    ),
+});
+
 export const prepareEigenLayerDepositInput = z.object({
   wallet: walletSchema,
   strategy: addressSchema,
@@ -1014,6 +1034,8 @@ export type PrepareLidoUnstakeArgs = z.infer<typeof prepareLidoUnstakeInput>;
 export type PrepareLidoWrapArgs = z.infer<typeof prepareLidoWrapInput>;
 export type PrepareLidoUnwrapArgs = z.infer<typeof prepareLidoUnwrapInput>;
 export type PrepareEigenLayerDepositArgs = z.infer<typeof prepareEigenLayerDepositInput>;
+export type PrepareRocketPoolStakeArgs = z.infer<typeof prepareRocketPoolStakeInput>;
+export type PrepareRocketPoolUnstakeArgs = z.infer<typeof prepareRocketPoolUnstakeInput>;
 export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
 export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;
 export type PrepareTokenSendArgs = z.infer<typeof prepareTokenSendInput>;

--- a/src/modules/staking/actions.ts
+++ b/src/modules/staking/actions.ts
@@ -1,7 +1,9 @@
-import { encodeFunctionData, parseEther, parseUnits, zeroAddress } from "viem";
+import { encodeFunctionData, formatEther, parseEther, parseUnits, zeroAddress } from "viem";
 import { stETHAbi, wstETHAbi, lidoWithdrawalQueueAbi } from "../../abis/lido.js";
 import { eigenStrategyManagerAbi } from "../../abis/eigenlayer-strategy-manager.js";
+import { rocketDepositPoolAbi, rocketTokenRETHAbi } from "../../abis/rocketpool.js";
 import { CONTRACTS } from "../../config/contracts.js";
+import { getClient } from "../../data/rpc.js";
 import { buildApprovalTx, chainApproval, resolveApprovalCap } from "../shared/approval.js";
 import type { UnsignedTx } from "../../types/index.js";
 
@@ -129,6 +131,124 @@ export function buildLidoUnwrap(p: LidoUnwrapParams): UnsignedTx {
     from: p.wallet,
     description: `Unwrap ${p.amountWstETH} wstETH into stETH`,
     decoded: { functionName: "unwrap", args: { amount: p.amountWstETH + " wstETH" } },
+  };
+}
+
+export interface RocketPoolStakeParams {
+  wallet: `0x${string}`;
+  amountEth: string;
+}
+
+/**
+ * Build an unsigned RocketDepositPool.deposit() payable tx that mints rETH at
+ * the current exchange rate. Preflight reads `getMaximumDepositAmount()`: if 0
+ * the pool is disabled or full and the on-chain tx would revert with
+ * "Deposits into Rocket Pool are currently disabled" / "The deposit pool size
+ * after depositing exceeds the maximum size"; if the requested amount exceeds
+ * it we refuse here to surface a clean error before the user signs.
+ *
+ * Min-deposit (~0.01 ETH per RocketDAOProtocolSettingsDeposit) is intentionally
+ * not preflight-checked — the on-chain revert message is clear enough and the
+ * extra RocketStorage lookup adds a transitive dep on the upgradeable settings
+ * contract that is not worth the complexity for an edge that the smallest UI
+ * already prevents.
+ */
+export async function buildRocketPoolStake(p: RocketPoolStakeParams): Promise<UnsignedTx> {
+  const amountWei = parseEther(p.amountEth);
+  const depositPool = CONTRACTS.ethereum.rocketpool.depositPool as `0x${string}`;
+
+  const client = getClient("ethereum");
+  const maxAmount = (await client.readContract({
+    address: depositPool,
+    abi: rocketDepositPoolAbi,
+    functionName: "getMaximumDepositAmount",
+  })) as bigint;
+  if (maxAmount === 0n) {
+    throw new Error(
+      "Rocket Pool deposits are currently disabled or the deposit pool is at capacity. Try again later or stake via Lido (`prepare_lido_stake`).",
+    );
+  }
+  if (amountWei > maxAmount) {
+    throw new Error(
+      `Rocket Pool deposit pool can currently accept at most ${formatEther(maxAmount)} ETH; requested ${p.amountEth} ETH would revert. Reduce the amount or wait for capacity.`,
+    );
+  }
+
+  return {
+    chain: "ethereum",
+    to: depositPool,
+    data: encodeFunctionData({
+      abi: rocketDepositPoolAbi,
+      functionName: "deposit",
+      args: [],
+    }),
+    value: amountWei.toString(),
+    from: p.wallet,
+    description: `Stake ${p.amountEth} ETH with Rocket Pool (mints rETH at current exchange rate)`,
+    decoded: { functionName: "deposit", args: { value: p.amountEth + " ETH" } },
+  };
+}
+
+export interface RocketPoolUnstakeParams {
+  wallet: `0x${string}`;
+  amountReth: string;
+}
+
+/**
+ * Build an unsigned rETH.burn(uint256) tx that redeems rETH for ETH from the
+ * rETH contract's collateral (its own balance + RocketDepositPool excess).
+ * No ERC-20 approve is needed — `burn` operates on `msg.sender`'s balance.
+ *
+ * Two preflight reverts the on-chain code throws are surfaced here so we
+ * don't burn user gas:
+ *   - "Insufficient rETH balance"           — wallet doesn't hold enough rETH
+ *   - "Insufficient ETH balance for exchange" — `getTotalCollateral()` < ETH
+ *     value of the burn. When this hits, the user can either burn a smaller
+ *     amount or unwind on the rETH/ETH Uniswap V3 pool — we surface both
+ *     options in the error string.
+ */
+export async function buildRocketPoolUnstake(p: RocketPoolUnstakeParams): Promise<UnsignedTx> {
+  const amountWei = parseEther(p.amountReth);
+  const reth = CONTRACTS.ethereum.rocketpool.rETH as `0x${string}`;
+
+  const client = getClient("ethereum");
+  const [balance, ethValue, totalCollateral] = await client.multicall({
+    contracts: [
+      { address: reth, abi: rocketTokenRETHAbi, functionName: "balanceOf", args: [p.wallet] },
+      { address: reth, abi: rocketTokenRETHAbi, functionName: "getEthValue", args: [amountWei] },
+      { address: reth, abi: rocketTokenRETHAbi, functionName: "getTotalCollateral" },
+    ],
+    allowFailure: false,
+  });
+  const balanceBn = balance as bigint;
+  const ethValueBn = ethValue as bigint;
+  const collateralBn = totalCollateral as bigint;
+  if (balanceBn < amountWei) {
+    throw new Error(
+      `Insufficient rETH balance: wallet holds ${formatEther(balanceBn)} rETH but the burn requested ${p.amountReth} rETH.`,
+    );
+  }
+  if (collateralBn < ethValueBn) {
+    throw new Error(
+      `Rocket Pool burn would revert: on-protocol ETH collateral is ${formatEther(collateralBn)} but ${p.amountReth} rETH redeems to ${formatEther(ethValueBn)} ETH. Burn a smaller amount, wait for liquidity to refill, or unwind via the rETH/ETH Uniswap V3 pool (prepare_uniswap_swap).`,
+    );
+  }
+
+  return {
+    chain: "ethereum",
+    to: reth,
+    data: encodeFunctionData({
+      abi: rocketTokenRETHAbi,
+      functionName: "burn",
+      args: [amountWei],
+    }),
+    value: "0",
+    from: p.wallet,
+    description: `Burn ${p.amountReth} rETH for ${formatEther(ethValueBn)} ETH via Rocket Pool`,
+    decoded: {
+      functionName: "burn",
+      args: { rethAmount: p.amountReth + " rETH", ethReceived: formatEther(ethValueBn) + " ETH" },
+    },
   };
 }
 

--- a/src/security/canonical-dispatch.ts
+++ b/src/security/canonical-dispatch.ts
@@ -84,6 +84,12 @@ const EXPECTED_TARGETS: Record<string, Partial<Record<SupportedChain, Set<string
   prepare_eigenlayer_deposit: chainSet({
     ethereum: [CONTRACTS.ethereum.eigenlayer.strategyManager],
   }),
+  prepare_rocketpool_stake: chainSet({
+    ethereum: [CONTRACTS.ethereum.rocketpool.depositPool],
+  }),
+  prepare_rocketpool_unstake: chainSet({
+    ethereum: [CONTRACTS.ethereum.rocketpool.rETH],
+  }),
 };
 
 function chainSet(

--- a/test/rocketpool-actions.test.ts
+++ b/test/rocketpool-actions.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseEther, toFunctionSelector } from "viem";
+
+/**
+ * Calldata + preflight tests for prepare_rocketpool_stake / unstake.
+ *
+ * Stake builder reads `getMaximumDepositAmount()` to refuse when the deposit
+ * pool is paused (returns 0) or saturated (returns < requested amount).
+ * Unstake builder reads rETH `balanceOf` + `getEthValue` + `getTotalCollateral`
+ * via multicall and refuses on insufficient wallet balance or insufficient
+ * on-protocol collateral. The rest is calldata-shape: `deposit()` selector,
+ * `burn(uint256)` selector, value/data fields.
+ */
+
+describe("buildRocketPoolStake", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  const wallet = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+
+  function mockClient(maxAmount: bigint) {
+    return {
+      readContract: vi.fn(async () => maxAmount),
+    };
+  }
+
+  it("produces a payable tx to RocketDepositPool with deposit() selector", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient(parseEther("100")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolStake } = await import("../src/modules/staking/actions.js");
+    const { CONTRACTS } = await import("../src/config/contracts.js");
+    const tx = await buildRocketPoolStake({ wallet, amountEth: "1.5" });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to.toLowerCase()).toBe(CONTRACTS.ethereum.rocketpool.depositPool.toLowerCase());
+    expect(tx.from).toBe(wallet);
+    expect(tx.value).toBe(parseEther("1.5").toString());
+    const selector = toFunctionSelector("deposit()");
+    expect(tx.data.toLowerCase().startsWith(selector.toLowerCase())).toBe(true);
+    // No args → 4-byte selector only.
+    expect(tx.data.length).toBe(2 + 8);
+  });
+
+  it("decoded metadata preserves user-facing amount", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient(parseEther("100")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolStake } = await import("../src/modules/staking/actions.js");
+    const tx = await buildRocketPoolStake({ wallet, amountEth: "2.25" });
+    expect(tx.decoded?.functionName).toBe("deposit");
+    expect(tx.decoded?.args.value).toBe("2.25 ETH");
+    expect(tx.description).toContain("2.25 ETH");
+  });
+
+  it("refuses when the deposit pool is disabled (getMaximumDepositAmount=0)", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient(0n),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolStake } = await import("../src/modules/staking/actions.js");
+    await expect(buildRocketPoolStake({ wallet, amountEth: "1" })).rejects.toThrow(
+      /currently disabled or the deposit pool is at capacity/,
+    );
+  });
+
+  it("refuses when amount exceeds current pool capacity", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () => mockClient(parseEther("0.5")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolStake } = await import("../src/modules/staking/actions.js");
+    await expect(buildRocketPoolStake({ wallet, amountEth: "1" })).rejects.toThrow(
+      /can currently accept at most 0.5 ETH/,
+    );
+  });
+});
+
+describe("buildRocketPoolUnstake", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  const wallet = "0x2222222222222222222222222222222222222222" as `0x${string}`;
+
+  function mockMulticall(balance: bigint, ethValue: bigint, totalCollateral: bigint) {
+    return {
+      multicall: vi.fn(async () => [balance, ethValue, totalCollateral]),
+    };
+  }
+
+  it("produces a tx to rETH with burn(uint256) selector encoding amount in wei", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () =>
+        mockMulticall(parseEther("10"), parseEther("0.27"), parseEther("100")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolUnstake } = await import("../src/modules/staking/actions.js");
+    const { CONTRACTS } = await import("../src/config/contracts.js");
+    const tx = await buildRocketPoolUnstake({ wallet, amountReth: "0.25" });
+    expect(tx.chain).toBe("ethereum");
+    expect(tx.to.toLowerCase()).toBe(CONTRACTS.ethereum.rocketpool.rETH.toLowerCase());
+    expect(tx.from).toBe(wallet);
+    expect(tx.value).toBe("0");
+    const selector = toFunctionSelector("burn(uint256)");
+    expect(tx.data.toLowerCase().startsWith(selector.toLowerCase())).toBe(true);
+    expect(tx.data.length).toBe(2 + 8 + 64);
+    const argHex = tx.data.slice(2 + 8);
+    expect(BigInt("0x" + argHex)).toBe(parseEther("0.25"));
+  });
+
+  it("decoded metadata reports both rETH burned and ETH received from getEthValue", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () =>
+        mockMulticall(parseEther("10"), parseEther("1.1"), parseEther("100")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolUnstake } = await import("../src/modules/staking/actions.js");
+    const tx = await buildRocketPoolUnstake({ wallet, amountReth: "1" });
+    expect(tx.decoded?.functionName).toBe("burn");
+    expect(tx.decoded?.args.rethAmount).toBe("1 rETH");
+    expect(tx.decoded?.args.ethReceived).toBe("1.1 ETH");
+    expect(tx.description).toContain("1 rETH");
+    expect(tx.description).toContain("1.1 ETH");
+  });
+
+  it("refuses when wallet rETH balance is below the burn amount", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () =>
+        mockMulticall(parseEther("0.1"), parseEther("0.11"), parseEther("100")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolUnstake } = await import("../src/modules/staking/actions.js");
+    await expect(
+      buildRocketPoolUnstake({ wallet, amountReth: "1" }),
+    ).rejects.toThrow(/Insufficient rETH balance/);
+  });
+
+  it("refuses when on-protocol collateral cannot cover the redemption", async () => {
+    vi.doMock("../src/data/rpc.js", () => ({
+      getClient: () =>
+        mockMulticall(parseEther("10"), parseEther("5"), parseEther("1")),
+      resetClients: () => {},
+    }));
+    const { buildRocketPoolUnstake } = await import("../src/modules/staking/actions.js");
+    await expect(
+      buildRocketPoolUnstake({ wallet, amountReth: "5" }),
+    ).rejects.toThrow(/on-protocol ETH collateral is 1/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `prepare_rocketpool_stake` (RocketDepositPool.deposit() payable → rETH at current exchange rate) and `prepare_rocketpool_unstake` (rETH.burn → ETH from on-protocol collateral).
- Ethereum mainnet only; rETH on L2s is bridged and not deposit-and-mint capable, matching the issue's scope.
- Both flows clear-sign on the Ledger ETH app: `deposit()` is a 4-byte selector with native value, `burn(uint256)` is a 4-byte selector + uint256.
- No SDK adoption — straight viem `encodeFunctionData` mirroring the Lido pattern. Canonical addresses pinned in `config/contracts.ts` from [Rocket Pool's official docs repo](https://github.com/rocket-pool/docs.rocketpool.net/blob/main/docs/en/protocol/contracts-integrations.md).

## Preflight checks

- **Stake**: reads `RocketDepositPool.getMaximumDepositAmount()`. Refuses with a clean error when deposits are paused (returns 0) or when the requested amount exceeds current pool capacity, instead of letting the on-chain revert burn user gas.
- **Unstake**: multicalls `rETH.balanceOf(wallet)` + `getEthValue(amount)` + `getTotalCollateral()`. Refuses on insufficient wallet rETH or insufficient on-protocol collateral; the latter error points at the rETH/ETH Uniswap V3 pool as the unwind path.

## Canonical-dispatch

Added `prepare_rocketpool_stake` → RocketDepositPool and `prepare_rocketpool_unstake` → rETH to the Inv #1.a allowlist in `src/security/canonical-dispatch.ts`. The existing regression test in `test/canonical-dispatch.test.ts` automatically validates both addresses resolve to real `CONTRACTS` entries.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 176 files / 2169 tests passing (incl. 8 new `rocketpool-actions.test.ts` cases covering selector, value, decoded metadata, and all four refusal paths)
- [x] `npm run build` — clean
- [ ] Live mainnet sanity-test against a real Ledger after merge (deferred — needs paired hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)