### PR TITLE
feat(tron): add prepare_sunswap_swap for same-chain TRX↔TRC20 swaps

### DIFF
--- a/src/config/tron.ts
+++ b/src/config/tron.ts
@@ -35,6 +35,32 @@ export const TRX_DECIMALS = 6;
 export const TRX_SYMBOL = "TRX";
 
 /**
+ * SunSwap V2 router on TRON mainnet — the canonical Uniswap-V2-fork DEX
+ * for same-chain TRX↔TRC20 swaps. Address per the SunSwap team's own
+ * deployment record at github.com/sunswapteam/sunswap2.0-contracts (verified
+ * 2026-04-28). Pinned as a constant rather than fetched from a registry
+ * because (a) router addresses are immutable on V2 and (b) a swap to the
+ * wrong contract loses funds — we want the address-correctness boundary
+ * checked against the source code, not an external lookup.
+ *
+ * Smart Router (which aggregates V1/V2/V3/PSM/SunCurve) is intentionally
+ * NOT used here — its only published address (TCFNp179...) is testnet-only
+ * per the sun-protocol/smart-exchange-router README, and its ABI is a
+ * different shape (multi-version path encoding, SwapData struct). Sticking
+ * to V2-router-only keeps the calldata encoding simple and the trust
+ * surface small. See issue #432.
+ */
+export const SUNSWAP_V2_ROUTER_TRON = "TNJVzGqKBWkJxJB5XYSqGAwUTV15U24pPq";
+
+/**
+ * Wrapped TRX (WTRX) on TRON mainnet. Used as the WETH-equivalent in
+ * SunSwap V2 paths — TRX → TRC20 routes have path = [WTRX, toToken];
+ * TRC20 → TRC20 routes use [fromToken, WTRX, toToken] when there's no
+ * direct pool. Verified via Bitquery on-chain explorer 2026-04-28.
+ */
+export const WTRX_TRON = "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR";
+
+/**
  * Validate a TRON mainnet base58 address. Mainnet addresses are 34 chars and
  * start with `T` (the mainnet prefix byte 0x41 encodes to `T...` in base58check).
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ import {
   prepareNativeStakeWithdraw,
   prepareSolanaLifiSwap,
   prepareTronLifiSwap,
+  prepareTronSunswapSwap,
   prepareKaminoInitUser,
   prepareKaminoSupply,
   prepareKaminoBorrow,
@@ -271,6 +272,7 @@ import {
   prepareNativeStakeWithdrawInput,
   prepareSolanaLifiSwapInput,
   prepareTronLifiSwapInput,
+  prepareTronSunswapSwapInput,
   prepareKaminoInitUserInput,
   prepareKaminoSupplyInput,
   prepareKaminoBorrowInput,
@@ -3347,7 +3349,36 @@ async function main() {
     handler(prepareTronLifiSwap, { toolName: "prepare_tron_lifi_swap" })
   );
 
-  registerTool(server, 
+  registerTool(server,
+    "prepare_sunswap_swap",
+    {
+      description:
+        "Build an unsigned SunSwap V2 same-chain swap on TRON. SunSwap V2 is a Uniswap-V2 fork; " +
+        "this tool routes through the V2 router (TNJVzGqKBWkJxJB5XYSqGAwUTV15U24pPq) using the " +
+        "standard `swapExactETHForTokens` / `swapExactTokensForETH` / `swapExactTokensForTokens` " +
+        "selectors based on which side is native TRX. Path encoding: TRX→TRC20 = [WTRX, toToken]; " +
+        "TRC20→TRX = [fromToken, WTRX]; TRC20→TRC20 = [fromToken, WTRX, toToken]. The builder " +
+        "(1) calls getAmountsOut on the router via /triggerconstantcontract to compute the " +
+        "expected output, (2) derives minOut as quotedOut * (10000 - slippageBps) / 10000, " +
+        "(3) for TRC-20 sources, reads `allowance(wallet, router)` and refuses with a recovery " +
+        "hint if insufficient — the user must run prepare_tron_trc20_approve(token, " +
+        "spender=router, amount) first, broadcast it, wait ~3s for it to land, then retry. " +
+        "(4) hand-rolls ABI calldata for the swap call (no SDK), (5) hits TronGrid " +
+        "/triggersmartcontract to build the tx, (6) verifies the returned raw_data_hex matches " +
+        "exactly what we asked for (selector + parameter + call_value + fee_limit) and refuses " +
+        "any drift. BLIND-SIGN on Ledger TRON app — the SunSwap router is not in the device's " +
+        "clear-sign allowlist. Enable \"Allow blind signing\" in the on-device TRON app Settings; " +
+        "the device shows the txID, which the user matches against the txID in the prepare " +
+        "receipt. Pair the Ledger via `pair_ledger_tron` first. Smart Router (V1+V2+V3+PSM " +
+        "aggregator) is intentionally not used — V2 router only — because Smart Router's mainnet " +
+        "address has not been published officially and its multi-version path encoding is a " +
+        "different ABI shape.",
+      inputSchema: prepareTronSunswapSwapInput.shape,
+    },
+    handler(prepareTronSunswapSwap, { toolName: "prepare_sunswap_swap" })
+  );
+
+  registerTool(server,
     "get_solana_setup_status",
     {
       description:

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -159,6 +159,7 @@ import type {
   PrepareNativeStakeWithdrawArgs,
   PrepareSolanaLifiSwapArgs,
   PrepareTronLifiSwapArgs,
+  PrepareTronSunswapSwapArgs,
   PrepareKaminoInitUserArgs,
   PrepareKaminoSupplyArgs,
   PrepareKaminoBorrowArgs,
@@ -700,6 +701,29 @@ export async function prepareTronLifiSwap(
     toToken: args.toToken,
     toAddress: args.toAddress,
     ...(slippage !== undefined ? { slippage } : {}),
+  });
+}
+
+export async function prepareTronSunswapSwap(
+  args: PrepareTronSunswapSwapArgs,
+): Promise<UnsignedTronTx> {
+  const { buildTronSunswapSwap } = await import("../tron/sunswap-swap.js");
+  return buildTronSunswapSwap({
+    wallet: args.wallet,
+    fromToken: args.fromToken,
+    toToken: args.toToken,
+    amount: args.amount,
+    ...(args.slippageBps !== undefined ? { slippageBps: args.slippageBps } : {}),
+    ...(args.deadlineSeconds !== undefined
+      ? { deadlineSeconds: args.deadlineSeconds }
+      : {}),
+    ...(args.fromTokenDecimals !== undefined
+      ? { fromTokenDecimals: args.fromTokenDecimals }
+      : {}),
+    ...(args.toTokenDecimals !== undefined
+      ? { toTokenDecimals: args.toTokenDecimals }
+      : {}),
+    ...(args.feeLimitTrx !== undefined ? { feeLimitTrx: args.feeLimitTrx } : {}),
   });
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -585,6 +585,103 @@ export const prepareTronLifiSwapInput = z.object({
 });
 
 /**
+ * SunSwap V2 same-chain swap on TRON. User signs a TRON tx via Ledger
+ * over USB; the swap settles atomically through the V2 router contract.
+ *
+ * BLIND-SIGN on Ledger — the SunSwap router is not in the TRON app's
+ * clear-sign allowlist. User must enable "Allow blind signing" in the
+ * on-device Settings; the device shows the txID (sha256 of raw_data_hex),
+ * which the user matches against the txID in the prepare receipt. TRC-20
+ * source flows require a prior approve to the V2 router — this builder
+ * verifies allowance up-front and refuses with a recovery hint if missing.
+ */
+export const prepareTronSunswapSwapInput = z.object({
+  wallet: z
+    .string()
+    .regex(TRON_ADDRESS)
+    .describe(
+      "TRON base58 wallet (T-prefixed, 34 chars) — funds the swap and signs " +
+        "the source tx on Ledger via USB. Pair via `pair_ledger_tron` first.",
+    ),
+  fromToken: z
+    .string()
+    .max(50)
+    .describe(
+      "Source token. Either the literal string \"TRX\" for native TRX, OR a " +
+        "T-prefixed TRC-20 contract address. TRC-20 source REQUIRES a prior " +
+        "approve to the SunSwap V2 router (TNJVzGqKBWkJxJB5XYSqGAwUTV15U24pPq) — " +
+        "this tool checks allowance up-front and refuses with a recovery hint if " +
+        "insufficient.",
+    ),
+  toToken: z
+    .string()
+    .max(50)
+    .describe(
+      "Destination token. Either the literal \"TRX\" or a T-prefixed TRC-20 " +
+        "contract address. Cannot equal fromToken.",
+    ),
+  amount: z
+    .string()
+    .max(50)
+    .describe(
+      "Human-readable amount of fromToken (e.g. \"100\" for 100 TRX, \"10.5\" " +
+        "for 10.5 USDT). Decimals are resolved from the canonical TRC-20 set " +
+        "(USDT/USDC/USDD/TUSD) or from `fromTokenDecimals` for non-canonical " +
+        "tokens.",
+    ),
+  slippageBps: z
+    .number()
+    .int()
+    .min(0)
+    .max(10_000)
+    .optional()
+    .describe(
+      "Slippage tolerance in basis points (50 = 0.5%). Default 50.",
+    ),
+  deadlineSeconds: z
+    .number()
+    .int()
+    .positive()
+    .max(86_400)
+    .optional()
+    .describe(
+      "Deadline window in seconds from now. Default 1200 (20 min). The router " +
+        "rejects the swap if it hasn't landed by then.",
+    ),
+  fromTokenDecimals: z
+    .number()
+    .int()
+    .min(0)
+    .max(36)
+    .optional()
+    .describe(
+      "REQUIRED when fromToken is a non-canonical TRC-20 (i.e. not USDT/USDC/" +
+        "USDD/TUSD or \"TRX\"). We refuse to guess decimals on a swap because an " +
+        "off-by-power-of-ten amountIn silently exposes the user to ~10^N-fold " +
+        "larger slippage than intended.",
+    ),
+  toTokenDecimals: z
+    .number()
+    .int()
+    .min(0)
+    .max(36)
+    .optional()
+    .describe(
+      "REQUIRED when toToken is a non-canonical TRC-20. Same reasoning as " +
+        "`fromTokenDecimals`.",
+    ),
+  feeLimitTrx: z
+    .string()
+    .regex(/^\d+(\.\d+)?$/)
+    .optional()
+    .describe(
+      "Override the energy fee_limit cap (default 100 TRX). Pass a human-readable " +
+        "TRX amount (e.g. \"50\"). Energy estimate is reported separately in " +
+        "`estimatedEnergyCostSun`.",
+    ),
+});
+
+/**
  * No args — `get_vaultpilot_config_status` returns a structured snapshot of
  * the local server config, intended for diagnostic / onboarding flows.
  * The output deliberately never echoes any secret values (API keys, RPC
@@ -1149,6 +1246,7 @@ export type GetSolanaStakingPositionsArgs = z.infer<typeof getSolanaStakingPosit
 export type GetSolanaSetupStatusArgs = z.infer<typeof getSolanaSetupStatusInput>;
 export type PrepareSolanaLifiSwapArgs = z.infer<typeof prepareSolanaLifiSwapInput>;
 export type PrepareTronLifiSwapArgs = z.infer<typeof prepareTronLifiSwapInput>;
+export type PrepareTronSunswapSwapArgs = z.infer<typeof prepareTronSunswapSwapInput>;
 
 /**
  * Kamino lending — first-time setup. Creates the user lookup table +

--- a/src/modules/tron/actions.ts
+++ b/src/modules/tron/actions.ts
@@ -17,16 +17,16 @@ import type { UnsignedTronTx } from "../../types/index.js";
  * Ledger Live / Tronlink default and far above typical energy burn for a
  * USDT-TRC20 transfer (~15 TRX at current mainnet energy price).
  */
