### PR TITLE
docs(claude-md): add fastmcp pattern-reference section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,15 @@
 - Scope: user-facing docs and PR descriptions. Internal plans, memory, code comments, chat replies can stay verbose.
 - Past incident 2026-04-28: README grew to 258 lines with the intro restated four times, Solana durable-nonce in three sections, WC-Tron/Solana fact in two. Rewrite cut to 227 without losing technical content. CLAUDE.md rewritten same day from 110 to 103 by trimming filler — dense rule content compresses less than feature/marketing prose.
 - **Don't re-explain synonyms.** Once a term is named clearly, don't paraphrase it in the next sentence "for clarity" — readers parse repetition as either condescension or signal that the first phrasing was wrong. Pick the strongest term, use it, move on.
+
+## Reference framework: fastmcp
+- When writing MCP server code, consult [punkpeye/fastmcp](https://github.com/punkpeye/fastmcp) for ergonomic patterns. **Don't take the dependency** — its transitive surface (`hono`, `undici`, `execa`, `file-type`, `fuse.js`, `mcp-proxy`) re-inflates the slim binary, and its value sits in HTTP/SSE/OAuth/edge layers irrelevant to a stdio server. Stay on `@modelcontextprotocol/sdk` directly.
+- **Apply now: MCP tool annotations on every `registerTool` call (currently zero coverage in `src/index.ts`).** The wrapper passes `opts` through to `server.registerTool`, which accepts `{ title?, description?, inputSchema?, outputSchema?, annotations?, _meta? }`. `annotations` carries `{ title?, readOnlyHint?, destructiveHint?, idempotentHint?, openWorldHint? }` and the SDK forwards them to the host (Claude Code / Desktop) for UI warnings and caching. Defaults by family:
+  - `get_*` / `list_*` / `preview_*` / `explain_*` / `check_*` / `resolve_*` / `verify_*` / `simulate_*` → `readOnly + openWorld`.
+  - `prepare_*` → `destructive + idempotent` (returns unsigned tx; re-prepare just rebuilds a draft).
+  - `send_transaction` → `destructive + openWorld`, NOT idempotent (nonce-bound; rebroadcasting a confirmed tx reverts).
+  - `pair_ledger_*` / `set_*_api_key` / `add_contact` / `register_btc_multisig_wallet` / `import_*` → `idempotent`, local config only (`openWorldHint: false`).
+  - `request_capability` → `openWorld`, NOT idempotent (creates a GitHub issue).
+  - Always set `annotations.title` for a human-readable label distinct from the snake_case name.
+- **Don't replace the `registerTool` wrapper with fastmcp's `server.addTool` builder.** The wrapper carries demo-mode dispatch (whale-persona auto-select for `prepare_*`, broadcast-tool simulation envelope, always-/conditionally-gated refusal branches) and conditional scope-loading via `isToolEnabled` — fastmcp's API has no slot for either.
+- **Defer until a real "feels stuck" report justifies it:** progress notifications (`_meta.progressToken` + `notifications/progress` via the handler `extra` arg) for fanout tools, and `UserError`-style typed user-vs-programmer error split.


### PR DESCRIPTION
## Summary
- Adds a **Reference framework: fastmcp** section to `CLAUDE.md`. Calls out [punkpeye/fastmcp](https://github.com/punkpeye/fastmcp) as a pattern source for new MCP-server code, while explicitly ruling out adopting the dependency (transitive surface — `hono`, `undici`, `execa`, `file-type`, `fuse.js`, `mcp-proxy` — would re-inflate the slim binary that #547/#548 just trimmed).
- Concrete coding-skill win: **MCP tool annotations** (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` / `title`) on every new `registerTool` call site. Coverage is currently zero across `src/index.ts` despite the SDK accepting `annotations` directly in the `opts` object the existing wrapper passes through. Lists the defaults by tool family (`get_*` / `list_*` → `readOnly + openWorld`; `prepare_*` → `destructive + idempotent`; `send_transaction` → `destructive + openWorld`, NOT idempotent; etc.).
- Non-goal: replacing the `registerTool` wrapper with fastmcp's `server.addTool` builder. The wrapper carries demo-mode dispatch (whale-persona auto-select, broadcast-tool simulation envelope, always-/conditionally-gated refusal branches) and conditional scope-loading via `isToolEnabled` — fastmcp's fluent API has no slot for either.
- Defers progress notifications + `UserError` typed-error split until a user-visible "feels stuck" report justifies them.

## Test plan
- [ ] Docs-only change; CI runs lint and any markdown checks.
- [ ] Verify the new section reads naturally after **Documentation Style** (the freshly merged section from #571) and complies with its conciseness rules.