### PR TITLE
perf(deps): stub kliquidity-sdk — drop ~125 MB from bundled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+!vendor/**/dist/
 release/
 *.log
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@kamino-finance/klend-sdk": "^7.3.22",
+        "@kamino-finance/kliquidity-sdk": "file:./vendor/kliquidity-stub",
         "@ledgerhq/hw-app-btc": "^10.21.1",
         "@ledgerhq/hw-app-solana": "^7.10.1",
         "@ledgerhq/hw-app-trx": "^6.34.1",
@@ -1016,15 +1017,6 @@
         "hono": "^4"
       }
     },
-    "node_modules/@hubbleprotocol/hubble-config": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hubbleprotocol/hubble-config/-/hubble-config-5.0.0.tgz",
-      "integrity": "sha512-oLdS2SwdYN8sggZhIesN+Kk8KQXGrbYn0kvnvTnk5Wh4pck1kR458ze5gh0XrMDpRVTdgwItf4mXhqiLXvQCKQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/web3.js": "^1.78.4"
-      }
-    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1095,12 +1087,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/@jup-ag/api": {
-      "version": "6.0.39",
-      "resolved": "https://registry.npmjs.org/@jup-ag/api/-/api-6.0.39.tgz",
-      "integrity": "sha512-cejW4IWf3dKM5ucmqu5jWtlPZ46LJJOCrx3s5vKmEIB+0X9ykSZsKkcIHFBCOqf3/lSbGyU7THZqXuxjKK9//g==",
-      "license": "MIT"
     },
     "node_modules/@kamino-finance/farms-sdk": {
       "version": "3.2.24",
@@ -1207,44 +1193,8 @@
       }
     },
     "node_modules/@kamino-finance/kliquidity-sdk": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@kamino-finance/kliquidity-sdk/-/kliquidity-sdk-8.5.10.tgz",
