### PR TITLE
feat(strategy): reject unknown keys in import_strategy / share_strategy

### DIFF
--- a/src/modules/strategy/index.ts
+++ b/src/modules/strategy/index.ts
@@ -47,6 +47,86 @@ const RISK_PROFILE_VALUES = new Set<NonNullable<SharedStrategy["meta"]["riskProf
   "aggressive",
 ]);
 
+// Known-key sets, frozen against the v1 schema. Validation refuses any key
+// outside these sets so a compromised producer can't smuggle directive-shaped
+// fields (`_delegateAuthority`, `_executor`, …) through silently. Issue #557.
+const KNOWN_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
+  "version",
+  "meta",
+  "positions",
+  "notes",
+]);
+const KNOWN_META_KEYS: ReadonlySet<string> = new Set([
+  "name",
+  "description",
+  "authorLabel",
+  "riskProfile",
+  "createdIso",
+  "chains",
+]);
+const KNOWN_POSITION_KEYS: ReadonlySet<string> = new Set([
+  "protocol",
+  "chain",
+  "kind",
+  "asset",
+  "pctOfTotal",
+  "healthFactor",
+  "feeTier",
+  "apr",
+  "inRange",
+]);
+
+/**
+ * Refuse any key not listed in `allowed`. The previous behavior (silently
+ * drop unknown keys via reconstruction) hid tampering — issue #557 wants
+ * the import side to surface it. Symmetric on emit so a future serializer
+ * drift adding a new field can't leak past validation either.
+ */
+function assertOnlyAllowedKeys(
+  obj: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  context: string,
+): void {
+  for (const key of Object.keys(obj)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `STRATEGY_UNKNOWN_KEY_REJECTED: ${context} contains unexpected key ` +
+          `"${key}". Strategy JSON must conform to the published ` +
+          `v${SHARED_STRATEGY_VERSION} schema; unknown keys are refused to surface ` +
+          `tampering by an upstream producer (a compromised MCP, a hand-edited ` +
+          `paste, or a directive-shaped sidecar like \`_delegateAuthority\` / ` +
+          `\`_executor\`). Allowed at ${context}: ` +
+          `${Array.from(allowed).sort().join(", ")}.`,
+      );
+    }
+  }
+}
+
+/** Walk top-level, meta, and each position and assert the strict shape. */
+function assertStrategyStrictShape(obj: Record<string, unknown>): void {
+  assertOnlyAllowedKeys(obj, KNOWN_TOP_LEVEL_KEYS, "strategy root");
+  const meta = obj.meta;
+  if (meta && typeof meta === "object") {
+    assertOnlyAllowedKeys(
+      meta as Record<string, unknown>,
+      KNOWN_META_KEYS,
+      "strategy.meta",
+    );
+  }
+  const positions = obj.positions;
+  if (Array.isArray(positions)) {
+    for (const p of positions) {
+      if (p && typeof p === "object") {
+        assertOnlyAllowedKeys(
+          p as Record<string, unknown>,
+          KNOWN_POSITION_KEYS,
+          "strategy.positions[]",
+        );
+      }
+    }
+  }
+}
+
 /** Sort positions by descending pctOfTotal so consumers see the dominant pieces first. */
 function sortPositions(positions: SharedStrategyPosition[]): SharedStrategyPosition[] {
   return [...positions].sort((a, b) => b.pctOfTotal - a.pctOfTotal);
@@ -115,6 +195,14 @@ export async function shareStrategy(
     notes,
   };
 
+  // Strict-shape guard. Backstop for serializer drift adding a new
+  // field — issue #557. Walks top-level + meta + each position and
+  // throws if any key falls outside the v1 schema. Defense in depth
+  // against a future code path that emits a directive-shaped sidecar
+  // (`_delegateAuthority`, `_executor`, …) that the recipient's import
+  // path would now refuse anyway, but this catches it at the source.
+  assertStrategyStrictShape(strategy as unknown as Record<string, unknown>);
+
   // Privacy guard. Throws RedactionError if anything in the JSON
   // matches an address / hash pattern. The serializer is expected to
   // produce clean output; this scan is a backstop for serializer drift
@@ -149,6 +237,7 @@ function validateSharedStrategy(value: unknown): SharedStrategy {
     );
   }
   const obj = value as Record<string, unknown>;
