### PR TITLE
fix(tron): TRON_TOKENS.USDD points at WTRX, not USDD (#507)

### DIFF
--- a/src/config/tron.ts
+++ b/src/config/tron.ts
@@ -26,7 +26,12 @@ export const TRONGRID_BASE_URL = "https://api.trongrid.io";
 export const TRON_TOKENS = {
   USDT: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
   USDC: "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
-  USDD: "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR",
+  // USDD ("Decentralized USD" by TRON DAO Reserve) on TRON mainnet.
+  // Issue #507: this entry previously pointed at TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR,
+  // which is actually Wrapped TRX (WTRX), not USDD. Verified via OKLink
+  // (oklink.com/tron/token/TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn — name
+  // "Decentralized USD", symbol "USDD"). Decimals stay at 18 (USDD spec).
+  USDD: "TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn",
   TUSD: "TUpMhErZL2fhh4sVNULAbNKLokS4GjC1F4",
 } as const;
 

--- a/test/tron-support.test.ts
+++ b/test/tron-support.test.ts
@@ -98,6 +98,23 @@ describe("TRON_TOKENS canonical registry", () => {
     expect(TRON_TOKENS.USDT).toBe("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t");
   });
 
+  // Issue #507 regression guard. USDD previously pointed at WTRX's contract
+  // address (TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR), which silently routed
+  // USDD balance/send/approve flows to Wrapped TRX. Pin the verified-
+  // correct USDD ("Decentralized USD" by TRON DAO Reserve) address so
+  // the wrong-address regression can't come back without this test
+  // failing. Also guard the WTRX address explicitly so a future
+  // refactor that introduces WTRX as a separate entry doesn't
+  // re-introduce the collision under a different key.
+  it("USDD points at the real USDD contract (issue #507 — not WTRX)", () => {
+    expect(TRON_TOKENS.USDD).toBe("TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn");
+    for (const [symbol, addr] of Object.entries(TRON_TOKENS)) {
+      expect(addr, `TRON_TOKENS.${symbol} must not be WTRX`).not.toBe(
+        "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR",
+      );
+    }
+  });
+
   it("every canonical address parses as a valid TRON address", () => {
     for (const [symbol, addr] of Object.entries(TRON_TOKENS)) {
       expect(isTronAddress(addr), `TRON_TOKENS.${symbol}`).toBe(true);


### PR DESCRIPTION
Closes #507.

## Summary
\`TRON_TOKENS.USDD\` in \`src/config/tron.ts\` was set to \`TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR\`, which is actually **Wrapped TRX (WTRX)**. The correct USDD (\"Decentralized USD\" by TRON DAO Reserve) address is \`TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn\`.

Verified via OKLink at probe time — the contract at \`TPYmHEhy…sghPDn\` is \"Decentralized USD\" with symbol \"USDD\". The bug was surfaced via #432 (\`prepare_sunswap_swap\`) implementation, where adding a \`WTRX_TRON\` constant exposed the address collision with the existing USDD entry.

## Impact before this fix
- \`get_portfolio_summary\` / TRON balance enumeration returned **WTRX's balance under the \"USDD\" label**. Users with WTRX got a misleading USDD line item; users with actual USDD saw zero.
- Any send / approve flow that resolved \"USDD\" via \`TRON_TOKENS.USDD\` **targeted the wrong contract**.

Decimals table unchanged — both USDD and the prior WTRX-labeled-as-USDD entry use 18 decimals.

## Test plan
- [x] +1 regression-guard test in \`test/tron-support.test.ts\`: pins the corrected USDD address AND asserts NO entry in \`TRON_TOKENS\` holds the WTRX address (so a future refactor that legitimately adds WTRX as a separate entry can't accidentally re-introduce the collision under a different key)
- [x] Typecheck clean, full suite 2417/2417 passing
- [ ] Verify CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)