-      "integrity": "sha512-E+e4TR4JWdolivMsA956eamfcG5rd1+Wtr1N/iJRmdqrN5cKVln9xX2JAGmw0yGmcwOgxcJfe1joG16AnwKx3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@coral-xyz/anchor": "^0.29.0",
-        "@coral-xyz/borsh": "^0.30.1",
-        "@hubbleprotocol/hubble-config": "^5.0.0",
-        "@jup-ag/api": "6.0.39",
-        "@kamino-finance/scope-sdk": "^10.1.0",
-        "@orca-so/common-sdk": "^0.6.11",
-        "@orca-so/whirlpools": "^2.0.0",
-        "@orca-so/whirlpools-core": "^2.0.0",
-        "@raydium-io/raydium-sdk-v2": "^0.1.126-alpha",
-        "@solana-program/address-lookup-table": "^0.8.0",
-        "@solana-program/compute-budget": "^0.9.0",
-        "@solana-program/system": "^0.8.0",
-        "@solana-program/token": "^0.6.0",
-        "@solana-program/token-2022": "^0.5.0",
-        "@solana/compat": "^2.3.0",
-        "@solana/kit": "^2.3.0",
-        "@solana/sysvars": "^2.3.0",
-        "axios": "^1.8.4",
-        "bn.js": "^5.2.1",
-        "bs58": "^6.0.0",
-        "buffer-layout": "^1.2.2",
-        "decimal.js": "^10.3.1",
-        "fzstd": "^0.1.1"
-      }
-    },
-    "node_modules/@kamino-finance/kliquidity-sdk/node_modules/@solana-program/compute-budget": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.9.0.tgz",
-      "integrity": "sha512-on7Cs1V48X9E2x1yVmfM6N6Xv0r4oGruXPcWnI50D3D3CIsHNWJ4gsvL4qZ4iey7zAP73FdM21K2CZBi1a/jzg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^3.0"
-      }
+      "resolved": "vendor/kliquidity-stub",
+      "link": true
     },
     "node_modules/@kamino-finance/scope-sdk": {
       "version": "10.2.2",
@@ -2029,123 +1979,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@orca-so/common-sdk": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/@orca-so/common-sdk/-/common-sdk-0.6.11.tgz",
-      "integrity": "sha512-7MJs71F8XJsYCx3+agsLc3MMGnzAC8l3FDbUq0qP3lEPI6B5IS/u2iKU4rWkK3IqIkynWcvuYL6WCi+90vu52w==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "decimal.js": "^10.5.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "peerDependencies": {
-        "@solana/spl-token": "^0.4.12",
-        "@solana/web3.js": "^1.90.0"
-      }
-    },
-    "node_modules/@orca-so/tx-sender": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@orca-so/tx-sender/-/tx-sender-1.0.2.tgz",
-      "integrity": "sha512-6PlGx4wwF9Q/XxfND43TtZsjiCJs6Ho5yIYBAkiXXaBOcIfqNTqKRhzhX598xv19TJl4DaldWhgx36m+nqmN8Q==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@solana-program/address-lookup-table": "^0.7.0",
-        "@solana-program/compute-budget": "^0.7.0",
-        "@solana-program/system": "^0.7.0"
-      },
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/tx-sender/node_modules/@solana-program/address-lookup-table": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/address-lookup-table/-/address-lookup-table-0.7.0.tgz",
-      "integrity": "sha512-dzCeIO5LtiK3bIg0AwO+TPeGURjSG2BKt0c4FRx7105AgLy7uzTktpUzUj6NXAK9SzbirI8HyvHUvw1uvL8O9A==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/tx-sender/node_modules/@solana-program/compute-budget": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.7.0.tgz",
-      "integrity": "sha512-/JJSE1fKO5zx7Z55Z2tLGWBDDi7tUE+xMlK8qqkHlY51KpqksMsIBzQMkG9Dqhoe2Cnn5/t3QK1nJKqW6eHzpg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/tx-sender/node_modules/@solana-program/system": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
-      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/whirlpools": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@orca-so/whirlpools/-/whirlpools-2.2.0.tgz",
-      "integrity": "sha512-a43HQ+yZ8jnzmrVJ0lgJojnIjbvOIi+NlqBcawDhvwtnLz1uHsI1HaQawN3LJZLNrJtTowHdLT6GUCu4o0X0bA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@orca-so/tx-sender": "1.0.2",
-        "@orca-so/whirlpools-client": "2.0.0",
-        "@orca-so/whirlpools-core": "2.0.0",
-        "@solana-program/memo": "^0.7.0",
-        "@solana-program/system": "^0.7.0",
-        "@solana-program/token": "^0.5.1",
-        "@solana-program/token-2022": "^0.4.0",
-        "@solana/sysvars": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/whirlpools-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@orca-so/whirlpools-client/-/whirlpools-client-2.0.0.tgz",
-      "integrity": "sha512-6/2CdK5aAypA2cT/01l28WLN4Avb55rCuUM9qNyv69NOKnCXRT3byv7FxXkFcJ5GzqoAYaR/fPsZimvi2ndkUg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/whirlpools-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@orca-so/whirlpools-core/-/whirlpools-core-2.0.0.tgz",
-      "integrity": "sha512-SzX9Jd9QDRk6UvUdM114Onq4woFVTl3rrx2Iu0IsnwBbA4lzFLPRYDxdsoyyRHceOgIrbhgpRU3IZc9jCRS8eg==",
-      "license": "SEE LICENSE IN LICENSE"
-    },
-    "node_modules/@orca-so/whirlpools/node_modules/@solana-program/system": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
-      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/whirlpools/node_modules/@solana-program/token": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
-      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@orca-so/whirlpools/node_modules/@solana-program/token-2022": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
-      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0",
-        "@solana/sysvars": "^2.1.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -2313,26 +2146,6 @@
         "@solana/web3.js": "^1.90.0",
         "bs58": "^5.0.0",
         "jito-ts": "^3.0.1"
