### PR TITLE
feat(token-send): surface non-standard transfer-semantics flags (#441)

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -3,6 +3,7 @@ import { encodeFunctionData, formatUnits, isAddress, parseEther, parseUnits } fr
 import { CONTRACTS } from "../../config/contracts.js";
 import qrcodeTerminal from "qrcode-terminal";
 import { resolveRecipient } from "../../contacts/resolver.js";
+import { lookupTokenClass } from "./token-class.js";
 import {
   initiatePairing,
   requestSendTransaction,
@@ -2559,6 +2560,7 @@ export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<Unsi
   const recipientDisplay = resolved.label
     ? `${resolved.label} (${to})`
     : to;
+  const tokenClass = lookupTokenClass(chain, token);
   return enrichTx({
     chain,
     to: token,
@@ -2584,6 +2586,7 @@ export async function prepareTokenSend(args: PrepareTokenSendArgs): Promise<Unsi
       source: resolved.source,
       ...(resolved.warnings.length > 0 ? { warnings: resolved.warnings } : {}),
     },
+    ...(tokenClass !== null ? { tokenClass } : {}),
   });
 }
 

--- a/src/modules/execution/token-class.ts
+++ b/src/modules/execution/token-class.ts
@@ -1,0 +1,129 @@
+/**
+ * Curated registry of tokens with non-standard ERC-20 transfer
+ * semantics (issue #441). Looked up at `prepare_token_send` time so
+ * the receipt carries `tokenClass.flags` + a user-facing warning
+ * before the user signs. The smoke-test trigger was script 019:
+ * a 0.3 stETH transfer where the calldata lands ~1-2 wei short of
+ * the requested amount due to share-rounding drift, with no warning.
+ *
+ * Scope cut for v1 (per issue #441 implementation plan): seed only
+ * the `rebasing` class. The other enum values are defined here so
+ * the type surface is forward-stable, but populating them needs a
+ * concrete failing case + curated address list for each — deferred
+ * to follow-up issues to avoid noisy warnings on common tokens
+ * (e.g. every USDC transfer would fire `upgradeable_admin`) and
+ * registry maintenance for tokens nobody actually transfers
+ * (long-tail FoT memecoins).
+ */
+
+import { CONTRACTS } from "../../config/contracts.js";
+import type { SupportedChain } from "../../types/index.js";
+
+/**
+ * The full enum surface. Adding a new class is just data — no schema
+ * change. The warning string is what the user actually reads, so it
+ * should be one or two sentences with a concrete next step (wrap, swap,
+ * verify recipient is not on the issuer's blocklist, etc.).
+ */
+export type TokenClassFlag =
+  | "standard"
+  | "rebasing"
+  | "fee_on_transfer"
+  | "pausable"
+  | "blocklisted"
+  | "upgradeable_admin";
+
+export interface TokenClassResult {
+  flags: TokenClassFlag[];
+  warnings: string[];
+}
+
+/**
+ * Internal registry shape — one entry per (chain, lowercase-address).
+ * Lowercase indexing avoids the ERC-55 checksum mismatch that would
+ * otherwise fall through to "no match" on case-different inputs.
+ */
+type RegistryKey = `${SupportedChain}:0x${string}`;
+type RegistryEntry = TokenClassResult;
+
+const registry = new Map<RegistryKey, RegistryEntry>();
+
+function key(chain: SupportedChain, address: string): RegistryKey {
+  return `${chain}:${address.toLowerCase() as `0x${string}`}` as RegistryKey;
+}
+
+function register(
+  chain: SupportedChain,
+  address: string,
+  entry: RegistryEntry,
+): void {
+  registry.set(key(chain, address), entry);
+}
+
+// --- Seed data: rebasing tokens ---------------------------------------
+
+// stETH on Ethereum — Lido's staked-ETH token. balanceOf grows as
+// rewards accrue; transfer() converts amount → shares at the current
+// index and back at the recipient's index. The two-step rounding
+// drops 1-2 wei on the recipient side. For frequent transfers, wrap
+// to wstETH first via prepare_lido_wrap (wstETH is non-rebasing —
+// balance is in shares, not stETH-equivalent).
+register(
+  "ethereum",
+  CONTRACTS.ethereum.lido.stETH,
+  {
+    flags: ["rebasing"],
+    warnings: [
+      "stETH is rebasing — the recipient may receive 1-2 wei less than the " +
+        "requested amount due to share-rounding drift. For frequent transfers " +
+        "wrap to wstETH first via `prepare_lido_wrap` (wstETH balance is in " +
+        "shares, not rebased), or use a DEX swap if the recipient prefers " +
+        "wstETH.",
+    ],
+  },
+);
+
+// AMPL on Ethereum — Ampleforth, the original elastic-supply rebasing
+// token. Whole-balance rebases happen daily based on price; transfer()
+// at any moment is correct, but a tx that sits in the mempool across a
+// rebase boundary lands a different fraction of the user's holdings
+// than they intended.
+register("ethereum", "0xD46bA6D942050d489DBd938a2C909A5d5039A161", {
+  flags: ["rebasing"],
+  warnings: [
+    "AMPL is an elastic-supply rebasing token — daily supply rebases mean " +
+      "a transfer that sits in the mempool across the rebase boundary " +
+      "(20:00 UTC) lands a different fraction of your holdings than you " +
+      "intended. Send during stable periods, or convert to a non-rebasing " +
+      "wrapper if your destination supports one.",
+  ],
+});
+
+// --- Lookup ----------------------------------------------------------
+
+/**
+ * Look up the token in the curated registry. Returns null when the
+ * token is not classified — caller should treat as "standard ERC-20"
+ * and not surface a tokenClass field on the receipt at all (vs.
+ * surfacing `flags: ["standard"]`, which would add visual noise to
+ * every plain transfer).
+ */
+export function lookupTokenClass(
+  chain: SupportedChain,
+  address: string,
+): TokenClassResult | null {
+  return registry.get(key(chain, address)) ?? null;
+}
+
+/**
+ * Test-only helper for asserting registry coverage shape (e.g. "every
+ * registered entry has at least one warning matching its flags"). NOT
+ * part of the public API — exported under an underscore prefix to
+ * make the test-only intent obvious to readers.
+ */
+export function _registrySnapshotForTests(): ReadonlyMap<
+  RegistryKey,
+  RegistryEntry
+> {
+  return registry;
+}

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -159,7 +159,10 @@ function formatDecoder(v: TxVerification): string {
 }
 
 export function renderVerificationBlock(
-  tx: Pick<UnsignedTx, "chain" | "to" | "value" | "data" | "recipient"> & {
+  tx: Pick<
+    UnsignedTx,
+    "chain" | "to" | "value" | "data" | "recipient" | "tokenClass"
+  > & {
     verification: TxVerification;
   },
 ): string {
@@ -185,6 +188,16 @@ export function renderVerificationBlock(
     `  Hash: ${v.payloadHash}  (short ${v.payloadHashShort}, echoed at send time)`,
   ];
   for (const w of tx.recipient?.warnings ?? []) {
+    lines.push(`  ⚠ ${w}`);
+  }
+  // Token-class warnings (issue #441) — non-standard ERC-20 transfer
+  // semantics flagged by the curated registry in
+  // `modules/execution/token-class.ts`. Same `⚠ <warning>` shape so
+  // the user reads them at the same scan position as recipient
+  // warnings; the token-class field is its own struct on UnsignedTx
+  // so renderers downstream can branch on the flags if they want
+  // different treatment per class.
+  for (const w of tx.tokenClass?.warnings ?? []) {
     lines.push(`  ⚠ ${w}`);
   }
   return lines.join("\n");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1258,6 +1258,27 @@ export interface UnsignedTx {
     warnings?: string[];
   };
   /**
+   * Non-standard ERC-20 transfer-semantics flags (issue #441) — looked
+   * up at `prepare_token_send` time from the curated registry in
+   * `modules/execution/token-class.ts`. Absent when the token is plain
+   * ERC-20 (no point surfacing `flags: ["standard"]` and adding noise
+   * to every receipt). When present, the verification renderer
+   * appends `warnings[]` as `⚠ <warning>` lines so the user reads
+   * them before signing — caught the smoke-test case where a 0.3 stETH
+   * transfer landed 1-2 wei short with no warning (script 019).
+   */
+  tokenClass?: {
+    flags: Array<
+      | "standard"
+      | "rebasing"
+      | "fee_on_transfer"
+      | "pausable"
+      | "blocklisted"
+      | "upgradeable_admin"
+    >;
+    warnings: string[];
+  };
+  /**
    * Set when the tx was built by `prepare_custom_call` after the user passed
    * the affirmative `acknowledgeNonProtocolTarget: true` schema-enforced
    * gate. Read by `assertTransactionSafe` to skip ONLY the catch-all

--- a/test/token-class.test.ts
+++ b/test/token-class.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Token-class registry + receipt-rendering tests (issue #441).
+ *
+ * Two layers:
+ *   1. Pure registry — `lookupTokenClass` returns the right entry
+ *      for case-different addresses, returns null for unknown
+ *      tokens, and the seed entries each have at least one
+ *      warning so empty-warning rows can't silently ship.
+ *   2. Renderer integration — `renderVerificationBlock` appends
+ *      `tokenClass.warnings` as `⚠ <warning>` lines (the same
+ *      shape as recipient warnings) so the user reads them at
+ *      the same scan position before signing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  lookupTokenClass,
+  _registrySnapshotForTests,
+  type TokenClassFlag,
+} from "../src/modules/execution/token-class.js";
+import { CONTRACTS } from "../src/config/contracts.js";
+
+describe("lookupTokenClass — curated registry (issue #441)", () => {
+  it("returns null for plain ERC-20 (USDC) — no noise on standard transfers", () => {
+    expect(
+      lookupTokenClass("ethereum", CONTRACTS.ethereum.tokens.USDC),
+    ).toBeNull();
+  });
+
+  it("returns rebasing flag + share-rounding warning for stETH on ethereum", () => {
+    const r = lookupTokenClass("ethereum", CONTRACTS.ethereum.lido.stETH);
+    expect(r).not.toBeNull();
+    expect(r!.flags).toEqual<TokenClassFlag[]>(["rebasing"]);
+    expect(r!.warnings).toHaveLength(1);
+    expect(r!.warnings[0]).toMatch(/rebasing/);
+    expect(r!.warnings[0]).toMatch(/share-rounding/);
+    expect(r!.warnings[0]).toMatch(/wstETH/);
+  });
+
+  it("returns rebasing flag for AMPL on ethereum with rebase-window guidance", () => {
+    const r = lookupTokenClass(
+      "ethereum",
+      "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+    );
+    expect(r).not.toBeNull();
+    expect(r!.flags).toEqual<TokenClassFlag[]>(["rebasing"]);
+    expect(r!.warnings[0]).toMatch(/elastic-supply|rebase/);
+  });
+
+  it("address lookup is case-insensitive (lowercase + checksum + uppercase)", () => {
+    const checksummed = CONTRACTS.ethereum.lido.stETH;
+    const lower = checksummed.toLowerCase();
+    const upper = checksummed.toUpperCase();
+    expect(lookupTokenClass("ethereum", checksummed)).not.toBeNull();
+    expect(lookupTokenClass("ethereum", lower)).not.toBeNull();
+    expect(lookupTokenClass("ethereum", upper)).not.toBeNull();
+  });
+
+  it("returns null when the same token address is queried on the wrong chain", () => {
+    // Ethereum stETH address has no entry on arbitrum (no Lido stETH there).
+    expect(
+      lookupTokenClass("arbitrum", CONTRACTS.ethereum.lido.stETH),
+    ).toBeNull();
+  });
+
+  it("registry invariant: every seeded entry has at least one warning matching its flags", () => {
+    const snap = _registrySnapshotForTests();
+    expect(snap.size).toBeGreaterThan(0);
+    for (const [k, v] of snap.entries()) {
+      expect(v.flags.length, `${k} must have ≥1 flag`).toBeGreaterThan(0);
+      expect(v.warnings.length, `${k} must have ≥1 warning`).toBeGreaterThan(0);
+      // Cheap shape check: every flag is mentioned in at least one
+      // warning, modulo light tense/wording flexibility. Catches
+      // copy-paste errors where a tag added to flags has no
+      // corresponding user-facing warning text.
+      const text = v.warnings.join(" ").toLowerCase();
+      for (const f of v.flags) {
+        if (f === "standard") continue;
+        const stem = f.replace(/_/g, " ");
+        // "rebasing" or "rebase", "fee on transfer" or "fee", etc.
+        const matches =
+          text.includes(stem) ||
+          (f === "rebasing" && text.includes("rebase")) ||
+          (f === "fee_on_transfer" && text.includes("fee")) ||
+          (f === "blocklisted" && text.includes("blocklist")) ||
+          (f === "pausable" && text.includes("pause")) ||
+          (f === "upgradeable_admin" && text.includes("upgrade"));
+        expect(matches, `${k} flag "${f}" not reflected in warnings`).toBe(
+          true,
+        );
+      }
+    }
+  });
+});
+
+describe("renderVerificationBlock — token-class warning surfaces in receipt", () => {
+  it("appends tokenClass.warnings as ⚠ lines below the hash", async () => {
+    const { renderVerificationBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderVerificationBlock({
+      chain: "ethereum",
+      to: CONTRACTS.ethereum.lido.stETH,
+      value: "0",
+      data: "0xa9059cbb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042b1d8d3a3f0000",
+      verification: {
+        payloadHash: "0xdeadbeef",
+        payloadHashShort: "deadbeef",
+        comparisonString: "ignored",
+        humanDecode: { functionName: "transfer", args: [], source: "none" },
+      },
+      tokenClass: {
+        flags: ["rebasing"],
+        warnings: [
+          "stETH is rebasing — the recipient may receive 1-2 wei less than requested.",
+        ],
+      },
+    });
+    expect(block).toMatch(/⚠ stETH is rebasing/);
+    // The warning should appear AFTER the hash line, so users see
+    // it at the bottom of the verify block where their attention
+    // lands before clicking "send".
+    const hashIdx = block.indexOf("Hash:");
+    const warnIdx = block.indexOf("⚠ stETH");
+    expect(warnIdx).toBeGreaterThan(hashIdx);
+  });
+
+  it("omits the warning section when tokenClass is absent (plain ERC-20)", async () => {
+    const { renderVerificationBlock } = await import(
+      "../src/signing/render-verification.js"
+    );
+    const block = renderVerificationBlock({
+      chain: "ethereum",
+      to: CONTRACTS.ethereum.tokens.USDC,
+      value: "0",
+      data: "0xa9059cbb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042b1d8d3a3f0000",
+      verification: {
+        payloadHash: "0xdeadbeef",
+        payloadHashShort: "deadbeef",
+        comparisonString: "ignored",
+        humanDecode: { functionName: "transfer", args: [], source: "none" },
+      },
+    });
+    expect(block).not.toMatch(/⚠/);
+  });
+});


### PR DESCRIPTION
Closes #441. Follow-up #508 tracks deferred classes.

## Summary
- Curated registry of tokens with non-standard ERC-20 transfer semantics. Looked up at `prepare_token_send` time; receipt carries `tokenClass.flags` + a user-facing warning before signing. Warnings render below the payload hash as `⚠ <warning>` lines (same shape as recipient warnings).
- Caught the smoke-test case (script 019: 0.3 stETH transfer landing 1-2 wei short of the requested amount due to share-rounding drift, no warning).

## Scope cut for v1
Framework + enum forward-stable; seed data is `rebasing` only — stETH and AMPL on ethereum. Other four classes (`blocklisted` / `fee_on_transfer` / `pausable` / `upgradeable_admin`) are tracked at #508 as data-only follow-ups, to avoid noisy warnings on common tokens (every USDC transfer would fire `upgradeable_admin`) and registry maintenance for tokens nobody actually transfers (long-tail FoT memecoins).

## What ships
- `src/modules/execution/token-class.ts` (new) — enum, registry, `lookupTokenClass(chain, address)` with case-insensitive matching
- `src/types/index.ts` — optional `tokenClass` field on `UnsignedTx`. Absent when token is plain ERC-20 (no `flags: [\"standard\"]` noise)
- `src/modules/execution/index.ts` — `prepareTokenSend` calls the lookup, conditionally attaches
- `src/signing/render-verification.ts` — `⚠` lines from `tokenClass.warnings` appear below the hash, after recipient warnings

## Test plan
- [x] +8 tests, full suite 2339/2339 passing
- [ ] Verify CI green
- [ ] Smoke: `prepare_token_send({ chain: \"ethereum\", token: stETH, ... })` → receipt contains `tokenClass.flags=[\"rebasing\"]` and the `⚠` line in the verification block
- [ ] Smoke: `prepare_token_send({ chain: \"ethereum\", token: USDC, ... })` → no `tokenClass` field, no `⚠` line (regression check for noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)