### PR TITLE
feat(security): add get_contract_abi — standalone Etherscan-V2 ABI fetch (closes #495)

### DIFF
--- a/src/config/scope.ts
+++ b/src/config/scope.ts
@@ -172,6 +172,7 @@ export function getToolScope(name: string): { family?: ChainFamily; protocol?: P
     name === "set_etherscan_api_key" ||
     name === "check_contract_security" ||
     name === "check_permission_risks" ||
+    name === "get_contract_abi" ||
     name.startsWith("get_nft_")
   )
     return { family: "evm" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,11 +83,13 @@ import {
   checkContractSecurityHandler,
   checkPermissionRisksHandler,
   getProtocolRiskScoreHandler,
+  getContractAbiHandler,
 } from "./modules/security/index.js";
 import {
   checkContractSecurityInput,
   checkPermissionRisksInput,
   getProtocolRiskScoreInput,
+  getContractAbiInput,
 } from "./modules/security/schemas.js";
 
 import { compareYields } from "./modules/yields/index.js";
@@ -2046,6 +2048,17 @@ async function main() {
       inputSchema: getProtocolRiskScoreInput.shape,
     },
     handler((a) => getProtocolRiskScoreHandler(a))
+  );
+
+  registerTool(server,
+    "get_contract_abi",
+    {
+      description:
+        "READ-ONLY — fetch a verified contract's ABI on any Etherscan-V2-supported EVM chain (Ethereum, Arbitrum, Polygon, Base, Optimism). Wraps the same `getsourcecode` path `prepare_custom_call` and `check_contract_security` use, so the call carries the user's `ETHERSCAN_API_KEY`, the `MAX_RESPONSE_BYTES` cap, the `sanitizeContractName` discipline, and the 24h cache. Returns `{ chain, address, isVerified, isProxy, implementation?, contractName?, compilerVersion?, abi?, abiSource }`. When the target is a proxy and `followProxy=true` (default), follows once to the implementation's ABI and reports `abiSource: \"proxy-implementation\"`; when `followProxy=false` or the implementation isn't verified, returns the proxy's own ABI with `abiSource: \"proxy-target\"` plus a `proxyFollowSkippedReason` explaining why. Unverified contracts return `{ isVerified: false }` and no ABI — ask the user to paste the ABI inline if they have it from the project's published artifacts. " +
+        "ALWAYS prefer this tool over a generic WebFetch against `etherscan.io`/`api.etherscan.io` for ABI lookups in this MCP's surface — that path doesn't carry the API key (the env var lives in the MCP process, not the agent's harness), loses the size cap + verified-vs-unverified discipline, loses the 24h cache, and pulls the response through the agent's web layer with no sanitization for attacker-controlled fields like `ContractName`. Issue #495.",
+      inputSchema: getContractAbiInput.shape,
+    },
+    handler((a) => getContractAbiHandler(a))
   );
 
   registerTool(server,

--- a/src/modules/security/contract-abi.ts
+++ b/src/modules/security/contract-abi.ts
@@ -1,0 +1,80 @@
+import { getContractInfo, type ContractInfo } from "../../data/apis/etherscan.js";
+import type { SupportedChain } from "../../types/index.js";
+
+export interface GetContractAbiResult extends ContractInfo {
+  /**
+   * `proxy-implementation` when `followProxy=true`, the target was a proxy,
+   * and we successfully resolved the implementation's ABI; the returned
+   * `abi` is the implementation's. `proxy-target` when the target was a
+   * proxy but we returned the proxy's own ABI (followProxy=false, or the
+   * implementation wasn't verified). `direct` when the target was not a
+   * proxy. Surfaced so the caller can tell, without re-deriving, whether a
+   * follow happened — important for the `prepare_custom_call` use case
+   * where the agent needs to know which contract's ABI it's encoding
+   * against.
+   */
+  abiSource: "direct" | "proxy-target" | "proxy-implementation";
+  /**
+   * When `abiSource === "proxy-target"`, explains why we didn't follow the
+   * implementation (followProxy=false vs. implementation unverified). When
+   * `abiSource !== "proxy-target"`, omitted.
+   */
+  proxyFollowSkippedReason?: "follow-proxy-disabled" | "implementation-unverified";
+}
+
+/**
+ * Read-only ABI fetch via Etherscan V2 (issue #495). Wraps the existing
+ * `getContractInfo` + 24h cache + sanitization. Optionally follows the
+ * EIP-1967 implementation pointer once when the target is a proxy and
+ * `followProxy` is true (default).
+ *
+ * Why a standalone tool exists: without this, the agent's only MCP path
+ * to an ABI is `prepare_custom_call`'s side-effect — which builds a tx
+ * the user may not want. Faced with "I just need the ABI", the agent
+ * would fall back to `WebFetch` against `etherscan.io`, bypassing the
+ * MCP trust boundary (no API key, no size cap, no cache, no
+ * sanitization). Closing that hole is the only reason this tool exists.
+ */
+export async function getContractAbi(
+  address: `0x${string}`,
+  chain: SupportedChain,
+  followProxy: boolean,
+): Promise<GetContractAbiResult> {
+  const info = await getContractInfo(address, chain);
+
+  if (!info.isProxy || !info.implementation) {
+    return { ...info, abiSource: "direct" };
+  }
+
+  if (!followProxy) {
+    return {
+      ...info,
+      abiSource: "proxy-target",
+      proxyFollowSkippedReason: "follow-proxy-disabled",
+    };
+  }
+
+  const impl = await getContractInfo(info.implementation, chain);
+  if (!impl.isVerified || !impl.abi || impl.abi.length === 0) {
+    return {
+      ...info,
+      abiSource: "proxy-target",
+      proxyFollowSkippedReason: "implementation-unverified",
+    };
+  }
+
+  // Return the implementation's ABI but keep the proxy as the surfaced
+  // `address` — the caller asked about that contract; the ABI is the
+  // implementation's because that's what the proxy delegates to.
+  return {
+    address: info.address,
+    chain: info.chain,
+    isVerified: info.isVerified,
+    isProxy: true,
+    implementation: info.implementation,
+    contractName: impl.contractName ?? info.contractName,
+    compilerVersion: impl.compilerVersion ?? info.compilerVersion,
+    abi: impl.abi,
+    abiSource: "proxy-implementation",
+  };
+}

--- a/src/modules/security/index.ts
+++ b/src/modules/security/index.ts
@@ -1,10 +1,12 @@
 import { checkContractSecurity } from "./verification.js";
 import { checkPermissionRisks } from "./permissions.js";
 import { getProtocolRiskScore } from "./risk-score.js";
+import { getContractAbi } from "./contract-abi.js";
 import type {
   CheckContractSecurityArgs,
   CheckPermissionRisksArgs,
   GetProtocolRiskScoreArgs,
+  GetContractAbiArgs,
 } from "./schemas.js";
 import type { SupportedChain } from "../../types/index.js";
 
@@ -18,4 +20,12 @@ export async function checkPermissionRisksHandler(args: CheckPermissionRisksArgs
 
 export async function getProtocolRiskScoreHandler(args: GetProtocolRiskScoreArgs) {
   return getProtocolRiskScore(args.protocol);
+}
+
+export async function getContractAbiHandler(args: GetContractAbiArgs) {
+  return getContractAbi(
+    args.address as `0x${string}`,
+    args.chain as SupportedChain,
+    args.followProxy,
+  );
 }

--- a/src/modules/security/schemas.ts
+++ b/src/modules/security/schemas.ts
@@ -19,6 +19,29 @@ export const getProtocolRiskScoreInput = z.object({
   protocol: z.string().min(1),
 });
 
+export const getContractAbiInput = z.object({
+  address: addressSchema.describe(
+    "EVM contract address to fetch the ABI for. Etherscan V2 covers Ethereum + Arbitrum + " +
+      "Polygon + Base + Optimism (the same five chains the rest of this MCP supports)."
+  ),
+  chain: chainEnum.describe(
+    "Which chain the contract is deployed on. The same address can map to different contracts " +
+      "on different chains; this arg disambiguates."
+  ),
+  followProxy: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "When the target is a proxy with a resolvable implementation, follow once to the " +
+        "implementation's verified ABI (typical caller intent — you want the function selectors " +
+        "the proxy delegates to, not the proxy's own admin surface). Set to false to inspect " +
+        "the proxy's own ABI (e.g. when calling `upgradeTo` on the proxy itself). " +
+        "`abiSource` in the response tells you which path was taken."
+    ),
+});
+
 export type CheckContractSecurityArgs = z.infer<typeof checkContractSecurityInput>;
 export type CheckPermissionRisksArgs = z.infer<typeof checkPermissionRisksInput>;
 export type GetProtocolRiskScoreArgs = z.infer<typeof getProtocolRiskScoreInput>;
+export type GetContractAbiArgs = z.infer<typeof getContractAbiInput>;

--- a/test/get-contract-abi.test.ts
+++ b/test/get-contract-abi.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `get_contract_abi` handler — issue #495.
+ *
+ * Wraps `getContractInfo` with optional follow-once-to-implementation
+ * logic. Tests pin the four reachable shapes:
+ *
+ *   1. direct (non-proxy verified)
+ *   2. proxy-implementation (proxy + implementation verified, followProxy=true)
+ *   3. proxy-target / follow-proxy-disabled (followProxy=false)
+ *   4. proxy-target / implementation-unverified (followProxy=true but the
+ *      target's implementation isn't Etherscan-verified)
+ *
+ * Plus the unverified-target shape (no ABI in either direction).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ContractInfo } from "../src/data/apis/etherscan.js";
+
+describe("getContractAbi", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  const proxyAddr = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+  const implAddr = "0x2222222222222222222222222222222222222222" as `0x${string}`;
+
+  function mockGetContractInfo(byAddress: Record<string, ContractInfo>) {
+    vi.doMock("../src/data/apis/etherscan.js", async () => {
+      const actual = await vi.importActual<typeof import("../src/data/apis/etherscan.js")>(
+        "../src/data/apis/etherscan.js",
+      );
+      return {
+        ...actual,
+        getContractInfo: vi.fn(async (a: `0x${string}`) => {
+          const hit = byAddress[a.toLowerCase()];
+          if (!hit) throw new Error(`unmocked address: ${a}`);
+          return hit;
+        }),
+      };
+    });
+  }
+
+  it("direct verified contract returns abiSource=direct + ABI from the target", async () => {
+    const fakeAbi = [
+      { type: "function", name: "transfer", inputs: [], outputs: [] },
+    ];
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: false,
+        contractName: "MyToken",
+        compilerVersion: "v0.8.20",
+        abi: fakeAbi,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", true);
+    expect(res.isVerified).toBe(true);
+    expect(res.isProxy).toBe(false);
+    expect(res.abi).toEqual(fakeAbi);
+    expect(res.abiSource).toBe("direct");
+    expect(res.proxyFollowSkippedReason).toBeUndefined();
+  });
+
+  it("proxy + verified implementation returns abiSource=proxy-implementation with the impl's ABI", async () => {
+    const proxyAbi = [{ type: "function", name: "upgradeTo" }];
+    const implAbi = [
+      { type: "function", name: "swap" },
+      { type: "function", name: "deposit" },
+    ];
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: implAddr,
+        contractName: "ProxyAdmin",
+        abi: proxyAbi,
+      },
+      [implAddr.toLowerCase()]: {
+        address: implAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: false,
+        contractName: "RouterImpl",
+        abi: implAbi,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", true);
+    expect(res.isProxy).toBe(true);
+    expect(res.address).toBe(proxyAddr); // surfaced address stays the proxy
+    expect(res.implementation).toBe(implAddr);
+    expect(res.abi).toEqual(implAbi);
+    expect(res.abiSource).toBe("proxy-implementation");
+    expect(res.contractName).toBe("RouterImpl"); // impl name wins
+  });
+
+  it("followProxy=false on a proxy returns abiSource=proxy-target with the proxy's ABI + reason=follow-proxy-disabled", async () => {
+    const proxyAbi = [{ type: "function", name: "upgradeTo" }];
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: implAddr,
+        contractName: "ProxyAdmin",
+        abi: proxyAbi,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", false);
+    expect(res.abiSource).toBe("proxy-target");
+    expect(res.proxyFollowSkippedReason).toBe("follow-proxy-disabled");
+    expect(res.abi).toEqual(proxyAbi);
+  });
+
+  it("proxy whose implementation is unverified returns abiSource=proxy-target with reason=implementation-unverified", async () => {
+    const proxyAbi = [{ type: "function", name: "upgradeTo" }];
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: implAddr,
+        contractName: "ProxyAdmin",
+        abi: proxyAbi,
+      },
+      [implAddr.toLowerCase()]: {
+        address: implAddr,
+        chain: "ethereum",
+        isVerified: false,
+        isProxy: false,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", true);
+    expect(res.abiSource).toBe("proxy-target");
+    expect(res.proxyFollowSkippedReason).toBe("implementation-unverified");
+    expect(res.abi).toEqual(proxyAbi); // proxy's own ABI surfaces
+  });
+
+  it("unverified target returns isVerified=false + no ABI + abiSource=direct", async () => {
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: false,
+        isProxy: false,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", true);
+    expect(res.isVerified).toBe(false);
+    expect(res.abi).toBeUndefined();
+    expect(res.abiSource).toBe("direct");
+  });
+
+  it("proxy with no implementation field falls through to direct (no follow attempt)", async () => {
+    const proxyAbi = [{ type: "function", name: "fallback" }];
+    mockGetContractInfo({
+      [proxyAddr.toLowerCase()]: {
+        address: proxyAddr,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true, // claims proxy but no implementation address
+        implementation: undefined,
+        abi: proxyAbi,
+      },
+    });
+    const { getContractAbi } = await import("../src/modules/security/contract-abi.js");
+    const res = await getContractAbi(proxyAddr, "ethereum", true);
+    expect(res.abiSource).toBe("direct");
+    expect(res.abi).toEqual(proxyAbi);
+  });
+});

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -62,6 +62,7 @@ describe("getToolScope — prefix-derived mapping", () => {
     ["compare_yields", "evm"],
     ["get_swap_quote", "evm"],
     ["check_contract_security", "evm"],
+    ["get_contract_abi", "evm"],
     ["get_nft_portfolio", "evm"],
     // Solana family-only
     ["prepare_solana_native_send", "solana"],


### PR DESCRIPTION
## Summary

Closes #495. Adds a read-only `get_contract_abi({ chain, address, followProxy? })` tool that wraps the existing `getContractInfo` path so agents have a first-class MCP entry point for ABI lookups instead of falling back to `WebFetch` against `etherscan.io` (which bypasses the API key, the size cap, the 24h cache, and the `sanitizeContractName` discipline).

- `abiSource` discriminator: `"direct"` / `"proxy-target"` / `"proxy-implementation"` so the caller knows which contract's ABI is in `abi[]` without re-deriving.
- `followProxy: boolean = true` follows once to the implementation when the target is a proxy and the implementation is verified. When `followProxy=false` or the implementation is unverified, returns the proxy's own ABI with a `proxyFollowSkippedReason` discriminator.
- Tool description explicitly steers agents away from `WebFetch` for ABI lookups.

## Implementation

- New `src/modules/security/contract-abi.ts` (the only meaningful logic — ~80 LoC).
- Schema + handler entry follow the existing `check_contract_security` / `check_permission_risks` pattern.
- Scope: `family: "evm"`, no protocol — same as `prepare_custom_call`. Conditional-context-loading layer (PR #492) handles it automatically.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 179 files / 2307 tests passing (+6 new in `test/get-contract-abi.test.ts`)
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)