### PR TITLE
fix(readme): drop self-referencing glama badge that breaks on glama.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![npm version](https://img.shields.io/npm/v/vaultpilot-mcp.svg)](https://www.npmjs.com/package/vaultpilot-mcp)
 [![license](https://img.shields.io/npm/l/vaultpilot-mcp.svg)](./LICENSE)
 [![node](https://img.shields.io/node/v/vaultpilot-mcp.svg)](package.json)
-[![vaultpilot-mcp MCP server](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp/badges/score.svg)](https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp)
 
 **Safety first. Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.**
 


### PR DESCRIPTION
## Summary

The glama \"score\" badge in `README.md` line 6 renders as a broken-image icon + visible alt text on glama.ai's own server-detail page (screenshot below). The URL itself is fine — `curl` returns HTTP 200 + valid SVG — but glama's own renderer either strips self-referencing badges and leaves the alt text behind, or applies a same-origin / referer restriction we can't see externally.

Either way, this badge:
- Doesn't add value where it's most prominent (glama already renders its own score badges in the directory UI).
- Actively breaks the rendering on the page that matters most for discovery.

Drop it. The three shields.io badges (npm version, license, node engine) keep doing their job.

## What changes

One-line deletion in `README.md`. No code, no tests.

## Test plan
- [x] After merge: re-check https://glama.ai/mcp/servers/szhygulin/vaultpilot-mcp — header should show three rendered shields.io badges, no broken-image icon, no stray "vaultpilot-mcp MCP server" alt-text leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)