### PR TITLE
feat(custom-call): refuse unlimited approve to burn addresses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,7 @@ import {
   prepareWethUnwrap,
   prepareTokenSend,
   prepareRevokeApproval,
+  prepareTokenApprove,
   prepareCustomCall,
   previewSend,
   previewSolanaSend,
@@ -344,6 +345,7 @@ import {
   prepareWethUnwrapInput,
   prepareTokenSendInput,
   prepareRevokeApprovalInput,
+  prepareTokenApproveInput,
   prepareCustomCallInput,
   previewSendInput,
   previewSolanaSendInput,
@@ -4323,6 +4325,16 @@ async function main() {
       inputSchema: prepareRevokeApprovalInput.shape,
     },
     txHandler("prepare_revoke_approval", prepareRevokeApproval)
+  );
+
+  registerTool(server,
+    "prepare_token_approve",
+    {
+      description:
+        "Build an unsigned `approve(spender, amount)` transaction that raises (or sets) an ERC-20 allowance — the structured inverse of `prepare_revoke_approval`. `amount` is a decimal in token units (e.g. \"10\" for 10 USDC) or the literal \"max\" for unlimited. Refuses unlimited approvals to canonical no-key addresses (`0x0…0`, `0x0…dEaD`, `0xdEaD…0`, `0xff…ff`) with `BURN_ADDRESS_UNLIMITED_APPROVAL`; override via `acknowledgeBurnApproval: true` only when the user explicitly asked for that exact spender + unlimited amount. Resolves a friendly spender label from the canonical CONTRACTS table so the description + Ledger preview reads as \"Approve USDC for Aave V3 Pool, 1000 USDC\" rather than a raw hex address. EVM-only. Prefer protocol-specific `prepare_*` (e.g. `prepare_aave_supply`) when the approval is bundled with a downstream action — those route through the shared `buildApprovalTx` helper which handles the USDT-style reset pattern in one step. Use this tool for one-off allowance-setting that doesn't fit a bundled prepare.",
+      inputSchema: prepareTokenApproveInput.shape,
+    },
+    txHandler("prepare_token_approve", prepareTokenApprove)
   );
 
   registerTool(server,

--- a/src/modules/custom-call/actions.ts
+++ b/src/modules/custom-call/actions.ts
@@ -1,6 +1,8 @@
 import { encodeFunctionData, type Abi } from "viem";
 import { getContractInfo } from "../../data/apis/etherscan.js";
+import { lookupKnownSpender } from "../../security/known-spenders.js";
 import type { SupportedChain, UnsignedTx } from "../../types/index.js";
+import { assertNotUnlimitedBurnApproval } from "../shared/approval.js";
 
 export interface BuildCustomCallParams {
   wallet: `0x${string}`;
@@ -11,48 +13,46 @@ export interface BuildCustomCallParams {
   value: string;
   abi?: readonly unknown[];
   acknowledgeBurnApproval?: boolean;
+  acknowledgeRawApproveBypass?: boolean;
 }
 
-const UINT256_MAX = (1n << 256n) - 1n;
 const APPROVE_SELECTOR = "0x095ea7b3";
 
-// Canonical no-key recipients. Lowercased for compare. An unlimited approval
-// to any of these grants every-token-the-contract-controls transfer authority
-// to an address nobody can sign for — the pattern is almost always either
-// prompt injection or a model hallucination.
-const BURN_ADDRESSES = new Set([
-  "0x0000000000000000000000000000000000000000",
-  "0x000000000000000000000000000000000000dead",
-  "0xdead000000000000000000000000000000000000",
-  "0xffffffffffffffffffffffffffffffffffffffff",
-]);
-
-function assertNotUnlimitedBurnApproval(
-  fn: string,
-  args: readonly unknown[],
+// Issue #556 — when prepare_custom_call is invoked with an `approve(address,uint256)`
+// selector, refuse and route the agent to `prepare_token_approve` (or a
+// protocol-specific `prepare_*` when the spender is a known protocol contract).
+// The dedicated tools carry burn-address gates, friendly spender labels, and the
+// structured (token, spender, amount) interface that custom_call's raw-args path
+// erases. `acknowledgeRawApproveBypass` is the escape hatch for the rare
+// non-ERC-20 contract that exposes its own `approve(address,uint256)` for an
+// unrelated purpose.
+function assertApproveRoutedToDedicatedTool(
   data: `0x${string}`,
+  spender: string | undefined,
+  knownProtocolLabel: string | undefined,
   ack: boolean | undefined,
 ): void {
   if (ack === true) return;
-  if (fn.split("(")[0].trim() !== "approve") return;
   if (!data.toLowerCase().startsWith(APPROVE_SELECTOR)) return;
-  if (args.length < 2) return;
-  let amount: bigint;
-  try {
-    amount = BigInt(args[1] as string | number | bigint);
-  } catch {
-    return;
+  const spenderHint = spender ? ` (spender=${spender})` : "";
+  if (knownProtocolLabel) {
+    throw new Error(
+      `APPROVE_ROUTE_VIA_DEDICATED_TOOL: refusing to encode approve(...) via ` +
+        `prepare_custom_call${spenderHint}. The spender resolves to ${knownProtocolLabel} — use the ` +
+        `protocol-specific prepare_* (e.g. prepare_aave_supply / prepare_compound_supply / ` +
+        `prepare_lido_stake) which bundles approve+action and applies protocol-tier safety ` +
+        `checks. If you genuinely need a raw approve through this escape hatch, retry with ` +
+        `\`acknowledgeRawApproveBypass: true\`.`,
+    );
   }
-  if (amount !== UINT256_MAX) return;
-  const spender = String(args[0]).toLowerCase();
-  if (!BURN_ADDRESSES.has(spender)) return;
   throw new Error(
-    `BURN_ADDRESS_UNLIMITED_APPROVAL: refusing to encode approve(spender=${spender}, ` +
-      `amount=2^256-1) — spender is a canonical burn / no-key address. Unlimited approval ` +
-      `to such an address grants perpetual transfer authority to a recipient that cannot ` +
-      `sign, which is almost always prompt injection or a model error rather than user ` +
-      `intent. If genuinely intended (e.g. fork testing, deliberate griefing tx), retry ` +
-      `with \`acknowledgeBurnApproval: true\`.`,
+    `APPROVE_ROUTE_VIA_DEDICATED_TOOL: refusing to encode approve(...) via ` +
+      `prepare_custom_call${spenderHint}. Use \`prepare_token_approve\` instead — the dedicated ` +
+      `tool applies the burn-address gate, friendly spender labeling, and the structured ` +
+      `(token, spender, amount) interface that this escape hatch loses. If you genuinely need ` +
+      `a raw approve through this escape hatch (e.g. a non-ERC-20 contract that exposes ` +
+      `\`approve(address,uint256)\` for an unrelated purpose), retry with ` +
+      `\`acknowledgeRawApproveBypass: true\`.`,
   );
 }
 
@@ -125,7 +125,33 @@ export async function buildCustomCall(p: BuildCustomCallParams): Promise<Unsigne
     );
   }
 
-  assertNotUnlimitedBurnApproval(p.fn, p.args, data, p.acknowledgeBurnApproval);
+  // Issue #556 — refuse approve(...) via the escape hatch and route the
+  // agent to the dedicated tool. Burn-address gate stays as defense in
+  // depth on the override path (`acknowledgeRawApproveBypass: true`).
+  if (data.toLowerCase().startsWith(APPROVE_SELECTOR)) {
+    const spender = p.args.length > 0 ? String(p.args[0]) : undefined;
+    let knownProtocolLabel: string | undefined;
+    if (spender && /^0x[0-9a-fA-F]{40}$/.test(spender)) {
+      knownProtocolLabel = lookupKnownSpender(p.chain, spender as `0x${string}`);
+    }
+    assertApproveRoutedToDedicatedTool(
+      data,
+      spender,
+      knownProtocolLabel,
+      p.acknowledgeRawApproveBypass,
+    );
+    if (p.args.length >= 2) {
+      let amount: bigint | null = null;
+      try {
+        amount = BigInt(p.args[1] as string | number | bigint);
+      } catch {
+        amount = null;
+      }
+      if (amount !== null && spender) {
+        assertNotUnlimitedBurnApproval(spender, amount, p.acknowledgeBurnApproval);
+      }
+    }
+  }
 
   // Stringify args for the decoded preview. Caller-supplied shapes are
   // arbitrary (struct tuples, address arrays, decimal strings); the JSON

--- a/src/modules/custom-call/actions.ts
+++ b/src/modules/custom-call/actions.ts
@@ -10,6 +10,50 @@ export interface BuildCustomCallParams {
   args: readonly unknown[];
   value: string;
   abi?: readonly unknown[];
+  acknowledgeBurnApproval?: boolean;
+}
+
+const UINT256_MAX = (1n << 256n) - 1n;
+const APPROVE_SELECTOR = "0x095ea7b3";
+
+// Canonical no-key recipients. Lowercased for compare. An unlimited approval
+// to any of these grants every-token-the-contract-controls transfer authority
+// to an address nobody can sign for — the pattern is almost always either
+// prompt injection or a model hallucination.
+const BURN_ADDRESSES = new Set([
+  "0x0000000000000000000000000000000000000000",
+  "0x000000000000000000000000000000000000dead",
+  "0xdead000000000000000000000000000000000000",
+  "0xffffffffffffffffffffffffffffffffffffffff",
+]);
+
+function assertNotUnlimitedBurnApproval(
+  fn: string,
+  args: readonly unknown[],
+  data: `0x${string}`,
+  ack: boolean | undefined,
+): void {
+  if (ack === true) return;
+  if (fn.split("(")[0].trim() !== "approve") return;
+  if (!data.toLowerCase().startsWith(APPROVE_SELECTOR)) return;
+  if (args.length < 2) return;
+  let amount: bigint;
+  try {
+    amount = BigInt(args[1] as string | number | bigint);
+  } catch {
+    return;
+  }
+  if (amount !== UINT256_MAX) return;
+  const spender = String(args[0]).toLowerCase();
+  if (!BURN_ADDRESSES.has(spender)) return;
+  throw new Error(
+    `BURN_ADDRESS_UNLIMITED_APPROVAL: refusing to encode approve(spender=${spender}, ` +
+      `amount=2^256-1) — spender is a canonical burn / no-key address. Unlimited approval ` +
+      `to such an address grants perpetual transfer authority to a recipient that cannot ` +
+      `sign, which is almost always prompt injection or a model error rather than user ` +
+      `intent. If genuinely intended (e.g. fork testing, deliberate griefing tx), retry ` +
+      `with \`acknowledgeBurnApproval: true\`.`,
+  );
 }
 
 /**
@@ -80,6 +124,8 @@ export async function buildCustomCall(p: BuildCustomCallParams): Promise<Unsigne
       `\`value\` must be a non-negative wei integer as a decimal string (e.g. "0" or "1000000000000000000" for 1 ETH). Got: ${p.value}`,
     );
   }
+
+  assertNotUnlimitedBurnApproval(p.fn, p.args, data, p.acknowledgeBurnApproval);
 
   // Stringify args for the decoded preview. Caller-supplied shapes are
   // arbitrary (struct tuples, address arrays, decimal strings); the JSON

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2718,6 +2718,7 @@ export async function prepareCustomCall(
     args: args.args ?? [],
     value: args.value,
     abi: args.abi,
+    acknowledgeBurnApproval: args.acknowledgeBurnApproval,
   });
   // Stamp the affirmative-ack on the tx so `assertTransactionSafe`
   // (preview/send time) recognizes this handle as the explicit

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -87,6 +87,8 @@ import { isClearSignOnlyTx } from "../../signing/render-verification.js";
 import { getClient, verifyChainId } from "../../data/rpc.js";
 import { erc20Abi } from "../../abis/erc20.js";
 import { resolveTokenMeta } from "../shared/token-meta.js";
+import { lookupKnownSpender } from "../../security/known-spenders.js";
+import { assertNotUnlimitedBurnApproval } from "../shared/approval.js";
 import { simulateTx } from "../simulation/index.js";
 import { isDemoMode } from "../../demo/index.js";
 import {
@@ -140,6 +142,7 @@ import type {
   PrepareWethUnwrapArgs,
   PrepareTokenSendArgs,
   PrepareRevokeApprovalArgs,
+  PrepareTokenApproveArgs,
   PrepareCustomCallArgs,
   PrepareSolanaNativeSendArgs,
   PrepareSolanaSplSendArgs,
@@ -2697,6 +2700,87 @@ export async function prepareRevokeApproval(
   });
 }
 
+/**
+ * Build an `approve(spender, amount)` tx that raises (or sets) the
+ * allowance `wallet` grants `spender` on `token`. Structured inverse of
+ * `prepare_revoke_approval`. Issue #556.
+ *
+ * `amount` is a decimal string in token units; pass `"max"` for the
+ * uint256-max unlimited allowance. Burn-address gate refuses unlimited
+ * approvals to canonical no-key recipients unless
+ * `acknowledgeBurnApproval: true` is set.
+ *
+ * Resolves a friendly spender label from the canonical `CONTRACTS` table
+ * so the description + Ledger-screen preview reads as "Approve USDC for
+ * Aave V3 Pool, 1000 USDC" rather than a raw hex address.
+ */
+export async function prepareTokenApprove(
+  args: PrepareTokenApproveArgs,
+): Promise<UnsignedTx> {
+  const wallet = args.wallet as `0x${string}`;
+  const chain = args.chain as SupportedChain;
+  const token = args.token as `0x${string}`;
+  const spender = args.spender as `0x${string}`;
+
+  const meta = await resolveTokenMeta(chain, token);
+
+  let amountWei: bigint;
+  let amountDisplay: string;
+  if (args.amount === "max") {
+    amountWei = (1n << 256n) - 1n;
+    amountDisplay = "unlimited";
+  } else if (/^\d+(\.\d+)?$/.test(args.amount)) {
+    amountWei = parseUnits(args.amount, meta.decimals);
+    amountDisplay = `${args.amount} ${meta.symbol}`;
+  } else {
+    throw new Error(
+      `\`amount\` must be a decimal string (e.g. "10" or "1.5") in ${meta.symbol} units, ` +
+        `or the literal "max" for unlimited. Got: "${args.amount}". Raw wei is NOT accepted.`,
+    );
+  }
+
+  if (amountWei === 0n) {
+    throw new Error(
+      `prepare_token_approve refuses approve(spender, 0) — that's the revoke pattern. ` +
+        `Use prepare_revoke_approval instead, which adds the "live allowance must be > 0" ` +
+        `pre-flight check and the friendly revoke description.`,
+    );
+  }
+
+  assertNotUnlimitedBurnApproval(spender, amountWei, args.acknowledgeBurnApproval);
+
+  const knownLabel = lookupKnownSpender(chain, spender);
+  const spenderDisplay = knownLabel ? `${knownLabel} (${spender})` : spender;
+
+  const { makeDurableBinding } = await import(
+    "../../security/durable-binding.js"
+  );
+  return enrichTx({
+    chain,
+    to: token,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [spender, amountWei],
+    }),
+    value: "0",
+    from: wallet,
+    description: `Approve ${meta.symbol} for ${spenderDisplay} on ${chain} (${amountDisplay})`,
+    decoded: {
+      functionName: "approve",
+      args: {
+        spender,
+        amount: amountDisplay,
+        symbol: meta.symbol,
+        ...(knownLabel ? { spenderLabel: knownLabel } : {}),
+      },
+    },
+    // Inv #14 — the spender selected here is the durable object the user
+    // must re-verify. Mirrors prepare_revoke_approval.
+    durableBindings: [makeDurableBinding("approval-spender-address", spender)],
+  });
+}
+
 export async function prepareCustomCall(
   args: PrepareCustomCallArgs,
 ): Promise<UnsignedTx> {
@@ -2719,6 +2803,7 @@ export async function prepareCustomCall(
     value: args.value,
     abi: args.abi,
     acknowledgeBurnApproval: args.acknowledgeBurnApproval,
+    acknowledgeRawApproveBypass: args.acknowledgeRawApproveBypass,
   });
   // Stamp the affirmative-ack on the tx so `assertTransactionSafe`
   // (preview/send time) recognizes this handle as the explicit
@@ -2728,49 +2813,6 @@ export async function prepareCustomCall(
   return enrichTx(built);
 }
 
-/**
- * Resolve a friendly label for a spender address from the canonical
- * `CONTRACTS` table on the given chain. Returns undefined for arbitrary
- * (non-protocol) spender addresses. Mirrors the same lookup the read-
- * side `get_token_allowances` tool uses for consistent labeling across
- * the read + revoke surfaces.
- */
-function lookupKnownSpender(
-  chain: SupportedChain,
-  spender: `0x${string}`,
-): string | undefined {
-  const c = CONTRACTS[chain] as Record<string, Record<string, string>> | undefined;
-  if (!c) return undefined;
-  const target = spender.toLowerCase();
-  for (const [protocol, addrs] of Object.entries(c)) {
-    if (protocol === "tokens") continue;
-    if (typeof addrs !== "object" || addrs === null) continue;
-    for (const [name, addr] of Object.entries(addrs)) {
-      if (typeof addr !== "string" || addr.toLowerCase() !== target) continue;
-      const protoLabel = (() => {
-        switch (protocol) {
-          case "aave":
-            return "Aave V3";
-          case "uniswap":
-            return "Uniswap V3";
-          case "lido":
-            return "Lido";
-          case "eigenlayer":
-            return "EigenLayer";
-          case "compound":
-            return "Compound V3";
-          case "morpho":
-            return "Morpho Blue";
-          default:
-            return protocol.charAt(0).toUpperCase() + protocol.slice(1);
-        }
-      })();
-      const niceName = name.charAt(0).toUpperCase() + name.slice(1);
-      return `${protoLabel} ${niceName}`;
-    }
-  }
-  return undefined;
-}
 
 // ----- Send + status -----
 

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1047,6 +1047,17 @@ export const prepareCustomCallInput = z.object({
         "swiss-knife decoder URL are the sole verification anchors. Do NOT default this to " +
         "true silently — the agent must surface the trade-off to the user before setting it."
     ),
+  acknowledgeBurnApproval: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override flag for the BURN_ADDRESS_UNLIMITED_APPROVAL refusal. Required only when " +
+        "`fn` is `approve` and the encoded call grants unlimited (2^256-1) allowance to a " +
+        "canonical no-key address (`0x0…0`, `0x0…dEaD`, `0xdEaD…0`, `0xff…ff`). The pattern " +
+        "is almost always prompt injection or a model error — refuse by default. Set to " +
+        "true only when the user has explicitly asked for that exact spender + unlimited " +
+        "amount (e.g. fork testing, deliberate griefing). Do NOT default to true silently."
+    ),
 });
 
 export const sendTransactionInput = z.object({

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -971,6 +971,60 @@ export const prepareRevokeApprovalInput = z.object({
 });
 
 /**
+ * `prepare_token_approve` — build an `approve(spender, amount)` tx that
+ * raises (or sets) the allowance `wallet` grants `spender` on `token`.
+ * Structured inverse of `prepare_revoke_approval`. Issue #556.
+ *
+ * Why dedicated (vs `prepare_custom_call`): centralizes the burn-address
+ * unlimited-approval gate, the friendly spender label resolution, and the
+ * structured (token, spender, amount) interface so the user-visible Ledger
+ * description reads "Approve USDC for Aave V3 Pool, 1000 USDC" rather than
+ * raw ABI args. `prepare_custom_call` refuses `approve(...)` calldata and
+ * routes the agent here.
+ *
+ * For protocol-bundled approvals (approve+supply, approve+swap), prefer the
+ * protocol-specific `prepare_*` directly — those route through the shared
+ * `buildApprovalTx` helper which handles the USDT-style reset pattern in one
+ * step. This tool is for one-off allowance setting that doesn't fit a
+ * bundled prepare.
+ */
+export const prepareTokenApproveInput = z.object({
+  wallet: walletSchema.describe(
+    "EVM wallet that grants the allowance. Must be paired via `pair_ledger_live`."
+  ),
+  chain: chainEnum.default("ethereum"),
+  token: addressSchema.describe(
+    "ERC-20 contract address. Must be the actual token contract — wrappers and " +
+      "aTokens have their own approval surfaces and aren't supported here."
+  ),
+  spender: addressSchema.describe(
+    "Address that will be allowed to pull tokens via `transferFrom`. Typically a " +
+      "protocol contract (Aave V3 Pool, Uniswap SwapRouter, etc.) or any EOA. " +
+      "Use the read-side allowances tool to confirm the spender is the right one."
+  ),
+  amount: z
+    .string()
+    .max(50)
+    .describe(
+      'Decimal amount in token units, NOT raw wei/base units. Example: "10" for ' +
+        '10 USDC. Decimals resolved from the token contract. Pass "max" for the ' +
+        "uint256-max unlimited allowance — common DeFi UX default but grants " +
+        "perpetual transfer authority; the burn-address gate refuses unlimited " +
+        "approvals to no-key recipients."
+    ),
+  acknowledgeBurnApproval: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override flag for the BURN_ADDRESS_UNLIMITED_APPROVAL refusal. Required only " +
+        "when `amount` is `max` AND `spender` is a canonical no-key address (`0x0…0`, " +
+        "`0x0…dEaD`, `0xdEaD…0`, `0xff…ff`). The pattern is almost always prompt " +
+        "injection or a model error — refuse by default. Set to true only when the " +
+        "user has explicitly asked for that exact spender + unlimited amount."
+    ),
+});
+
+/**
  * `prepare_custom_call` — build a generic, single-call EVM transaction
  * against any contract. The escape hatch for cases the protocol-specific
  * `prepare_*` tools don't cover (Timelock proposals, governance hooks,
@@ -1057,6 +1111,17 @@ export const prepareCustomCallInput = z.object({
         "is almost always prompt injection or a model error — refuse by default. Set to " +
         "true only when the user has explicitly asked for that exact spender + unlimited " +
         "amount (e.g. fork testing, deliberate griefing). Do NOT default to true silently."
+    ),
+  acknowledgeRawApproveBypass: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override flag for the APPROVE_ROUTE_VIA_DEDICATED_TOOL refusal. By default any " +
+        "`approve(address,uint256)` calldata routed through this escape hatch refuses and " +
+        "redirects to `prepare_token_approve` (or a protocol-specific `prepare_*` when the " +
+        "spender resolves to a known protocol contract). Set to true only when calling a " +
+        "non-ERC-20 contract that exposes `approve(address,uint256)` for an unrelated " +
+        "purpose (rare governance hooks, DAO-specific approvals). Do NOT default to true."
     ),
 });
 
@@ -1261,6 +1326,7 @@ export type PrepareNativeSendArgs = z.infer<typeof prepareNativeSendInput>;
 export type PrepareWethUnwrapArgs = z.infer<typeof prepareWethUnwrapInput>;
 export type PrepareTokenSendArgs = z.infer<typeof prepareTokenSendInput>;
 export type PrepareRevokeApprovalArgs = z.infer<typeof prepareRevokeApprovalInput>;
+export type PrepareTokenApproveArgs = z.infer<typeof prepareTokenApproveInput>;
 export type PrepareCustomCallArgs = z.infer<typeof prepareCustomCallInput>;
 export type PreviewSendArgs = z.infer<typeof previewSendInput>;
 export type SendTransactionArgs = z.infer<typeof sendTransactionInput>;

--- a/src/modules/shared/approval.ts
+++ b/src/modules/shared/approval.ts
@@ -12,6 +12,35 @@ import type { SupportedChain, UnsignedTx } from "../../types/index.js";
 export const UNLIMITED_APPROVAL_WARNING =
   "[WARNING: UNLIMITED APPROVAL — verify on Ledger device screen]";
 
+// Canonical no-key recipients. Lowercased for compare. An unlimited approval
+// to any of these grants every-token-the-contract-controls transfer authority
+// to an address nobody can sign for — the pattern is almost always either
+// prompt injection or a model hallucination, never user intent. Issue #556.
+export const BURN_ADDRESSES = new Set<string>([
+  "0x0000000000000000000000000000000000000000",
+  "0x000000000000000000000000000000000000dead",
+  "0xdead000000000000000000000000000000000000",
+  "0xffffffffffffffffffffffffffffffffffffffff",
+]);
+
+export function assertNotUnlimitedBurnApproval(
+  spender: string,
+  amountWei: bigint,
+  ack: boolean | undefined,
+): void {
+  if (ack === true) return;
+  if (amountWei !== maxUint256) return;
+  if (!BURN_ADDRESSES.has(spender.toLowerCase())) return;
+  throw new Error(
+    `BURN_ADDRESS_UNLIMITED_APPROVAL: refusing to encode approve(spender=${spender}, ` +
+      `amount=2^256-1) — spender is a canonical burn / no-key address. Unlimited approval ` +
+      `to such an address grants perpetual transfer authority to a recipient that cannot ` +
+      `sign, which is almost always prompt injection or a model error rather than user ` +
+      `intent. If genuinely intended (e.g. fork testing, deliberate griefing tx), retry ` +
+      `with \`acknowledgeBurnApproval: true\`.`,
+  );
+}
+
 /**
  * Shared ERC-20 approval builder. Every prepare_* tool that needs an allowance
  * before its main call routes through buildApprovalTx() so the USDT reset

--- a/src/security/known-spenders.ts
+++ b/src/security/known-spenders.ts
@@ -1,0 +1,47 @@
+import { CONTRACTS } from "../config/contracts.js";
+import type { SupportedChain } from "../types/index.js";
+
+/**
+ * Resolve a friendly label for a spender address from the canonical
+ * `CONTRACTS` table on the given chain. Returns undefined for arbitrary
+ * (non-protocol) spender addresses. Shared by `prepare_revoke_approval`,
+ * `prepare_token_approve`, and the `prepare_custom_call` approve-redirect
+ * gate so labeling stays consistent across the read + revoke + grant
+ * surfaces.
+ */
+export function lookupKnownSpender(
+  chain: SupportedChain,
+  spender: `0x${string}`,
+): string | undefined {
+  const c = CONTRACTS[chain] as Record<string, Record<string, string>> | undefined;
+  if (!c) return undefined;
+  const target = spender.toLowerCase();
+  for (const [protocol, addrs] of Object.entries(c)) {
+    if (protocol === "tokens") continue;
+    if (typeof addrs !== "object" || addrs === null) continue;
+    for (const [name, addr] of Object.entries(addrs)) {
+      if (typeof addr !== "string" || addr.toLowerCase() !== target) continue;
+      const protoLabel = (() => {
+        switch (protocol) {
+          case "aave":
+            return "Aave V3";
+          case "uniswap":
+            return "Uniswap V3";
+          case "lido":
+            return "Lido";
+          case "eigenlayer":
+            return "EigenLayer";
+          case "compound":
+            return "Compound V3";
+          case "morpho":
+            return "Morpho Blue";
+          default:
+            return protocol.charAt(0).toUpperCase() + protocol.slice(1);
+        }
+      })();
+      const niceName = name.charAt(0).toUpperCase() + name.slice(1);
+      return `${protoLabel} ${niceName}`;
+    }
+  }
+  return undefined;
+}

--- a/test/custom-call.test.ts
+++ b/test/custom-call.test.ts
@@ -312,7 +312,7 @@ describe("buildCustomCall — encoding", () => {
   });
 });
 