-      }
-    },
-    "node_modules/@raydium-io/raydium-sdk-v2": {
-      "version": "0.1.126-alpha",
-      "resolved": "https://registry.npmjs.org/@raydium-io/raydium-sdk-v2/-/raydium-sdk-v2-0.1.126-alpha.tgz",
-      "integrity": "sha512-wpCb1rDvlENO+nfdjC1QVh6P4ImzgF/uhApw5194ycU1i8OSJrb0iZc1Egy5chafcn4i3gY2B1ivMdEeaNsSzA==",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.1",
-        "@solana/spl-token": "^0.4.8",
-        "@solana/web3.js": "^1.95.3",
-        "axios": "^1.1.3",
-        "big.js": "^6.2.1",
-        "bn.js": "^5.2.1",
-        "dayjs": "^1.11.5",
-        "decimal.js-light": "^2.5.1",
-        "jsonfile": "^6.1.0",
-        "lodash": "^4.17.21",
-        "toformat": "^2.0.0",
-        "tsconfig-paths": "^4.2.0"
       }
     },
     "node_modules/@roberts_lando/vfs": {
@@ -2712,15 +2525,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
       "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^2.1.0"
-      }
-    },
-    "node_modules/@solana-program/memo": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/memo/-/memo-0.7.0.tgz",
-      "integrity": "sha512-3T9iUjWSYtN/5S5jzJuasD2yQfVfFAQ9yTwIE25+P9peWqz4oarn6ZQvRj/FLcBqaMLtSqLhU1hN2cyVBS6hyg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
@@ -4393,21 +4197,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -5809,12 +5598,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5836,12 +5619,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decompress-response": {
@@ -6444,13 +6221,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -6650,12 +6420,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/fzstd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
-      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
-      "license": "MIT"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -7320,21 +7084,6 @@
         "ws": "*"
       }
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7464,18 +7213,6 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -7563,25 +7300,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ledger-bitcoin/node_modules/ledger-bitcoin": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
-      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
-      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bitcoinerlab/descriptors": "^1.0.2",
-        "@bitcoinerlab/secp256k1": "^1.0.5",
-        "@ledgerhq/hw-transport": "^6.20.0",
-        "bip32-path": "^0.4.2",
-        "bitcoinjs-lib": "^6.1.3"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -9596,15 +9314,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -9734,12 +9443,6 @@
         "real-require": "^0.2.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
@@ -9842,12 +9545,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz",
-      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==",
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -9868,20 +9565,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tslib": {
       "version": "1.14.1",
