### PR TITLE
chore(release): bump to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -4393,6 +4393,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6429,6 +6444,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7298,6 +7320,21 @@
         "ws": "*"
       }
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7526,6 +7563,25 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/ledger-bitcoin": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
+      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
+      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^1.0.2",
+        "@bitcoinerlab/secp256k1": "^1.0.5",
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.1.3"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -9883,7 +9939,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.12.1";
+const SERVER_VERSION = "0.13.0";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
Release **v0.13.0** — versions synced across `package.json`, `server.json` (top-level + `packages[0]`), and the embedded `SERVER_VERSION` constant in `src/modules/incident-report/index.ts`.

Tests: 2455 / 2455 passing locally; \`npm run build\` clean.

After this PR merges to \`main\`, fire the publish workflow by tagging the merge commit and creating a GitHub Release:

\`\`\`sh
git fetch origin main
git tag v0.13.0 origin/main
git push origin v0.13.0
gh release create v0.13.0 --title "v0.13.0" --notes-file <release-notes>
\`\`\`

The publish workflow (\`.github/workflows/publish.yml\`) is \`on: release: types: [published]\` — pushing the tag alone won't fire it; the GitHub Release event is the trigger.

## Highlights

### New tools
- **\`resolve_token\`** (#440) — symbol+chain → canonical contract w/ bridged-variant warnings (USDC vs USDC.e on Arbitrum/Polygon/Optimism, USDC vs USDbC on Base).
- **\`list_solana_validators\`** (#436) — stakewiz-backed ranking helper for \`prepare_native_stake_delegate\`. Surfaces wiz_score, commission, MEV-enabled, APY estimate, delinquent + superminority flags.
- **\`prepare_sunswap_swap\`** (#432) — TRON-native DEX for same-chain TRX↔TRC20 swaps.
- **EVM + Solana swap filters** (#439, #516) — \`excludeExchanges\`/\`excludeBridges\`/\`order\` (LiFi), \`dexes\`/\`excludeDexes\` (Jupiter).

### Security hardening
- **Invariant #14** (#460) — \`durableBindings\` field on every prepare_* tool that binds funds to a durable on-chain object selected from a multi-candidate set (validator vote pubkey, TRON SR, Compound Comet, Morpho marketId, MarginFi bank, Uniswap V3 LP tokenId, BTC multisig xpub, allowance spender). Skill consumes it as the assertion target.
- **Invariant #8 BIP-137 hardening** (#454) — \`messageSha256\` byte-fingerprint in \`sign_message_btc\`/\`ltc\` responses + drainer-string refusal (\`transfer\` / \`authorize\` / \`grant\` / \`custody\` / \`release\` / \`consent\` markers, plus multi-word templates).
- **\`SignedContactEntry.intendedChains\`** (#482) — \`CONTACT-CHAIN MISMATCH\` warning when prepare's \`chain\` arg doesn't match the contact's intended chain set. Defense-in-depth for the script-133 Carol-on-Arbitrum-sent-on-Ethereum scenario.
- **\`UnsignedTx.secondLlmRequired\`** scaffold (#501) — flag for Inv #12.5 hard-trigger ops.

### Token-send
- **tokenClass framework** (#441) — non-standard transfer-semantics flags (rebasing seeded; blocklisted/FoT/pausable/upgradeable_admin deferred per #508).
- **\`prepare_solana_native_send\` memo** (#434) — optional UTF-8 memo via SPL Memo program v2.
- **\`prepare_morpho_repay\` accepts \`amount: "max"\`** (#437) — shares-mode close, exact regardless of accrued interest between sign and broadcast.

### Yields v2 (#431)
- **DefiLlama bundle** (#287, #289, #290, #291) — Marinade + Jito + Kamino-lend + Morpho-Blue curated vaults via one cached fetch.
- **MarginFi on-chain wallet-less reader** (#288) — DefiLlama doesn't carry MarginFi borrow-lend, so this one needed the on-chain bank reader.
- **EigenLayer + native-stake deferred indefinitely** (#292, #293) — LRT issuers + Marinade/Jito are the practical substitutes; per-operator/per-validator row shape was too expensive for the marginal user value.

### PnL
- **\`get_pnl_summary\` mtd period** (#447) — calendar month-to-date.

### Fixes
- \`TRON_TOKENS.USDD\` pointed at WTRX (#507).
- Self-referencing glama badge breaking on glama.ai (#521).

### Roadmap defers
- BIP-322 message signing (#438), \`prepare_eip7702_authorization\` (#481), Tier-1 bridge facet decoders (#451), Solana NFT trio (#474/#475/#476), BTC/LTC dryRun (#479), solo-validator deposit (#430).

## Deliberately deferred

- **Token-class seed data for blocklisted/FoT/pausable/upgradeable_admin** (#508) — closed as won't-fix-until-concrete-case. Three classes have no live targets; \`upgradeable_admin\` needs a more targeted rule. Framework itself is shipped.
- **Multi-route swap comparison endpoint** (#517) — closed; \`order: "CHEAPEST"\` covers the dominant case.
- **Skill-side coordination** for Invariant #14 enforcement (#460) — companion work in \`vaultpilot-security-skill\`. The MCP-side \`durableBindings\` field is wire-ready; skill version bump + sentinel update lands separately.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run\` — 2455/2455 pass
- [x] \`git grep "0.12.1"\` — no stale references outside lockfile/fixtures
- [ ] CI green on this PR
- [ ] After merge: tag, GitHub Release, publish workflow runs through to npm + MCP Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)