### PR TITLE
fix(yields): flag null riskScore rows with notes[] warning

### DIFF
--- a/src/modules/yields/index.ts
+++ b/src/modules/yields/index.ts
@@ -153,6 +153,18 @@ async function compareYieldsImpl(args: CompareYieldsArgs): Promise<CompareYields
   );
   for (const row of allRows) {
     row.riskScore = riskByProtocol.get(row.protocol) ?? null;
+    if (row.riskScore === null) {
+      // Issue #542: an honest MCP normally has a risk score for every row
+      // (the protocol slug enum is closed and DefiLlama covers all of
+      // them). A null score means an upstream lookup failed — surface it
+      // so the agent can flag the row instead of relaying it as benign.
+      // Pairs with the skill-side allowlist check that catches fabricated
+      // protocol slugs from a rogue MCP.
+      row.notes = [
+        ...(row.notes ?? []),
+        "risk score unavailable — verify protocol legitimacy independently before recommending",
+      ];
+    }
   }
 
   // Filter: minTvlUsd. Rows with `tvl: null` are not filtered out

--- a/test/yields.test.ts
+++ b/test/yields.test.ts
@@ -275,6 +275,36 @@ describe("compareYields composer", () => {
     expect(protocols.has("jito")).toBe(false);
   });
 
+  it("appends a notes[] warning to rows whose riskScore resolved to null (issue #542)", async () => {
+    const { compareYields } = await withMocks({
+      aave: {
+        rows: [
+          { protocol: "aave-v3", chain: "ethereum", market: "USDC", supplyApr: 0.05, supplyApy: 0.051, tvl: null, riskScore: null },
+        ],
+      },
+      compound: {
+        rows: [
+          { protocol: "compound-v3", chain: "ethereum", market: "cUSDCv3", supplyApr: 0.06, supplyApy: 0.062, tvl: null, riskScore: null, notes: ["paused actions: supply"] },
+        ],
+      },
+      // aave-v3 has no risk score (DefiLlama miss); compound-v3 does.
+      riskScores: { "compound-v3": 80 },
+    });
+    const out = await compareYields({ asset: "USDC" });
+    const aave = out.rows.find((r: any) => r.protocol === "aave-v3");
+    const compound = out.rows.find((r: any) => r.protocol === "compound-v3");
+    expect(aave?.riskScore).toBeNull();
+    expect(aave?.notes ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("risk score unavailable"),
+      ]),
+    );
+    // Populated riskScore → note NOT appended; adapter-emitted notes
+    // (e.g. "paused actions: supply") are preserved verbatim.
+    expect(compound?.riskScore).toBe(80);
+    expect(compound?.notes).toEqual(["paused actions: supply"]);
+  });
+
   it("expands 'stables' into USDC + USDT and queries adapters for both", async () => {
     const { compareYields } = await withMocks({
       compound: {


### PR DESCRIPTION
Closes #542.

## Summary
- When `compare_yields` resolves a row with `riskScore: null`, append a `notes[]` entry: `"risk score unavailable — verify protocol legitimacy independently before recommending"`. Adapter-emitted notes (paused / frozen / etc.) are preserved verbatim alongside.
- An honest MCP normally has a risk score for every row (the `protocol` field is a closed TS enum and DefiLlama covers all entries). A null score means the upstream lookup failed; surfacing it through the existing notes channel lets the agent flag the row rather than relay it as benign.
- Pairs with issue #542's suggested fix #1 (skill-side allowlist of known-good protocol names — separate repo, deferred).

## Threat-model honesty
This is defense-in-depth, not a primary defense. A rogue MCP doesn't run our validation code and can return any rows it invents (the smoke-test scenarios cited in the issue exercise exactly that). The structural defense is in the preflight skill: an agent-side check that any row whose `protocol` doesn't appear in the known-good allowlist gets flagged `⚠ UNRECOGNIZED PROTOCOL`. This PR only ensures that when the MCP IS honest but DefiLlama has failed, that fact is transparent in the output instead of silently dropping a `riskScore: null` row alongside fully-scored ones.

## Test plan
- [x] `npx vitest run test/yields.test.ts` — new test covers both the "null score → note appended" path and the "populated score → adapter notes preserved unchanged" path. All 20 yields tests pass.
- [x] `npx tsc --noEmit` clean.
- [x] Full suite (190 files, 2456 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)