### PR TITLE
fix(custom-call): honor acknowledgeNonProtocolTarget at preview/send time

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2672,17 +2672,21 @@ export async function prepareCustomCall(
         "user's affirmative ack that they're calling a non-protocol target.",
     );
   }
-  return enrichTx(
-    await buildCustomCall({
-      wallet: args.wallet as `0x${string}`,
-      chain: args.chain as SupportedChain,
-      contract: args.contract as `0x${string}`,
-      fn: args.fn,
-      args: args.args ?? [],
-      value: args.value,
-      abi: args.abi,
-    }),
-  );
+  const built = await buildCustomCall({
+    wallet: args.wallet as `0x${string}`,
+    chain: args.chain as SupportedChain,
+    contract: args.contract as `0x${string}`,
+    fn: args.fn,
+    args: args.args ?? [],
+    value: args.value,
+    abi: args.abi,
+  });
+  // Stamp the affirmative-ack on the tx so `assertTransactionSafe`
+  // (preview/send time) recognizes this handle as the explicit
+  // non-protocol-target bypass and skips ONLY its catch-all "unknown
+  // destination" refusal. Issue #496.
+  built.acknowledgedNonProtocolTarget = true;
+  return enrichTx(built);
 }
 
 /**

--- a/src/signing/pre-sign-check.ts
+++ b/src/signing/pre-sign-check.ts
@@ -282,14 +282,32 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
     return;
   }
 
-  // 4) Every other selector: must be a known protocol destination.
+  // 4) Every other selector: must be a known protocol destination — UNLESS
+  //    this handle came through `prepare_custom_call`'s affirmative-ack
+  //    path (`acknowledgeNonProtocolTarget: true`). The schema-enforced
+  //    gate at build time already covered consent for the non-protocol
+  //    target; refusing here would render the escape hatch dead-on-arrival
+  //    at the very next step (the bug from issue #496). Note this skips
+  //    ONLY the catch-all unknown-destination refusal — the approve()
+  //    spender-allowlist (block 2 above), the transfer()-on-unknown-token
+  //    refusal (block 3), and the per-destination ABI-selector check
+  //    (block 5 below) all stay active because they protect against
+  //    distinct attack shapes that the ack does not subsume.
   if (!dest) {
+    if (tx.acknowledgedNonProtocolTarget === true) {
+      // Pre-sign defenses #2 (approve spender allowlist) and #3 (transfer
+      // on unknown token) are already past; this catch-all is the right
+      // place to cleanly accept the call.
+      return;
+    }
     throw new Error(
       `Pre-sign check: refusing to sign against unknown contract ${tx.to} on ${tx.chain} ` +
         `(selector ${selector}). Accepted destinations: Aave V3 Pool, Compound V3 Comet markets, ` +
         `Morpho Blue, Lido (stETH/Queue), EigenLayer StrategyManager, Uniswap V3 NPM, Uniswap V3 SwapRouter02, LiFi Diamond, ` +
         `and known ERC-20s. An unknown destination with non-empty calldata is exactly the shape of ` +
-        `a prompt-injection attack.`
+        `a prompt-injection attack. (If you intended an arbitrary contract call, use ` +
+        `\`prepare_custom_call\` with \`acknowledgeNonProtocolTarget: true\` — that path is ` +
+        `built specifically to bypass this check.)`
     );
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1257,6 +1257,20 @@ export interface UnsignedTx {
     /** Non-fatal warnings (e.g. "contacts file failed verification — recipient label not checked"). */
     warnings?: string[];
   };
+  /**
+   * Set when the tx was built by `prepare_custom_call` after the user passed
+   * the affirmative `acknowledgeNonProtocolTarget: true` schema-enforced
+   * gate. Read by `assertTransactionSafe` to skip ONLY the catch-all
+   * "unknown destination" refusal at preview/send time — every other
+   * pre-sign defense (approve-spender allowlist, transfer-on-unknown-token,
+   * allowed-ABI-selector check) stays active. Issue #496.
+   *
+   * Trust note: this flag flows through the handle store keyed by the
+   * server-minted UUID; the agent cannot fabricate it on a tx that didn't
+   * come through `prepare_custom_call`'s build path. Setting it to true on
+   * any other prepare path is a server bug, not a user-controllable lever.
+   */
+  acknowledgedNonProtocolTarget?: boolean;
 }
 
 /** Shape of ~/.vaultpilot-mcp/config.json. */

--- a/test/pre-sign-check.test.ts
+++ b/test/pre-sign-check.test.ts
@@ -501,3 +501,139 @@ describe("Pre-sign check: WETH9-specific selectors", () => {
     ).rejects.toThrow(/not a known function on weth9/);
   });
 });
