### PR TITLE
feat(custom-call): add prepare_custom_call escape-hatch tool

### DIFF
--- a/src/config/scope.ts
+++ b/src/config/scope.ts
@@ -158,6 +158,7 @@ export function getToolScope(name: string): { family?: ChainFamily; protocol?: P
     name === "prepare_swap" ||
     name === "prepare_weth_unwrap" ||
     name === "prepare_revoke_approval" ||
+    name === "prepare_custom_call" ||
     name === "get_token_allowances" ||
     name === "resolve_ens_name" ||
     name === "reverse_resolve_ens" ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,7 @@ import {
   prepareWethUnwrap,
   prepareTokenSend,
   prepareRevokeApproval,
+  prepareCustomCall,
   previewSend,
   previewSolanaSend,
   sendTransaction,
@@ -339,6 +340,7 @@ import {
   prepareWethUnwrapInput,
   prepareTokenSendInput,
   prepareRevokeApprovalInput,
+  prepareCustomCallInput,
   previewSendInput,
   previewSolanaSendInput,
   sendTransactionInput,
@@ -4213,6 +4215,16 @@ async function main() {
       inputSchema: prepareRevokeApprovalInput.shape,
     },
     txHandler("prepare_revoke_approval", prepareRevokeApproval)
+  );
+
+  registerTool(server,
+    "prepare_custom_call",
+    {
+      description:
+        "ESCAPE HATCH for arbitrary EVM contract calls — Timelock proposals, governance hooks, DAO ops, anything not covered by a protocol-specific `prepare_*`. BYPASSES the canonical-dispatch allowlist by design; the schema's `acknowledgeNonProtocolTarget: true` literal is the user's affirmative gate. ABI source: pass `abi: [...]` inline (preferred when you have the project's published artifact), OR omit it and the tool fetches via Etherscan V2 — refuses on unverified contracts with NO raw-bytecode fallback. Proxies are followed once to the implementation when Etherscan exposes the link; deeper proxy chains require an inline ABI. Pass `fn` as a name (\"schedule\") when unambiguous or as the full signature (\"schedule(address,uint256,bytes,bytes32,bytes32,uint256)\") to disambiguate overloads. `args` types are validated by viem's encoder at build time — uint256 expects a decimal string, address expects a 0x-prefixed lowercase hex, bytes/bytes32 expect 0x-prefixed hex, structs are objects with their named fields. `value` is RAW WEI (decimal string), not human-readable. The standard prepare-receipt + verification envelope (payloadHash, decoderUrl, humanDecode) applies; on-device verification is blind-sign by definition (no Ledger plugin decodes arbitrary calldata) — the swiss-knife decoder URL surfaced in chat is the user-side anchor. Use a protocol-specific `prepare_*` whenever one fits — this tool exists for the long tail.",
+      inputSchema: prepareCustomCallInput.shape,
+    },
+    txHandler("prepare_custom_call", prepareCustomCall)
   );
 
   // ---- Module 8: Compound V3 ----

--- a/src/modules/custom-call/actions.ts
+++ b/src/modules/custom-call/actions.ts
@@ -1,0 +1,106 @@
+import { encodeFunctionData, type Abi } from "viem";
+import { getContractInfo } from "../../data/apis/etherscan.js";
+import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+
+export interface BuildCustomCallParams {
+  wallet: `0x${string}`;
+  chain: SupportedChain;
+  contract: `0x${string}`;
+  fn: string;
+  args: readonly unknown[];
+  value: string;
+  abi?: readonly unknown[];
+}
+
+/**
+ * Resolve the ABI to use for encoding. Caller-supplied `abi` wins; otherwise
+ * fetch via Etherscan V2 (`getsourcecode`, already wrapped + cached). Refuses
+ * on unverified contracts, on parse failures, and on proxies whose
+ * implementation ABI we can't reach — the user can always pass `abi` inline
+ * to bypass any of those refusals when they have a trusted ABI source.
+ *
+ * Why we never fall back to raw-bytecode encoding: the whole point of
+ * `prepare_custom_call` is that the user is bypassing the canonical-dispatch
+ * allowlist; the verified-ABI gate is the agent-side anchor that the
+ * function selector + args actually correspond to a real, source-published
+ * function rather than arbitrary bytes the caller hopes will work.
+ */
+async function resolveCallAbi(
+  contract: `0x${string}`,
+  chain: SupportedChain,
+): Promise<Abi> {
+  const info = await getContractInfo(contract, chain);
+  if (!info.isVerified) {
+    throw new Error(
+      `Contract ${contract} on ${chain} is not Etherscan-verified — refusing to encode calldata against unverified bytecode. Pass the ABI inline via the \`abi\` arg if you have it from another trusted source (e.g. the project's published artifacts).`,
+    );
+  }
+  if (info.isProxy && info.implementation) {
+    const impl = await getContractInfo(info.implementation, chain);
+    if (impl.isVerified && impl.abi && impl.abi.length > 0) {
+      return impl.abi as Abi;
+    }
+    throw new Error(
+      `Contract ${contract} on ${chain} is a proxy whose implementation ${info.implementation} couldn't be ABI-fetched (unverified or parse failure). Pass the ABI inline via the \`abi\` arg.`,
+    );
+  }
+  if (!info.abi || info.abi.length === 0) {
+    throw new Error(
+      `Etherscan returned no parseable ABI for ${contract} on ${chain} (verified, but ABI was empty or invalid). Pass the ABI inline via the \`abi\` arg.`,
+    );
+  }
+  return info.abi as Abi;
+}
+
+export async function buildCustomCall(p: BuildCustomCallParams): Promise<UnsignedTx> {
+  const abi: Abi = p.abi
+    ? (p.abi as Abi)
+    : await resolveCallAbi(p.contract, p.chain);
+
+  let data: `0x${string}`;
+  try {
+    data = encodeFunctionData({
+      abi,
+      functionName: p.fn,
+      args: p.args as readonly unknown[],
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `Failed to encode calldata for ${p.fn} on ${p.contract} (${p.chain}): ${msg}. ` +
+        `Check that \`fn\` matches an ABI entry (use the full signature like ` +
+        `"schedule(address,uint256,bytes,bytes32,bytes32,uint256)" to disambiguate ` +
+        `overloads) and that \`args\` types match the function's inputs in order.`,
+    );
+  }
+
+  // value is a raw wei decimal string; reject anything that isn't.
+  if (!/^\d+$/.test(p.value)) {
+    throw new Error(
+      `\`value\` must be a non-negative wei integer as a decimal string (e.g. "0" or "1000000000000000000" for 1 ETH). Got: ${p.value}`,
+    );
+  }
+
+  // Stringify args for the decoded preview. Caller-supplied shapes are
+  // arbitrary (struct tuples, address arrays, decimal strings); the JSON
+  // form is the most faithful agent-readable rendering without losing
+  // structural detail. Caps at 4KB so a pathological bytes argument
+  // doesn't blow up the prepare-receipt block.
+  const argsJson = JSON.stringify(p.args, (_, v) =>
+    typeof v === "bigint" ? v.toString() : v,
+  );
+  const argsPreview = argsJson.length > 4096 ? `${argsJson.slice(0, 4096)}…` : argsJson;
+
+  return {
+    chain: p.chain,
+    to: p.contract,
+    data,
+    value: p.value,
+    from: p.wallet,
+    description: `Custom call: ${p.fn} on ${p.contract} (${p.chain})`,
+    decoded: {
+      functionName: p.fn,
+      args: { args: argsPreview },
+    },
+  };
+}

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -112,6 +112,7 @@ import {
   buildRocketPoolUnstake,
 } from "../staking/actions.js";
 import { buildWethUnwrap } from "../weth/actions.js";
+import { buildCustomCall } from "../custom-call/actions.js";
 import { getTokenPrice } from "../../data/prices.js";
 import type {
   PairLedgerTronArgs,
@@ -138,6 +139,7 @@ import type {
   PrepareWethUnwrapArgs,
   PrepareTokenSendArgs,
   PrepareRevokeApprovalArgs,
+  PrepareCustomCallArgs,
   PrepareSolanaNativeSendArgs,
   PrepareSolanaSplSendArgs,
   PrepareSolanaNonceInitArgs,
@@ -2655,6 +2657,32 @@ export async function prepareRevokeApproval(
       },
     },
   });
+}
+
+export async function prepareCustomCall(
+  args: PrepareCustomCallArgs,
+): Promise<UnsignedTx> {
+  // Schema enforces `acknowledgeNonProtocolTarget: z.literal(true)` so
+  // anything that lands here has already crossed the affirmative gate.
+  // Re-assert defensively in case a future caller bypasses the schema.
+  if (args.acknowledgeNonProtocolTarget !== true) {
+    throw new Error(
+      "prepare_custom_call requires acknowledgeNonProtocolTarget=true. The tool " +
+        "BYPASSES the canonical-dispatch allowlist by design; this flag is the " +
+        "user's affirmative ack that they're calling a non-protocol target.",
+    );
+  }
+  return enrichTx(
+    await buildCustomCall({
+      wallet: args.wallet as `0x${string}`,
+      chain: args.chain as SupportedChain,
+      contract: args.contract as `0x${string}`,
+      fn: args.fn,
+      args: args.args ?? [],
+      value: args.value,
+      abi: args.abi,
+    }),
+  );
 }
 
 /**

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -839,6 +839,85 @@ export const prepareRevokeApprovalInput = z.object({
   ),
 });
 
+/**
+ * `prepare_custom_call` — build a generic, single-call EVM transaction
+ * against any contract. The escape hatch for cases the protocol-specific
+ * `prepare_*` tools don't cover (Timelock proposals, governance hooks,
+ * arbitrary DAO contracts, …). BYPASSES the canonical-dispatch allowlist
+ * by design — `acknowledgeNonProtocolTarget: true` is the affirmative gate.
+ *
+ * ABI source: inline `abi` arg (caller-supplied) wins; otherwise the tool
+ * fetches it via Etherscan V2 and refuses on unverified contracts. No raw-
+ * bytecode encoding path — the verified-or-inline-ABI gate is the agent-
+ * side anchor that the function selector + args correspond to a real,
+ * source-published function.
+ *
+ * Verification: the standard prepare-receipt + `verification` envelope
+ * (payloadHash, decoderUrl, humanDecode) applies. Blind-sign on-device is
+ * automatic — only `transfer`/`approve`/empty-calldata clear-sign, and
+ * `prepare_custom_call` is by definition none of those.
+ */
+export const prepareCustomCallInput = z.object({
+  wallet: walletSchema.describe(
+    "EVM wallet that will sign + broadcast the call. Must be paired via `pair_ledger_live`."
+  ),
+  chain: chainEnum.default("ethereum"),
+  contract: addressSchema.describe(
+    "Target contract address. Must be Etherscan-verified OR the `abi` arg must be passed inline. " +
+      "NOT canonical-dispatch-allowlist gated — this is the explicit escape hatch for arbitrary calls."
+  ),
+  fn: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe(
+      'Function name to call (e.g. "schedule"). Pass the FULL signature ' +
+        '("schedule(address,uint256,bytes,bytes32,bytes32,uint256)") to disambiguate when ' +
+        "the ABI has overloads for the same name."
+    ),
+  args: z
+    .array(z.unknown())
+    .default([])
+    .describe(
+      "Array of args matching the function's inputs in order. Decimal strings for uint256 " +
+        '(e.g. "1000000000000000000" for 1 ETH-as-wei), hex strings for bytes32/bytes, ' +
+        "lowercase 0x-prefixed addresses, plain numbers/booleans for primitives, nested " +
+        "arrays/objects for structs and tuples. viem's encoder validates types at build time."
+    ),
+  value: z
+    .string()
+    .regex(/^\d+$/)
+    .default("0")
+    .describe(
+      'Native-coin value in WEI (decimal string). Use "0" for non-payable functions. ' +
+        'For payable functions, pass the wei amount (e.g. "1000000000000000000" for 1 ETH). ' +
+        "Human-readable amounts are NOT accepted here — the tool can't infer the function's " +
+        "expected denomination from an arbitrary signature."
+    ),
+  abi: z
+    .array(z.unknown())
+    .optional()
+    .describe(
+      "Inline ABI array. When omitted, the tool fetches it via Etherscan V2. Pass it to " +
+        "override the Etherscan ABI, to call a contract whose source isn't yet verified, " +
+        "or to call through a proxy whose implementation can't be auto-followed. NEVER let " +
+        "an untrusted source supply this — the ABI determines selector encoding, so a " +
+        "malicious ABI can route a benign-looking `fn` to a value-exfil selector on the " +
+        "target contract."
+    ),
+  acknowledgeNonProtocolTarget: z
+    .literal(true)
+    .describe(
+      "AFFIRMATIVE GATE — must be true. The tool BYPASSES the canonical-dispatch allowlist " +
+        "by design (used for arbitrary contract calls like Timelock proposals, governance " +
+        "hooks, DAO ops). Setting this to true is the user's affirmative ack that they " +
+        "understand the call doesn't have the protocol-tier safety net of " +
+        "`prepare_aave_*` / `prepare_lido_*` / etc.; the on-device blind-sign hash + the " +
+        "swiss-knife decoder URL are the sole verification anchors. Do NOT default this to " +
+        "true silently — the agent must surface the trade-off to the user before setting it."
+    ),
+});
+
 export const sendTransactionInput = z.object({
   handle: z
     .string()
@@ -1040,6 +1119,7 @@ export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
 export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;
 export type PrepareTokenSendArgs = z.infer<typeof prepareTokenSendInput>;
 export type PrepareRevokeApprovalArgs = z.infer<typeof prepareRevokeApprovalInput>;
+export type PrepareCustomCallArgs = z.infer<typeof prepareCustomCallInput>;
 export type PreviewSendArgs = z.infer<typeof previewSendInput>;
 export type SendTransactionArgs = z.infer<typeof sendTransactionInput>;
 export type GetTransactionStatusArgs = z.infer<typeof getTransactionStatusInput>;

--- a/test/custom-call.test.ts
+++ b/test/custom-call.test.ts
@@ -1,0 +1,330 @@
+/**
+ * `prepare_custom_call` tests. Covers the build-side of the new escape-
+ * hatch tool — issue #493.
+ *
+ * Coverage:
+ *   - ABI source: inline arg wins; Etherscan fallback works for verified
+ *     contracts; unverified contracts refuse with NO raw-bytecode path;
+ *     proxies are followed once to the implementation.
+ *   - Schema: `acknowledgeNonProtocolTarget: z.literal(true)` rejects
+ *     `false` / `undefined` / non-boolean values at zod-parse time.
+ *   - Calldata encoding matches viem's expected output for known sigs.
+ *   - The wired txHandler doesn't throw INV_1A on a non-canonical target —
+ *     `prepare_custom_call` must NOT be in the EXPECTED_TARGETS allowlist
+ *     (it's the explicit allowlist-bypass tool).
+ *   - Function-overload disambiguation: `fn` accepts both bare name and
+ *     full signature.
+ *   - `value` rejects non-decimal-integer strings (zod regex + builder
+ *     re-assertion).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { encodeFunctionData } from "viem";
+
+const getContractInfoMock = vi.fn();
+vi.mock("../src/data/apis/etherscan.js", () => ({
+  getContractInfo: (...a: unknown[]) => getContractInfoMock(...a),
+}));
+
+import { buildCustomCall } from "../src/modules/custom-call/actions.js";
+import { prepareCustomCallInput } from "../src/modules/execution/schemas.js";
+import { assertCanonicalDispatchOnTxChain } from "../src/security/canonical-dispatch.js";
+
+const WALLET = "0xC0f5b7f7703BA95dC7C09D4eF50A830622234075" as const;
+const TIMELOCK = "0x22bc85C483103950441EaaB8312BE9f07e234634" as const;
+const PROXY = "0x1111111111111111111111111111111111111111" as const;
+const IMPL = "0x2222222222222222222222222222222222222222" as const;
+
+// Minimal Timelock fragment — schedule(...) — exact shape of the v4
+// OpenZeppelin TimelockController on mainnet.
+const TIMELOCK_ABI = [
+  {
+    type: "function",
+    name: "schedule",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "target", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+      { name: "predecessor", type: "bytes32" },
+      { name: "salt", type: "bytes32" },
+      { name: "delay", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+beforeEach(() => {
+  getContractInfoMock.mockReset();
+});
+
+describe("prepare_custom_call schema (issue #493)", () => {
+  it("requires acknowledgeNonProtocolTarget=true literally", () => {
+    expect(() =>
+      prepareCustomCallInput.parse({
+        wallet: WALLET,
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        acknowledgeNonProtocolTarget: false,
+      }),
+    ).toThrow();
+    expect(() =>
+      prepareCustomCallInput.parse({
+        wallet: WALLET,
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        // missing
+      }),
+    ).toThrow();
+    // true passes — combined with required wallet + contract + fn.
+    const ok = prepareCustomCallInput.parse({
+      wallet: WALLET,
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [],
+      acknowledgeNonProtocolTarget: true,
+    });
+    expect(ok.acknowledgeNonProtocolTarget).toBe(true);
+    expect(ok.value).toBe("0"); // default
+    expect(ok.chain).toBe("ethereum"); // default
+  });
+
+  it("rejects non-decimal-integer value", () => {
+    expect(() =>
+      prepareCustomCallInput.parse({
+        wallet: WALLET,
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        value: "0.5", // decimal — must be wei integer
+        acknowledgeNonProtocolTarget: true,
+      }),
+    ).toThrow();
+    expect(() =>
+      prepareCustomCallInput.parse({
+        wallet: WALLET,
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        value: "1000000000000000000", // 1 ETH in wei
+        acknowledgeNonProtocolTarget: true,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("buildCustomCall — ABI resolution", () => {
+  it("uses inline ABI when provided (no Etherscan fetch)", async () => {
+    const args: readonly unknown[] = [
+      "0x0000000000000000000000000000000000000001",
+      "0",
+      "0x",
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "172800",
+    ];
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "schedule",
+      args,
+      value: "0",
+      abi: TIMELOCK_ABI as unknown as readonly unknown[],
+    });
+    expect(getContractInfoMock).not.toHaveBeenCalled();
+    expect(tx.to).toBe(TIMELOCK);
+    expect(tx.chain).toBe("ethereum");
+    // Compare bit-exactly against viem's encoder.
+    const expected = encodeFunctionData({
+      abi: TIMELOCK_ABI,
+      functionName: "schedule",
+      args,
+    });
+    expect(tx.data).toBe(expected);
+  });
+
+  it("fetches ABI via Etherscan when verified and not a proxy", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: TIMELOCK_ABI as unknown as unknown[],
+    });
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0",
+        "0x",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "172800",
+      ],
+      value: "0",
+    });
+    expect(getContractInfoMock).toHaveBeenCalledOnce();
+    expect(tx.data.startsWith("0x01d5062a")).toBe(true); // schedule selector
+  });
+
+  it("refuses unverified contracts with NO raw-bytecode fallback", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: false,
+      isProxy: false,
+    });
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        value: "0",
+      }),
+    ).rejects.toThrow(/not Etherscan-verified/);
+  });
+
+  it("follows proxy → implementation once for ABI lookup", async () => {
+    getContractInfoMock
+      .mockResolvedValueOnce({
+        address: PROXY,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: IMPL,
+        abi: [], // proxy itself has only fallback
+      })
+      .mockResolvedValueOnce({
+        address: IMPL,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: false,
+        abi: TIMELOCK_ABI as unknown as unknown[],
+      });
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: PROXY,
+      fn: "schedule",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0",
+        "0x",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "172800",
+      ],
+      value: "0",
+    });
+    expect(getContractInfoMock).toHaveBeenCalledTimes(2);
+    expect(tx.to).toBe(PROXY); // outer call still targets the proxy
+  });
+
+  it("refuses proxy when implementation is unverified", async () => {
+    getContractInfoMock
+      .mockResolvedValueOnce({
+        address: PROXY,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: IMPL,
+        abi: [],
+      })
+      .mockResolvedValueOnce({
+        address: IMPL,
+        chain: "ethereum",
+        isVerified: false,
+        isProxy: false,
+      });
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: PROXY,
+        fn: "schedule",
+        args: [],
+        value: "0",
+      }),
+    ).rejects.toThrow(/proxy.*implementation.*couldn't be ABI-fetched/);
+  });
+
+  it("refuses verified contract with empty parsed ABI", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: undefined,
+    });
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [],
+        value: "0",
+      }),
+    ).rejects.toThrow(/no parseable ABI/);
+  });
+});
+
+describe("buildCustomCall — encoding", () => {
+  it("surfaces a useful error when fn doesn't match the ABI", async () => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "totallyMadeUpFn",
+        args: [],
+        value: "0",
+        abi: TIMELOCK_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/Failed to encode calldata/);
+  });
+
+  it("preserves passed value (wei) in the unsigned tx", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0",
+        "0x",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "172800",
+      ],
+      value: "1000000000000000000",
+      abi: TIMELOCK_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.value).toBe("1000000000000000000");
+  });
+});
+
+describe("canonical-dispatch wiring (#483 / PR #489)", () => {
+  it("is a no-op for prepare_custom_call regardless of `to`", () => {
+    // The wired txHandler walks to the action leg and asserts canonical
+    // dispatch. `prepare_custom_call` is the explicit allowlist-bypass
+    // tool — it must NOT match any EXPECTED_TARGETS entry. Verify by
+    // running the same shape txHandler runs against an arbitrary `to`.
+    const tx = {
+      chain: "ethereum" as const,
+      to: "0x000000000000000000000000000000000000beef" as `0x${string}`,
+      data: "0x" as `0x${string}`,
+      value: "0",
+      description: "",
+    };
+    expect(() => assertCanonicalDispatchOnTxChain("prepare_custom_call", tx)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #493 (smallest first cut — selector-classifier deferred to a follow-up issue).

## Summary
- New `prepare_custom_call` tool: build an arbitrary EVM contract call against any `(contract, fn, args, value)` tuple. Lives in `src/modules/custom-call/actions.ts`; schema in `src/modules/execution/schemas.ts`; handler exported from `src/modules/execution/index.ts`; registered in `src/index.ts`; gated under `family=evm` (no protocol) in `src/config/scope.ts`.
- ABI source: caller-supplied `abi` wins; otherwise Etherscan V2 via the existing `getContractInfo` wrapper. Refuses unverified contracts with NO raw-bytecode fallback. Proxies are followed once to the implementation.
- Schema-enforced affirmative gate: `acknowledgeNonProtocolTarget: z.literal(true)` — agent can't default it.
- BYPASSES the canonical-dispatch allowlist by design (the explicit escape hatch); the wired `assertCanonicalDispatchOnTxChain` in `txHandler` (PR #489) is a no-op for tool families not in `EXPECTED_TARGETS`, so this falls out for free.
- Blind-sign on-device falls out naturally via `isClearSignOnlyTx` (only `transfer`/`approve`/empty calldata clear-sign).

## What's deferred
- Selector classifier for value-exfil patterns (`transferFrom(self, attacker, …)`, `approve(attacker, max)`, etc.). Issue says \"reuse the security skill's classifier\" but no such classifier exists in the codebase yet — designing it (false-positive rate, ownership detection of the target, etc.) warrants its own issue.
- User-side defenses still in the loop for this cut: swiss-knife decoder URL surfaced in the verification block, simulation revert reason in `enrichTx`, on-device blind-sign hash from `preview_send`.

## Skill-side coordination
- The on-disk vaultpilot-preflight skill is at v4 (no INV_1A canonical-dispatch invariant) — safe to ship today.
- When skill v8 lands the agent-side allowlist mirror, the skill needs an explicit carveout so `prepare_custom_call` doesn't trip its dispatch-target check. Tracked separately in the [vaultpilot-security-skill](https://github.com/szhygulin/vaultpilot-security-skill) repo.

## Test plan
- [x] `npx vitest run test/custom-call.test.ts` — 11 new tests covering schema literal-true gate, value regex, ABI inline / Etherscan fetch / unverified refusal / proxy follow / proxy-impl-unverified refusal / empty-ABI refusal, encoding errors, value preservation, and canonical-dispatch wiring no-op.
- [x] `npx vitest run` — full suite 2300/2300 pass.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)