+  assertOnlyAllowedKeys(obj, KNOWN_TOP_LEVEL_KEYS, "strategy root");
   if (obj.version !== SHARED_STRATEGY_VERSION) {
     throw new Error(
       `Imported strategy version ${String(obj.version)} is not supported. ` +
@@ -159,6 +248,7 @@ function validateSharedStrategy(value: unknown): SharedStrategy {
   if (!meta || typeof meta !== "object") {
     throw new Error("Imported strategy missing required `meta` object.");
   }
+  assertOnlyAllowedKeys(meta, KNOWN_META_KEYS, "strategy.meta");
   if (typeof meta.name !== "string" || meta.name.length === 0) {
     throw new Error(
       "Imported strategy `meta.name` must be a non-empty string.",
@@ -195,6 +285,7 @@ function validateSharedStrategy(value: unknown): SharedStrategy {
       throw new Error("Each position must be an object.");
     }
     const p = raw as Record<string, unknown>;
+    assertOnlyAllowedKeys(p, KNOWN_POSITION_KEYS, "strategy.positions[]");
     if (typeof p.protocol !== "string") {
       throw new Error("Position `protocol` must be a string.");
     }

--- a/test/strategy.test.ts
+++ b/test/strategy.test.ts
@@ -388,3 +388,100 @@ describe("importStrategy — privacy + validation", () => {
     ).rejects.toThrow(/kind/);
   });
 });
+
+describe("importStrategy — strict-shape gate (issue #557)", () => {
+  /** Shorthand for a minimum-valid v1 strategy we can mutate per test. */
+  function aValidStrategy(): Record<string, unknown> {
+    return {
+      version: 1,
+      meta: {
+        name: "x",
+        createdIso: "2026-04-26T12:00:00.000Z",
+        chains: ["ethereum"],
+      },
+      positions: [
+        {
+          protocol: "wallet",
+          chain: "ethereum",
+          kind: "balance",
+          asset: "ETH",
+          pctOfTotal: 100,
+        },
+      ],
+      notes: [],
+    };
+  }
+
+  it("refuses unknown top-level keys (e.g. _delegateAuthority)", async () => {
+    const { importStrategy } = await import("../src/modules/strategy/index.ts");
+    const hostile = aValidStrategy();
+    hostile._delegateAuthority = "0xDeadBeef";
+    await expect(
+      importStrategy({ json: hostile }),
+    ).rejects.toThrow(/STRATEGY_UNKNOWN_KEY_REJECTED.*strategy root.*_delegateAuthority/s);
+  });
+
+  it("refuses unknown nested keys under meta (e.g. _executor)", async () => {
+    const { importStrategy } = await import("../src/modules/strategy/index.ts");
+    const hostile = aValidStrategy();
+    (hostile.meta as Record<string, unknown>)._executor = "Bob";
+    await expect(
+      importStrategy({ json: hostile }),
+    ).rejects.toThrow(/STRATEGY_UNKNOWN_KEY_REJECTED.*strategy\.meta.*_executor/s);
+  });
+
+  it("refuses unknown nested keys under positions[]", async () => {
+    const { importStrategy } = await import("../src/modules/strategy/index.ts");
+    const hostile = aValidStrategy();
+    (hostile.positions as Array<Record<string, unknown>>)[0]._delegate = "Bob";
+    await expect(
+      importStrategy({ json: hostile }),
+    ).rejects.toThrow(/STRATEGY_UNKNOWN_KEY_REJECTED.*strategy\.positions\[\].*_delegate/s);
+  });
+
+  it("refuses non-underscore unknown keys too (the gate is whitelist-based, not pattern-based)", async () => {
+    const { importStrategy } = await import("../src/modules/strategy/index.ts");
+    const hostile = aValidStrategy();
+    hostile.somethingNew = "value";
+    await expect(
+      importStrategy({ json: hostile }),
+    ).rejects.toThrow(/STRATEGY_UNKNOWN_KEY_REJECTED/);
+  });
+
+  it("accepts a valid v1 strategy with all known fields populated", async () => {
+    const { importStrategy } = await import("../src/modules/strategy/index.ts");
+    const valid = {
+      version: 1,
+      meta: {
+        name: "x",
+        description: "an example",
+        authorLabel: "alice",
+        riskProfile: "moderate",
+        createdIso: "2026-04-26T12:00:00.000Z",
+        chains: ["ethereum"],
+      },
+      positions: [
+        {
+          protocol: "aave-v3",
+          chain: "ethereum",
+          kind: "supply",
+          asset: "USDC",
+          pctOfTotal: 75,
+          healthFactor: 2.1,
+          apr: 0.04,
+        },
+        {
+          protocol: "uniswap-v3",
+          chain: "ethereum",
+          kind: "lp",
+          asset: "ETH/USDC",
+          pctOfTotal: 25,
+          feeTier: 3000,
+          inRange: true,
+        },
+      ],
+      notes: ["a note"],
+    };
+    await expect(importStrategy({ json: valid })).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #557.

## Summary
`validateSharedStrategy` previously silently dropped unknown top-level / nested-meta / nested-position keys via reconstruction — that hid tampering by an upstream producer (compromised MCP, hand-edited paste, directive-shaped sidecar like `_delegateAuthority` / `_executor`). It now rejects with a structured `STRATEGY_UNKNOWN_KEY_REJECTED` error so the agent + user see the input was tampered.

The same strict-shape walk runs on `share_strategy` output before return — defense in depth against a future serializer drift adding a new field.

## What's whitelisted (v1)
- Top-level: `version`, `meta`, `positions`, `notes`
- `meta`: `name`, `description`, `authorLabel`, `riskProfile`, `createdIso`, `chains`
- `positions[]`: `protocol`, `chain`, `kind`, `asset`, `pctOfTotal`, `healthFactor`, `feeTier`, `apr`, `inRange`

## Out of scope
- **Skill-side anchors** (`list_contacts(label=<recipient>)` re-derivation before `share_strategy`, CHECKS PERFORMED block) — live in [vaultpilot-security-skill](https://github.com/szhygulin/vaultpilot-security-skill); separate PR.
- **`get_verification_artifact` integration for `share_strategy`** — that helper is tx-signing-handle-coupled (EVM/TRON/Solana payloadHash + preSignHash). Strategy export has no signing flow, so retrofitting it is plumbing for a defense the flow doesn't need today.
- **String-field directive-pattern scan** (`name` / `description` / `notes`) — false-positive risk too high (legitimate text mentioning the term), and a directive sitting inside a string field doesn't auto-action; that would be an agent bug, not an MCP gap.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run test/strategy.test.ts` — 22/22
- New tests cover: `_delegateAuthority` at top level; `_executor` under `meta`; `_delegate` under `positions[]`; non-`_` unknown key (whitelist-based, not pattern-based); valid v1 strategy with all known fields still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)