### PR TITLE
docs(claude.md): require reading issue comments when working an issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@
 - If the user says "do it anyway", proceed.
 - Past incident 2026-04-27: user asked to retrigger release-binaries.yml on the v0.9.4 tag for a missing macos-arm64 upload; tag predated #346 / #349 / #361 (size + retry fixes). Right move was flag the frozen-tag problem and recommend cutting v0.9.5.
 
+## Issue Analysis
+- **When asked to work on an issue, read the comments too — not just the body — and fold relevant content into the analysis.** Comments are where reviewers add follow-up scope, push back on the original framing, or specify defense layers the body left implicit. Skipping them ships a half-answer to the wrong question. `gh api repos/<owner>/<repo>/issues/<N>/comments` returns the thread.
+- Past incident 2026-04-29: implemented #556 (burn-address approval refusal) from the body alone. The user's follow-up comment ("agent should route this through the approve tool, not prepare_custom_call") was the second defense layer the issue actually required — caught only after the user pointed it out, costing a round-trip.
+
 ## Smallest-Solution Discipline
 - **Push back with the smallest solution that solves the stated problem.** Minimum change first; escalate only if it demonstrably doesn't cover the requirement. Issue/plan text is a problem description, not a license to build infrastructure.
 - Tells the proposal is too big: persistence layer for a one-shot operation; new module when an inline call-site change would do; background worker/scheduler for an action that fires once per request; generalizing for hypothetical future callers; "while I'm here" refactors bundled into a fix PR.


### PR DESCRIPTION
Adds a short Issue Analysis section to CLAUDE.md: when asked to work on an issue, read the comments too — not just the body — and fold relevant content into the analysis. Comments often carry follow-up scope or defense-layer requirements the body leaves implicit.

Includes the 2026-04-29 incident as the past-failure anchor: #556 (burn-address approval refusal) was implemented from the body alone, and the user's follow-up comment ("agent should route this through the approve tool, not prepare_custom_call") — which turned out to be the second defense layer the issue actually required — was caught only when the user pointed it out, costing a round-trip.

## Test plan
- [x] Markdown only — no code changes, no tests run