### PR TITLE
feat(contacts): per-EVM-chain tag for CONTACT-CHAIN MISMATCH (#482)

### DIFF
--- a/src/contacts/canonicalize.ts
+++ b/src/contacts/canonicalize.ts
@@ -76,12 +76,27 @@ export function canonicalize(value: unknown): string {
  * sorted by `label` ascending so that two callers ending up with the
  * same logical contact set produce identical signatures.
  */
+/**
+ * Per-entry shape that flows into the signing preimage. `intendedChains`
+ * (issue #482) is optional — when absent on the source entry the field
+ * is OMITTED from the preimage entirely (not serialized as `null` or
+ * `[]`), so existing signed blobs without the field reproduce the same
+ * canonical bytes they signed and continue to verify. Adding the field
+ * is therefore additive: no schemaVersion bump, no migration.
+ */
+export interface PreimageEntry {
+  label: string;
+  address: string;
+  addedAt: string;
+  intendedChains?: ReadonlyArray<string>;
+}
+
 export interface SigningPreimage {
   chainId: string;
   version: number;
   anchorAddress: string;
   signedAt: string;
-  entries: ReadonlyArray<{ label: string; address: string; addedAt: string }>;
+  entries: ReadonlyArray<PreimageEntry>;
 }
 
 export function buildSigningPreimage(args: {
@@ -89,16 +104,28 @@ export function buildSigningPreimage(args: {
   version: number;
   anchorAddress: string;
   signedAt: string;
-  entries: ReadonlyArray<{ label: string; address: string; addedAt: string }>;
+  entries: ReadonlyArray<PreimageEntry>;
 }): SigningPreimage {
   const sorted = [...args.entries].sort((a, b) =>
     a.label < b.label ? -1 : a.label > b.label ? 1 : 0,
   );
+  // Spread `intendedChains` ONLY when set on the source entry —
+  // canonicalize() throws on undefined values, and we want byte-
+  // equality with pre-#482 preimages on entries that don't carry
+  // the tag.
+  const projected: PreimageEntry[] = sorted.map((e) => ({
+    label: e.label,
+    address: e.address,
+    addedAt: e.addedAt,
+    ...(e.intendedChains !== undefined
+      ? { intendedChains: e.intendedChains }
+      : {}),
+  }));
   return {
     chainId: args.chainId,
     version: args.version,
     anchorAddress: args.anchorAddress,
     signedAt: args.signedAt,
-    entries: sorted,
+    entries: projected,
   };
 }

--- a/src/contacts/index.ts
+++ b/src/contacts/index.ts
@@ -223,10 +223,26 @@ export async function addContact(args: AddContactArgs): Promise<{
    */
   unsigned?: boolean;
 }> {
+  // Issue #482 — `intendedChains` is meaningful only for EVM, where the
+  // single `evm` blob covers ethereum/arbitrum/polygon/base/optimism and
+  // the resolver has no other signal to fire CONTACT-CHAIN MISMATCH on.
+  // Reject early (before the demo / no-Ledger branches) so the rejection
+  // is consistent across all three storage paths.
+  if (args.intendedChains !== undefined && args.chain !== "evm") {
+    throw new Error(
+      `${ContactsError.IntendedChainsEvmOnly}: intendedChains is EVM-only ` +
+        `(issue #482); contacts on chain "${args.chain}" cannot carry it. ` +
+        `Drop the field or save the contact under chain="evm".`,
+    );
+  }
   // Demo mode: route to the in-memory store, no Ledger interaction.
   // `version` and `anchorAddress` are placeholders so the response shape
   // matches the production tool — agents that branch on those fields
   // see a sentinel ("DEMO_ANCHOR") rather than a missing key.
+  // NOTE: the demo store does not currently track `intendedChains`; the
+  // tag is silently dropped in demo mode, matching demo's documented
+  // less-secure-by-design trust model (the simulation envelope intercept
+  // is the address-poisoning defense, not crypto chain consistency).
   if (isDemoMode()) {
     addDemoContact({
       chain: args.chain,
@@ -309,6 +325,9 @@ export async function addContact(args: AddContactArgs): Promise<{
     address: args.address,
     addedAt:
       oldEntries.find((e) => e.label === args.label)?.addedAt ?? nowIso(),
+    ...(args.intendedChains !== undefined
+      ? { intendedChains: args.intendedChains }
+      : {}),
   };
   const nextEntries = [...filtered, newEntry];
   const nextVersion = (existingBlob?.version ?? 0) + 1;

--- a/src/contacts/resolver.ts
+++ b/src/contacts/resolver.ts
@@ -83,15 +83,17 @@ function looksLikeLiteralAddress(input: string, chain: ContactChain): boolean {
 }
 
 /**
- * Reverse-lookup outcome. Three states:
+ * Reverse-lookup outcome. Four states:
  *   - `match`: blob verified AND a saved entry matched the address.
+ *     Also returns `intendedChains` (issue #482) when set on the
+ *     entry, so the caller can fire CONTACT-CHAIN MISMATCH.
  *   - `noMatch`: blob verified, but no saved entry matched.
  *   - `tampered`: blob present on disk but failed verification —
  *     the caller hoists a warning instead of silently skipping.
  *   - `noBlob`: no blob persisted yet — silently skip (no decoration).
  */
 type ReverseLookupResult =
-  | { state: "match"; label: string }
+  | { state: "match"; label: string; intendedChains?: string[] }
   | { state: "noMatch" }
   | { state: "tampered" }
   | { state: "noBlob" };
@@ -118,20 +120,30 @@ async function reverseLookup(
   const target = chain === "evm" ? addr.toLowerCase() : addr;
   for (const entry of blob.entries) {
     const candidate = chain === "evm" ? entry.address.toLowerCase() : entry.address;
-    if (candidate === target) return { state: "match", label: entry.label };
+    if (candidate === target) {
+      return {
+        state: "match",
+        label: entry.label,
+        ...(entry.intendedChains !== undefined
+          ? { intendedChains: [...entry.intendedChains] }
+          : {}),
+      };
+    }
   }
   return { state: "noMatch" };
 }
 
 /**
  * Forward-lookup: scan the verified blob for `entry.label === label`.
- * Throws CONTACTS_TAMPERED via the inner verifier when the file is
- * tampered (NOT silent — this is the abort path).
+ * Returns the address + the entry's `intendedChains` (issue #482) when
+ * set, so the caller can fire CONTACT-CHAIN MISMATCH alongside the
+ * resolved address. Throws CONTACTS_TAMPERED via the inner verifier
+ * when the file is tampered (NOT silent — this is the abort path).
  */
 async function forwardLookup(
   chain: "btc" | "evm",
   label: string,
-): Promise<string | null> {
+): Promise<{ address: string; intendedChains?: string[] } | null> {
   // Use a STRICT read here so tamper aborts (matches the plan).
   // tryReadVerifiedBlob silently returns null on tamper, which is
   // the wrong shape for label resolution — we want to know.
@@ -150,7 +162,37 @@ async function forwardLookup(
     );
   }
   const hit = blob.entries.find((e) => e.label === label);
-  return hit ? hit.address : null;
+  if (!hit) return null;
+  return {
+    address: hit.address,
+    ...(hit.intendedChains !== undefined
+      ? { intendedChains: [...hit.intendedChains] }
+      : {}),
+  };
+}
+
+/**
+ * Issue #482 — emit a `CONTACT-CHAIN MISMATCH` warning when the
+ * contact has an `intendedChains` tag and the prepare's `chain` arg
+ * isn't in the list. No-op when the contact is untagged (legacy) or
+ * when `chain` matches. Returns the warning string to push, or null
+ * for no-op. Centralized so the forward + reverse + ENS-decorate
+ * paths produce identical wording.
+ */
+function chainMismatchWarning(
+  label: string,
+  chain: string,
+  intendedChains: ReadonlyArray<string> | undefined,
+): string | null {
+  if (intendedChains === undefined || intendedChains.length === 0) return null;
+  if (intendedChains.includes(chain)) return null;
+  const list = intendedChains.join(", ");
+  return (
+    `CONTACT-CHAIN MISMATCH: contact "${label}" is tagged for [${list}] but ` +
+    `you're sending on ${chain}. Verify the recipient is correct on this ` +
+    `chain — the same address on a different EVM chain may go to the wrong ` +
+    `account or a contract you don't control.`
+  );
 }
 
 export async function resolveRecipient(
@@ -216,6 +258,8 @@ export async function resolveRecipient(
     if (cc === "btc" || cc === "evm") {
       const r = await reverseLookup(cc, input);
       if (r.state === "match") {
+        const w = chainMismatchWarning(r.label, chain, r.intendedChains);
+        if (w) warnings.push(w);
         return {
           address: input,
           source: "literal",
@@ -251,8 +295,10 @@ export async function resolveRecipient(
   if (cc === "btc" || cc === "evm") {
     const labelHit = await forwardLookup(cc, input);
     if (labelHit) {
+      const w = chainMismatchWarning(input, chain, labelHit.intendedChains);
+      if (w) warnings.push(w);
       return {
-        address: labelHit,
+        address: labelHit.address,
         source: "contact",
         label: input,
         warnings,
@@ -283,8 +329,11 @@ export async function resolveRecipient(
         // contacts verify cleanly). Falls back to unsigned (#428).
         const r = await reverseLookup("evm", ens.address);
         let label: string | undefined;
-        if (r.state === "match") label = r.label;
-        else if (r.state === "tampered") {
+        if (r.state === "match") {
+          label = r.label;
+          const w = chainMismatchWarning(r.label, chain, r.intendedChains);
+          if (w) warnings.push(w);
+        } else if (r.state === "tampered") {
           warnings.push(
             "contacts file failed verification — ENS reverse-decoration skipped",
           );

--- a/src/contacts/schemas.ts
+++ b/src/contacts/schemas.ts
@@ -28,6 +28,24 @@ import {
 export const ContactChain = z.enum(["btc", "evm", "solana", "tron"]);
 export type ContactChain = z.infer<typeof ContactChain>;
 
+/**
+ * Per-EVM-chain tag set on EVM contacts (issue #482). Optional —
+ * absent means "any EVM chain", legacy behavior. The contacts file
+ * is per-chain-family (one `evm` blob), so without this tag the
+ * resolver has no schema-level signal to fire `CONTACT-CHAIN
+ * MISMATCH` on the smoke-test scenario (Carol-on-Arbitrum sent on
+ * Ethereum). Listed via the same SupportedChain literals the
+ * prepare flows pass to the resolver.
+ */
+export const EvmChainTag = z.enum([
+  "ethereum",
+  "arbitrum",
+  "polygon",
+  "base",
+  "optimism",
+]);
+export type EvmChainTag = z.infer<typeof EvmChainTag>;
+
 /** Per-chain anchor address types. EVM is just an address; BTC has format. */
 export const BtcAnchorAddressType = z.enum([
   "legacy",
@@ -41,6 +59,16 @@ export const SignedContactEntry = z.object({
   label: z.string().min(1).max(64),
   address: z.string().min(1).max(80),
   addedAt: z.string().datetime(),
+  /**
+   * Per-EVM-chain tag (issue #482). Optional — absent means "any
+   * EVM chain" (legacy behavior; existing signed blobs without the
+   * field verify unchanged because the canonical preimage omits
+   * absent fields). Only meaningful on `evm` entries; rejected at
+   * the `add_contact` API layer for btc/solana/tron contacts. When
+   * set, the resolver emits a `CONTACT-CHAIN MISMATCH` warning if
+   * the prepare's `chain` arg isn't in the list.
+   */
+  intendedChains: z.array(EvmChainTag).min(1).optional(),
 });
 export type SignedContactEntry = z.infer<typeof SignedContactEntry>;
 
@@ -153,6 +181,18 @@ export const addContactInput = z.object({
       "Free-form tags ('family', 'cex-deposit', etc.). Like notes — " +
         "stored in the unsigned metadata sidecar.",
     ),
+  intendedChains: z
+    .array(EvmChainTag)
+    .min(1)
+    .optional()
+    .describe(
+      "EVM-only (issue #482). Tag the contact for specific EVM chains so " +
+        "`preview_send` emits a `CONTACT-CHAIN MISMATCH` warning when a " +
+        "prepare's chain isn't in this list (defense-in-depth for the " +
+        "Carol-on-Arbitrum-sent-on-Ethereum class of mistake). Omit for " +
+        "legacy 'any EVM chain' behavior. Rejected with a clear error " +
+        "for btc/solana/tron contacts.",
+    ),
 });
 export type AddContactArgs = z.infer<typeof addContactInput>;
 
@@ -253,6 +293,7 @@ export const ContactsError = {
   VersionRollback: "CONTACTS_VERSION_ROLLBACK",
   AddressFormatMismatch: "CONTACTS_ADDRESS_FORMAT_MISMATCH",
   LabelNotFound: "CONTACTS_LABEL_NOT_FOUND",
+  IntendedChainsEvmOnly: "CONTACTS_INTENDED_CHAINS_EVM_ONLY",
 } as const;
 
 /** Address-shape regexes per chain — used to validate `add_contact` inputs. */

--- a/test/contacts.test.ts
+++ b/test/contacts.test.ts
@@ -561,6 +561,165 @@ describe("resolveRecipient", () => {
   });
 });
 
+// ---------- intendedChains tag (issue #482) ----------
+
+describe("intendedChains (issue #482)", () => {
+  it("addContact accepts intendedChains on EVM and the entry round-trips through verify", async () => {
+    const { addContact, verifyContacts, listContacts } = await import(
+      "../src/contacts/index.js"
+    );
+    await addContact({
+      chain: "evm",
+      label: "Carol",
+      address: "0xCAfE000000000000000000000000000000000000",
+      intendedChains: ["arbitrum"],
+    });
+    const verified = await verifyContacts({ chain: "evm" });
+    expect(verified.results[0].ok).toBe(true);
+    // listContacts joins by label; the intendedChains tag lives on the
+    // signed entry — confirm it round-tripped to disk by reading the
+    // raw blob back.
+    const out = await listContacts({});
+    expect(out.contacts).toHaveLength(1);
+    expect(out.contacts[0].label).toBe("Carol");
+    const { contactsPath } = await import("../src/contacts/storage.js");
+    const file = JSON.parse(readFileSync(contactsPath(), "utf8"));
+    expect(file.chains.evm.entries[0].intendedChains).toEqual(["arbitrum"]);
+  });
+
+  it("addContact rejects intendedChains on BTC with CONTACTS_INTENDED_CHAINS_EVM_ONLY", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await expect(
+      addContact({
+        chain: "btc",
+        label: "Carol",
+        address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+        // @ts-expect-error — intendedChains shouldn't be passed for btc;
+        // schema-layer types narrow this, but the runtime guard is the
+        // load-bearing rule under JS callers and demo-mode fallthroughs.
+        intendedChains: ["ethereum"],
+      }),
+    ).rejects.toThrow(/CONTACTS_INTENDED_CHAINS_EVM_ONLY/);
+  });
+
+  it("forward label resolution: tagged contact + matching chain → no warning", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Carol",
+      address: "0xCAfE000000000000000000000000000000000000",
+      intendedChains: ["arbitrum"],
+    });
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    const out = await resolveRecipient("Carol", "arbitrum");
+    expect(out.source).toBe("contact");
+    expect(out.label).toBe("Carol");
+    expect(out.warnings).not.toContainEqual(
+      expect.stringMatching(/CONTACT-CHAIN MISMATCH/),
+    );
+  });
+
+  it("forward label resolution: tagged contact + non-matching chain → CONTACT-CHAIN MISMATCH warning", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Carol",
+      address: "0xCAfE000000000000000000000000000000000000",
+      intendedChains: ["arbitrum"],
+    });
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    const out = await resolveRecipient("Carol", "ethereum");
+    expect(out.source).toBe("contact");
+    expect(out.label).toBe("Carol");
+    expect(out.warnings).toContainEqual(
+      expect.stringMatching(/CONTACT-CHAIN MISMATCH.*Carol.*arbitrum.*ethereum/),
+    );
+  });
+
+  it("legacy contact (no intendedChains) on any EVM chain → no warning (backward compat)", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Mom",
+      address: "0xdEAD000000000000000000000000000000000000",
+    });
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    for (const c of ["ethereum", "arbitrum", "polygon", "base", "optimism"]) {
+      const out = await resolveRecipient("Mom", c);
+      expect(out.warnings).not.toContainEqual(
+        expect.stringMatching(/CONTACT-CHAIN MISMATCH/),
+      );
+    }
+  });
+
+  it("reverse-decoration on a literal address: tagged contact + non-matching chain → warning fires", async () => {
+    const { addContact } = await import("../src/contacts/index.js");
+    await addContact({
+      chain: "evm",
+      label: "Carol",
+      address: "0xCAfE000000000000000000000000000000000000",
+      intendedChains: ["arbitrum", "polygon"],
+    });
+    const { resolveRecipient } = await import("../src/contacts/resolver.js");
+    const out = await resolveRecipient(
+      "0xcafe000000000000000000000000000000000000",
+      "base",
+    );
+    expect(out.source).toBe("literal");
+    expect(out.label).toBe("Carol");
+    expect(out.warnings).toContainEqual(
+      expect.stringMatching(/CONTACT-CHAIN MISMATCH.*Carol.*arbitrum, polygon.*base/),
+    );
+  });
+
+  it("preimage byte-equality: legacy entry produces the same canonical bytes as before #482", async () => {
+    // The fix only adds `intendedChains` to the preimage when SET on
+    // the source entry. Legacy entries (no field) must produce the
+    // exact same canonical JSON as the pre-#482 code path so existing
+    // signed blobs verify unchanged.
+    const { canonicalize, buildSigningPreimage } = await import(
+      "../src/contacts/canonicalize.js"
+    );
+    const legacyPreimage = canonicalize(
+      buildSigningPreimage({
+        chainId: "evm",
+        version: 1,
+        anchorAddress: "0xanchor",
+        signedAt: "2026-04-28T00:00:00.000Z",
+        entries: [
+          {
+            label: "Mom",
+            address: "0xdEAD000000000000000000000000000000000000",
+            addedAt: "2026-04-28T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+    // Sentinel — what the pre-#482 code produced byte-for-byte.
+    expect(legacyPreimage).toBe(
+      '{"anchorAddress":"0xanchor","chainId":"evm","entries":[{"addedAt":"2026-04-28T00:00:00.000Z","address":"0xdEAD000000000000000000000000000000000000","label":"Mom"}],"signedAt":"2026-04-28T00:00:00.000Z","version":1}',
+    );
+    // Tagged entry adds `intendedChains` only on entries that carry it.
+    const taggedPreimage = canonicalize(
+      buildSigningPreimage({
+        chainId: "evm",
+        version: 1,
+        anchorAddress: "0xanchor",
+        signedAt: "2026-04-28T00:00:00.000Z",
+        entries: [
+          {
+            label: "Carol",
+            address: "0xCAfE000000000000000000000000000000000000",
+            addedAt: "2026-04-28T00:00:00.000Z",
+            intendedChains: ["arbitrum"],
+          },
+        ],
+      }),
+    );
+    expect(taggedPreimage).toContain('"intendedChains":["arbitrum"]');
+  });
+});
+
 // ---------- WC namespace expansion ----------
 
 describe("REQUIRED_NAMESPACES", () => {


### PR DESCRIPTION
Closes #482.

## Summary
- Adds optional `intendedChains` (one of ethereum/arbitrum/polygon/base/optimism) to `SignedContactEntry`. When set, the resolver emits a `CONTACT-CHAIN MISMATCH` warning if the prepare's `chain` arg isn't in the list — defense-in-depth for the Carol-on-Arbitrum-sent-on-Ethereum smoke-test scenario the per-chain-family contacts file has no schema-level signal to catch otherwise.
- The warning flows through the existing `ResolvedRecipient.warnings[]` channel that already hoists into `preview_send`'s verification block — no new plumbing.

## Why this avoids a `schemaVersion` bump
The issue noted that putting `intendedChains` in the signed blob the right way would require bumping the contacts file's schemaVersion + a migration path. The smaller move: make the field **optional** on the entry AND have `buildSigningPreimage` include it in the canonical JSON **only when set on the source entry**. Existing signed blobs without the field reproduce byte-identical canonical preimage, verify unchanged under their existing BIP-137 / EIP-191 signatures. No migration; the field is purely additive.

The `preimage byte-equality` test pins this to a sentinel-string assertion so a future refactor can't silently change the legacy preimage shape.

## Wiring
- Forward (label → address) lookup returns `intendedChains` from the matched entry; resolver appends warning if mismatch.
- Reverse (address → label decoration) returns the same; resolver appends warning if mismatch.
- ENS reverse-decoration runs the same check on the matched contact.
- New error `CONTACTS_INTENDED_CHAINS_EVM_ONLY` fires for non-EVM contacts where the tag would be inert.
- Demo-mode contacts don't track the tag (demo store is in-memory and intentionally less-secure-by-design — the simulation envelope intercept is the address-poisoning defense there, documented in `demo-store.ts`).

## Test plan
- [x] +7 tests, full suite 2320/2320 passing locally
- [ ] Verify CI green
- [ ] Smoke: `add_contact({ chain: "evm", label: "Carol", address: 0x..., intendedChains: ["arbitrum"] })` → `prepare_token_send({ chain: "ethereum", to: "Carol" })` → preview_send block contains `CONTACT-CHAIN MISMATCH`.
- [ ] Smoke: legacy contact without the field → no warning on any EVM chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)