@@ -9939,6 +9622,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10780,6 +10464,15 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "vendor/kliquidity-stub": {
+      "name": "@kamino-finance/kliquidity-sdk",
+      "version": "8.5.10-vaultpilot-stub.0",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "decimal.js": "^10.4.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@kamino-finance/klend-sdk": "^7.3.22",
+    "@kamino-finance/kliquidity-sdk": "file:./vendor/kliquidity-stub",
     "@ledgerhq/hw-app-btc": "^10.21.1",
     "@ledgerhq/hw-app-solana": "^7.10.1",
     "@ledgerhq/hw-app-trx": "^6.34.1",
@@ -178,6 +179,7 @@
     "@coral-xyz/anchor": "^0.30.1",
     "@coral-xyz/borsh": "^0.30.1",
     "bs58": "^6.0.0",
+    "@kamino-finance/kliquidity-sdk": "file:./vendor/kliquidity-stub",
     "@marinade.finance/marinade-ts-sdk": {
       "@coral-xyz/anchor": "^0.28.0",
       "@coral-xyz/borsh": "^0.28.0",

--- a/vendor/kliquidity-stub/dist/index.d.ts
+++ b/vendor/kliquidity-stub/dist/index.d.ts
@@ -1,0 +1,23 @@
+import Decimal from "decimal.js";
+import BN from "bn.js";
+
+export declare const ZERO: Decimal;
+export declare const ZERO_BN: BN;
+export declare const DECIMALS_SOL: 9;
+export declare const FullBPS: 10000;
+export declare const FullBPSDecimal: Decimal;
+
+export declare function aprToApy(apr: Decimal, compoundPeriods: number): Decimal;
+export declare function chunks<T>(array: T[], size: number): T[][];
+export declare function batchFetch<T, R>(
+    addresses: T[],
+    fetchBatch: (chunk: T[]) => Promise<R[]>,
+    chunkSize?: number,
+): Promise<R[]>;
+export declare function collToLamportsDecimal(amount: Decimal, decimals: number): Decimal;
+
+export declare class Kamino {
+    constructor(...args: unknown[]);
+}
+
+export type KaminoPrices = unknown;

--- a/vendor/kliquidity-stub/dist/index.js
+++ b/vendor/kliquidity-stub/dist/index.js
@@ -1,0 +1,58 @@
+"use strict";
+// Stub of @kamino-finance/kliquidity-sdk for vaultpilot-mcp.
+//
+// Only the symbols klend-sdk + farms-sdk reach at runtime are implemented.
+// Each helper mirrors the real impl byte-for-byte in behavior; the `Kamino`
+// class throws if instantiated (kliquidity vault flows are not supported in
+// the stripped binary).
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+
+const decimal_js_1 = __importDefault(require("decimal.js"));
+const bn_js_1 = __importDefault(require("bn.js"));
+
+// from kliquidity-sdk/dist/utils/math.js
+exports.ZERO = new decimal_js_1.default(0);
+exports.aprToApy = function aprToApy(apr, compoundPeriods) {
+    return new decimal_js_1.default(1).add(apr.div(compoundPeriods)).pow(compoundPeriods).sub(1);
+};
+
+// from kliquidity-sdk/dist/utils/batch.js
+exports.chunks = function chunks(array, size) {
+    return [...new Array(Math.ceil(array.length / size)).keys()].map((_, index) => array.slice(index * size, (index + 1) * size));
+};
+exports.batchFetch = async function batchFetch(addresses, fetchBatch, chunkSize = 100) {
+    const results = await Promise.all(exports.chunks(addresses, chunkSize).map((chunk) => fetchBatch(chunk)));
+    return results.reduce((acc, curr) => acc.concat(...curr), new Array());
+};
+
+// from kliquidity-sdk/dist/utils/utils.js
+exports.collToLamportsDecimal = function collToLamportsDecimal(amount, decimals) {
+    const factor = new decimal_js_1.default(10).pow(decimals);
+    return amount.mul(factor);
+};
+
+// from kliquidity-sdk/dist/utils/tokenUtils.js
+exports.DECIMALS_SOL = 9;
+
+// from kliquidity-sdk/dist/constants/numericalValues.js
+exports.ZERO_BN = new bn_js_1.default(0);
+
+// from kliquidity-sdk/dist/utils/CreationParameters.js (also re-exported here
+// because farms-sdk + klend-sdk reach the bare path for these in some branches)
+exports.FullBPS = 10_000;
+exports.FullBPSDecimal = new decimal_js_1.default(exports.FullBPS);
+
+class Kamino {
+    constructor() {
+        throw new Error(
+            "@kamino-finance/kliquidity-sdk is stubbed in vaultpilot-mcp to keep the bundled binary small. " +
+            "This code path (Kamino vault strategies) requires the real package — install it separately " +
+            "or remove the kliquidity-sdk override in package.json to restore."
+        );
+    }
+}
+exports.Kamino = Kamino;

--- a/vendor/kliquidity-stub/dist/utils/CreationParameters.d.ts
+++ b/vendor/kliquidity-stub/dist/utils/CreationParameters.d.ts
@@ -1,0 +1,4 @@
+import Decimal from "decimal.js";
+
+export declare const FullBPS: 10000;
+export declare const FullBPSDecimal: Decimal;

--- a/vendor/kliquidity-stub/dist/utils/CreationParameters.js
+++ b/vendor/kliquidity-stub/dist/utils/CreationParameters.js
@@ -1,0 +1,14 @@
+"use strict";
+// Stub of @kamino-finance/kliquidity-sdk/dist/utils/CreationParameters.
+// klend-sdk's vault.js + leverage/operations.js require this subpath
+// directly. Mirrors the real exports for FullBPS / FullBPSDecimal.
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+
+const decimal_js_1 = __importDefault(require("decimal.js"));
+
+exports.FullBPS = 10_000;
+exports.FullBPSDecimal = new decimal_js_1.default(exports.FullBPS);

--- a/vendor/kliquidity-stub/package.json
+++ b/vendor/kliquidity-stub/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@kamino-finance/kliquidity-sdk",
+  "version": "8.5.10-vaultpilot-stub.0",
+  "description": "Stub of @kamino-finance/kliquidity-sdk for vaultpilot-mcp's bundled binary. Provides the 8 utility symbols klend-sdk + farms-sdk reach into, without the Raydium/Orca/Meteora dependency cone.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "bn.js": "^5.2.1",
+    "decimal.js": "^10.4.3"
+  }
+}


