### PR TITLE
feat(swap): excludeExchanges/excludeBridges/order on EVM, dexes/excludeDexes on Solana

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -523,6 +523,8 @@ export async function getSolanaSwapQuote(args: GetSolanaSwapQuoteArgs) {
     amount: args.amount,
     slippageBps: args.slippageBps,
     swapMode: args.swapMode,
+    ...(args.dexes !== undefined ? { dexes: args.dexes } : {}),
+    ...(args.excludeDexes !== undefined ? { excludeDexes: args.excludeDexes } : {}),
   });
 }
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -167,6 +167,29 @@ export const getSolanaSwapQuoteInput = z.object({
       "ExactIn: sell exactly `amount` inputMint, receive at least minOutput. " +
         "ExactOut: buy exactly `amount` outputMint, sell at most maxInput."
     ),
+  // Issue #439 — DEX allow / block lists. Jupiter ranks routes by output
+  // amount by default; constraining to a specific DEX is the way to
+  // honor "swap on Raydium" / "avoid Orca" intent.
+  dexes: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      'Restrict Jupiter routing to a specific set of DEXes. Common values: "Raydium", ' +
+        '"Orca V2", "Meteora", "Meteora DLMM", "Phoenix", "Lifinity V2", "Whirlpool". ' +
+        'When the user names a DEX ("via Raydium"), pass it here — without a filter, ' +
+        "Jupiter silently picks the best-output route regardless. Multiple entries OR'd. " +
+        "If no route exists the call errors clearly; agent should offer to retry without filter."
+    ),
+  excludeDexes: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      'Blocklist version of `dexes` — DEXes Jupiter must avoid. Use when the user ' +
+        'says "not via Raydium" or "avoid Orca". Independent of `dexes`: pass both to ' +
+        "constrain to allowlist minus blocklist."
+    ),
 });
 
 export const prepareSolanaSwapInput = z.object({

--- a/src/modules/solana/jupiter.ts
+++ b/src/modules/solana/jupiter.ts
@@ -143,6 +143,20 @@ export interface JupiterQuoteParams {
   amount: string;
   slippageBps: number;
   swapMode?: "ExactIn" | "ExactOut";
+  /**
+   * Issue #439 — restrict Jupiter routing to a specific set of DEXes
+   * (e.g. ["Raydium", "Orca V2"]). When set, Jupiter only considers
+   * pools on the listed DEXes; if no satisfying route exists the API
+   * returns an error rather than silently picking another DEX.
+   * Pass-through to Jupiter's `dexes` query param (comma-separated).
+   */
+  dexes?: string[];
+  /**
+   * Issue #439 — blocklist version of `dexes`. Jupiter routes around
+   * any DEX listed here. Independent of `dexes`; both can be set
+   * simultaneously. Pass-through to Jupiter's `excludeDexes`.
+   */
+  excludeDexes?: string[];
 }
 
 /**
@@ -181,6 +195,12 @@ export async function getJupiterQuote(
     // cap that still lets most routes through (Jupiter's own UI default).
     maxAccounts: "40",
   });
+  // Jupiter v6 expects comma-separated DEX names in a single `dexes` /
+  // `excludeDexes` query param. Per-element `qs.append("dexes", x)` would
+  // produce repeated `dexes=a&dexes=b` which Jupiter rejects.
+  if (p.dexes && p.dexes.length > 0) qs.append("dexes", p.dexes.join(","));
+  if (p.excludeDexes && p.excludeDexes.length > 0)
+    qs.append("excludeDexes", p.excludeDexes.join(","));
   const res = await fetchWithTimeout(`${JUPITER_BASE}/quote?${qs}`);
   if (!res.ok) {
     const body = await res.text();

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -416,6 +416,13 @@ export async function getSwapQuote(args: GetSwapQuoteArgs) {
     ...(args.bridges && args.bridges.length > 0
       ? { allowBridges: args.bridges }
       : {}),
+    ...(args.excludeExchanges && args.excludeExchanges.length > 0
+      ? { denyExchanges: args.excludeExchanges }
+      : {}),
+    ...(args.excludeBridges && args.excludeBridges.length > 0
+      ? { denyBridges: args.excludeBridges }
+      : {}),
+    ...(args.order !== undefined ? { order: args.order } : {}),
   } as Parameters<typeof fetchQuote>[0];
 
   const [quote, oneInchRaw] = await Promise.all([
@@ -602,6 +609,13 @@ export async function prepareSwap(args: PrepareSwapArgs): Promise<UnsignedTx> {
     ...(args.bridges && args.bridges.length > 0
       ? { allowBridges: args.bridges }
       : {}),
+    ...(args.excludeExchanges && args.excludeExchanges.length > 0
+      ? { denyExchanges: args.excludeExchanges }
+      : {}),
+    ...(args.excludeBridges && args.excludeBridges.length > 0
+      ? { denyBridges: args.excludeBridges }
+      : {}),
+    ...(args.order !== undefined ? { order: args.order } : {}),
   } as Parameters<typeof fetchQuote>[0];
   const quote = await fetchQuote(lifiReq).catch((err: unknown) => {
     throw rephraseLifiNoRouteError(err, args);

--- a/src/modules/swap/lifi.ts
+++ b/src/modules/swap/lifi.ts
@@ -85,6 +85,23 @@ interface LifiQuoteRequestBase {
    */
   allowExchanges?: string[];
   allowBridges?: string[];
+  /**
+   * Issue #439 — blocklists for DEX aggregators / bridges. Mirrors
+   * `allowExchanges`/`allowBridges` but inverted: LiFi will route
+   * around any tool listed here. Independent of the allowlists; both
+   * can be set simultaneously (allowlist intersect, then blocklist
+   * subtract). Pass-through to LiFi's `denyExchanges` / `denyBridges`.
+   */
+  denyExchanges?: string[];
+  denyBridges?: string[];
+  /**
+   * Sort criterion LiFi applies when ranking candidate routes. The
+   * default is `RECOMMENDED` (LiFi's mix of price + safety). Set
+   * `CHEAPEST` for "best rate available" intent (highest output amount),
+   * `FASTEST` for low-latency bridges, `SAFEST` for the most-vetted
+   * tool set. Pass-through to LiFi's `order` param.
+   */
+  order?: "RECOMMENDED" | "FASTEST" | "CHEAPEST" | "SAFEST";
 }
 
 export type LifiQuoteRequest =
@@ -132,9 +149,9 @@ export async function fetchQuote(req: LifiQuoteRequest) {
           : NATIVE
       : req.toToken;
 
-  // LiFi's `getQuote` accepts `allowExchanges`/`allowBridges` as
-  // optional filters; spread them in only when set so the default
-  // (full routing graph) is preserved.
+  // LiFi's `getQuote` accepts allow/deny lists + `order` as optional
+  // filters; spread them in only when set so the default (full routing
+  // graph, RECOMMENDED order) is preserved.
   const filterFields = {
     ...(req.allowExchanges && req.allowExchanges.length > 0
       ? { allowExchanges: req.allowExchanges }
@@ -142,6 +159,13 @@ export async function fetchQuote(req: LifiQuoteRequest) {
     ...(req.allowBridges && req.allowBridges.length > 0
       ? { allowBridges: req.allowBridges }
       : {}),
+    ...(req.denyExchanges && req.denyExchanges.length > 0
+      ? { denyExchanges: req.denyExchanges }
+      : {}),
+    ...(req.denyBridges && req.denyBridges.length > 0
+      ? { denyBridges: req.denyBridges }
+      : {}),
+    ...(req.order !== undefined ? { order: req.order } : {}),
   };
 
   if (req.toAmount !== undefined) {

--- a/src/modules/swap/schemas.ts
+++ b/src/modules/swap/schemas.ts
@@ -143,6 +143,35 @@ const baseSwapSchema = z.object({
         '"arbitrum-bridge". Mirrors `exchanges` but for bridge selection. Only ' +
         "applies to cross-chain routes; ignored for intra-chain swaps.",
     ),
+  // Issue #439 — blocklists + ranking criterion.
+  excludeExchanges: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      "Blocklist version of `exchanges` — DEXes/aggregators LiFi must avoid. Use " +
+        'when the user says "not via 1inch" or "avoid Sushiswap". Independent of ' +
+        "`exchanges`: pass both to constrain to allowlist minus blocklist. Pass-through " +
+        "to LiFi's `denyExchanges`.",
+    ),
+  excludeBridges: z
+    .array(z.string().min(1).max(40))
+    .max(20)
+    .optional()
+    .describe(
+      "Blocklist version of `bridges` — bridge protocols LiFi must avoid on cross-chain " +
+        "routes. Pass-through to LiFi's `denyBridges`.",
+    ),
+  order: z
+    .enum(["RECOMMENDED", "FASTEST", "CHEAPEST", "SAFEST"])
+    .optional()
+    .describe(
+      "Route ranking criterion. RECOMMENDED (default) — LiFi's mix of price + safety. " +
+        "CHEAPEST — pick the route with the highest output amount; use this for " +
+        '"best rate available" intent. FASTEST — minimize execution time (relevant ' +
+        "for cross-chain bridges where settlement varies). SAFEST — prefer the " +
+        "most-vetted tool set. Pass-through to LiFi's `order`.",
+    ),
 });
 
 export const getSwapQuoteInput = baseSwapSchema;

--- a/test/solana-jupiter.test.ts
+++ b/test/solana-jupiter.test.ts
@@ -169,6 +169,109 @@ describe("getJupiterQuote", () => {
       }),
     ).rejects.toThrow(/Jupiter \/quote failed \(HTTP 400\):.*Invalid mint/);
   });
