### PR TITLE
feat(security): drainer-pattern refusal + byte-fingerprint on sign_message_btc/ltc (#454)

### DIFF
--- a/src/modules/btc/actions.ts
+++ b/src/modules/btc/actions.ts
@@ -916,6 +916,14 @@ export interface SignBitcoinMessageArgs {
 export interface SignedBitcoinMessage {
   address: string;
   message: string;
+  /**
+   * SHA-256 of the exact UTF-8 bytes submitted to the device (issue
+   * #454 part a). Surface alongside the verbatim message so the user
+   * can detect Unicode-confusable substitution that the OLED
+   * rendering would otherwise hide (em-dash vs hyphen, Cyrillic А vs
+   * Latin A — the bytes differ, the hash differs).
+   */
+  messageBytesSha256: string;
   signature: string;
   format: "BIP-137";
   addressType: PairedBtcAddressType;
@@ -942,6 +950,17 @@ export async function signBitcoinMessage(
         `into 16-char windows and a multi-KB string is not realistically reviewable.`,
     );
   }
+  // Issue #454 — drainer-pattern refusal. Runs BEFORE the pairing /
+  // device-call branches so a refusal is silent (no hardware round
+  // trip wasted, no Ledger prompt the user has to dismiss).
+  const { refuseIfDrainerLike, messageBytesSha256 } = await import(
+    "../../signing/message-sign-guard.js"
+  );
+  refuseIfDrainerLike({
+    wallet: args.wallet,
+    message: args.message,
+    toolName: "sign_message_btc",
+  });
   const paired = getPairedBtcByAddress(args.wallet);
   if (!paired) {
     throw new Error(
@@ -963,6 +982,7 @@ export async function signBitcoinMessage(
   return {
     address: args.wallet,
     message: args.message,
+    messageBytesSha256: messageBytesSha256(args.message),
     signature: result.signature,
     format: result.format,
     addressType: paired.addressType,

--- a/src/modules/litecoin/actions.ts
+++ b/src/modules/litecoin/actions.ts
@@ -457,6 +457,12 @@ export interface SignLitecoinMessageArgs {
 export interface SignedLitecoinMessage {
   address: string;
   message: string;
+  /**
+   * SHA-256 of the exact UTF-8 bytes submitted to the device (issue
+   * #454 part a). See the BTC equivalent in `modules/btc/actions.ts`
+   * for the rationale.
+   */
+  messageBytesSha256: string;
   signature: string;
   format: "BIP-137";
   addressType: PairedLtcAddressType;
@@ -479,6 +485,16 @@ export async function signLitecoinMessage(
       `Message length ${args.message.length} exceeds the 10000-char ceiling.`,
     );
   }
+  // Issue #454 — drainer-pattern refusal mirrors the BTC handler.
+  // Runs BEFORE the pairing / device-call branches.
+  const { refuseIfDrainerLike, messageBytesSha256 } = await import(
+    "../../signing/message-sign-guard.js"
+  );
+  refuseIfDrainerLike({
+    wallet: args.wallet,
+    message: args.message,
+    toolName: "sign_message_ltc",
+  });
   const paired = getPairedLtcByAddress(args.wallet);
   if (!paired) {
     throw new Error(
@@ -500,6 +516,7 @@ export async function signLitecoinMessage(
   return {
     address: args.wallet,
     message: args.message,
+    messageBytesSha256: messageBytesSha256(args.message),
     signature: result.signature,
     format: result.format,
     addressType: paired.addressType,

--- a/src/signing/message-sign-guard.ts
+++ b/src/signing/message-sign-guard.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Drainer-pattern refusal heuristic for `sign_message_btc` /
+ * `sign_message_ltc` (issue #454).
+ *
+ * Adversarial smoke-test script a110 catalogued the failure modes
+ * for on-device review: skim, line-1-only (Nano OLED scrolls and the
+ * user reads the first frame), trust-the-agent, Unicode-confusable
+ * substitution. Inv #8 raises the bar but terminates at the user's
+ * eyes; for high-stakes message classes (proof-of-funds, custody-
+ * transfer-shaped, exchange-deposit-prove) that's a structural HIGH
+ * risk.
+ *
+ * The MCP-side refusal is the load-bearing defense: BIP-137 sign-
+ * message produces a signature an attacker can later present as
+ * evidence of consent. Refuse by design when the message text
+ * contains drainer markers; no override flag — adding one would let
+ * a rogue agent silently bypass exactly this defense, and the
+ * message-text restriction is narrow enough that the user can
+ * rephrase a legitimate proof-of-ownership statement to avoid the
+ * trigger.
+ *
+ * Trade-off, documented: bare semantic markers (transfer, authorize,
+ * grant, custody, release, consent) are noisy. A legitimate "I, the
+ * owner, received a transfer ..." statement would refuse. The choice
+ * here is strict-by-default per the issue's "outright" wording — if
+ * false positives surface in practice, tune the regex in a follow-up.
+ */
+
+/**
+ * Explicit drainer-template phrases — fixed-form attestations the
+ * attacker chains into a phishing flow. Any single hit refuses the
+ * sign call. Patterns are case-insensitive and anchored on word
+ * boundaries so "I authorizer" (the dictionary word) doesn't fire,
+ * but "I authorize" (start of a drainer template) does.
+ */
+const DRAINER_TEMPLATE_PHRASES: ReadonlyArray<RegExp> = [
+  /\bI\s+authorize\b/i,
+  /\bI\s+consent\s+to\b/i,
+  /\bI\s+grant\b/i,
+  /\bgranting\s+(?:full\s+)?custody\b/i,
+  /\brelease\s+of\s+(?:all\s+)?funds\b/i,
+  /\btransfer\s+(?:all\s+)?funds\b/i,
+  /\bauthorize\s+(?:transfer|release|custody)\b/i,
+];
+
+/**
+ * Bare-word semantic markers. Looser than templates — a single
+ * marker is a soft signal, but two or more co-occurring markers
+ * indicate a high-risk class regardless of phrasing. "I am the
+ * owner who received this transfer" trips a single marker only;
+ * "I authorize the transfer of custody" trips three.
+ */
+const SEMANTIC_MARKERS: ReadonlyArray<RegExp> = [
+  /\btransfer\b/i,
+  /\bauthorize\b/i,
+  /\bgrant\b/i,
+  /\bcustody\b/i,
+  /\brelease\b/i,
+  /\bconsent\b/i,
+];
+
+/**
+ * Bitcoin / Litecoin address regex covering the four address types
+ * the Ledger BTC + LTC apps support: legacy (1.../L...), p2sh-segwit
+ * (3.../M.../3...), segwit (bc1q.../ltc1q...), taproot (bc1p...).
+ * Used to extract embedded addresses from the message body so the
+ * caller can reject any address that isn't the user's signing wallet.
+ *
+ * Crude on purpose: this is a tripwire, not an address validator. If
+ * the regex matches a legitimate non-address pattern in the body
+ * (extremely rare given the prefix anchors), the message refuses and
+ * the user rephrases — the cost of a false positive here is one
+ * round-trip, the cost of a false negative is a signed drainer
+ * attestation.
+ */
+const EMBEDDED_BTC_OR_LTC_ADDRESS = new RegExp(
+  // segwit / taproot (bech32) — bc1, ltc1, prefix + payload
+  "(?:(?:bc1|ltc1)[qp][023456789ac-hj-np-z]{38,87})" +
+    "|" +
+    // legacy / p2sh — base58, 25-34 chars, prefix 1 / 3 / L / M
+    "(?:[13LM][a-km-zA-HJ-NP-Z1-9]{25,34})",
+  "g",
+);
+
+export interface DrainerCheckArgs {
+  wallet: string;
+  message: string;
+  /** Friendly tool name for the error message. */
+  toolName: "sign_message_btc" | "sign_message_ltc";
+}
+
+/**
+ * Throws when `message` matches a drainer pattern. Caller invokes
+ * BEFORE the device prompt so the refusal is silent (no hardware
+ * round-trip wasted).
+ */
+export function refuseIfDrainerLike(args: DrainerCheckArgs): void {
+  // Template phrases — any single hit refuses.
+  for (const re of DRAINER_TEMPLATE_PHRASES) {
+    const match = args.message.match(re);
+    if (match) {
+      throw new Error(
+        `Refusing to sign — message contains drainer-template phrase: ` +
+          `"${match[0]}". BIP-137 message-sign on this server is restricted to ` +
+          `proof-of-ownership flows (your own address + a challenge nonce). ` +
+          `Phrases like "I authorize" / "I consent to" / "granting custody" ` +
+          `produce signatures attackers can later present as evidence of ` +
+          `consent. Rephrase to drop the trigger phrase, or use a different ` +
+          `signing path if you genuinely need to sign this exact text. ` +
+          `(${args.toolName} drainer-template guard, issue #454)`,
+      );
+    }
+  }
+
+  // Semantic markers — refuse on 2+ co-occurring matches. A single
+  // bare word is too noisy to refuse on alone (legitimate "I, the
+  // owner, received a transfer ..." trips one); two or more is a
+  // high-risk class regardless of exact phrasing.
+  const markerHits: string[] = [];
+  for (const re of SEMANTIC_MARKERS) {
+    const m = args.message.match(re);
+    if (m) markerHits.push(m[0]);
+  }
+  if (markerHits.length >= 2) {
+    throw new Error(
+      `Refusing to sign — message contains multiple drainer-pattern semantic ` +
+        `markers (${markerHits.join(", ")}). Proof-of-ownership messages ` +
+        `typically use "own" / "control", not multiple action verbs. Rephrase ` +
+        `to remove the markers, or use a different signing path if you ` +
+        `genuinely need to sign this exact text. (${args.toolName} ` +
+        `semantic-marker guard, issue #454)`,
+    );
+  }
+
+  // Embedded addresses — refuse when the body contains an address
+  // that isn't the user's signing wallet. Heuristic per the issue:
+  // "addresses appearing in proof-of-ownership messages should be
+  // the user's own". Strict by intent — if the user has multiple
+  // addresses to attest to, sign separately from each.
+  const matches = args.message.matchAll(EMBEDDED_BTC_OR_LTC_ADDRESS);
+  for (const m of matches) {
+    const addr = m[0];
+    if (addr !== args.wallet) {
+      throw new Error(
+        `Refusing to sign — message embeds an external address (${addr}) ` +
+          `that is not your signing wallet (${args.wallet}). Proof-of-` +
+          `ownership messages typically embed your own address; embedding ` +
+          `someone else's is the canonical phishing-attestation pattern. ` +
+          `If you need to attest to multiple addresses you control, sign ` +
+          `from each address separately (one ${args.toolName} call per ` +
+          `address). (drainer-pattern guard, issue #454)`,
+      );
+    }
+  }
+}
+
+/**
+ * Per issue #454 part (a) — return the SHA-256 of the exact UTF-8
+ * bytes the agent submitted to the device, so the caller surfaces it
+ * to the user alongside the verbatim message string. The user
+ * confirms the on-device text matches the displayed text; the SHA
+ * is a secondary anchor that survives Unicode-confusable substitution
+ * (e.g. em-dash vs hyphen, Cyrillic А vs Latin A) — the bytes
+ * differ, so the SHA differs, even when the rendering looks identical.
+ */
+export function messageBytesSha256(message: string): string {
+  return (
+    "0x" +
+    createHash("sha256").update(Buffer.from(message, "utf-8")).digest("hex")
+  );
+}

--- a/test/message-sign-guard.test.ts
+++ b/test/message-sign-guard.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Drainer-pattern refusal + byte-fingerprint helper for
+ * `sign_message_btc` / `sign_message_ltc` (issue #454). Pure unit
+ * tests on the guard module — the integration with the actual
+ * signers is covered by the existing message-sign tests
+ * (`btc-pr4-portfolio-message-sign.test.ts` /
+ * `litecoin-core.test.ts`), which the guard's additive output field
+ * (`messageBytesSha256`) and its no-op-on-benign-message default
+ * leave green.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  refuseIfDrainerLike,
+  messageBytesSha256,
+} from "../src/signing/message-sign-guard.js";
+import { createHash } from "node:crypto";
+
+const SEGWIT_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const OTHER_BTC_ADDR = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+const LTC_ADDR = "ltc1qhzjptwpym9afcdjhs7jcz6fd0jma0l0rc0e5yr";
+
+function safeSubject(extra?: Partial<{ wallet: string; toolName: "sign_message_btc" | "sign_message_ltc" }>) {
+  return {
+    wallet: extra?.wallet ?? SEGWIT_ADDR,
+    toolName: extra?.toolName ?? ("sign_message_btc" as const),
+  };
+}
+
+describe("refuseIfDrainerLike — drainer template phrases (any single hit refuses)", () => {
+  const templates = [
+    "I authorize the use of these funds.",
+    "Granting custody of this wallet to bob",
+    "Granting full custody to a third party",
+    "I consent to the transfer of all funds",
+    "I grant access to my private keys",
+    "release of funds approved",
+    "release of all funds approved",
+    "transfer all funds to the recipient",
+    "authorize transfer of holdings",
+    "authorize release of escrow",
+    "authorize custody change",
+  ];
+  it.each(templates)("refuses on template phrase: %s", (msg) => {
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).toThrow(/drainer-template phrase|drainer-pattern/i);
+  });
+});
+
+describe("refuseIfDrainerLike — semantic markers (refuse on 2+ co-occurring matches)", () => {
+  it("refuses when message contains two markers (transfer + authorize)", () => {
+    const msg = "Please authorize the transfer.";
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).toThrow(/semantic markers/i);
+  });
+
+  it("refuses when message contains three markers without a template phrase", () => {
+    // Three markers (transfer, custody, release) co-occur but no
+    // template anchor like "I grant" / "I authorize" — exercises the
+    // semantic-markers branch directly.
+    const msg = "Reviewing the transfer, the custody change, and the release.";
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).toThrow(/semantic markers/i);
+  });
+
+  it("does NOT refuse on a single marker in a benign sentence", () => {
+    // "I, the owner, received a transfer ..." — single marker, no
+    // template, no foreign address. False-positive risk would be
+    // here; we deliberately allow it.
+    const msg = "I, the owner of this wallet, received a transfer on 2026-04-28";
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).not.toThrow();
+  });
+
+  it("does NOT refuse on a benign proof-of-ownership challenge", () => {
+    const msg = "challenge nonce 7f2a93";
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).not.toThrow();
+  });
+});
+
+describe("refuseIfDrainerLike — embedded address must be the signing wallet", () => {
+  it("refuses on a foreign BTC segwit address in the body", () => {
+    const msg = `I attest ownership of ${OTHER_BTC_ADDR} as of 2026-04-28`;
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).toThrow(/external address/i);
+  });
+
+  it("refuses on a foreign address even when the wallet is also embedded", () => {
+    const msg = `Owner of ${SEGWIT_ADDR} attests for ${OTHER_BTC_ADDR}.`;
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).toThrow(/external address/i);
+  });
+
+  it("does NOT refuse when only the signing wallet is embedded", () => {
+    const msg = `I am the owner of ${SEGWIT_ADDR}. challenge=abc`;
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: msg }),
+    ).not.toThrow();
+  });
+
+  it("works for LTC signing wallet + foreign LTC address", () => {
+    const msg = `proof for ${LTC_ADDR} (foreign)`;
+    expect(() =>
+      refuseIfDrainerLike({
+        wallet: "ltc1qjyj7lr3a23ejfsm2vvld6ugxx9wpgu33uxmd2k",
+        toolName: "sign_message_ltc",
+        message: msg,
+      }),
+    ).toThrow(/external address/i);
+  });
+});
+
+describe("refuseIfDrainerLike — error messages cite the issue + tool", () => {
+  it("template error names the tool and issue", () => {
+    expect(() =>
+      refuseIfDrainerLike({ ...safeSubject(), message: "I authorize this." }),
+    ).toThrow(/sign_message_btc.*#454/);
+  });
+
+  it("LTC tool name flows into the LTC-side error", () => {
+    expect(() =>
+      refuseIfDrainerLike({
+        ...safeSubject({ toolName: "sign_message_ltc" }),
+        message: "I authorize this.",
+      }),
+    ).toThrow(/sign_message_ltc.*#454/);
+  });
+});
+
+describe("messageBytesSha256 — pinned hashes", () => {
+  it("returns the SHA-256 of the UTF-8 bytes (ASCII)", () => {
+    const msg = "hello world";
+    const expected =
+      "0x" + createHash("sha256").update(Buffer.from(msg, "utf-8")).digest("hex");
+    expect(messageBytesSha256(msg)).toBe(expected);
+  });
+
+  it("differs for visually-confusable Unicode (em-dash vs hyphen)", () => {
+    const withHyphen = "I own bc1qabc - challenge 7f";
+    const withEmDash = "I own bc1qabc — challenge 7f";
+    expect(messageBytesSha256(withHyphen)).not.toBe(
+      messageBytesSha256(withEmDash),
+    );
+  });
+
+  it("differs for Cyrillic-А vs Latin-A confusable", () => {
+    const latin = "Address attestation A";
+    const cyrillic = "Address attestation А"; // U+0410 CYRILLIC CAPITAL A
+    expect(messageBytesSha256(latin)).not.toBe(messageBytesSha256(cyrillic));
+  });
+
+  it("returns 0x-prefixed lowercase hex of length 66 (32 bytes + prefix)", () => {
+    const out = messageBytesSha256("anything");
+    expect(out).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
Closes #454. Implements parts (a) and (c) of the proposal; part (b) (Ledger app coordination) is out of scope for this repo.

## Summary
- **(a) Byte-fingerprint preview** — \`SignedBitcoinMessage\` / \`SignedLitecoinMessage\` now carry \`messageBytesSha256\`. Surfaces alongside the verbatim message so the user can detect Unicode-confusable substitution that the OLED rendering would hide (em-dash vs hyphen, Cyrillic А vs Latin A — bytes differ → hash differs).
- **(c) Drainer-pattern refusal** — new \`src/signing/message-sign-guard.ts\` runs **before** the device call (silent refusal, no hardware round-trip wasted) and refuses on three triggers:
  - Drainer-template phrases (any single hit refuses): \`I authorize\`, \`I consent to\`, \`I grant\`, \`granting (full) custody\`, \`release of (all) funds\`, \`transfer (all) funds\`, \`authorize transfer/release/custody\`. Word-bounded so dictionary words like \"authorizer\" don't false-fire.
  - Semantic markers (refuse on 2+ co-occurring): \`transfer\`, \`authorize\`, \`grant\`, \`custody\`, \`release\`, \`consent\`. A single bare word is too noisy to refuse on alone (legit \"I, the owner, received a transfer ...\" trips one); two or more is a high-risk class regardless of phrasing.
  - Embedded foreign address: any BTC/LTC address in the body that isn't the signing wallet refuses. To attest to multiple addresses, sign separately from each.

## NO override flag
Adding \`acknowledgeRiskyMessageContent: true\` would let a rogue agent silently bypass exactly this defense. Strict-by-default per the issue's \"outright\" wording. The text restriction is narrow enough that a legitimate proof-of-ownership statement can be rephrased to avoid the trigger.

## Trade-off documented in the guard module
Bare semantic markers are noisy. If false positives surface in practice, tune the regex in a follow-up rather than ship a back door.

## Test plan
- [x] +25 unit tests on the guard helper (template hits, semantic-marker behavior, embedded-address paths, error-message attribution, byte-fingerprint pinned hashes including Unicode confusables)
- [x] Existing 23 message-sign tests still pass (the new \`messageBytesSha256\` field is additive, the test messages don't trip the drainer guard)
- [x] Typecheck clean, full suite 2441/2441 passing
- [ ] Verify CI green
- [ ] Smoke: \`sign_message_btc({ wallet, message: \"I authorize transfer\" })\` → refuses with the drainer-template error citing \`#454\`. Benign \"challenge nonce abc\" → signs and returns \`messageBytesSha256\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)