-// Minimal ERC-20 fragment — only `approve` is needed for the burn-address gate.
+// Minimal ERC-20 fragment — only `approve` is needed for the redirect gate.
 const ERC20_APPROVE_ABI = [
   {
     type: "function",
@@ -327,69 +327,87 @@ const ERC20_APPROVE_ABI = [
 ] as const;
 
 const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const RANDOM_EOA = "0x000000000000000000000000000000000000beef" as const;
+const UNISWAP_ROUTER02 = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45" as const;
 const UINT256_MAX = (1n << 256n) - 1n;
 
-describe("buildCustomCall — burn-address unlimited-approval refusal (issue #556)", () => {
-  it.each([
-    ["0xdead000000000000000000000000000000000000"], // leading dead — what triggered the bug
-    ["0x000000000000000000000000000000000000dead"], // trailing dead
-    ["0x0000000000000000000000000000000000000000"], // zero
-    ["0xffffffffffffffffffffffffffffffffffffffff"], // max
-  ])("refuses unlimited approve to canonical burn address %s", async (burn) => {
+describe("buildCustomCall — approve-route refusal (issue #556)", () => {
+  it("refuses approve(...) and points to prepare_token_approve when spender is unknown", async () => {
     await expect(
       buildCustomCall({
         wallet: WALLET,
         chain: "ethereum",
         contract: USDC,
         fn: "approve",
-        args: [burn, UINT256_MAX.toString()],
+        args: [RANDOM_EOA, "1000000"],
         value: "0",
         abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/APPROVE_ROUTE_VIA_DEDICATED_TOOL[\s\S]*prepare_token_approve/);
+  });
+
+  it("refuses approve(...) and points to protocol-specific prepare_* when spender is a known protocol", async () => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "approve",
+        args: [UNISWAP_ROUTER02, UINT256_MAX.toString()],
+        value: "0",
+        abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/APPROVE_ROUTE_VIA_DEDICATED_TOOL[\s\S]*Uniswap V3/);
+  });
+
+  it("allows approve(...) when acknowledgeRawApproveBypass=true (escape hatch)", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "approve",
+      args: [RANDOM_EOA, "1000000"],
+      value: "0",
+      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+      acknowledgeRawApproveBypass: true,
+    });
+    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+  });
+
+  it("burn-address gate still fires on the override path (defense in depth)", async () => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "approve",
+        args: ["0xdead000000000000000000000000000000000000", UINT256_MAX.toString()],
+        value: "0",
+        abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+        acknowledgeRawApproveBypass: true,
       }),
     ).rejects.toThrow(/BURN_ADDRESS_UNLIMITED_APPROVAL/);
   });
 
-  it("allows unlimited approve to burn address when acknowledgeBurnApproval=true", async () => {
+  it("does not fire on non-approve calldata (Timelock schedule)", async () => {
     const tx = await buildCustomCall({
       wallet: WALLET,
       chain: "ethereum",
-      contract: USDC,
-      fn: "approve",
-      args: ["0xdead000000000000000000000000000000000000", UINT256_MAX.toString()],
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0",
+        "0x",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "172800",
+      ],
       value: "0",
-      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
-      acknowledgeBurnApproval: true,
+      abi: TIMELOCK_ABI as unknown as readonly unknown[],
     });
-    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+    expect(tx.data.startsWith("0x01d5062a")).toBe(true);
   });
-
-  it("allows non-unlimited approve to burn address (only the unlimited variant refuses)", async () => {
-    // approve(burn, 0) is the revoke pattern — must remain expressible.
-    const tx = await buildCustomCall({
-      wallet: WALLET,
-      chain: "ethereum",
-      contract: USDC,
-      fn: "approve",
-      args: ["0xdead000000000000000000000000000000000000", "0"],
-      value: "0",
-      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
-    });
-    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
-  });
-
-  it("allows unlimited approve to non-burn spender", async () => {
-    const tx = await buildCustomCall({
-      wallet: WALLET,
-      chain: "ethereum",
-      contract: USDC,
-      fn: "approve",
-      args: ["0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45", UINT256_MAX.toString()],
-      value: "0",
-      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
-    });
-    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
-  });
-
 });
 
 describe("canonical-dispatch wiring (#483 / PR #489)", () => {

--- a/test/custom-call.test.ts
+++ b/test/custom-call.test.ts
@@ -312,6 +312,86 @@ describe("buildCustomCall — encoding", () => {
   });
 });
 
