### PR TITLE
chore(diag): log unhandledRejection + uncaughtException to stderr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4689,6 +4689,23 @@ async function main() {
 // `process.exit(1)` would propagate as an unhandled rejection that
 // vitest reports as a CI failure even though every test asserted
 // passed.
+// Diagnostic crash-loggers — turn silent server deaths into stderr lines that
+// Claude Code captures in mcp-logs-vaultpilot-mcp/. Without these, an
+// unhandled rejection or uncaught exception under Node 22's default
+// `--unhandled-rejections=throw` exits the process with no stack trace, and
+// MCP clients only surface `-32000: Connection closed` — see periodic
+// crashes captured 2026-04-24 and 2026-04-28 with no stderr to chase.
+// Logging only; the process is still allowed to exit on uncaughtException
+// per the Node default, so we don't paper over a corrupted state.
+if (!process.env.VITEST) {
+  process.on("unhandledRejection", (reason) => {
+    console.error("[vaultpilot-mcp] unhandledRejection:", reason);
+  });
+  process.on("uncaughtException", (err) => {
+    console.error("[vaultpilot-mcp] uncaughtException:", err?.stack ?? err);
+  });
+}
+
 if (!process.env.VITEST) {
   main().catch((err) => {
     console.error("[vaultpilot-mcp] fatal:", err);


### PR DESCRIPTION
## Summary
- Periodic MCP-server crashes (`-32000: Connection closed`) captured on 2026-04-24 and 2026-04-28 in `mcp-logs-vaultpilot-mcp/` had **no stderr** to chase — Node 22's default `--unhandled-rejections=throw` terminates the process silently when any promise chain rejects without a `.catch`, and there was no global handler to surface the stack.
- Add `process.on('unhandledRejection')` + `process.on('uncaughtException')` that write to stderr. Claude Code captures stderr into the MCP-log JSONL stream as `Server stderr:` events (verified: this is how the 2026-04-26 `ERR_MODULE_NOT_FOUND` crash was visible — startup-only stderr happened to fire there).
- Logging only — the process is still allowed to exit on `uncaughtException` per the Node default, so we don't paper over a corrupted state. Skipped under Vitest so test mocks that throw don't flood test stderr.

## Why this is the smallest fix
The investigation in this branch's seed conversation found no specific bug (handlers have try/catch, the WC keepalive's IIFE wraps a function that catches internally, the skill-pin-drift fire-and-forget calls a function with try/finally). The blind-spot is diagnostic, not behavioral — without these handlers we can't tell whether the next crash is from WC, oracle-poller, an HID transport segfault, or something else. Ship the logger first, fix the actual cause once we have a stack.

## Test plan
- [ ] Verify CI green (typecheck + 2158 existing tests)
- [ ] After merge + restart of MCP server, the next `Connection closed` event in `~/.cache/claude-cli-nodejs/-home-szhygulin-dev-recon-mcp/mcp-logs-vaultpilot-mcp/*.jsonl` should carry a `Server stderr: [vaultpilot-mcp] unhandledRejection: ...` or `... uncaughtException: ...` line with the stack
- [ ] If the next crash still has no stderr, root cause is below the JS layer (native segfault, SIGKILL/OOM); next step would be `node --unhandled-rejections=warn` + a `dmesg | grep node` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)