### PR TITLE
chore(release): bump to 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.13.0";
+const SERVER_VERSION = "0.13.1";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
Patch release covering 4 docs PRs since v0.13.0.

## Highlights
- **AGENTS.md binary-installer patience rules** — pre-warns the agent that the bundled-Node binary is several hundred MB (1–10 min realistic download), forbids the npm fallback when Node was confirmed absent, and tells it to trust the installer's auto-registration rather than manually editing config files. Live Windows + Claude Code Desktop install regression caught the failure mode (#546).
- **Roadmap maintenance** — 9 backlog plans linked into ROADMAP and archived (#535), 6 tool-follow-up plans linked + archived (#533), all archived plan links retargeted to \`claude-work/archive/\` (#534).

## Included PRs
- #533 — docs(roadmap): link 8 entries from claude-work tool-follow-up plans
- #534 — docs(roadmap): retarget archived plan links to claude-work/archive/
- #535 — docs(roadmap): link 9 backlog plans + archive their files
- #546 — docs(agents): patience + no-fallback rules for the binary installer path

## What changes in this PR
- \`package.json\` 0.13.0 → 0.13.1
- \`server.json\` 0.13.0 → 0.13.1 (both top-level and \`packages[0].version\`)
- \`src/modules/incident-report/index.ts\` \`SERVER_VERSION\` constant 0.13.0 → 0.13.1 (so \`build_incident_report\` stamps the new version)

## Test plan
- [x] \`npm run build\` clean
- [x] Full suite 2455/2455 passing
- [ ] After merge: tag v0.13.1 on the merge commit, push tag, create GitHub Release — both \`publish.yml\` (npm + MCP Registry, OIDC provenance) and \`release-binaries.yml\` fire on \`release.published\`

## Deliberately deferred
- No tool surface or runtime-behavior changes in this release. AGENTS.md is for the agent reading the install instructions, not the server runtime.
- \`install.ps1\` progress output (bytes/sec) — would help patience heuristics but is a separate code change, not a docs fix.
- Tier-2 binary slim ([roadmap](https://github.com/szhygulin/vaultpilot-mcp/blob/main/ROADMAP.md), strips Kamino kliquidity, saves ~100 MB of the 420 MB Windows binary) — addresses the root of the slow-download pain but a separate effort gated on whether Tier-1 mitigations stop sufficing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)