+// Minimal ERC-20 fragment — only `approve` is needed for the burn-address gate.
+const ERC20_APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+const UINT256_MAX = (1n << 256n) - 1n;
+
+describe("buildCustomCall — burn-address unlimited-approval refusal (issue #556)", () => {
+  it.each([
+    ["0xdead000000000000000000000000000000000000"], // leading dead — what triggered the bug
+    ["0x000000000000000000000000000000000000dead"], // trailing dead
+    ["0x0000000000000000000000000000000000000000"], // zero
+    ["0xffffffffffffffffffffffffffffffffffffffff"], // max
+  ])("refuses unlimited approve to canonical burn address %s", async (burn) => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "approve",
+        args: [burn, UINT256_MAX.toString()],
+        value: "0",
+        abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/BURN_ADDRESS_UNLIMITED_APPROVAL/);
+  });
+
+  it("allows unlimited approve to burn address when acknowledgeBurnApproval=true", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "approve",
+      args: ["0xdead000000000000000000000000000000000000", UINT256_MAX.toString()],
+      value: "0",
+      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+      acknowledgeBurnApproval: true,
+    });
+    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+  });
+
+  it("allows non-unlimited approve to burn address (only the unlimited variant refuses)", async () => {
+    // approve(burn, 0) is the revoke pattern — must remain expressible.
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "approve",
+      args: ["0xdead000000000000000000000000000000000000", "0"],
+      value: "0",
+      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+  });
+
+  it("allows unlimited approve to non-burn spender", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "approve",
+      args: ["0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45", UINT256_MAX.toString()],
+      value: "0",
+      abi: ERC20_APPROVE_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+  });
+
+});
+
 describe("canonical-dispatch wiring (#483 / PR #489)", () => {
   it("is a no-op for prepare_custom_call regardless of `to`", () => {
     // The wired txHandler walks to the action leg and asserts canonical

--- a/test/prepare-token-approve.test.ts
+++ b/test/prepare-token-approve.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for `prepareTokenApprove` — the write-side counterpart to
+ * `prepare_revoke_approval`, gated dedicated tool for setting non-zero
+ * ERC-20 allowances. Issue #556.
+ *
+ * Coverage:
+ *   - Happy path: decimal amount + "max" both encode to the right
+ *     approve(spender, amount) calldata; friendly label appears in the
+ *     description / decoded.args when the spender is in CONTRACTS.
+ *   - Burn-address gate: refuses unlimited approve to canonical no-key
+ *     addresses (0x0…0, 0x0…dEaD, 0xdEaD…0, 0xff…ff).
+ *   - Override: `acknowledgeBurnApproval: true` allows the call through.
+ *   - Decimal-amount + burn spender is NOT refused (only unlimited is).
+ *   - amount === 0 refuses with a redirect to prepare_revoke_approval.
+ *   - amount validation rejects non-decimal / non-"max" inputs.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { decodeFunctionData } from "viem";
+import { erc20Abi } from "../src/abis/erc20.js";
+
+const { readContractMock, multicallMock, callMock, estimateGasMock, getGasPriceMock } =
+  vi.hoisted(() => ({
+    readContractMock: vi.fn(),
+    multicallMock: vi.fn(),
+    callMock: vi.fn(),
+    estimateGasMock: vi.fn(),
+    getGasPriceMock: vi.fn(),
+  }));
+
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: readContractMock,
+    multicall: multicallMock,
+    call: callMock,
+    estimateGas: estimateGasMock,
+    getGasPrice: getGasPriceMock,
+    getChainId: vi.fn(),
+  }),
+  verifyChainId: vi.fn().mockResolvedValue(undefined),
+  resetClients: vi.fn(),
+}));
+
+vi.mock("../src/data/prices.js", () => ({
+  getTokenPrice: vi.fn().mockResolvedValue(undefined),
+  getTokenPrices: vi.fn().mockResolvedValue(new Map()),
+  getDefillamaCoinPrice: vi.fn().mockResolvedValue(undefined),
+}));
+
+const WALLET = "0x000000000000000000000000000000000000dEaD";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const AAVE_POOL = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"; // known label
+const RANDOM_SPENDER = "0x1111111111111111111111111111111111111111";
+const UINT256_MAX = (1n << 256n) - 1n;
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  multicallMock.mockReset();
+  callMock.mockReset();
+  estimateGasMock.mockReset();
+  getGasPriceMock.mockReset();
+  // Token metadata = USDC (6 decimals).
+  multicallMock.mockResolvedValue([6, "USDC"]);
+  callMock.mockResolvedValue({
+    data: "0x0000000000000000000000000000000000000000000000000000000000000001",
+  });
+  estimateGasMock.mockResolvedValue(50_000n);
+  getGasPriceMock.mockResolvedValue(10_000_000_000n);
+});
+
+describe("prepareTokenApprove — happy path", () => {
+  it("encodes approve(spender, amountWei) for a decimal amount", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareTokenApprove({
+      wallet: WALLET,
+      chain: "ethereum",
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      amount: "100",
+    });
+    expect(tx.to.toLowerCase()).toBe(USDC.toLowerCase());
+    expect(tx.value).toBe("0");
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decoded.functionName).toBe("approve");
+    expect(decoded.args?.[0]).toBe(RANDOM_SPENDER);
+    expect(decoded.args?.[1]).toBe(100_000_000n); // 100 * 10^6
+  });
+
+  it("encodes approve(spender, uint256.max) for amount=\"max\"", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareTokenApprove({
+      wallet: WALLET,
+      chain: "ethereum",
+      token: USDC,
+      spender: RANDOM_SPENDER,
+      amount: "max",
+    });
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decoded.args?.[1]).toBe(UINT256_MAX);
+    expect(tx.description).toContain("unlimited");
+  });
+
+  it("surfaces friendly spender label for known protocol contracts", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareTokenApprove({
+      wallet: WALLET,
+      chain: "ethereum",
+      token: USDC,
+      spender: AAVE_POOL,
+      amount: "100",
+    });
+    expect(tx.description).toContain("Aave V3");
+    expect(tx.decoded?.args.spenderLabel).toContain("Aave V3");
+  });
+});
+
+describe("prepareTokenApprove — burn-address gate (issue #556)", () => {
+  it.each([
+    ["0xdead000000000000000000000000000000000000"],
+    ["0x000000000000000000000000000000000000dead"],
+    ["0x0000000000000000000000000000000000000000"],
+    ["0xffffffffffffffffffffffffffffffffffffffff"],
+  ])("refuses amount=\"max\" to canonical burn address %s", async (burn) => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareTokenApprove({
+        wallet: WALLET,
+        chain: "ethereum",
+        token: USDC,
+        spender: burn as `0x${string}`,
+        amount: "max",
+      }),
+    ).rejects.toThrow(/BURN_ADDRESS_UNLIMITED_APPROVAL/);
+  });
+
+  it("allows amount=\"max\" to burn address with acknowledgeBurnApproval=true", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareTokenApprove({
+      wallet: WALLET,
+      chain: "ethereum",
+      token: USDC,
+      spender: "0xdead000000000000000000000000000000000000",
+      amount: "max",
+      acknowledgeBurnApproval: true,
+    });
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decoded.args?.[1]).toBe(UINT256_MAX);
+  });
+
+  it("allows finite amount to burn address (gate fires only on unlimited)", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    const tx = await prepareTokenApprove({
+      wallet: WALLET,
+      chain: "ethereum",
+      token: USDC,
+      spender: "0xdead000000000000000000000000000000000000",
+      amount: "100",
+    });
+    expect(tx.data.startsWith("0x095ea7b3")).toBe(true);
+  });
+});
+
+describe("prepareTokenApprove — input validation", () => {
+  it("refuses amount=0 with a redirect to prepare_revoke_approval", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareTokenApprove({
+        wallet: WALLET,
+        chain: "ethereum",
+        token: USDC,
+        spender: RANDOM_SPENDER,
+        amount: "0",
+      }),
+    ).rejects.toThrow(/prepare_revoke_approval/);
+  });
+
+  it("refuses non-decimal non-\"max\" amount strings", async () => {
+    const { prepareTokenApprove } = await import(
+      "../src/modules/execution/index.js"
+    );
+    await expect(
+      prepareTokenApprove({
+        wallet: WALLET,
+        chain: "ethereum",
+        token: USDC,
+        spender: RANDOM_SPENDER,
+        amount: "abc",
+      }),
+    ).rejects.toThrow(/decimal string|max/);
+  });
+});


