### PR TITLE
docs(yields): sharpen EigenLayer + native-stake deferred-notes (option C, #431)

### DIFF
--- a/src/modules/yields/index.ts
+++ b/src/modules/yields/index.ts
@@ -70,12 +70,14 @@ const DEFERRED_PROTOCOLS: ReadonlyArray<{
   {
     protocol: "eigenlayer",
     chain: "ethereum",
-    reason: "EigenLayer restaking yield is operator/AVS-dependent — needs a separate plan, not a single APR.",
+    reason:
+      "EigenLayer restaking yield has no single APR — it's fragmented across operators × AVS reward tokens, and DefiLlama publishes no `eigenlayer` project. As a practical proxy, the LRT issuers (Renzo, Kelp, ether.fi, Swell) bundle restaking yield into a tradable token and DO have DefiLlama coverage; they're the realistic answer to \"where do I park ETH for restaking yield\". Native EigenLayer per-operator + per-AVS row shape is deferred until usage data justifies the AVS reward-token pricing infrastructure.",
   },
   {
     protocol: "native-stake",
     chain: "solana",
-    reason: "Solana native-stake yield is validator-commission-dependent — needs separate plan to avoid misleading single-rate quote.",
+    reason:
+      "Solana native-stake yield depends on validator selection (commission + MEV-enabled flag) — a single network-wide APR misleads. Marinade (`marinade-liquid-staking`) and Jito (`jito-liquid-staking`) are the practical substitutes already covered by `compare_yields`: both LSTs delegate to a curated validator set and surface the realized post-commission yield as one row, with no validator-selection cognitive load on the user. Per-validator row shape is deferred until usage data justifies the validators.app / Stakewiz integration.",
   },
 ];
 


### PR DESCRIPTION
## Summary

Final piece of issue [#431](https://github.com/szhygulin/vaultpilot-mcp/issues/431) — sharpens the deferred-note text for EigenLayer (#292) and Solana native-stake (#293) and closes both as won't-fix.

## Decision

Per scoping pass on 2026-04-28, both protocols already have user-accessible substitutes inside `compare_yields`:

- **EigenLayer** → LRT issuers (Renzo, Kelp, ether.fi, Swell). DefiLlama publishes no `eigenlayer` project, but covers all four LRTs that bundle restaking yield into tradable tokens. The LRT row is the realistic answer to "where do I park ETH for restaking yield" today.
- **Solana native-stake** → Marinade + Jito LST adapters (already shipped via the DefiLlama bundle in #287/#289/#290/#291). Both delegate to a curated validator set and surface realized post-commission APY as one row.

Per-operator / per-AVS rows for EigenLayer and per-validator rows for native-stake are NOT shipped because:

- The plan documented design questions that affect what the rows mean (operator-vs-AVS aggregation, MEV-enabled column-vs-filter, AVS reward-token pricing fragmentation).
- The substitutes above already cover the user-visible "where do I get yield" question with less cognitive load.
- Shipping a "single per-protocol APR" row for either would mislead users (the plan's risk register flags this explicitly).

## What changes

- `src/modules/yields/index.ts` — two `DEFERRED_PROTOCOLS` reasons rewritten to (1) explain why no single APR is the right shape and (2) point users at the substitute adapters they can use today.

That's it — no code, no tests. The reasons are user-visible in `compare_yields` responses' `unavailable[]` array.

## Closes

- Closes #292 (won't fix — LRTs are the substitute).
- Closes #293 (won't fix — Marinade + Jito are the substitutes).

If future usage data justifies revisiting either, the plan in `claude-work/plan-yields-v2-followups.md` still captures the design decisions both adapters would need.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run test/yields.test.ts` — all 19 yields tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)