### PR TITLE
docs(agents): patience + no-fallback rules for binary installer (Windows install regression)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,75 @@ Idempotent: re-running the script re-downloads (this is also the
 update path) and the wizard recognizes already-present clients/skills
 so a re-run on a configured machine emits `status: "already_installed"`.
 
+#### Patience expectations — the binary is large, the download is slow
+
+The bundled-Node binary is several hundred MB. Realistic timings:
+
+- Broadband / corporate connection — **1–3 minutes**.
+- Slow / metered / mobile-tethered — **5–10 minutes**.
+- Very slow / packet-loss-prone — **up to 15 minutes** before you
+  should suspect a real problem.
+
+**Do NOT abort the install before it has run for at least 10 minutes.**
+A live 2026-04-28 user report on Windows + Claude Code Desktop shows
+the worst-case failure mode of premature aborts: agent saw "this is
+taking a while", killed the install.ps1 mid-download, then attempted
+to fall back to npm (futile — the user had no Node, that's why we
+took the binary path), then flailed through `claude mcp add` →
+manual `settings.json` edit → `/update-config` skill → project-scoped
+`.mcp.json` creation, none of which actually registered the server.
+The user's machine was left with a broken setup and no install.
+
+If 10 minutes elapse with no completion, surface the situation to the
+user verbatim: "the binary download is taking longer than expected;
+this can happen on slow connections. The script is still running.
+Want to wait another 5 minutes, or stop and try a different approach?"
+Let the user decide. Do **not** silently fall back to a different path.
+
+#### When the binary install fails (real failure, not slow download)
+
+If the install.ps1 / install.sh **completes** but reports a real
+error (non-zero exit, or `status: "error"` in the InstallEnvelope),
+do NOT fall back to npm if the Step 0 probe showed Node was absent
+— that path is futile by construction; you've already confirmed
+the prerequisite isn't there. Surface the binary failure to the
+user with the install URL so they can investigate directly:
+"the binary installer failed with `<error>`. The full installer
+script is at `https://github.com/szhygulin/vaultpilot-mcp/releases/latest/download/install.ps1`
+— want me to try a different approach, or would you like to look
+at what went wrong yourself?"
+
+Only fall back to npm if Step 0 confirmed Node ≥ 18.17 IS available
+(rare on this code path, but possible if the binary install fails
+for a different reason on a Node-equipped machine).
+
+#### Trust the installer's auto-registration — do NOT manually edit MCP-client config files after
+
+The shell installer's step (3) calls `vaultpilot-mcp-setup --non-
+interactive --json` which detects every installed MCP client (Claude
+Desktop, Claude Code, Cursor) and registers vaultpilot-mcp with each
+in their canonical config location:
+
+- Claude Code (CLI) — `~/.claude.json` MCP-server entry
+- Claude Desktop — `claude_desktop_config.json`
+  (`%APPDATA%\Claude\` on Windows, `~/Library/Application Support/Claude/` on macOS)
+- Cursor — `~/.cursor/mcp.json`
+
+If the InstallEnvelope reports `clients_registered` non-empty, the
+registration is **done**. Do NOT then run `claude mcp add` or
+manually edit the user's `settings.json` or create a project-scoped
+`.mcp.json` — those are different config surfaces and stacking
+them creates the broken-setup-with-zero-working-registration mode
+caught above. The installer's `clients_registered` list is
+authoritative; relay it to the user verbatim and tell them to
+restart the named clients.
+
+If the InstallEnvelope reports `clients_not_detected` non-empty for
+the client the user actually uses (e.g. Claude Code Desktop) AND
+`clients_registered` doesn't include it, that's the case for
+manually adding the config. Check [INSTALL.md](./INSTALL.md) for the
+exact path to edit on the user's platform; do **not** improvise.
+
 ## What to tell the user BEFORE running the install
 
 Get explicit consent. Tell the user:


### PR DESCRIPTION
## Summary
Live 2026-04-28 user report on Windows + Claude Code Desktop. Agent ran \`install.ps1\` (correct — Node was absent, binary path is the gating recipe), then bailed mid-download with \"this seems stuck\", then flailed through five wrong-path attempts, none of which registered vaultpilot-mcp. User left with a broken setup.

This PR adds three new subsections under \"If Node is missing or older than 18.17: shell installer\" to prevent the failure mode from recurring. No code change — the agent's behavior is what needs updating, not the installer's.

## What ships in AGENTS.md

1. **Patience expectations** — binary is several hundred MB. 1–3 min on broadband, 5–10 min on slow connections, up to 15 min on very slow. **Do NOT abort before 10 minutes elapsed.** Past 10 min, surface to user verbatim and let them decide; do not silently fall back.

2. **No npm fallback when Node was confirmed absent** — Step 0 probe gates the path choice; falling back to npm after a binary failure is futile by construction (npm requires Node, which Step 0 already confirmed isn't there). On real binary failure, surface the failure + installer URL to the user.

3. **Trust the installer's auto-registration — do NOT manually edit MCP-client config files after** — \`vaultpilot-mcp-setup --non-interactive --json\` detects each installed MCP client and registers in their canonical config locations:
   - Claude Code CLI → \`~/.claude.json\`
   - Claude Desktop → \`claude_desktop_config.json\` (\`%APPDATA%\Claude\\` on Windows)
   - Cursor → \`~/.cursor/mcp.json\`
   
   If \`clients_registered\` is non-empty, the registration is done. Do NOT then run \`claude mcp add\` or edit \`settings.json\` or create \`.mcp.json\` — those are different config surfaces that don't compose. Stacking them produces the broken-setup-with-zero-working-registration failure caught here.

## Test plan
- [x] Diff is +69 lines in \`AGENTS.md\` only.
- [ ] Verify CI green.
- [ ] Smoke (re-run the failing prompt on a fresh Windows VM without Node): \"Install vaultpilot-mcp for me — see https://github.com/szhygulin/vaultpilot-mcp/blob/main/AGENTS.md\". Expected: agent runs install.ps1, waits patiently for the multi-minute download, relays \`clients_registered\` from the InstallEnvelope, does NOT touch \`settings.json\` / \`.mcp.json\` manually.

## Possible follow-ups (not this PR)
- \`install.ps1\` itself could emit clearer progress output (download percent, bytes/sec). Would help the agent's patience heuristic AND the user's. Separate code change.
- Tier-2 binary slim ([roadmap entry](https://github.com/szhygulin/vaultpilot-mcp/blob/main/ROADMAP.md), strip Kamino kliquidity — saves ~100 MB of the 420 MB binary). Reduces the download-time pain at root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)