### PR DESCRIPTION
Closes #556.

## Summary
Two layers of defence for unlimited approval to canonical burn / no-key addresses, addressing both the original finding and the follow-up review comment ("agent should route this through the approve tool").

**Layer 1 — burn-address gate.** `prepare_token_approve` (new) and `prepare_custom_call` (override path) both refuse `approve(spender, 2^256-1)` when `spender` ∈ `{0x0…0, 0x0…dEaD, 0xdEaD…0, 0xff…ff}` with `BURN_ADDRESS_UNLIMITED_APPROVAL`. Override via `acknowledgeBurnApproval: true`.

**Layer 2 — route approvals through the dedicated tool.** `prepare_custom_call` now refuses any `approve(address,uint256)` calldata with `APPROVE_ROUTE_VIA_DEDICATED_TOOL`:
- spender resolves to a known protocol → redirects to the protocol-specific `prepare_*` (e.g. `prepare_aave_supply`).
- otherwise → redirects to the new `prepare_token_approve`.
- Override via `acknowledgeRawApproveBypass: true` for the rare non-ERC-20 contract that exposes its own `approve(address,uint256)`. Burn-address gate still fires on that path.

## New tool: `prepare_token_approve`
Structured inverse of `prepare_revoke_approval`. Takes `(wallet, chain, token, spender, amount)` where `amount` is a decimal in token units (e.g. `"100"` for 100 USDC) or the literal `"max"` for unlimited. Resolves friendly spender labels from the canonical `CONTRACTS` table so the Ledger preview reads "Approve USDC for Aave V3 Pool, 100 USDC" rather than raw hex. Refuses `amount: "0"` with a redirect to `prepare_revoke_approval`.

## Refactors
- Extracted `BURN_ADDRESSES` + `assertNotUnlimitedBurnApproval` into `src/modules/shared/approval.ts` so the gate is one source of truth.
- Extracted `lookupKnownSpender` into `src/security/known-spenders.ts` so `prepare_custom_call`, `prepare_revoke_approval`, and `prepare_token_approve` share label resolution.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run` — 2472/2472 pass
- New tests cover: burn variants refused on `prepare_token_approve`; `acknowledgeBurnApproval` override; finite amount to burn (only unlimited refuses); approve-redirect refusal in `prepare_custom_call` (known protocol vs unknown spender); `acknowledgeRawApproveBypass` escape hatch with burn gate still firing as defense in depth; non-approve calldata unaffected; `amount: "0"` redirects to revoke; non-decimal/non-max amount strings refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