+
+  // Issue #439 — DEX allowlist / blocklist forwarding.
+  it("forwards `dexes` to Jupiter as a comma-separated query param", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+      dexes: ["Raydium", "Orca V2"],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    // URLSearchParams URL-encodes spaces as `+` and commas as `%2C`.
+    expect(url).toContain("dexes=Raydium%2COrca+V2");
+    expect(url).not.toContain("excludeDexes=");
+  });
+
+  it("forwards `excludeDexes` as a comma-separated query param", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+      excludeDexes: ["Phoenix"],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("excludeDexes=Phoenix");
+    expect(url).not.toContain("dexes=Phoenix"); // (would be a substring match)
+  });
+
+  it("supports both lists simultaneously", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+      dexes: ["Raydium"],
+      excludeDexes: ["Orca V2"],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("dexes=Raydium");
+    expect(url).toContain("excludeDexes=Orca+V2");
+  });
+
+  it("does NOT add dex params to URL when both are omitted (default routing preserved)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).not.toContain("dexes=");
+    expect(url).not.toContain("excludeDexes=");
+  });
+
+  it("ignores empty arrays (treats them as no filter)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => SAMPLE_QUOTE,
+    });
+    const { getJupiterQuote } = await import(
+      "../src/modules/solana/jupiter.js"
+    );
+    await getJupiterQuote({
+      inputMint: WSOL,
+      outputMint: USDC_MINT,
+      amount: "1000000000",
+      slippageBps: 50,
+      dexes: [],
+      excludeDexes: [],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).not.toContain("dexes=");
+    expect(url).not.toContain("excludeDexes=");
+  });
 });
 
 describe("buildJupiterSwap", () => {

--- a/test/swap-protocol-routing.test.ts
+++ b/test/swap-protocol-routing.test.ts
@@ -217,6 +217,94 @@ describe("issue #411 — routedVia surfacing in getSwapQuote", () => {
   });
 });
 