-const DEFAULT_FEE_LIMIT_SUN = 100_000_000n;
+export const DEFAULT_FEE_LIMIT_SUN = 100_000_000n;
 
 /** Hardcoded TRC-20 decimals for canonical stablecoins (same as balances.ts). */
-const TOKEN_DECIMALS: Record<keyof typeof TRON_TOKENS, number> = {
+export const TOKEN_DECIMALS: Record<keyof typeof TRON_TOKENS, number> = {
   USDT: 6,
   USDC: 6,
   USDD: 18,
   TUSD: 18,
 };
-const SYMBOL_BY_CONTRACT: Record<string, keyof typeof TRON_TOKENS> = Object.fromEntries(
+export const SYMBOL_BY_CONTRACT: Record<string, keyof typeof TRON_TOKENS> = Object.fromEntries(
   (Object.entries(TRON_TOKENS) as [keyof typeof TRON_TOKENS, string][]).map(
     ([symbol, addr]) => [addr, symbol]
   )
@@ -37,7 +37,7 @@ const SYMBOL_BY_CONTRACT: Record<string, keyof typeof TRON_TOKENS> = Object.from
  * Mirrors viem's `parseUnits` but doesn't import viem (keeps the TRON
  * path free of EVM-only helpers).
  */
-function parseUnits(value: string, decimals: number): bigint {
+export function parseUnits(value: string, decimals: number): bigint {
   if (!/^\d+(\.\d+)?$/.test(value)) {
     throw new Error(`Invalid amount "${value}" — expected a positive decimal number.`);
   }
@@ -51,7 +51,7 @@ function parseUnits(value: string, decimals: number): bigint {
   return BigInt(whole + padded);
 }
 
-async function trongridPost<T>(
+export async function trongridPost<T>(
   path: string,
   body: Record<string, unknown>,
   apiKey: string | undefined
@@ -129,7 +129,7 @@ interface TrongridBandwidthResourceResponse {
  * Called after the tx is built (we need `rawDataHex` for size) but before
  * the handle is issued, so the error surfaces at prepare time.
  */
-async function assertBandwidthSufficient(
+export async function assertBandwidthSufficient(
   from: string,
   rawDataHex: string,
   apiKey: string | undefined
@@ -213,7 +213,7 @@ interface TrongridDirectTx {
   visible?: boolean;
 }
 
-interface TrongridTriggerResponse {
+export interface TrongridTriggerResponse {
   result?: { result?: boolean; message?: string; code?: string };
   transaction?: {
     txID?: string;
@@ -223,7 +223,7 @@ interface TrongridTriggerResponse {
   };
 }
 
-interface TrongridConstantResponse {
+export interface TrongridConstantResponse {
   result?: { result?: boolean; message?: string; code?: string };
   energy_used?: number;
   constant_result?: string[];
@@ -237,7 +237,7 @@ interface TrongridConstantResponse {
  * /wallet/getchainparameters is possible but not worth the extra round-trip
  * for a preview-only number.
  */
-const ENERGY_PRICE_SUN = 420n;
+export const ENERGY_PRICE_SUN = 420n;
 
 /** Well-known solidity revert selector: Error(string) = 0x08c379a0. */
 const ERROR_STRING_SELECTOR = "08c379a0";
@@ -275,7 +275,7 @@ function decodeRevertString(constantResult: string[] | undefined): string | unde
  * that would revert on-chain (insufficient balance, paused token, blocked
  * recipient). Returns the energy estimate for the preview.
  */
-async function preflightConstantContract(
+export async function preflightConstantContract(
   body: Record<string, unknown>,
   apiKey: string | undefined
 ): Promise<{ energyUsed: bigint }> {

--- a/src/modules/tron/sunswap-swap.ts
+++ b/src/modules/tron/sunswap-swap.ts
@@ -1,0 +1,512 @@
+import {
+  isTronAddress,
+  TRX_DECIMALS,
+  SUNSWAP_V2_ROUTER_TRON,
+  WTRX_TRON,
+} from "../../config/tron.js";
+import { resolveTronApiKey, readUserConfig } from "../../config/user-config.js";
+import { issueTronHandle } from "../../signing/tron-tx-store.js";
+import { base58ToHex } from "./address.js";
+import { assertTronRawDataMatches } from "./verify-raw-data.js";
+import {
+  trongridPost,
+  preflightConstantContract,
+  assertBandwidthSufficient,
+  parseUnits,
+  TOKEN_DECIMALS,
+  SYMBOL_BY_CONTRACT,
+  ENERGY_PRICE_SUN,
+  DEFAULT_FEE_LIMIT_SUN,
+  type TrongridConstantResponse,
+  type TrongridTriggerResponse,
+} from "./actions.js";
+import type { UnsignedTronTx } from "../../types/index.js";
+
+/**
+ * SunSwap V2 same-chain swap builder for TRON.
+ *
+ * SunSwap V2 is a Uniswap-V2 fork on TRON; the router ABI is identical
+ * (selectors + struct layout) so we hand-roll calldata against the
+ * standard signatures rather than adopting an SDK. The probe at issue
+ * #432 plan time confirmed: no official SunSwap TS SDK on npm; the
+ * one community package (`sunswap-sdk`, last published >1yr ago) is an
+ * EVM Uniswap V2 repackage. Hand-rolling matches the existing TRON
+ * pipeline (raw HTTP to TronGrid + manual ABI-param encoding via
+ * `encodeTrc20TransferParam`-shaped helpers).
+ *
+ * Smart Router (V1+V2+V3+PSM+SunCurve aggregator) is intentionally NOT
+ * used — its ABI is a different shape (multi-version path encoding,
+ * SwapData struct), and its only published address is testnet-only per
+ * the sun-protocol/smart-exchange-router README. V2-router-only keeps
+ * the calldata encoding simple and the trust surface small.
+ *
+ * BLIND-SIGN on Ledger TRON app — the SunSwap router is not in the
+ * device's clear-sign allowlist (which currently only covers Transfer,
+ * Vote, Freeze, and a few canonical TRC-20 selectors). User must enable
+ * "Allow blind signing" in the TRON app's on-device Settings; the device
+ * displays the txID (sha256 of raw_data_hex), which the user matches
+ * against the txID in the prepare receipt.
+ */
+
+/** Sentinel for native TRX in `fromToken`/`toToken`. Internally swapped for WTRX in path encoding. */
+const TRX_SENTINEL = "TRX";
+
+/**
+ * SunSwap V2 router selectors. SunSwap V2 inherits Uniswap V2's ABI verbatim
+ * (including the "ETH" naming despite the chain being TRON), so these are
+ * the well-known Uniswap V2 selectors.
+ *
+ *   swapExactETHForTokens(uint256,address[],address,uint256)            -> fb3bdb41
+ *   swapExactTokensForETH(uint256,uint256,address[],address,uint256)    -> 18cbafe5
+ *   swapExactTokensForTokens(uint256,uint256,address[],address,uint256) -> 38ed1739
+ *   getAmountsOut(uint256,address[])                                    -> d06ca61f
+ *
+ * Hardcoded as constants to avoid a runtime keccak. The verifier rejects
+ * a swap whose data doesn't match `selector || parameterHex`, so a
+ * selector typo here surfaces immediately as a verify-time refusal
+ * rather than as a wrong-method on-chain call.
+ */
+const SELECTOR_SWAP_EXACT_ETH_FOR_TOKENS = "fb3bdb41";
+const SELECTOR_SWAP_EXACT_TOKENS_FOR_ETH = "18cbafe5";
+const SELECTOR_SWAP_EXACT_TOKENS_FOR_TOKENS = "38ed1739";
+
+const FUNCTION_SIG_SWAP_EXACT_ETH_FOR_TOKENS =
+  "swapExactETHForTokens(uint256,address[],address,uint256)";
+const FUNCTION_SIG_SWAP_EXACT_TOKENS_FOR_ETH =
+  "swapExactTokensForETH(uint256,uint256,address[],address,uint256)";
+const FUNCTION_SIG_SWAP_EXACT_TOKENS_FOR_TOKENS =
+  "swapExactTokensForTokens(uint256,uint256,address[],address,uint256)";
+
+const DEFAULT_SLIPPAGE_BPS = 50;
+const DEFAULT_DEADLINE_SEC = 1200;
+
+// --- ABI param encoding (no viem; same convention as encodeTrc20TransferParam) ---
+
+function encodeUint256(value: bigint): string {
+  if (value < 0n) throw new Error("uint256 must be non-negative");
+  return value.toString(16).padStart(64, "0");
+}
+
+function encodeAddressWord(base58: string): string {
+  // TRC-20 ABI uses the 20-byte EVM-style form (drops the 0x41 TRON prefix).
+  // Same convention as encodeTrc20TransferParam in address.ts.
+  const hex21 = base58ToHex(base58);
+  return hex21.slice(2).padStart(64, "0");
+}
+
+function encodeAddressArray(addresses: string[]): string {
+  const length = encodeUint256(BigInt(addresses.length));
+  const elements = addresses.map(encodeAddressWord).join("");
+  return length + elements;
+}
+
+// --- Public input shape ---------------------------------------------------
+
+export interface BuildTronSunswapSwapArgs {
+  /** Source wallet — funds the swap and signs. T-prefix base58. */
+  wallet: string;
+  /** Source token: "TRX" sentinel for native TRX, OR T-prefix TRC20 contract. */
+  fromToken: string;
+  /** Destination token: same shape as fromToken. */
+  toToken: string;
+  /** Human-readable amount of fromToken (e.g. "100" for 100 TRX). */
+  amount: string;
+  /** Slippage in basis points; default 50 (0.5%). */
+  slippageBps?: number;
+  /** Deadline window in seconds from now; default 1200 (20 min). */
+  deadlineSeconds?: number;
+  /** Required when fromToken is a non-canonical TRC-20 (USDT/USDC/etc auto-resolve). */
+  fromTokenDecimals?: number;
+  /** Required when toToken is a non-canonical TRC-20. */
+  toTokenDecimals?: number;
+  /** Optional override fee limit in TRX (default 100 TRX). */
+  feeLimitTrx?: string;
+}
+
+interface ResolvedToken {
+  /** "TRX" or T-prefix TRC20 base58 — what the caller passed. */
+  raw: string;
+  /** What goes into the V2 path (always WTRX for the TRX sentinel). */
+  pathAddress: string;
+  /** Display symbol — canonical lookup, or "TRC-20 <addr>" for unknown. */
+  symbol: string;
+  /** Decimals — TRX=6, canonical TRC20s from the table, others from caller. */
+  decimals: number;
+}
+
+function resolveToken(
+  token: string,
+  explicitDecimals: number | undefined,
+  side: "from" | "to",
+): ResolvedToken {
+  if (token === TRX_SENTINEL) {
+    return {
+      raw: TRX_SENTINEL,
+      pathAddress: WTRX_TRON,
+      symbol: "TRX",
+      decimals: TRX_DECIMALS,
+    };
+  }
+  if (!isTronAddress(token)) {
+    throw new Error(
+      `${side}Token must be either "TRX" (literal) or a T-prefixed TRC-20 contract; got "${token}"`,
+    );
+  }
+  const canonical = SYMBOL_BY_CONTRACT[token];
+  if (canonical) {
+    return {
+      raw: token,
+      pathAddress: token,
+      symbol: canonical,
+      decimals: TOKEN_DECIMALS[canonical],
+    };
+  }
+  if (explicitDecimals === undefined) {
+    throw new Error(
+      `${side}Token ${token} is not in the canonical TRC-20 set (USDT/USDC/USDD/TUSD). ` +
+        `Pass an explicit \`${side}TokenDecimals\` argument — we refuse to guess decimals on a swap ` +
+        `because an off-by-power-of-ten amountIn (or minOut) silently exposes the user to a ` +
+        `~10^N-fold larger price slippage than they intended.`,
+    );
+  }
+  return {
+    raw: token,
+    pathAddress: token,
+    symbol: `TRC-20 ${token}`,
+    decimals: explicitDecimals,
+  };
+}
+
+function buildPath(from: ResolvedToken, to: ResolvedToken): string[] {
+  // V2 path rules:
+  //   TRX   → TRC20: [WTRX, toToken]
+  //   TRC20 → TRX  : [fromToken, WTRX]
+  //   TRC20 → TRC20: [fromToken, WTRX, toToken]
+  // SunSwap's WTRX pools dominate TRON liquidity, so the WTRX hop is
+  // a stable predictable depth. Direct-pool optimisation can land later
+  // if a real path exposes meaningfully better pricing.
+  if (from.raw === TRX_SENTINEL) return [WTRX_TRON, to.pathAddress];
+  if (to.raw === TRX_SENTINEL) return [from.pathAddress, WTRX_TRON];
+  return [from.pathAddress, WTRX_TRON, to.pathAddress];
+}
+
+interface SwapEncoding {
+  selector: string;
+  functionSignature: string;
+  parameterHex: string;
+  callValueSun: bigint;
+}
+
+function encodeSwapCall(opts: {
+  from: ResolvedToken;
+  to: ResolvedToken;
+  amountInBase: bigint;
+  minOutBase: bigint;
+  path: string[];
+  wallet: string;
+  deadlineUnix: bigint;
+}): SwapEncoding {
+  if (opts.from.raw === TRX_SENTINEL) {
+    // swapExactETHForTokens(uint256 amountOutMin, address[] path, address to, uint256 deadline)
+    // Head: amountOutMin | offset(path) | to | deadline = 4 * 32 = 128 bytes; offset = 0x80 = 128
+    const head =
+      encodeUint256(opts.minOutBase) +
+      encodeUint256(128n) +
+      encodeAddressWord(opts.wallet) +
+      encodeUint256(opts.deadlineUnix);
+    return {
+      selector: SELECTOR_SWAP_EXACT_ETH_FOR_TOKENS,
+      functionSignature: FUNCTION_SIG_SWAP_EXACT_ETH_FOR_TOKENS,
+      parameterHex: head + encodeAddressArray(opts.path),
+      callValueSun: opts.amountInBase,
+    };
+  }
+  // TRC20 → X: amountIn first, then minOut, path-offset, to, deadline.
+  // Head = 5 * 32 = 160; offset = 0xa0 = 160.
+  const head =
+    encodeUint256(opts.amountInBase) +
+    encodeUint256(opts.minOutBase) +
+    encodeUint256(160n) +
+    encodeAddressWord(opts.wallet) +
+    encodeUint256(opts.deadlineUnix);
+  if (opts.to.raw === TRX_SENTINEL) {
+    return {
+      selector: SELECTOR_SWAP_EXACT_TOKENS_FOR_ETH,
+      functionSignature: FUNCTION_SIG_SWAP_EXACT_TOKENS_FOR_ETH,
+      parameterHex: head + encodeAddressArray(opts.path),
+      callValueSun: 0n,
+    };
+  }
+  return {
+    selector: SELECTOR_SWAP_EXACT_TOKENS_FOR_TOKENS,
+    functionSignature: FUNCTION_SIG_SWAP_EXACT_TOKENS_FOR_TOKENS,
+    parameterHex: head + encodeAddressArray(opts.path),
+    callValueSun: 0n,
+  };
+}
+
+async function quoteAmountOut(opts: {
+  wallet: string;
+  amountInBase: bigint;
+  path: string[];
+  apiKey: string | undefined;
+}): Promise<bigint> {
+  // getAmountsOut(uint256 amountIn, address[] path)
+  // Head: amountIn | offset(path) = 2 * 32 = 64; offset = 0x40 = 64.
+  const parameter =
+    encodeUint256(opts.amountInBase) +
+    encodeUint256(64n) +
+    encodeAddressArray(opts.path);
+
+  const res = await trongridPost<TrongridConstantResponse>(
+    "/wallet/triggerconstantcontract",
+    {
+      owner_address: opts.wallet,
+      contract_address: SUNSWAP_V2_ROUTER_TRON,
+      function_selector: "getAmountsOut(uint256,address[])",
+      parameter,
+      visible: true,
+    },
+    opts.apiKey,
+  );
+  if (res.result?.result === false) {
+    throw new Error(
+      `SunSwap V2 router rejected getAmountsOut: ${res.result.message ?? "unknown error"}. ` +
+        `The path may have no liquidity or one of the addresses may not be a valid TRC-20 token.`,
+    );
+  }
+  const data = res.constant_result?.[0];
+  if (!data) {
+    throw new Error("SunSwap V2 getAmountsOut returned no result — unexpected TronGrid shape.");
+  }
+  // Decode `uint256[]` return:
+  //   bytes [0..31]    = offset to array (typically 0x20)
+  //   bytes [32..63]   = array length
+  //   bytes [64..]     = elements, 32 bytes each
+  // Want the LAST element (final output through the path).
+  const hex = data.replace(/^0x/, "");
+  if (hex.length < 192) {
+    throw new Error(
+      `SunSwap V2 getAmountsOut returned shorter-than-expected payload (${hex.length} chars).`,
+    );
+  }
+  const length = Number(BigInt("0x" + hex.slice(64, 128)));
+  if (length < 2) {
+    throw new Error(`SunSwap V2 getAmountsOut returned ${length}-element array; expected ≥ 2.`);
+  }
+  const finalStart = 128 + (length - 1) * 64;
+  const finalHex = hex.slice(finalStart, finalStart + 64);
+  if (finalHex.length !== 64) {
+    throw new Error("SunSwap V2 getAmountsOut payload truncated before the final amount.");
+  }
+  return BigInt("0x" + finalHex);
+}
+
+async function readAllowance(opts: {
+  wallet: string;
+  token: string;
+  apiKey: string | undefined;
+}): Promise<bigint> {
+  // allowance(address owner, address spender)
+  const parameter =
+    encodeAddressWord(opts.wallet) + encodeAddressWord(SUNSWAP_V2_ROUTER_TRON);
+  const res = await trongridPost<TrongridConstantResponse>(
+    "/wallet/triggerconstantcontract",
+    {
+      owner_address: opts.wallet,
+      contract_address: opts.token,
+      function_selector: "allowance(address,address)",
+      parameter,
+      visible: true,
+    },
+    opts.apiKey,
+  );
+  if (res.result?.result === false) {
+    throw new Error(
+      `Allowance read failed for token ${opts.token}: ${res.result.message ?? "unknown error"}`,
+    );
+  }
+  const data = res.constant_result?.[0];
+  if (!data) return 0n;
+  const hex = data.replace(/^0x/, "");
+  if (hex.length === 0) return 0n;
+  return BigInt("0x" + hex.slice(0, 64));
+}
+
+/** Format a base-units bigint as a human decimal string. Strips trailing zeros. */
+function formatBase(value: bigint, decimals: number): string {
+  if (decimals === 0) return value.toString();
+  const s = value.toString().padStart(decimals + 1, "0");
+  const whole = s.slice(0, s.length - decimals);
+  const frac = s.slice(s.length - decimals).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+export async function buildTronSunswapSwap(
+  args: BuildTronSunswapSwapArgs,
+): Promise<UnsignedTronTx> {
+  if (!isTronAddress(args.wallet)) {
+    throw new Error(`"wallet" is not a valid TRON mainnet address: ${args.wallet}`);
+  }
+  if (args.fromToken === TRX_SENTINEL && args.toToken === TRX_SENTINEL) {
+    throw new Error("fromToken and toToken cannot both be TRX — that's not a swap.");
+  }
+  if (args.fromToken === args.toToken) {
+    throw new Error(
+      `fromToken and toToken are identical (${args.fromToken}) — that's not a swap.`,
+    );
+  }
+
+  const slippageBps = args.slippageBps ?? DEFAULT_SLIPPAGE_BPS;
+  if (slippageBps < 0 || slippageBps > 10_000) {
+    throw new Error(`slippageBps must be in [0, 10000]; got ${slippageBps}`);
+  }
+  const deadlineSeconds = args.deadlineSeconds ?? DEFAULT_DEADLINE_SEC;
+  if (deadlineSeconds <= 0 || deadlineSeconds > 24 * 3600) {
+    throw new Error(`deadlineSeconds must be in (0, 86400]; got ${deadlineSeconds}`);
+  }
+
+  const from = resolveToken(args.fromToken, args.fromTokenDecimals, "from");
+  const to = resolveToken(args.toToken, args.toTokenDecimals, "to");
+  const amountInBase = parseUnits(args.amount, from.decimals);
+  if (amountInBase <= 0n) {
+    throw new Error(`amount must be greater than 0 (got "${args.amount}").`);
+  }
+
+  const apiKey = resolveTronApiKey(readUserConfig());
+  const path = buildPath(from, to);
+
+  // Quote BEFORE the approval check — if the path has no liquidity we want
+  // the better error (no liquidity) rather than the misleading "insufficient
+  // allowance" the user might attribute to a missing approve.
+  const quotedOut = await quoteAmountOut({
+    wallet: args.wallet,
+    amountInBase,
+    path,
+    apiKey,
+  });
+  if (quotedOut <= 0n) {
+    throw new Error(
+      `SunSwap V2 quote returned 0 output for ${from.symbol} → ${to.symbol}. ` +
+        `Insufficient liquidity along path [${path.join(", ")}]; refusing to prepare a swap that would revert.`,
+    );
+  }
+  // minOut = quotedOut * (10000 - slippageBps) / 10000
+  const minOutBase = (quotedOut * BigInt(10_000 - slippageBps)) / 10_000n;
+
+  // TRC-20 source flows require allowance on the V2 router. Per CLAUDE.md
+  // ("Crypto/DeFi Transaction Preflight Checks: (4) approval status for
+  // ERC20 operations"), check + refuse rather than letting the on-chain
+  // swap revert.
+  if (from.raw !== TRX_SENTINEL) {
+    const allowance = await readAllowance({
+      wallet: args.wallet,
+      token: from.raw,
+      apiKey,
+    });
+    if (allowance < amountInBase) {
+      throw new Error(
+        `SunSwap V2 router has insufficient allowance for ${from.symbol}: ` +
+          `${allowance.toString()} < ${amountInBase.toString()} (${args.amount} ${from.symbol}). ` +
+          `Run prepare_tron_trc20_approve(token: "${from.raw}", spender: "${SUNSWAP_V2_ROUTER_TRON}", ` +
+          `amount: "${args.amount}") first, broadcast it, then retry this swap. If you've just ` +
+          `signed an approve, wait ~3 seconds for the block to land before retrying — TRON's ` +
+          `triggerconstantcontract reads the latest mined state, not the mempool.`,
+      );
+    }
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const deadlineUnix = BigInt(nowSeconds + deadlineSeconds);
+  const swap = encodeSwapCall({
+    from,
+    to,
+    amountInBase,
+    minOutBase,
+    path,
+    wallet: args.wallet,
+    deadlineUnix,
+  });
+
+  const feeLimitSun = args.feeLimitTrx
+    ? parseUnits(args.feeLimitTrx, TRX_DECIMALS)
+    : DEFAULT_FEE_LIMIT_SUN;
+
+  const body = {
+    owner_address: args.wallet,
+    contract_address: SUNSWAP_V2_ROUTER_TRON,
+    function_selector: swap.functionSignature,
+    parameter: swap.parameterHex,
+    fee_limit: Number(feeLimitSun),
+    call_value: Number(swap.callValueSun),
+    visible: true,
+  };
+
+  const { energyUsed } = await preflightConstantContract(body, apiKey);
+  const estimatedEnergySun = energyUsed * ENERGY_PRICE_SUN;
+  const res = await trongridPost<TrongridTriggerResponse>(
+    "/wallet/triggersmartcontract",
+    body,
+    apiKey,
+  );
+  if (!res.result?.result) {
+    throw new Error(
+      `TronGrid triggersmartcontract failed: ${res.result?.message ?? "unknown error"}`,
+    );
+  }
+  const ttx = res.transaction;
+  if (!ttx?.txID || !ttx.raw_data_hex) {
+    throw new Error("TronGrid triggersmartcontract returned no transaction — unexpected shape.");
+  }
+
+  assertTronRawDataMatches(ttx.raw_data_hex, {
+    kind: "sunswap_swap",
+    from: args.wallet,
+    contract: SUNSWAP_V2_ROUTER_TRON,
+    selector: swap.selector,
+    parameterHex: swap.parameterHex,
+    callValue: swap.callValueSun,
+    feeLimitSun,
+  });
+  await assertBandwidthSufficient(args.wallet, ttx.raw_data_hex, apiKey);
+
+  const quotedHuman = formatBase(quotedOut, to.decimals);
+  const minOutHuman = formatBase(minOutBase, to.decimals);
+  const description =
+    `SunSwap V2 swap — ${args.amount} ${from.symbol} → ~${quotedHuman} ${to.symbol} ` +
+    `(min ${minOutHuman}, ${(slippageBps / 100).toFixed(2)}% slippage)`;
+
+  const tx: UnsignedTronTx = {
+    chain: "tron",
+    action: "sunswap_swap",
+    from: args.wallet,
+    txID: ttx.txID,
+    rawData: ttx.raw_data,
+    rawDataHex: ttx.raw_data_hex,
+    description,
+    decoded: {
+      functionName: swap.functionSignature,
+      args: {
+        fromToken: from.raw,
+        fromSymbol: from.symbol,
+        toToken: to.raw,
+        toSymbol: to.symbol,
+        amountIn: args.amount,
+        amountInBase: amountInBase.toString(),
+        amountOutQuoted: quotedHuman,
+        amountOutMin: minOutHuman,
+        amountOutMinBase: minOutBase.toString(),
+        path: path.join(" -> "),
+        slippageBps: String(slippageBps),
+        deadlineUnix: deadlineUnix.toString(),
+        router: SUNSWAP_V2_ROUTER_TRON,
+        callValueSun: swap.callValueSun.toString(),
+      },
+      parameterHex: swap.parameterHex,
+    },
+    feeLimitSun: feeLimitSun.toString(),
+    estimatedEnergyUsed: energyUsed.toString(),
+    estimatedEnergyCostSun: estimatedEnergySun.toString(),
+  };
+  return issueTronHandle(tx);
+}

--- a/src/modules/tron/verify-raw-data.ts
+++ b/src/modules/tron/verify-raw-data.ts
@@ -174,7 +174,20 @@ export type TronRawDataExpectation =
       resource: "bandwidth" | "energy";
     }
   | { kind: "withdraw_expire_unfreeze"; from: string }
-  | { kind: "claim_rewards"; from: string };
+  | { kind: "claim_rewards"; from: string }
+  | {
+      // SunSwap V2 router same-chain swap. We pin selector + parameter
+      // so a TronGrid swap-with-different-path or different-amount
+      // substitution is rejected on the prepare path, not at on-chain
+      // revert time.
+      kind: "sunswap_swap";
+      from: string;
+      contract: string;
+      selector: string;
+      parameterHex: string;
+      callValue: bigint;
+      feeLimitSun?: bigint;
+    };
 
 // --- Main entry point ------------------------------------------------------
 
@@ -263,6 +276,8 @@ export function assertTronRawDataMatches(
         expected.from,
         "WithdrawBalanceContract"
       );
+    case "sunswap_swap":
+      return verifySunswapSwap(type, inner, expected, feeLimit);
   }
 }
 
@@ -351,6 +366,49 @@ function verifyTriggerSmartContract(
     throw new Error(
       `TRON rawData verify: fee_limit mismatch — raw_data_hex has ${actualFeeLimit} sun, ` +
         `we asked for ${e.feeLimitSun} sun.`
+    );
+  }
+}
+
+function verifySunswapSwap(
+  type: number,
+  inner: FieldMap,
+  e: Extract<TronRawDataExpectation, { kind: "sunswap_swap" }>,
+  actualFeeLimit: bigint,
+): void {
+  expectType(type, CONTRACT_TYPE.TriggerSmartContract, "TriggerSmartContract");
+  expectAddress(
+    requireBytes(inner, 1, "TriggerSmartContract.owner_address"),
+    e.from,
+    "owner_address",
+  );
+  expectAddress(
+    requireBytes(inner, 2, "TriggerSmartContract.contract_address"),
+    e.contract,
+    "contract_address",
+  );
+  const callValue = optionalVarint(inner, 3);
+  if (callValue !== e.callValue) {
+    throw new Error(
+      `TRON rawData verify: call_value mismatch on SunSwap swap — raw_data_hex has ${callValue}, ` +
+        `we asked for ${e.callValue}. (This is the TRX amount sent with the call; mismatch means ` +
+        `TronGrid built a different-value tx than the swap parameters specified.)`,
+    );
+  }
+  const dataBytes = optionalBytes(inner, 4) ?? new Uint8Array();
+  const dataHex = toHex(dataBytes).toLowerCase();
+  const expectedFullData = (e.selector + e.parameterHex).toLowerCase();
+  if (dataHex !== expectedFullData) {
+    throw new Error(
+      `TRON rawData verify: SunSwap router data mismatch — got 0x${dataHex}, ` +
+        `expected 0x${expectedFullData}. Either the function selector or the encoded ` +
+        `(amountOutMin, path, to, deadline) tuple drifted from what we computed. Refusing to sign.`,
+    );
+  }
+  if (e.feeLimitSun !== undefined && actualFeeLimit !== e.feeLimitSun) {
+    throw new Error(
+      `TRON rawData verify: fee_limit mismatch on SunSwap swap — raw_data_hex has ${actualFeeLimit} sun, ` +
+        `we asked for ${e.feeLimitSun} sun.`,
     );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -912,7 +912,8 @@ export interface UnsignedTronTx {
     | "unfreeze"
     | "withdraw_expire_unfreeze"
     | "vote"
-    | "lifi_swap";
+    | "lifi_swap"
+    | "sunswap_swap";
   /** Base58 owner address (prefix T). */
   from: string;
   /** TronGrid-returned transaction ID (sha256 of raw_data_hex, hex string). */

--- a/test/tron-sunswap-swap.test.ts
+++ b/test/tron-sunswap-swap.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  TRON_TOKENS,
+  SUNSWAP_V2_ROUTER_TRON,
+  WTRX_TRON,
+} from "../src/config/tron.js";
+import { buildTronSunswapSwap } from "../src/modules/tron/sunswap-swap.js";
+import { hasTronHandle } from "../src/signing/tron-tx-store.js";
+import { encodeTriggerSmartContractRawData } from "./helpers/tron-raw-data-encode.js";
+import { maybeTronBandwidthResponse } from "./helpers/tron-bandwidth-mock.js";
+import { base58ToHex } from "../src/modules/tron/address.js";
+
+/**
+ * SunSwap V2 same-chain swap builder tests. Three load-bearing pieces:
+ *
+ *   1. ABI calldata encoding for swapExactETHForTokens / swapExactTokensForETH /
+ *      swapExactTokensForTokens (path layout, head/tail offsets, native-vs-token).
+ *   2. Quote → minOut derivation (quotedOut * (10000 - slippageBps) / 10000).
+ *   3. Allowance preflight refusal for TRC-20 source flows.
+ *
+ * The TronGrid mock routes by URL + (for triggerconstantcontract) the
+ * embedded function_selector — getAmountsOut, allowance, and the per-call
+ * preflight all hit the same endpoint with different selectors.
+ */
+
+const ADDR_WALLET = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+const ADDR_USDT = TRON_TOKENS.USDT;
+const ADDR_USDC = TRON_TOKENS.USDC;
+
+// Selectors hardcoded in src/modules/tron/sunswap-swap.ts.
+const SELECTOR_SWAP_EXACT_ETH_FOR_TOKENS = "fb3bdb41";
+const SELECTOR_SWAP_EXACT_TOKENS_FOR_ETH = "18cbafe5";
+const SELECTOR_SWAP_EXACT_TOKENS_FOR_TOKENS = "38ed1739";
+
+interface MockOpts {
+  /**
+   * Output amounts the mocked router returns from getAmountsOut. Encoded
+   * as a uint256[] return; the builder picks amounts[length-1] as the
+   * final output. Must be at least 2 entries (path is always ≥ 2 hops).
+   */
+  amountsOut: bigint[];
+  /**
+   * Allowance the mocked router reports for any TRC-20 allowance() read.
+   * For TRX-source swaps this is irrelevant (builder skips the read);
+   * default 0 here exposes any unexpected TRC-20 source path.
+   */
+  allowance?: bigint;
+  /**
+   * Capture for the final triggersmartcontract POST body — useful for
+   * pinning calldata fixtures.
+   */
+  capture?: { body?: Record<string, unknown> };
+}
+
+function encodeUintReturn(value: bigint): string {
+  return value.toString(16).padStart(64, "0");
+}
+
+function encodeUintArrayReturn(values: bigint[]): string {
+  const offset = (32n).toString(16).padStart(64, "0");
+  const length = BigInt(values.length).toString(16).padStart(64, "0");
+  const elements = values.map(encodeUintReturn).join("");
+  return offset + length + elements;
+}
+
+function trongridFetchMock(opts: MockOpts) {
+  const allowanceHex = encodeUintReturn(opts.allowance ?? 0n);
+  const amountsOutHex = encodeUintArrayReturn(opts.amountsOut);
+
+  return async (url: string, init?: RequestInit) => {
+    const preflight = maybeTronBandwidthResponse(url);
+    if (preflight) return preflight;
+    if (url === "https://api.trongrid.io/wallet/triggerconstantcontract") {
+      const body = JSON.parse(init!.body as string);
+      const selector = body.function_selector as string;
+      if (selector.startsWith("getAmountsOut")) {
+        return new Response(
+          JSON.stringify({
+            result: { result: true },
+            energy_used: 50_000,
+            constant_result: [amountsOutHex],
+          }),
+          { status: 200 },
+        );
+      }
+      if (selector.startsWith("allowance")) {
+        return new Response(
+          JSON.stringify({
+            result: { result: true },
+            energy_used: 5_000,
+            constant_result: [allowanceHex],
+          }),
+          { status: 200 },
+        );
+      }
+      // Otherwise it's the per-call preflight (stub call before
+      // triggersmartcontract). Return a benign empty constant_result.
+      return new Response(
+        JSON.stringify({
+          result: { result: true },
+          energy_used: 90_000,
+          constant_result: [""],
+        }),
+        { status: 200 },
+      );
+    }
+    expect(url).toBe("https://api.trongrid.io/wallet/triggersmartcontract");
+    const body = JSON.parse(init!.body as string);
+    if (opts.capture) opts.capture.body = body;
+    const callValue = body.call_value === 0 ? 0n : BigInt(body.call_value);
+    return new Response(
+      JSON.stringify({
+        result: { result: true },
+        transaction: {
+          txID: "deadbeef".repeat(8),
+          raw_data: { expiration: 0 },
+          raw_data_hex: encodeTriggerSmartContractRawData({
+            from: ADDR_WALLET,
+            contract: SUNSWAP_V2_ROUTER_TRON,
+            dataHex: (body.function_selector as string).startsWith(
+              "swapExactETHForTokens",
+            )
+              ? SELECTOR_SWAP_EXACT_ETH_FOR_TOKENS + body.parameter
+              : (body.function_selector as string).startsWith(
+                    "swapExactTokensForETH",
+                  )
+                ? SELECTOR_SWAP_EXACT_TOKENS_FOR_ETH + body.parameter
+                : SELECTOR_SWAP_EXACT_TOKENS_FOR_TOKENS + body.parameter,
+            callValue,
+            feeLimitSun: BigInt(body.fee_limit),
+          }),
+          visible: true,
+        },
+      }),
+      { status: 200 },
+    );
+  };
+}
+
+describe("buildTronSunswapSwap — happy paths", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("TRX → USDT: swapExactETHForTokens, call_value=amountIn, path=[WTRX, USDT]", async () => {
+    const capture: MockOpts["capture"] = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [100_000_000n, 99_500_000n], // 100 TRX → 99.5 USDT
+          capture,
+        }),
+      ),
+    );
+    const tx = await buildTronSunswapSwap({
+      wallet: ADDR_WALLET,
+      fromToken: "TRX",
+      toToken: ADDR_USDT,
+      amount: "100",
+    });
+
+    expect(tx.action).toBe("sunswap_swap");
+    expect(tx.from).toBe(ADDR_WALLET);
+    expect(tx.txID).toMatch(/^[0-9a-f]{64}$/);
+    expect(tx.handle).toBeDefined();
+    expect(hasTronHandle(tx.handle!)).toBe(true);
+    expect(tx.decoded.functionName).toBe(
+      "swapExactETHForTokens(uint256,address[],address,uint256)",
+    );
+    expect(tx.decoded.args.fromSymbol).toBe("TRX");
+    expect(tx.decoded.args.toSymbol).toBe("USDT");
+    expect(tx.decoded.args.amountIn).toBe("100");
+    // 100 TRX × 6 decimals = 100_000_000 sun
+    expect(tx.decoded.args.amountInBase).toBe("100000000");
+    // Quoted out 99_500_000 base → 99.5 USDT
+    expect(tx.decoded.args.amountOutQuoted).toBe("99.5");
+    // minOut at 0.5% slippage = 99.5 × (1 - 0.005) = 99.0025
+    expect(tx.decoded.args.amountOutMinBase).toBe(
+      ((99_500_000n * 9_950n) / 10_000n).toString(),
+    );
+    expect(tx.decoded.args.path).toBe(`${WTRX_TRON} -> ${ADDR_USDT}`);
+    expect(tx.decoded.args.router).toBe(SUNSWAP_V2_ROUTER_TRON);
+    expect(tx.decoded.args.callValueSun).toBe("100000000");
+
+    // call_value on the TronGrid request equals amountIn in sun
+    expect(capture.body!.call_value).toBe(100_000_000);
+    expect(capture.body!.contract_address).toBe(SUNSWAP_V2_ROUTER_TRON);
+    expect(capture.body!.function_selector).toBe(
+      "swapExactETHForTokens(uint256,address[],address,uint256)",
+    );
+  });
+
+  it("USDT → TRX: swapExactTokensForETH, call_value=0, path=[USDT, WTRX]", async () => {
+    const capture: MockOpts["capture"] = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [10_000_000n, 9_950_000n], // 10 USDT → 9.95 TRX
+          allowance: 100_000_000n, // plenty
+          capture,
+        }),
+      ),
+    );
+    const tx = await buildTronSunswapSwap({
+      wallet: ADDR_WALLET,
+      fromToken: ADDR_USDT,
+      toToken: "TRX",
+      amount: "10",
+    });
+
+    expect(tx.action).toBe("sunswap_swap");
+    expect(tx.decoded.functionName).toBe(
+      "swapExactTokensForETH(uint256,uint256,address[],address,uint256)",
+    );
+    expect(tx.decoded.args.fromSymbol).toBe("USDT");
+    expect(tx.decoded.args.toSymbol).toBe("TRX");
+    expect(tx.decoded.args.amountInBase).toBe("10000000");
+    expect(tx.decoded.args.path).toBe(`${ADDR_USDT} -> ${WTRX_TRON}`);
+    expect(tx.decoded.args.callValueSun).toBe("0");
+    // Tron API uses call_value 0 (not absent) for TRC-20 calls
+    expect(capture.body!.call_value).toBe(0);
+  });
+
+  it("USDT → USDC: swapExactTokensForTokens with WTRX hop, path=[USDT, WTRX, USDC]", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [
+            10_000_000n, // amountIn
+            32_500_000_000n, // intermediate WTRX (USDT × ~3250 TRX/USDT, fictional)
+            9_980_000n, // final USDC
+          ],
+          allowance: 100_000_000n,
+        }),
+      ),
+    );
+    const tx = await buildTronSunswapSwap({
+      wallet: ADDR_WALLET,
+      fromToken: ADDR_USDT,
+      toToken: ADDR_USDC,
+      amount: "10",
+    });
+
+    expect(tx.decoded.functionName).toBe(
+      "swapExactTokensForTokens(uint256,uint256,address[],address,uint256)",
+    );
+    expect(tx.decoded.args.path).toBe(
+      `${ADDR_USDT} -> ${WTRX_TRON} -> ${ADDR_USDC}`,
+    );
+    expect(tx.decoded.args.amountOutQuoted).toBe("9.98");
+    // minOut at default 0.5% = 9_980_000 × 0.995 = 9_930_100
+    expect(tx.decoded.args.amountOutMinBase).toBe("9930100");
+  });
+
+  it("custom slippage applies to minOut", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [100_000_000n, 100_000_000n], // 1:1 quote (10000 base → 10000 base)
+        }),
+      ),
+    );
+    const tx = await buildTronSunswapSwap({
+      wallet: ADDR_WALLET,
+      fromToken: "TRX",
+      toToken: ADDR_USDT,
+      amount: "100",
+      slippageBps: 100, // 1%
+    });
+    // 100_000_000 × (10000 - 100) / 10000 = 99_000_000
+    expect(tx.decoded.args.amountOutMinBase).toBe("99000000");
+    expect(tx.decoded.args.slippageBps).toBe("100");
+  });
+
+  it("encodes swapExactETHForTokens parameter with correct head/tail offsets", async () => {
+    const capture: MockOpts["capture"] = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [100_000_000n, 99_500_000n],
+          capture,
+        }),
+      ),
+    );
+    await buildTronSunswapSwap({
+      wallet: ADDR_WALLET,
+      fromToken: "TRX",
+      toToken: ADDR_USDT,
+      amount: "100",
+      slippageBps: 0, // minOut == quotedOut for a clean fixture
+    });
+
+    const param = capture.body!.parameter as string;
+    // 4 head words (each 64 hex) + 1 length word + 2 path words = 7 * 64 = 448
+    expect(param.length).toBe(448);
+
+    const word = (i: number) => param.slice(i * 64, (i + 1) * 64);
+    // Word 0 = amountOutMin = 99_500_000
+    expect(BigInt("0x" + word(0))).toBe(99_500_000n);
+    // Word 1 = offset to path = 0x80 = 128
+    expect(BigInt("0x" + word(1))).toBe(128n);
+    // Word 2 = `to` (wallet, dropped 0x41 prefix, left-padded)
+    expect(word(2).slice(24)).toBe(base58ToHex(ADDR_WALLET).slice(2));
+    // Word 4 = path length = 2
+    expect(BigInt("0x" + word(4))).toBe(2n);
+    // Word 5 = WTRX address (path[0])
+    expect(word(5).slice(24)).toBe(base58ToHex(WTRX_TRON).slice(2));
+    // Word 6 = USDT address (path[1])
+    expect(word(6).slice(24)).toBe(base58ToHex(ADDR_USDT).slice(2));
+  });
+});
+
+describe("buildTronSunswapSwap — refusals", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("rejects an invalid wallet", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: "0xnotvalidtron",
+        fromToken: "TRX",
+        toToken: ADDR_USDT,
+        amount: "100",
+      }),
+    ).rejects.toThrow(/not a valid TRON mainnet address/);
+  });
+
+  it("rejects fromToken == toToken", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: ADDR_USDT,
+        toToken: ADDR_USDT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/identical/);
+  });
+
+  it("rejects TRX → TRX", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TRX",
+        toToken: "TRX",
+        amount: "1",
+      }),
+    ).rejects.toThrow(/cannot both be TRX/);
+  });
+
+  it("rejects non-canonical fromToken without explicit decimals", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TUpMhErZL2fhh4sVNULAbNKLokS4GjC1F4", // canonical TUSD
+        toToken: ADDR_USDT,
+        amount: "10",
+        // no fromTokenDecimals — but TUSD is canonical, so this should pass!
+      }),
+    ).rejects.toThrow(); // will fail later (no liquidity mock), but not on decimals
+    // Now exercise the actual non-canonical-without-decimals path:
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TZ4UXDV5ZhNW7fb2AMSbgfAEZ7hWsnYS2g", // arbitrary non-canonical
+        toToken: ADDR_USDT,
+        amount: "10",
+      }),
+    ).rejects.toThrow(/refuse to guess decimals/);
+  });
+
+  it("rejects when getAmountsOut returns 0 (insufficient liquidity)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [100_000_000n, 0n], // pool returns 0 — no liquidity
+        }),
+      ),
+    );
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TRX",
+        toToken: ADDR_USDT,
+        amount: "100",
+      }),
+    ).rejects.toThrow(/Insufficient liquidity/);
+  });
+
+  it("refuses TRC-20 source with insufficient allowance + provides recovery hint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        trongridFetchMock({
+          amountsOut: [10_000_000n, 9_950_000n],
+          allowance: 5_000_000n, // less than amountIn = 10_000_000
+        }),
+      ),
+    );
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: ADDR_USDT,
+        toToken: "TRX",
+        amount: "10",
+      }),
+    ).rejects.toThrow(/insufficient allowance/);
+    // And the message should name prepare_tron_trc20_approve as the fix
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: ADDR_USDT,
+        toToken: "TRX",
+        amount: "10",
+      }),
+    ).rejects.toThrow(/prepare_tron_trc20_approve/);
+  });
+
+  it("rejects amount = 0", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TRX",
+        toToken: ADDR_USDT,
+        amount: "0",
+      }),
+    ).rejects.toThrow(/greater than 0/);
+  });
+
+  it("rejects slippageBps out of range", async () => {
+    await expect(
+      buildTronSunswapSwap({
+        wallet: ADDR_WALLET,
+        fromToken: "TRX",
+        toToken: ADDR_USDT,
+        amount: "100",
+        slippageBps: 10_001,
+      }),
+    ).rejects.toThrow(/slippageBps/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `prepare_sunswap_swap` — first MCP path for same-chain TRON DEX swaps. Closes #432.
- Targets the SunSwap V2 router directly. Hand-rolled ABI calldata, no SDK (probe found none viable).
- Reuses the existing TRON pipeline: TronGrid `triggerconstantcontract` for quote/allowance, `triggersmartcontract` for tx build, `assertTronRawDataMatches` for byte-level verification, `assertBandwidthSufficient` preflight, `issueTronHandle` for the signing handle.

## Scope-probe verdict (per CLAUDE.md SDK probe discipline)

| Source | Verdict |
|---|---|
| `@sunswap/sdk`, `@sunswapv2/sdk`, `@justswap/sdk` | 404 on npm |
| `sunswap-sdk` (community) | Stale, last published >1yr ago, EVM Uniswap V2 repackage (not TRON-native) |
| Official SunSwap team repos | Contracts only, no TS SDK |
| **Decision** | **Hand-roll calldata**. Same convention as `encodeTrc20TransferParam` (no viem on the TRON path). |

| Address | Source | Tier |
|---|---|---|
| SunSwap V2 Router `TNJVzGqKBWkJxJB5XYSqGAwUTV15U24pPq` | [sunswapteam/sunswap2.0-contracts README](https://github.com/sunswapteam/sunswap2.0-contracts) Deployments | Verified |
| WTRX `TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR` | [Bitquery](https://explorer.bitquery.io/tron/trc20token/TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR/smart_contract) + [OKLink](https://www.oklink.com/tron/token/TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR) + OKX Wallet (3 sources) | Verified |
| Smart Router (V1+V2+V3+PSM aggregator) | Only published address is testnet-only; ABI is a different shape (multi-version path) | **Not used** |

## Behavior

| fromToken | toToken | Selector | Path | call_value |
|---|---|---|---|---|
| `"TRX"` | TRC-20 | `swapExactETHForTokens` | `[WTRX, toToken]` | amountIn |
| TRC-20 | `"TRX"` | `swapExactTokensForETH` | `[fromToken, WTRX]` | 0 |
| TRC-20 | TRC-20 | `swapExactTokensForTokens` | `[fromToken, WTRX, toToken]` | 0 |

Other defaults: 0.5% slippage, 20-min deadline, 100 TRX fee_limit cap. All overridable.

## Preflight checks (per CLAUDE.md "Crypto/DeFi Transaction Preflight Checks")

- (1) **Bandwidth**: `assertBandwidthSufficient` — same as the other TRON builders.
- (4) **Allowance**: TRC-20 source flows read `allowance(wallet, router)` and refuse with a recovery hint pointing at `prepare_tron_trc20_approve` if insufficient. Includes the "wait ~3s for the approve to mine" guidance from the existing approve-then-act feedback memory.
- **Liquidity**: refuses if `getAmountsOut` returns 0 (better error than on-chain revert).
- **Decimals**: canonical TRC-20 set (USDT/USDC/USDD/TUSD) auto-resolved; non-canonical tokens REQUIRE explicit `fromTokenDecimals` / `toTokenDecimals` (refuses to guess — off-by-power-of-ten amountIn = 10^N-fold slippage).

## Verification

The swap is added as a new `kind: "sunswap_swap"` in `TronRawDataExpectation` — `assertTronRawDataMatches` decodes the protobuf and refuses if the selector, parameter payload, call_value, or fee_limit drift from what the builder asked for. Catches a TronGrid MITM that returns a benign-looking JSON `raw_data` but tampered hex bytes.

## Tests

- 13 new tests in `test/tron-sunswap-swap.test.ts` covering happy paths (TRX↔TRC20, multi-hop), fixture-pinned ABI parameter encoding, refusal cases (invalid wallet, identical tokens, insufficient allowance with recovery hint, zero quote, slippage range).
- Full repo test suite: 2344 tests pass, no regressions.

## Surfaced in passing

`TRON_TOKENS.USDD` in `src/config/tron.ts` currently points to WTRX's address — pre-existing bug, filed separately as #507. Not fixed in this PR per smallest-solution discipline.

## Test plan

- [ ] CI green
- [ ] Manual: 100 TRX → USDT on mainnet (real Ledger TRON USB sign + broadcast)
- [ ] Manual: 10 USDT → TRX (with prior `prepare_tron_trc20_approve` for the V2 router)
- [ ] Manual: confirm device displays the txID and matches the prepare receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)