### PR TITLE
fix(skill-pin): bump to v9 (advisory hygiene rules) — closes #536

### DIFF
--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "01d8d68d03a3c34a832e2c2595c92f666776cbe895341940c08f3c3563101414";
+  "d7428dae8a223a39b378cc3e37dbed97a2beb3ec2d8efc5c3d9072194b7ac576";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v8_";
-export const EXPECTED_SKILL_SENTINEL_C = "4aac027a9df315a9";
+export const EXPECTED_SKILL_SENTINEL_B = "_v9_";
+export const EXPECTED_SKILL_SENTINEL_C = "8b2c1d6e5f7a9301";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =


### PR DESCRIPTION
Closes #536.

## Summary
Coordinated MCP-side companion to [vaultpilot-security-skill v0.7.0](https://github.com/szhygulin/vaultpilot-security-skill/pull/20) (merged). Updates the three skill-pin constants in \`src/diagnostics/skill-pin-drift.ts\`:

- \`EXPECTED_SKILL_SHA256\`: \`01d8d68d...3563101414\` → \`d7428dae...94b7ac576\`
- \`EXPECTED_SKILL_SENTINEL_B\`: \`_v8_\` → \`_v9_\`
- \`EXPECTED_SKILL_SENTINEL_C\`: \`4aac027a9df315a9\` → \`8b2c1d6e5f7a9301\`

## Skill v9 changes
Adds an \"Advisory hygiene (cooperating-agent guidance)\" section: hardware-vendor URL allowlist (only \`ledger.com\` / \`trezor.io\`), categorical refusal of seed-handling anti-patterns (cloud backup / recovery services / sharing-with-support / pre-configured devices), trigger-phrase scan, prohibition on framing third-party seed handling as VaultPilot-sanctioned.

Per the #536 thread, the skill section ships with an **explicit honest scope label** — these rules guide cooperating agents, they do NOT defend against a rogue agent that ignores them. The architectural fix lives at the model-safety-tuning or chat-client output-filter layer, neither of which the MCP or skill can provide.

## Companion methodology issue
Filed [vaultpilot-mcp-smoke-test#21](https://github.com/szhygulin/vaultpilot-mcp-smoke-test/issues/21) proposing Role A scope reframing so advisory-layer-only attacks (Role A doing harmful free-form text generation outside any tool call) aren't filed as MCP/skill defects — the architectural gap is upstream of both.

## Test plan
- [x] Pin tests (7/7) pass
- [x] Full suite (2455/2455) pass
- [ ] Verify CI green
- [ ] After merge: skill-pin-drift startup check on a server with the canonical v0.7.0 SKILL.md installed reports no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)