+describe("issue #439 — excludeExchanges/excludeBridges/order forwarding", () => {
+  it("forwards `excludeExchanges` to LiFi as denyExchanges", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("uniswap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      excludeExchanges: ["sushiswap", "0x"],
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.denyExchanges).toEqual(["sushiswap", "0x"]);
+    expect(lifiCall.allowExchanges).toBeUndefined();
+  });
+
+  it("forwards `excludeBridges` to LiFi as denyBridges", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("across"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      excludeBridges: ["hop"],
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.denyBridges).toEqual(["hop"]);
+  });
+
+  it("forwards `order: \"CHEAPEST\"` to LiFi as order", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("1inch"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      order: "CHEAPEST",
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.order).toBe("CHEAPEST");
+  });
+
+  it("allows allow-list + deny-list + order to be combined", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("uniswap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+      exchanges: ["uniswap", "1inch"],
+      excludeExchanges: ["sushiswap"],
+      order: "FASTEST",
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.allowExchanges).toEqual(["uniswap", "1inch"]);
+    expect(lifiCall.denyExchanges).toEqual(["sushiswap"]);
+    expect(lifiCall.order).toBe("FASTEST");
+  });
+
+  it("does NOT set deny lists or order when omitted (defaults preserved)", async () => {
+    fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("sushiswap"));
+    const { getSwapQuote } = await import("../src/modules/swap/index.js");
+    await getSwapQuote({
+      wallet: EVM_WALLET,
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      fromToken: ETH_USDC,
+      toToken: ETH_WETH,
+      amount: "100",
+    });
+    const lifiCall = fetchQuoteMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(lifiCall.denyExchanges).toBeUndefined();
+    expect(lifiCall.denyBridges).toBeUndefined();
+    expect(lifiCall.order).toBeUndefined();
+  });
+});
+
 describe("issue #411 — prepareSwap description carries the routing note", () => {
   it("description includes 'via <tool>' even with no filter", async () => {
     fetchQuoteMock.mockResolvedValue(makeIntraChainQuote("sushiswap"));


### PR DESCRIPTION
## Summary

Closes part of #439 — the DEX-filter and ranking-criterion gaps. Multi-route comparison is deferred to a separate issue (filed alongside this PR).

| Tool | Allowlist | Blocklist | `order` |
|---|---|---|---|
| `get_swap_quote` / `prepare_swap` (EVM) | `exchanges` (existing, #411) | **`excludeExchanges`** (new) → LiFi `denyExchanges` | **new** → LiFi `order: RECOMMENDED\|FASTEST\|CHEAPEST\|SAFEST` |
| same, for bridges | `bridges` (existing) | **`excludeBridges`** (new) → LiFi `denyBridges` | n/a |
| `get_solana_swap_quote` (Jupiter v6) | **`dexes`** (new) → Jupiter `dexes` | **`excludeDexes`** (new) → Jupiter `excludeDexes` | n/a — Jupiter has no order equivalent |

## Smoke-test mapping

| Script | Intent | Pre-PR behavior | Post-PR resolution |
|---|---|---|---|
| 021 ("via Uniswap, mainnet") | EVM allowlist | already worked via existing `exchanges` (#411) — no change |
| 022 ("best rate available") | rank by output | LiFi default was RECOMMENDED — couldn't ask for CHEAPEST | `order: "CHEAPEST"` |
| 030 ("via Raydium if cheaper") | Solana allowlist | no filter at all | `dexes: ["Raydium"]` |

## Why no Solana `order`

Jupiter v6's `/quote` API has no `order` parameter — it ranks by output amount unconditionally. The "best rate" intent is therefore Jupiter's default, so there's nothing to plumb on the Solana side.

## Why no multi-route this PR

The third item in #439 (full ranked-list `get_swap_routes` / `routes: true`) is a substantially different shape:
- LiFi's `/v1/advanced/routes` is a different SDK call with a different response shape
- Jupiter v6 has no multi-route endpoint at all (only single best-route)
- New tool registration + new response schema + simulating Jupiter multi-route by N parallel calls = enough scope to deserve its own probe + design pass

Filed as a separate follow-up issue (linked below) so reviewers can evaluate the API design independently.

## Tests

- 5 new tests in `swap-protocol-routing.test.ts` (EVM forwarding of `excludeExchanges`, `excludeBridges`, `order`, combined; defaults preserved)
- 5 new tests in `solana-jupiter.test.ts` (Jupiter `dexes` URL encoding, `excludeDexes`, both simultaneously, omitted, empty arrays)
- Full suite: 2396 tests pass, no regressions.

## Test plan

- [ ] CI green
- [ ] Manual: `get_swap_quote` with `order: "CHEAPEST"` returns a different route than the default for an asymmetric pair
- [ ] Manual: `get_solana_swap_quote` with `dexes: ["Raydium"]` returns only Raydium routePlan entries
- [ ] Manual: `excludeExchanges: ["sushiswap"]` filters Sushi out on a route where it would normally win

🤖 Generated with [Claude Code](https://claude.com/claude-code)