### PR TITLE
feat(yields): bundle Marinade + Jito + Kamino + Morpho via DefiLlama (#431 part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,9 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 - **`check_liquidation_risk`** — per-asset "ETH drops X% triggers liquidation" math across Aave V3 / Compound V3 / Morpho Blue. Replaces today's raw-HF-number output with actionable price deltas. ([plan](./claude-work/plan-health-factor-monitoring.md))
 - **`get_pnl_summary`** — wallet-level net PnL over preset periods across EVM / TRON / Solana. Balance-delta minus net user contribution, priced via DefiLlama historical. ([plan](./claude-work/plan-pnl-summary-tool.md))
 
-**`compare_yields` adapter expansion** — v1 covers Aave V3 + Compound V3 + Lido (PR #282). The remaining seven protocols on the original plan ship as separate adapters; full scope, ordering, and bundling rationale in [plan-yields-v2-followups.md](./claude-work/plan-yields-v2-followups.md).
+**`compare_yields` adapter expansion** — v1 covers Aave V3 + Compound V3 + Lido (PR #282); v2 bundles Marinade + Jito + Kamino-lend + Morpho-Blue via DefiLlama. The remaining three protocols ship as separate adapters; full scope and rationale in [plan-yields-v2-followups.md](./claude-work/plan-yields-v2-followups.md).
 
-- **Marinade + Jito APY readers** — bundled, ~150 LoC, mirror `getLidoApr()`'s DefiLlama path. The quick-win.
-- **MarginFi + Kamino + Morpho Blue lending adapters** — wallet-less reader split-out from the existing wallet-aware position readers. Same shape `getCompoundMarketInfo` already establishes.
+- **MarginFi lending adapter** — DefiLlama doesn't carry MarginFi borrow-lend (only their LST product); needs an on-chain wallet-less bank reader split out from `getMarginfiPositions`. Same shape `getCompoundMarketInfo` already establishes.
 - **EigenLayer + Solana native-stake adapters** — structurally different (per-operator / per-validator rows, not per-protocol APR); each needs its own plan file before implementation.
 
 **Wallet integrations**
@@ -129,7 +128,7 @@ Ledger Live's WalletConnect bridge does not honor the `tron:` namespace (verifie
 
 **Recently shipped** (previously on this list)
 
-- **`compare_yields`** — ranked supply-side yield comparison across integrated lending / staking protocols. v1 covers Aave V3 (5 EVM chains), Compound V3 (5 EVM chains, multi-market), and Lido stETH. Surfaces data, doesn't pick — the user decides. Adapter expansion for the other 7 protocols on the roadmap above (#282).
+- **`compare_yields`** — ranked supply-side yield comparison across integrated lending / staking protocols. Covers Aave V3 (5 EVM chains), Compound V3 (5 EVM chains, multi-market), Lido stETH, plus DefiLlama-backed Marinade / Jito / Kamino-lend / Morpho-Blue curated vaults. Surfaces data, doesn't pick — the user decides. Remaining adapters (MarginFi on-chain, EigenLayer, Solana native-stake) on the roadmap above (#282 v1, #431 v2 bundle).
 - **Nonce-aware dropped-tx polling** (Solana) — on-chain nonce is the authoritative signal for whether a durable-nonce tx can still land; replaces the `lastValidBlockHeight` path that's meaningless for nonce-protected sends (#137).
 - **Solana liquid + native staking** — Marinade / Jito / native stake-account reads (#141, portfolio fold-in #143), Marinade writes (#145), native SOL delegate / deactivate / withdraw (#149).
 - **LiFi cross-chain EVM ↔ Solana routing** (#153, #155).

--- a/src/modules/yields/adapters/defillama.ts
+++ b/src/modules/yields/adapters/defillama.ts
@@ -1,0 +1,303 @@
+/**
+ * DefiLlama-backed yields adapter — bundles four protocols whose APY
+ * data DefiLlama already publishes:
+ *
+ *   - Marinade liquid staking  (MSOL, Solana)        project: marinade-liquid-staking
+ *   - Jito liquid staking      (JITOSOL, Solana)     project: jito-liquid-staking
+ *   - Kamino lending           (USDC/USDT/SOL+, Solana) project: kamino-lend
+ *   - Morpho Blue vaults       (curated MetaMorpho, EVM) project: morpho-blue
+ *
+ * Pattern mirrors `getLidoApr()` in `src/modules/staking/lido.ts`: one
+ * cached fetch of `https://yields.llama.fi/pools`, filtered by
+ * (project, chain, symbol). Trade-off vs. on-chain: DefiLlama refreshes
+ * every ~5 min so rates lag a fresh on-chain read by minutes — fine for
+ * a "where should I park USDC" comparison; the user's actual supply
+ * goes through `prepare_*` tools which read fresh on-chain rates.
+ *
+ * Why bundled instead of per-protocol adapters: the DefiLlama endpoint
+ * is one HTTP call covering all four protocols. Splitting into four
+ * adapters means four cache keys, four fetches, same data. The
+ * cache-amortized cost of one fetch + four filter passes is strictly
+ * smaller.
+ *
+ * MarginFi borrow-lend is intentionally out of scope here — DefiLlama
+ * only publishes `marginfi-lst` (MarginFi's LST product), not the
+ * borrow-lend platform. MarginFi banks need an on-chain wallet-less
+ * reader (issue #288).
+ */
+import { cache } from "../../../data/cache.js";
+import { CACHE_TTL } from "../../../config/cache.js";
+import { fetchWithTimeout } from "../../../data/http.js";
+import type { AnyChain, SupportedChain } from "../../../types/index.js";
+import type { YieldRow, UnavailableProtocolEntry } from "../types.js";
+import type { SupportedAsset } from "../asset-map.js";
+import { aprToApy } from "../types.js";
+
+interface DefiLlamaPool {
+  project: string;
+  chain: string;
+  symbol: string;
+  apy: number | null;
+  apyBase: number | null;
+  tvlUsd: number | null;
+  poolMeta: string | null;
+}
+
+interface DefiLlamaResponse {
+  data: DefiLlamaPool[];
+}
+
+const DEFILLAMA_URL = "https://yields.llama.fi/pools";
+
+/** Fetch + cache the full DefiLlama yields catalog. Single shared key —
+ * every protocol filter below reuses the same cached payload, so the
+ * adapter does at most one network call per `CACHE_TTL.YIELD` window
+ * regardless of how many protocols / chains / assets the caller asks
+ * for. */
+async function fetchDefiLlamaPools(): Promise<DefiLlamaPool[] | undefined> {
+  return cache.remember("yields:defillama-pools", CACHE_TTL.YIELD, async () => {
+    try {
+      const res = await fetchWithTimeout(DEFILLAMA_URL);
+      if (!res.ok) return undefined;
+      const body = (await res.json()) as DefiLlamaResponse;
+      return Array.isArray(body?.data) ? body.data : undefined;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
+/** DefiLlama uses display-cased chain names — map to our `AnyChain`. */
+const DEFILLAMA_CHAIN_TO_OURS: Record<string, AnyChain> = {
+  Ethereum: "ethereum",
+  Arbitrum: "arbitrum",
+  Polygon: "polygon",
+  Base: "base",
+  Optimism: "optimism",
+  Solana: "solana",
+};
+
+/** EVM chains we'll emit Morpho Blue rows on. Other DefiLlama-listed
+ * Morpho chains (Hyperliquid L1, Katana, Unichain, etc.) aren't in our
+ * `SupportedChain` union, so we'd have nowhere to render them. */
+const MORPHO_EVM_CHAINS: ReadonlyArray<SupportedChain> = [
+  "ethereum",
+  "base",
+  "arbitrum",
+  "polygon",
+  "optimism",
+];
+
+/** TVL floor for Morpho Blue vault rows. The catalog includes thousands
+ * of dust pools (sub-$10k); they bottom-rank automatically but pollute
+ * the row count. Top-N per (asset, chain) above this floor keeps the
+ * comparison readable. */
+const MORPHO_VAULT_TVL_FLOOR_USD = 5_000_000;
+
+/** Max Morpho vault rows surfaced per (asset, chain). The composer
+ * ranks by APY descending; the user sees the strongest few rather than
+ * a 50-row vault table. */
+const MORPHO_VAULTS_PER_ASSET_CHAIN = 3;
+
+/** Map our `SupportedAsset` to a substring matcher for Morpho Blue
+ * vault token symbols. Vault names embed the underlying asset
+ * (STEAKUSDC, GTUSDC, GTWETH, …); a case-insensitive substring catches
+ * the bulk without false matches into LST-flavored vaults (stETH,
+ * weETH, wstETH — these have separate yields elsewhere on DefiLlama
+ * via lido / ether.fi / etc.). */
+function morphoSymbolMatcher(asset: SupportedAsset): RegExp | null {
+  switch (asset) {
+    case "USDC":
+      return /USDC/i;
+    case "USDT":
+      return /USDT/i;
+    case "ETH":
+      // Match WETH-flavored vaults only — bare /ETH/ catches stETH,
+      // weETH, oseth, etc. which are LST vaults with their own yield
+      // sources, not pure ETH supply.
+      return /WETH/i;
+    case "BTC":
+      return /WBTC/i;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Emit `YieldRow`s from DefiLlama for the protocols this adapter
+ * covers. The composer applies risk-score enrichment, filters, and
+ * ranking after — same as every other adapter.
+ */
+export async function readDefiLlamaYields(
+  asset: SupportedAsset,
+  requestedChains: ReadonlyArray<AnyChain>,
+): Promise<{ rows: YieldRow[]; unavailable: UnavailableProtocolEntry[] }> {
+  const pools = await fetchDefiLlamaPools();
+
+  if (!pools) {
+    // One fetch covers all four protocols — surface the failure once
+    // per protocol×chain that the caller actually requested, so the
+    // user sees the coverage gap explicitly rather than silent absence.
+    const unavailable: UnavailableProtocolEntry[] = [];
+    if (requestedChains.includes("solana")) {
+      unavailable.push(
+        {
+          protocol: "marinade",
+          chain: "solana",
+          available: false,
+          reason: "DefiLlama yields endpoint unreachable — try again or check connectivity",
+        },
+        {
+          protocol: "jito",
+          chain: "solana",
+          available: false,
+          reason: "DefiLlama yields endpoint unreachable — try again or check connectivity",
+        },
+        {
+          protocol: "kamino",
+          chain: "solana",
+          available: false,
+          reason: "DefiLlama yields endpoint unreachable — try again or check connectivity",
+        },
+      );
+    }
+    for (const c of MORPHO_EVM_CHAINS) {
+      if (requestedChains.includes(c)) {
+        unavailable.push({
+          protocol: "morpho-blue",
+          chain: c,
+          available: false,
+          reason: "DefiLlama yields endpoint unreachable — try again or check connectivity",
+        });
+      }
+    }
+    return { rows: [], unavailable };
+  }
+
+  const rows: YieldRow[] = [];
+
+  // Marinade — only emits for asset=SOL on Solana.
+  if (asset === "SOL" && requestedChains.includes("solana")) {
+    const pool = pools.find(
+      (p) =>
+        p.project === "marinade-liquid-staking" &&
+        p.chain === "Solana" &&
+        p.symbol === "MSOL",
+    );
+    const row = poolToRow(pool, "marinade", "solana", "MSOL");
+    if (row) rows.push(row);
+  }
+
+  // Jito — only emits for asset=SOL on Solana.
+  if (asset === "SOL" && requestedChains.includes("solana")) {
+    const pool = pools.find(
+      (p) =>
+        p.project === "jito-liquid-staking" &&
+        p.chain === "Solana" &&
+        p.symbol === "JITOSOL",
+    );
+    const row = poolToRow(pool, "jito", "solana", "JITOSOL");
+    if (row) rows.push(row);
+  }
+
+  // Kamino lending — exact-symbol match for USDC/USDT/SOL on Solana.
+  // Kamino has multiple markets (Main, JLP, etc.); each appears as a
+  // separate row keyed by `(symbol, poolMeta)` so the user sees market
+  // diversity rather than one collapsed APR.
+  if (requestedChains.includes("solana")) {
+    const targetSymbol = kaminoSymbolFor(asset);
+    if (targetSymbol) {
+      const matches = pools.filter(
+        (p) =>
+          p.project === "kamino-lend" &&
+          p.chain === "Solana" &&
+          p.symbol === targetSymbol,
+      );
+      for (const pool of matches) {
+        const market = pool.poolMeta
+          ? `Kamino ${pool.poolMeta} · ${pool.symbol}`
+          : `Kamino · ${pool.symbol}`;
+        const row = poolToRow(pool, "kamino", "solana", market);
+        if (row) rows.push(row);
+      }
+    }
+  }
+
+  // Morpho Blue — top-N curated vaults per (asset, EVM chain) above
+  // TVL floor. Substring match on vault token symbol; full vault label
+  // surfaced in `market`.
+  const morphoMatcher = morphoSymbolMatcher(asset);
+  if (morphoMatcher) {
+    for (const evmChain of MORPHO_EVM_CHAINS) {
+      if (!requestedChains.includes(evmChain)) continue;
+      const llamaChain = ourChainToDefiLlama(evmChain);
+      if (!llamaChain) continue;
+
+      const vaults = pools
+        .filter(
+          (p) =>
+            p.project === "morpho-blue" &&
+            p.chain === llamaChain &&
+            morphoMatcher.test(p.symbol) &&
+            (p.tvlUsd ?? 0) >= MORPHO_VAULT_TVL_FLOOR_USD &&
+            (p.apy ?? 0) > 0,
+        )
+        .sort((a, b) => (b.apy ?? 0) - (a.apy ?? 0))
+        .slice(0, MORPHO_VAULTS_PER_ASSET_CHAIN);
+
+      for (const pool of vaults) {
+        const market = `Morpho · ${pool.symbol}`;
+        const row = poolToRow(pool, "morpho-blue", evmChain, market);
+        if (row) rows.push(row);
+      }
+    }
+  }
+
+  return { rows, unavailable: [] };
+}
+
+/** Reverse the chain map. */
+function ourChainToDefiLlama(chain: AnyChain): string | null {
+  for (const [llama, ours] of Object.entries(DEFILLAMA_CHAIN_TO_OURS)) {
+    if (ours === chain) return llama;
+  }
+  return null;
+}
+
+function kaminoSymbolFor(asset: SupportedAsset): string | null {
+  switch (asset) {
+    case "USDC":
+      return "USDC";
+    case "USDT":
+      return "USDT";
+    case "SOL":
+      return "SOL";
+    default:
+      return null;
+  }
+}
+
+/** Build a `YieldRow` from a DefiLlama pool, or null if the pool is
+ * absent / has no usable rate. DefiLlama's `apy` field is already a
+ * percentage (4.28 = 4.28%); we store it as a fraction (0.0428) to
+ * match the rest of the codebase. */
+function poolToRow(
+  pool: DefiLlamaPool | undefined,
+  protocol: YieldRow["protocol"],
+  chain: AnyChain,
+  market: string,
+): YieldRow | null {
+  if (!pool) return null;
+  const apy = pool.apy;
+  if (typeof apy !== "number" || apy <= 0) return null;
+  const apr = apy / 100;
+  return {
+    protocol,
+    chain,
+    market,
+    supplyApr: apr,
+    supplyApy: aprToApy(apr),
+    tvl: typeof pool.tvlUsd === "number" ? pool.tvlUsd : null,
+    riskScore: null, // enriched by composer
+  };
+}

--- a/src/modules/yields/index.ts
+++ b/src/modules/yields/index.ts
@@ -16,6 +16,7 @@ import type { SupportedChain, AnyChain } from "../../types/index.js";
 import { readAaveYields } from "./adapters/aave.js";
 import { readCompoundYields } from "./adapters/compound.js";
 import { readLidoYields } from "./adapters/lido.js";
+import { readDefiLlamaYields } from "./adapters/defillama.js";
 import {
   resolveAsset,
   expandStables,
@@ -43,29 +44,9 @@ const DEFERRED_PROTOCOLS: ReadonlyArray<{
   reason: string;
 }> = [
   {
-    protocol: "morpho-blue",
-    chain: "ethereum",
-    reason: "Morpho Blue per-market reader not yet split out from the wallet-aware getMorphoPositions — follow-up.",
-  },
-  {
     protocol: "marginfi",
     chain: "solana",
-    reason: "MarginFi wallet-less reader not yet split out from getMarginfiPositions — follow-up.",
-  },
-  {
-    protocol: "kamino",
-    chain: "solana",
-    reason: "Kamino wallet-less reader not yet split out from getKaminoPositions — follow-up.",
-  },
-  {
-    protocol: "marinade",
-    chain: "solana",
-    reason: "Marinade has no APY reader exposed in src/modules/solana/marinade.ts — follow-up.",
-  },
-  {
-    protocol: "jito",
-    chain: "solana",
-    reason: "Jito has no APY reader exposed in src/modules/solana/jito.ts — follow-up.",
+    reason: "MarginFi borrow-lend isn't published on DefiLlama yields (only marginfi-lst); on-chain wallet-less bank reader is the follow-up — issue #288.",
   },
   {
     protocol: "eigenlayer",
@@ -128,6 +109,7 @@ async function compareYieldsImpl(args: CompareYieldsArgs): Promise<CompareYields
       readAaveYields(sub, evmChains),
       readCompoundYields(sub, evmChains),
       readLidoYields(sub),
+      readDefiLlamaYields(sub, requestedChains),
     ]);
     for (const r of settled) {
       if (r.status === "fulfilled") {

--- a/test/yields-defillama-adapter.test.ts
+++ b/test/yields-defillama-adapter.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for the DefiLlama-backed yields adapter (PR #431-bundle).
+ *
+ * The adapter lives in `src/modules/yields/adapters/defillama.ts` and
+ * covers four protocols (Marinade, Jito, Kamino-lend, Morpho-Blue) by
+ * filtering a single `https://yields.llama.fi/pools` payload.
+ *
+ * Tests stub `fetchWithTimeout` with a controlled fixture so we can
+ * assert filter / threshold / per-asset behavior deterministically
+ * without depending on live DefiLlama state.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FixturePool {
+  project: string;
+  chain: string;
+  symbol: string;
+  apy: number | null;
+  apyBase: number | null;
+  tvlUsd: number | null;
+  poolMeta: string | null;
+}
+
+function fixture(): FixturePool[] {
+  return [
+    // Marinade — only emits for SOL.
+    {
+      project: "marinade-liquid-staking",
+      chain: "Solana",
+      symbol: "MSOL",
+      apy: 7.42,
+      apyBase: 7.42,
+      tvlUsd: 1_000_000_000,
+      poolMeta: null,
+    },
+    // Jito — only emits for SOL.
+    {
+      project: "jito-liquid-staking",
+      chain: "Solana",
+      symbol: "JITOSOL",
+      apy: 7.95,
+      apyBase: 7.95,
+      tvlUsd: 1_500_000_000,
+      poolMeta: null,
+    },
+    // Kamino lending — exact symbol match.
+    {
+      project: "kamino-lend",
+      chain: "Solana",
+      symbol: "USDC",
+      apy: 4.22,
+      apyBase: 4.22,
+      tvlUsd: 8_184_000,
+      poolMeta: null,
+    },
+    {
+      project: "kamino-lend",
+      chain: "Solana",
+      symbol: "USDC",
+      apy: 6.5,
+      apyBase: 6.5,
+      tvlUsd: 1_500_000,
+      poolMeta: "JLP",
+    },
+    {
+      project: "kamino-lend",
+      chain: "Solana",
+      symbol: "SOL",
+      apy: 4.28,
+      apyBase: 4.28,
+      tvlUsd: 31_000_000,
+      poolMeta: null,
+    },
+    // Morpho Blue — top vaults above TVL floor (5M).
+    {
+      project: "morpho-blue",
+      chain: "Ethereum",
+      symbol: "STEAKUSDC",
+      apy: 4.24,
+      apyBase: 3.92,
+      tvlUsd: 118_000_000,
+      poolMeta: null,
+    },
+    {
+      project: "morpho-blue",
+      chain: "Base",
+      symbol: "STEAKUSDC",
+      apy: 4.07,
+      apyBase: 4.07,
+      tvlUsd: 471_000_000,
+      poolMeta: null,
+    },
+    {
+      project: "morpho-blue",
+      chain: "Ethereum",
+      symbol: "GTUSDC",
+      apy: 4.18,
+      apyBase: 3.86,
+      tvlUsd: 160_000_000,
+      poolMeta: null,
+    },
+    {
+      project: "morpho-blue",
+      chain: "Ethereum",
+      symbol: "GTUSDCP",
+      apy: 4.34,
+      apyBase: 4.02,
+      tvlUsd: 111_000_000,
+      poolMeta: null,
+    },
+    // Below TVL floor — should NOT appear.
+    {
+      project: "morpho-blue",
+      chain: "Ethereum",
+      symbol: "AUSDC",
+      apy: 5.1,
+      apyBase: 5.1,
+      tvlUsd: 100_000,
+      poolMeta: null,
+    },
+    // APY=0 — should NOT appear.
+    {
+      project: "morpho-blue",
+      chain: "Polygon",
+      symbol: "USDC",
+      apy: 0,
+      apyBase: null,
+      tvlUsd: 6_000_000,
+      poolMeta: null,
+    },
+    // ETH-flavored vault — only emits for asset=ETH.
+    {
+      project: "morpho-blue",
+      chain: "Ethereum",
+      symbol: "GTWETH",
+      apy: 2.1,
+      apyBase: 2.1,
+      tvlUsd: 50_000_000,
+      poolMeta: null,
+    },
+    // Hyperliquid L1 isn't in our SupportedChain union — should be dropped.
+    {
+      project: "morpho-blue",
+      chain: "Hyperliquid L1",
+      symbol: "GTUSDC-HL",
+      apy: 9.99,
+      apyBase: 9.99,
+      tvlUsd: 50_000_000,
+      poolMeta: null,
+    },
+  ];
+}
+
+async function setup(opts: { fetchOk?: boolean; pools?: FixturePool[] } = {}) {
+  vi.resetModules();
+  const fetchOk = opts.fetchOk ?? true;
+  const pools = opts.pools ?? fixture();
+  vi.doMock("../src/data/http.js", () => ({
+    fetchWithTimeout: vi.fn(async () => ({
+      ok: fetchOk,
+      json: async () => ({ data: pools }),
+    })),
+  }));
+  // Cache wrap is bypassed so each test runs the real adapter logic.
+  vi.doMock("../src/data/cache.js", () => ({
+    cache: {
+      remember: async (_k: string, _t: number, fn: () => Promise<unknown>) =>
+        fn(),
+      get: () => undefined,
+      set: () => {},
+    },
+  }));
+  return import("../src/modules/yields/adapters/defillama.js");
+}
+
+describe("readDefiLlamaYields — bundled adapter", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("emits Marinade + Jito + Kamino rows when asset=SOL and chain includes solana", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("SOL", ["solana"]);
+    const protocols = rows.map((r) => r.protocol).sort();
+    expect(protocols).toContain("marinade");
+    expect(protocols).toContain("jito");
+    expect(protocols).toContain("kamino");
+  });
+
+  it("Kamino emits multiple rows for USDC across markets, distinguished by poolMeta", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("USDC", ["solana"]);
+    const kaminoRows = rows.filter((r) => r.protocol === "kamino");
+    expect(kaminoRows.length).toBe(2);
+    const markets = kaminoRows.map((r) => r.market).sort();
+    expect(markets[0]).toMatch(/Kamino/);
+    expect(markets.find((m) => /JLP/.test(m))).toBeTruthy();
+  });
+
+  it("Morpho emits top-N curated vaults per (asset, chain), filtered by TVL floor and APY>0", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("USDC", ["ethereum", "base", "polygon"]);
+    const morpho = rows.filter((r) => r.protocol === "morpho-blue");
+    // Ethereum: 3 vaults above floor (STEAKUSDC, GTUSDC, GTUSDCP). Base: 1.
+    // Polygon: only an apy=0 row, dropped. AUSDC dropped (TVL 100k below 5M).
+    const chains = morpho.map((r) => r.chain).sort();
+    expect(chains).toEqual(["base", "ethereum", "ethereum", "ethereum"]);
+    expect(morpho.every((r) => /Morpho/.test(r.market))).toBe(true);
+  });
+
+  it("Morpho ETH asset matches WETH-flavored vault names only", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("ETH", ["ethereum"]);
+    const morpho = rows.filter((r) => r.protocol === "morpho-blue");
+    expect(morpho.length).toBe(1);
+    expect(morpho[0]?.market).toBe("Morpho · GTWETH");
+  });
+
+  it("respects requested chain filter — empty when chain not asked for", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows: solOnly } = await readDefiLlamaYields("USDC", ["solana"]);
+    expect(solOnly.every((r) => r.chain === "solana")).toBe(true);
+    expect(solOnly.find((r) => r.protocol === "morpho-blue")).toBeUndefined();
+  });
+
+  it("converts apy → fraction (DefiLlama publishes percentage)", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("SOL", ["solana"]);
+    const marinade = rows.find((r) => r.protocol === "marinade");
+    expect(marinade).toBeDefined();
+    expect(marinade!.supplyApr).toBeCloseTo(0.0742, 4);
+    expect(marinade!.supplyApy).toBeGreaterThan(marinade!.supplyApr!);
+  });
+
+  it("populates tvl when DefiLlama provides it", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("SOL", ["solana"]);
+    const jito = rows.find((r) => r.protocol === "jito");
+    expect(jito?.tvl).toBe(1_500_000_000);
+  });
+
+  it("returns unavailable rows when DefiLlama fetch fails (per requested chain)", async () => {
+    const { readDefiLlamaYields } = await setup({ fetchOk: false });
+    const { rows, unavailable } = await readDefiLlamaYields("USDC", [
+      "solana",
+      "ethereum",
+    ]);
+    expect(rows).toHaveLength(0);
+    const unprotocols = new Set(unavailable.map((u) => u.protocol));
+    expect(unprotocols.has("marinade")).toBe(true);
+    expect(unprotocols.has("jito")).toBe(true);
+    expect(unprotocols.has("kamino")).toBe(true);
+    expect(unprotocols.has("morpho-blue")).toBe(true);
+  });
+
+  it("emits no Solana-only protocols when only EVM chains are requested", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("USDC", ["ethereum"]);
+    expect(rows.find((r) => r.protocol === "marinade")).toBeUndefined();
+    expect(rows.find((r) => r.protocol === "jito")).toBeUndefined();
+    expect(rows.find((r) => r.protocol === "kamino")).toBeUndefined();
+  });
+
+  it("drops Morpho rows on chains outside our SupportedChain union (e.g. Hyperliquid L1)", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("USDC", [
+      "ethereum",
+      "base",
+      "arbitrum",
+      "polygon",
+      "optimism",
+    ]);
+    expect(rows.find((r) => /HL/.test(r.market))).toBeUndefined();
+  });
+
+  it("emits no rows for asset=BTC (no DefiLlama-tracked protocol carries WBTC for our four)", async () => {
+    const { readDefiLlamaYields } = await setup();
+    const { rows } = await readDefiLlamaYields("BTC", ["ethereum", "solana"]);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/test/yields.test.ts
+++ b/test/yields.test.ts
@@ -104,6 +104,7 @@ describe("compareYields composer", () => {
     aave?: { rows: any[]; unavailable?: any[] };
     compound?: { rows: any[]; unavailable?: any[] };
     lido?: { rows: any[]; unavailable?: any[] };
+    defillama?: { rows: any[]; unavailable?: any[] };
     riskScores?: Record<string, number | undefined>;
   }) {
     vi.doMock("../src/modules/yields/adapters/aave.js", () => ({
@@ -120,6 +121,11 @@ describe("compareYields composer", () => {
       readLidoYields: vi
         .fn()
         .mockResolvedValue(opts.lido ?? { rows: [], unavailable: [] }),
+    }));
+    vi.doMock("../src/modules/yields/adapters/defillama.js", () => ({
+      readDefiLlamaYields: vi
+        .fn()
+        .mockResolvedValue(opts.defillama ?? { rows: [], unavailable: [] }),
     }));
     vi.doMock("../src/modules/security/risk-score.js", () => ({
       getProtocolRiskScore: vi.fn(async (slug: string) => ({
@@ -248,14 +254,18 @@ describe("compareYields composer", () => {
     expect(compoundUnavail[0].reason).toContain("RPC down");
   });
 
-  it("surfaces deferred protocols (Morpho/MarginFi/Kamino/...) in unavailable[]", async () => {
+  it("surfaces remaining deferred protocols (MarginFi / EigenLayer / native-stake) in unavailable[]", async () => {
     const { compareYields } = await withMocks({});
     const out = await compareYields({ asset: "USDC" });
     const protocols = new Set(out.unavailable.map((u: any) => u.protocol));
-    expect(protocols.has("morpho-blue")).toBe(true);
     expect(protocols.has("marginfi")).toBe(true);
-    expect(protocols.has("kamino")).toBe(true);
     expect(protocols.has("eigenlayer")).toBe(true);
+    expect(protocols.has("native-stake")).toBe(true);
+    // Morpho / Kamino / Marinade / Jito now ship live via the DefiLlama adapter.
+    expect(protocols.has("morpho-blue")).toBe(false);
+    expect(protocols.has("kamino")).toBe(false);
+    expect(protocols.has("marinade")).toBe(false);
+    expect(protocols.has("jito")).toBe(false);
   });
 
   it("expands 'stables' into USDC + USDT and queries adapters for both", async () => {


### PR DESCRIPTION
## Summary

First of four PRs landing issue [#431](https://github.com/szhygulin/vaultpilot-mcp/issues/431). Adds a single DefiLlama-backed adapter that covers four of the seven `compare_yields` protocols deferred in PR #282 — Marinade, Jito, Kamino-lend, Morpho Blue — by filtering one cached payload from `https://yields.llama.fi/pools`. Mirrors the existing `getLidoApr()` pattern.

Closes #290 (Marinade), #291 (Jito), #289 (Kamino), #287 (Morpho Blue).

## What changes

- New file: `src/modules/yields/adapters/defillama.ts`
  - One cached HTTP call per `CACHE_TTL.YIELD` window; per-protocol filters reuse the same payload.
  - **Marinade** — emits MSOL row when `asset=SOL` + Solana requested.
  - **Jito** — emits JITOSOL row when `asset=SOL` + Solana requested.
  - **Kamino-lend** — exact-symbol match for USDC/USDT/SOL; multi-market support via `poolMeta` (Main + JLP appear as separate rows).
  - **Morpho Blue** — top-N=3 curated vaults per (asset, EVM chain) above $5M TVL with APY > 0. Substring match on vault token symbol (`STEAKUSDC`, `GTUSDC`, `GTWETH`, …).
- Composer wiring: `src/modules/yields/index.ts` — register adapter, drop covered protocols from `DEFERRED_PROTOCOLS`. MarginFi stays deferred with updated reason (DefiLlama doesn't carry borrow-lend, only `marginfi-lst`).
- Tests: 11 new adapter unit tests (`test/yields-defillama-adapter.test.ts`) covering per-protocol shape, TVL floor, APY-zero filter, chain-out-of-union drop (Hyperliquid L1), failure mode. Existing composer tests (`test/yields.test.ts`) updated to mock the new adapter and adjust the "deferred protocols" assertion.
- README — recently-shipped section updated.

## Trade-offs

- **Freshness**: DefiLlama refreshes every ~5 min; rates lag a fresh on-chain read by minutes. Acceptable for a comparison ranking — the user's actual supply tx goes through `prepare_*` tools that read fresh on-chain rates.
- **Morpho coverage**: top-N curated vaults per (asset, chain), not full event-walk discovery. Catches the high-TVL flow (STEAKUSDC, GTUSDC, etc., aggregating $100M+) without the RPC-pressure cost of `discoverMorphoMarketIds`.
- **MarginFi gap**: DefiLlama publishes only `marginfi-lst`, not the borrow-lend platform. MarginFi follow-up via on-chain wallet-less reader (#288) — separate PR.

## Test plan
- [ ] `npm run build` clean
- [ ] `npx vitest run` — all 2324 tests pass locally
- [ ] CI green
- [ ] Manual: `compare_yields({asset:"USDC", chains:["solana","ethereum","base"]})` returns Aave + Compound + Morpho-Blue + Kamino rows
- [ ] Manual: `compare_yields({asset:"SOL"})` returns Marinade + Jito rows alongside Kamino-SOL

🤖 Generated with [Claude Code](https://claude.com/claude-code)