+
+describe("Pre-sign check: prepare_custom_call escape hatch (issue #496)", () => {
+  // OpenZeppelin TimelockController on mainnet — outside our canonical
+  // CONTRACTS table, exactly the use case `prepare_custom_call` was filed
+  // for in #493. The bug from #496: preview_send / send_transaction's
+  // assertTransactionSafe refuses any tx whose `to` isn't in
+  // KNOWN_DESTINATIONS, which made every prepare_custom_call handle dead-
+  // on-arrival.
+  const TIMELOCK = "0x22bc85C483103950441EaaB8312BE9f07e234634" as const;
+  // schedule(address,uint256,bytes,bytes32,bytes32,uint256) selector +
+  // valid abi-encoded args (zero target, zero value, empty bytes, two
+  // zero bytes32 salts, 172800 delay).
+  const SCHEDULE_CALLDATA =
+    ("0x01d5062a" +
+      "0000000000000000000000000000000000000000000000000000000000000001" + // target
+      "0000000000000000000000000000000000000000000000000000000000000000" + // value
+      "00000000000000000000000000000000000000000000000000000000000000c0" + // bytes offset
+      "0000000000000000000000000000000000000000000000000000000000000000" + // predecessor
+      "0000000000000000000000000000000000000000000000000000000000000000" + // salt
+      "000000000000000000000000000000000000000000000000000000000002a300" + // delay (172800)
+      "0000000000000000000000000000000000000000000000000000000000000000") as `0x${string}`; // empty bytes len=0
+
+  it("WITHOUT the affirmative-ack flag — refuses unknown destination (current behavior)", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: TIMELOCK as `0x${string}`,
+        data: SCHEDULE_CALLDATA,
+        value: "0",
+        from: WALLET,
+        description: "schedule call on a third-party Timelock",
+      }),
+    ).rejects.toThrow(/refusing to sign against unknown contract/);
+  });
+
+  it("error message points the user at prepare_custom_call as the right path", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: TIMELOCK as `0x${string}`,
+        data: SCHEDULE_CALLDATA,
+        value: "0",
+        from: WALLET,
+        description: "schedule call on a third-party Timelock",
+      }),
+    ).rejects.toThrow(/prepare_custom_call.*acknowledgeNonProtocolTarget/);
+  });
+
+  it("WITH acknowledgedNonProtocolTarget=true — accepts the unknown destination", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: TIMELOCK as `0x${string}`,
+        data: SCHEDULE_CALLDATA,
+        value: "0",
+        from: WALLET,
+        description: "prepare_custom_call: schedule on Timelock",
+        acknowledgedNonProtocolTarget: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("the ack does NOT bypass the approve() spender allowlist", async () => {
+    // A user calling `approve(attacker, max)` via prepare_custom_call
+    // should still hit the allowlist refusal — the approve gate (block
+    // 2 in assertTransactionSafe) is independent of the catch-all
+    // unknown-destination check (block 4) the ack bypasses.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [ATTACKER as `0x${string}`, maxUint256],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: USDC_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "prepare_custom_call: approve attacker max USDC",
+        acknowledgedNonProtocolTarget: true,
+      }),
+    ).rejects.toThrow(/spender is not in the protocol allowlist/);
+  });
+
+  it("the ack does NOT bypass the transfer-on-unknown-token refusal", async () => {
+    // A custom-call transfer() against an unrecognized token contract
+    // still hits block 3 (transfer-on-unknown-token), not the catch-all.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [ATTACKER as `0x${string}`, 100n],
+    });
+    const RANDOM_TOKEN = "0x9999999999999999999999999999999999999999";
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: RANDOM_TOKEN as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "prepare_custom_call: transfer on a random contract",
+        acknowledgedNonProtocolTarget: true,
+      }),
+    ).rejects.toThrow(/token is not in our.*recognized set/);
+  });
+
+  it("the ack does NOT bypass the per-destination ABI-selector check on KNOWN destinations", async () => {
+    // If the ack-tagged handle somehow lands on a known protocol
+    // destination (Aave Pool) but with an arbitrary selector that isn't
+    // a real Aave function, the per-destination ABI guard (block 5)
+    // still fires. The ack only opens the catch-all branch for
+    // genuinely unknown destinations.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = ("0xdeadbeef" + "00".repeat(32)) as `0x${string}`;
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: AAVE_POOL_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "prepare_custom_call: bogus selector on Aave",
+        acknowledgedNonProtocolTarget: true,
+      }),
+    ).rejects.toThrow(/not a known function on aave-v3-pool/);
+    // Suppress unused warning — zeroAddress is imported by the file's
+    // existing tests; this block doesn't reference it.
+    void zeroAddress;
+  });
+});


### PR DESCRIPTION
Closes #496.

## Summary
- Threads the `acknowledgeNonProtocolTarget: true` affirmative ack from `prepare_custom_call` (PR #494) through to `assertTransactionSafe` so handles built by the escape-hatch tool aren't blocked at `preview_send` / `send_transaction` by the second allowlist (`KNOWN_DESTINATIONS` in `src/signing/pre-sign-check.ts`).
- New optional field on `UnsignedTx`: `acknowledgedNonProtocolTarget?: boolean`. Stamped by `prepareCustomCall` after the schema gate passes; flows through the handle store keyed by the server-minted UUID so the agent cannot fabricate it.
- `assertTransactionSafe` reads the flag at the catch-all unknown-destination refusal (block 4) and accepts cleanly. Every OTHER defense stays active:
  - approve() spender allowlist (block 2) still refuses `approve(attacker, max)`
  - transfer-on-unknown-token (block 3) still refuses `transfer()` on a contract outside `CONTRACTS[chain].tokens`
  - per-destination ABI-selector (block 5) still refuses arbitrary selectors on known protocol contracts (Aave Pool, etc.)
- Refusal copy points users at `prepare_custom_call` so the failure path teaches the right tool when triggered legitimately.

## Test plan
- [x] `npx vitest run test/pre-sign-check.test.ts` — 30/30 pass (24 existing + 6 new): without-flag refusal, error-copy points at prepare_custom_call, with-flag accepts unknown destination, and three negative tests asserting each non-bypassed defense (approve allowlist, transfer-on-unknown-token, per-dest ABI-selector) still fires when the flag is set.
- [x] `npx vitest run` — full suite 2306/2306 pass.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)