### PR TITLE
feat(pnl): add mtd (calendar month-to-date) period to get_pnl_summary

### DIFF
--- a/src/modules/pnl/index.ts
+++ b/src/modules/pnl/index.ts
@@ -55,6 +55,11 @@ function resolvePeriod(period: GetPnlSummaryArgs["period"]): {
     case "30d":
       startMs = endMs - 30 * 86_400_000;
       break;
+    case "mtd": {
+      const now = new Date(endMs);
+      startMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+      break;
+    }
     case "ytd":
       startMs = Date.UTC(new Date(endMs).getUTCFullYear(), 0, 1);
       break;

--- a/src/modules/pnl/schemas.ts
+++ b/src/modules/pnl/schemas.ts
@@ -47,15 +47,16 @@ export const getPnlSummaryInput = z.object({
         "history into the PnL.",
     ),
   period: z
-    .enum(["24h", "7d", "30d", "ytd", "inception"])
+    .enum(["24h", "7d", "30d", "mtd", "ytd", "inception"])
     .default("30d")
     .describe(
-      'Time window. "24h" / "7d" / "30d" are rolling; "ytd" is calendar-' +
-        'year-to-date (UTC); "inception" is a 365-day rolling window in v1 — ' +
-        '"since wallet creation" is approximated, not literal, to keep the ' +
-        "history fetch bounded. Periods longer than ~30d may under-count flows " +
-        "because the underlying history fetcher caps at ~50 items per chain; " +
-        "the response surfaces `truncated: true` when this happens.",
+      'Time window. "24h" / "7d" / "30d" are rolling; "mtd" is calendar-' +
+        'month-to-date (UTC, from the 1st of the current month); "ytd" is ' +
+        'calendar-year-to-date (UTC); "inception" is a 365-day rolling window ' +
+        'in v1 — "since wallet creation" is approximated, not literal, to keep ' +
+        "the history fetch bounded. Periods longer than ~30d may under-count " +
+        "flows because the underlying history fetcher caps at ~50 items per " +
+        "chain; the response surfaces `truncated: true` when this happens.",
     ),
 });
 
@@ -115,7 +116,7 @@ export interface PnlChainSlice {
  * any other intra-wallet effects).
  */
 export interface PnlSummary {
-  period: "24h" | "7d" | "30d" | "ytd" | "inception";
+  period: "24h" | "7d" | "30d" | "mtd" | "ytd" | "inception";
   periodStartIso: string;
   periodEndIso: string;
 

--- a/test/pnl.test.ts
+++ b/test/pnl.test.ts
@@ -381,6 +381,29 @@ describe("getPnlSummary — inception period", () => {
   });
 });
 
+describe("getPnlSummary — mtd period", () => {
+  it("resolves mtd to the 1st of the current UTC month at 00:00:00", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "mtd" });
+    const startMs = new Date(r.periodStartIso).getTime();
+    const now = new Date();
+    const expectedStartMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+    expect(startMs).toBe(expectedStartMs);
+    // Sanity: ISO must end with "T00:00:00.000Z" — UTC midnight.
+    expect(r.periodStartIso).toMatch(/T00:00:00\.000Z$/);
+  });
+
+  it("yields a window strictly shorter than 31 days (caps at month length)", async () => {
+    const { getPnlSummary } = await import("../src/modules/pnl/index.ts");
+    const r = await getPnlSummary({ wallet: WALLET, period: "mtd" });
+    const startMs = new Date(r.periodStartIso).getTime();
+    const endMs = new Date(r.periodEndIso).getTime();
+    const spanDays = (endMs - startMs) / 86_400_000;
+    expect(spanDays).toBeGreaterThanOrEqual(0);
+    expect(spanDays).toBeLessThan(31);
+  });
+});
+
 describe("getPnlSummary — notes carry v1 caveats", () => {
   it("surfaces DeFi-exclusion and gas-exclusion caveats", async () => {
     const { getPnlSummary } = await import("../src/modules/pnl/index.ts");


### PR DESCRIPTION
## Summary

Closes the smoke-test gap from script 072 ("what's my PnL this month?"). Previously the user had to either approximate via `30d` (rolling — mismatches calendar boundaries) or wait for `ytd` and subtract last month's total.

`period: "mtd"` resolves to the 1st of the current UTC month at 00:00:00 → now.

## Scope

Per the recommendation in the linked thread on #447: **`mtd` only**. Other periods listed in the issue:

- `qtd` — speculative beyond what the smoke test actually surfaced; same code shape as `mtd`, can land later if usage demands
- ISO date range `{from, to}` — structurally different param + needs validation/bounds-check vs the existing ~30d truncation warning; deferred to its own scope-probe pass

Issue #447 stays open as the tracker if either lands.

## Diff (3 files, 37 LOC)

- `src/modules/pnl/schemas.ts` — `mtd` added to the period zod enum + the `PnlSummary` response type union; describe text updated
- `src/modules/pnl/index.ts` — new `case "mtd"` in `resolvePeriod` (3 lines: `Date.UTC(year, month, 1)`)
- `test/pnl.test.ts` — 2 new tests pinning the start to `Date.UTC(year, month, 1)` and the window length to `< 31` days

## Test plan

- [x] `npx vitest run test/pnl.test.ts` — 11/11 pass
- [x] `npx vitest run` — 2418/2418 pass, no regressions
- [x] `npx tsc --noEmit` — clean
- [ ] CI green
- [ ] Manual: `get_pnl_summary({wallet, period: "mtd"})` returns a window starting on the 1st of the current month

🤖 Generated with [Claude Code](https://claude.com/claude-code)