### PR DESCRIPTION
## Summary
- Stubs `@kamino-finance/kliquidity-sdk` with a 50-LoC local package at `vendor/kliquidity-stub/`. Removes the Raydium (85 MB) + Orca (13 MB) + assorted DEX-adapter transit through kliquidity from the bundled binary.
- Wired via npm `overrides` + a top-level `dependencies` entry pointing at the stub. Both `klend-sdk` and `farms-sdk` dedupe to the hoisted stub at install time.

## Why
Tier-1 (Sui strip, #361) brought linux-x64 from 504 MB → 420 MB. Tier-2 was deferred to [`claude-work/archive/plan-binary-slim-tier2-kamino.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/claude-work/archive/plan-binary-slim-tier2-kamino.md) because the plan flagged a high-severity risk: klend-sdk / farms-sdk `require("@kamino-finance/kliquidity-sdk")` at the top of multiple internal modules, so a naive "delete the dep" approach crashes klend-sdk at boot.

Pre-flight inspection of `node_modules/@kamino-finance/{klend,farms}-sdk/dist/**.js` enumerated the **complete** kliquidity surface area klend + farms reach at runtime:

| Symbol | Type | Real impl |
|---|---|---|
| `ZERO` | `Decimal` | `new Decimal(0)` |
| `ZERO_BN` | `BN` | `new BN(0)` |
| `aprToApy(apr, n)` | helper | `(1 + apr/n)^n − 1` |
| `batchFetch(items, fn, size?)` | helper | chunked `Promise.all` |
| `chunks(arr, size)` | helper | array slicer |
| `collToLamportsDecimal(amt, dec)` | helper | `amt × 10^dec` |
| `DECIMALS_SOL` | const | `9` |
| `FullBPS` / `FullBPSDecimal` | const | `10000` |

Eight symbols, all vanilla math/array helpers — none touch Raydium/Orca/Meteora. Stubs mirror the real impls byte-for-byte for bit-exactness; `Kamino` is a throwing-constructor placeholder (vault-strategy flows aren't used in this codebase and will fail loudly with a clear message if ever reached).

## Measurements
- `node_modules` (`--omit=dev`): **~556 MB → 446 MB** (-110 MB, transitive prune)
- `pkg` linux-x64 binary: **420 MB → 295 MB** (-125 MB) — better than the plan's 100 MB estimate
- All **2455 tests pass**
- Local smoke test (`scripts/smoke-test-binary.mjs`) reports `tools: 185` against the new binary

## Revert path
If Kamino vault-strategy reads (`kliquidity-sdk`'s `KaminoVault` / `Strategy` classes) are added to the codebase later, revert by dropping:
- `package.json` `dependencies['@kamino-finance/kliquidity-sdk']`
- `package.json` `overrides['@kamino-finance/kliquidity-sdk']`
- `vendor/kliquidity-stub/`

…then re-run `npm install --legacy-peer-deps`. The real package returns. (Tracked at the top of `vendor/kliquidity-stub/dist/index.js` so future-me sees the comment when grepping.)

## Test plan
- [x] `npm install --legacy-peer-deps` clean
- [x] `npm run build` clean
- [x] `npm test` — 2455 / 2455 pass
- [x] Local pkg build (`pkg --target node20-linux-x64 .`) succeeds, binary boots, smoke test passes
- [ ] CI release-binaries.yml succeeds across all four targets
- [ ] **Live integration test** before merge: pair Ledger + Solana app, run `prepare_kamino_supply` against Kamino main market with $1 USDC, verify the resulting tx serializes + description is correct (do NOT submit). This is the gate the plan flagged as non-optional — it catches any klend-sdk runtime path I missed in static inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)