### PR TITLE
fix(skill-pin): bump to v10 (read-only data integrity rules)

### DIFF
--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "d7428dae8a223a39b378cc3e37dbed97a2beb3ec2d8efc5c3d9072194b7ac576";
+  "18ca800d2696720de9ca22e3a037a89a788ef069a17cfcdcd6649fa2f62b11cb";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v9_";
-export const EXPECTED_SKILL_SENTINEL_C = "8b2c1d6e5f7a9301";
+export const EXPECTED_SKILL_SENTINEL_B = "_v10_";
+export const EXPECTED_SKILL_SENTINEL_C = "3f4d8e2a6c9b1057";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =


### PR DESCRIPTION
Closes #537.

## Summary
Coordinated MCP-side companion to [vaultpilot-security-skill v0.8.0](https://github.com/szhygulin/vaultpilot-security-skill/releases/tag/v0.8.0) ([PR #22](https://github.com/szhygulin/vaultpilot-security-skill/pull/22), merged).

- `EXPECTED_SKILL_SHA256`: `d7428dae…` → `18ca800d…`
- `EXPECTED_SKILL_SENTINEL_B`: `_v9_` → `_v10_`
- `EXPECTED_SKILL_SENTINEL_C`: `8b2c1d6e5f7a9301` → `3f4d8e2a6c9b1057`

Live SHA verified against `raw.githubusercontent.com/szhygulin/vaultpilot-security-skill/master/SKILL.md`.

## Scope
Skill v0.8.0 adds **read-only data integrity rules** — cooperating-agent guidance for `get_portfolio_summary` / `get_portfolio_diff` session-anchor checks, PnL / tax-figure independent-verify nudges, and `compare_yields` / `get_protocol_risk_score` protocol-name allowlist (mirroring the MCP-side `notes[]` warning shipped in #550).

Per the canonical pattern from #536 / [vaultpilot-mcp-smoke-test#21](https://github.com/szhygulin/vaultpilot-mcp-smoke-test/issues/21), the skill section ships with the explicit honest scope label — these rules guide cooperating agents, they do NOT defend against a rogue agent that ignores them. The architectural fix for rogue-agent advisory attacks lives at the model-safety-tuning or chat-client output-filter layer.

## Test plan
- [x] `npx vitest run test/preflight-pin-block.test.ts` — 7/7 pass.
- [x] `npx tsc --noEmit` clean.
- [x] Live-SHA recompute matches the pinned constant exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)