### PR TITLE
feat(explain_tx): expose rawInput + decodedCall args for replay flows

### DIFF
--- a/src/modules/postmortem/decode-call.ts
+++ b/src/modules/postmortem/decode-call.ts
@@ -1,0 +1,112 @@
+/**
+ * Top-level calldata decoder for `explain_tx`. Resolves the 4-byte
+ * selector via 4byte.directory and tries each candidate signature with
+ * viem's `decodeFunctionData`. The chosen signature is the first one
+ * whose decoded args re-encode to the exact original bytes — selector
+ * collisions are real (registry spam + genuinely identical parameter
+ * layouts), so the round-trip equality check is the integrity gate.
+ *
+ * When the selector is unregistered or no candidate round-trips, the
+ * caller surfaces `rawInput` only and the agent falls back to manual
+ * decode (Etherscan / swiss-knife / contract source).
+ */
+
+import {
+  decodeFunctionData,
+  encodeFunctionData,
+  parseAbiItem,
+  toFunctionSelector,
+  type AbiFunction,
+  type Hex,
+} from "viem";
+import { fetch4byteSignatures } from "../../data/apis/fourbyte.js";
+import { cache } from "../../data/cache.js";
+import type { ExplainTxDecodedCall } from "./schemas.js";
+
+const SIGNATURES_TTL = 86_400_000;
+
+async function getSignaturesForSelector(selector: string): Promise<string[]> {
+  const key = `4byte-sigs:${selector.toLowerCase()}`;
+  const cached = cache.get<string[]>(key);
+  if (cached) return cached;
+  try {
+    const sigs = await fetch4byteSignatures(selector);
+    cache.set(key, sigs, SIGNATURES_TTL);
+    return sigs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Convert viem-decoded arg values into JSON-friendly equivalents.
+ * Bigints become decimal strings, hex stays hex, tuples / arrays
+ * recurse. Anything we don't recognize passes through.
+ */
+function jsonifyArg(v: unknown): unknown {
+  if (typeof v === "bigint") return v.toString();
+  if (Array.isArray(v)) return v.map(jsonifyArg);
+  if (v !== null && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      out[k] = jsonifyArg(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+export async function decodeCallArgs(
+  calldata: string,
+): Promise<ExplainTxDecodedCall | undefined> {
+  if (!calldata || calldata === "0x" || calldata.length < 10) return undefined;
+  const selector = calldata.slice(0, 10).toLowerCase();
+  if (!/^0x[0-9a-f]{8}$/.test(selector)) return undefined;
+
+  const signatures = await getSignaturesForSelector(selector);
+  if (signatures.length === 0) {
+    return { selector };
+  }
+
+  const ambiguous = signatures.length > 1;
+  const data = calldata as Hex;
+
+  for (const sig of signatures) {
+    let abiItem: AbiFunction;
+    try {
+      abiItem = parseAbiItem(`function ${sig}`) as AbiFunction;
+    } catch {
+      continue;
+    }
+    try {
+      if (toFunctionSelector(abiItem).toLowerCase() !== selector) continue;
+    } catch {
+      continue;
+    }
+    let args: readonly unknown[];
+    try {
+      const decoded = decodeFunctionData({ abi: [abiItem], data });
+      args = (decoded.args ?? []) as readonly unknown[];
+    } catch {
+      continue;
+    }
+    try {
+      const reencoded = encodeFunctionData({
+        abi: [abiItem],
+        functionName: abiItem.name,
+        args: args as never,
+      });
+      if (reencoded.toLowerCase() !== data.toLowerCase()) continue;
+    } catch {
+      continue;
+    }
+    return {
+      selector,
+      signature: sig,
+      args: args.map(jsonifyArg),
+      ...(ambiguous ? { ambiguous: true } : {}),
+    };
+  }
+
+  return { selector, ...(ambiguous ? { ambiguous: true } : {}) };
+}

--- a/src/modules/postmortem/per-chain/evm.ts
+++ b/src/modules/postmortem/per-chain/evm.ts
@@ -23,6 +23,7 @@ import { decodeEventLog, type Hex, type Log } from "viem";
 import { erc20Abi } from "../../../abis/erc20.js";
 import { getClient } from "../../../data/rpc.js";
 import { resolveSelectors } from "../../history/decode.js";
+import { decodeCallArgs } from "../decode-call.js";
 import { getTokenPrice } from "../../../data/prices.js";
 import { NATIVE_SYMBOL } from "../../../config/contracts.js";
 import { formatUnits } from "../../../data/format.js";
@@ -178,16 +179,26 @@ export async function evmPostmortem(
   const status: "success" | "failed" =
     receipt.status === "success" ? "success" : "failed";
 
-  // Decode top-level method, when there's calldata.
+  // Decode top-level method, when there's calldata. Two parallel
+  // requests against 4byte: `resolveSelectors` for the cached method
+  // name + ambiguity flag we use in step labels and the summary, and
+  // `decodeCallArgs` for the full lossless arg decode surfaced under
+  // `decodedCall`. Both sit on the same 24h cache so a repeat call on
+  // the same selector pays one HTTP round-trip total.
   const input = (tx.input ?? "0x") as Hex;
   const selector = input.length >= 10 ? input.slice(0, 10).toLowerCase() : null;
   let methodName: string | undefined;
   let methodAmbiguous = false;
+  let decodedCall: Awaited<ReturnType<typeof decodeCallArgs>> = undefined;
   if (selector) {
-    const resolved = await resolveSelectors([selector]);
+    const [resolved, decoded] = await Promise.all([
+      resolveSelectors([selector]),
+      decodeCallArgs(input),
+    ]);
     const r = resolved.get(selector);
     methodName = r?.methodName;
     methodAmbiguous = r?.ambiguous ?? false;
+    decodedCall = decoded;
   }
 
   // Decode logs.
@@ -461,6 +472,8 @@ export async function evmPostmortem(
     approvalChanges,
     heuristics: [],
     notes: [],
+    rawInput: input,
+    ...(decodedCall ? { decodedCall } : {}),
   };
 }
 

--- a/src/modules/postmortem/schemas.ts
+++ b/src/modules/postmortem/schemas.ts
@@ -118,6 +118,42 @@ export interface ExplainTxBalanceChange {
   valueUsd?: number;
 }
 
+/**
+ * Decoded top-level call. Surfaces calldata in a form replay-style flows
+ * can consume: timelock `execute(...)` after a prior `schedule(...)`,
+ * Safe re-broadcast, custom-call recovery, post-mortem reproduction.
+ *
+ * `signature` and `args` populate only when 4byte.directory resolves the
+ * selector AND viem's `decodeFunctionData` round-trips losslessly
+ * against the calldata. When the selector is unregistered or no
+ * candidate decodes cleanly, only `selector` is set; the caller falls
+ * back to the parent envelope's `rawInput`.
+ *
+ * `args` is JSON-friendly: bigints stringified as decimal, addresses
+ * preserved as `0x` hex, fixed/dynamic bytes as `0x` hex, tuples as
+ * arrays / nested objects. Order matches the parameter order in
+ * `signature`. EVM-only in v1.
+ */
+export interface ExplainTxDecodedCall {
+  /** 4-byte selector with `0x` prefix, e.g. `0x01d5062a`. */
+  selector: string;
+  /**
+   * Canonical signature, e.g.
+   * `schedule(address,uint256,bytes,bytes32,bytes32,uint256)`. Absent
+   * when 4byte returned nothing or no candidate round-tripped.
+   */
+  signature?: string;
+  /** Decoded arguments, JSON-friendly. Absent when `signature` is absent. */
+  args?: unknown[];
+  /**
+   * True when 4byte returned more than one candidate. The chosen
+   * signature is the first that round-tripped, but selector collisions
+   * exist (registry spam + genuinely identical layouts), so surface
+   * the uncertainty.
+   */
+  ambiguous?: boolean;
+}
+
 /** Approval change for an ERC-20 / TRC-20 owner → spender pair. */
 export interface ExplainTxApprovalChange {
   symbol?: string;
@@ -184,6 +220,19 @@ export interface ExplainTxResult {
   heuristics: ExplainTxHeuristic[];
   /** Free-form scope reminders / partial-data flags. */
   notes: string[];
+  /**
+   * Raw transaction input calldata. EVM only — `0x` for native sends
+   * with no data, full hex for contract calls. Surfaced verbatim so
+   * replay-style flows (timelock `execute()` after `schedule()`,
+   * Safe re-broadcast, custom-call recovery) have something to fall
+   * back to when `decodedCall.signature` is absent.
+   */
+  rawInput?: string;
+  /**
+   * Decoded top-level call. EVM only. Absent for native sends with no
+   * calldata and for non-EVM chains.
+   */
+  decodedCall?: ExplainTxDecodedCall;
   /** Pre-rendered narrative string. Absent when `format === "structured"`. */
   narrative?: string;
 }

--- a/test/postmortem.test.ts
+++ b/test/postmortem.test.ts
@@ -21,6 +21,7 @@ const resolveSelectorsMock = vi.fn();
 const fetchWithTimeoutMock = vi.fn();
 const getDefillamaCoinPriceMock = vi.fn();
 const solanaGetParsedTransactionMock = vi.fn();
+const fetch4byteSignaturesMock = vi.fn();
 
 vi.mock("../src/data/rpc.js", () => ({
   getClient: () => ({
@@ -45,6 +46,10 @@ vi.mock("../src/data/prices.js", async (importOriginal) => {
 
 vi.mock("../src/modules/history/decode.js", () => ({
   resolveSelectors: (...a: unknown[]) => resolveSelectorsMock(...a),
+}));
+
+vi.mock("../src/data/apis/fourbyte.js", () => ({
+  fetch4byteSignatures: (...a: unknown[]) => fetch4byteSignaturesMock(...a),
 }));
 
 vi.mock("../src/data/http.js", async (importOriginal) => {
@@ -81,7 +86,7 @@ function encUint(n: bigint): `0x${string}` {
   return `0x${n.toString(16).padStart(64, "0")}` as `0x${string}`;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   evmGetTransactionMock.mockReset();
   evmGetTransactionReceiptMock.mockReset();
   evmGetBlockMock.mockReset();
@@ -91,9 +96,11 @@ beforeEach(() => {
   fetchWithTimeoutMock.mockReset();
   getDefillamaCoinPriceMock.mockReset();
   solanaGetParsedTransactionMock.mockReset();
+  fetch4byteSignaturesMock.mockReset();
 
-  // Default: no method resolves, no prices.
+  // Default: no method resolves, no prices, no 4byte signatures.
   resolveSelectorsMock.mockResolvedValue(new Map());
+  fetch4byteSignaturesMock.mockResolvedValue([]);
   getTokenPriceMock.mockResolvedValue(undefined);
   evmGetBlockMock.mockResolvedValue({ timestamp: 1714128000n });
   // ERC-20 metadata defaults: USDC.
@@ -103,6 +110,12 @@ beforeEach(() => {
     throw new Error(`unexpected readContract: ${call.functionName}`);
   });
   getDefillamaCoinPriceMock.mockResolvedValue(undefined);
+
+  // Clear the in-memory cache so 4byte-sig results don't leak across
+  // tests (selector→signatures persists for 24h via the module-level
+  // TTL cache).
+  const { cache } = await import("../src/data/cache.js");
+  cache.clear();
 });
 
 afterEach(() => {
@@ -395,6 +408,183 @@ describe("explainTx — Solana happy path", () => {
     expect(usdc).toBeDefined();
     expect(usdc.delta).toBe("-5");
     expect(r.steps.find((s) => s.kind === "instruction")).toBeDefined();
+  });
+});
+
+describe("explainTx — decoded call args (#603)", () => {
+  it("returns rawInput + decodedCall.args for an OZ TimelockController schedule()", async () => {
+    // schedule(address target, uint256 value, bytes data, bytes32 predecessor, bytes32 salt, uint256 delay)
+    // Selector: 0x01d5062a
+    const selector = "0x01d5062a";
+    const target = "0x1111111111111111111111111111111111111111";
+    const value = 0n;
+    // payload bytes for the inner call (whatever — opaque to us, just round-trip)
+    const innerData = "0xabcdef";
+    const predecessor =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+    const salt =
+      "0x000000000000000000000000000000000000000000000000000000000000beef";
+    const delay = 86400n;
+
+    // Encode the calldata for real so the decode path has something
+    // legitimate to round-trip. Borrow viem locally so the test mirrors
+    // production behavior bit-exactly.
+    const { encodeFunctionData, parseAbiItem } = await import("viem");
+    const sig =
+      "schedule(address,uint256,bytes,bytes32,bytes32,uint256)";
+    const calldata = encodeFunctionData({
+      abi: [parseAbiItem(`function ${sig}`)],
+      functionName: "schedule",
+      args: [target, value, innerData, predecessor, salt, delay],
+    });
+
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: RECIPIENT,
+      value: 0n,
+      input: calldata,
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 100_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: RECIPIENT,
+      logs: [],
+    });
+    resolveSelectorsMock.mockResolvedValue(
+      new Map([[selector, { methodName: "schedule" }]]),
+    );
+    fetch4byteSignaturesMock.mockResolvedValue([sig]);
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.rawInput).toBe(calldata);
+    expect(r.decodedCall).toBeDefined();
+    expect(r.decodedCall!.selector).toBe(selector);
+    expect(r.decodedCall!.signature).toBe(sig);
+    expect(r.decodedCall!.ambiguous).toBeUndefined();
+    expect(r.decodedCall!.args).toEqual([
+      target,
+      "0", // bigint stringified
+      innerData,
+      predecessor,
+      salt,
+      "86400",
+    ]);
+  });
+
+  it("marks ambiguous=true when 4byte returns multiple candidates", async () => {
+    const sig =
+      "schedule(address,uint256,bytes,bytes32,bytes32,uint256)";
+    const { encodeFunctionData, parseAbiItem } = await import("viem");
+    const calldata = encodeFunctionData({
+      abi: [parseAbiItem(`function ${sig}`)],
+      functionName: "schedule",
+      args: [
+        "0x1111111111111111111111111111111111111111",
+        0n,
+        "0xabcdef",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x000000000000000000000000000000000000000000000000000000000000beef",
+        86400n,
+      ],
+    });
+
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: RECIPIENT,
+      value: 0n,
+      input: calldata,
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 100_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: RECIPIENT,
+      logs: [],
+    });
+    // Two candidates registered for the selector — the first decodes,
+    // ambiguous flag fires.
+    fetch4byteSignaturesMock.mockResolvedValue([
+      sig,
+      "spam_collision_0x01d5062a()",
+    ]);
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.decodedCall!.ambiguous).toBe(true);
+    expect(r.decodedCall!.signature).toBe(sig);
+  });
+
+  it("returns selector-only when 4byte has no entry", async () => {
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: RECIPIENT,
+      value: 0n,
+      input: "0xdeadbeef" + "00".repeat(32),
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 50_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: RECIPIENT,
+      logs: [],
+    });
+    fetch4byteSignaturesMock.mockResolvedValue([]);
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.rawInput).toBe("0xdeadbeef" + "00".repeat(32));
+    expect(r.decodedCall).toEqual({ selector: "0xdeadbeef" });
+  });
+
+  it("omits decodedCall and reports rawInput=0x for native sends with no calldata", async () => {
+    evmGetTransactionMock.mockResolvedValue({
+      from: WALLET,
+      to: RECIPIENT,
+      value: 1_000_000_000_000_000n,
+      input: "0x",
+    });
+    evmGetTransactionReceiptMock.mockResolvedValue({
+      status: "success",
+      blockNumber: 19_000_000n,
+      gasUsed: 21_000n,
+      effectiveGasPrice: 10_000_000_000n,
+      from: WALLET,
+      to: RECIPIENT,
+      logs: [],
+    });
+
+    const { explainTx } = await import("../src/modules/postmortem/index.ts");
+    const r = await explainTx({
+      hash: TX_HASH,
+      chain: "ethereum",
+      format: "structured",
+    });
+
+    expect(r.rawInput).toBe("0x");
+    expect(r.decodedCall).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #603.

## Summary

Adds two fields to the EVM `explain_tx` envelope so replay-style flows can consume calldata programmatically:

- `rawInput` — tx input bytes verbatim (`0x` for native sends).
- `decodedCall` — `{ selector, signature?, args?, ambiguous? }`.

`signature` and `args` populate only when 4byte.directory resolves the selector AND viem's `decodeFunctionData` round-trips losslessly against the calldata (re-encoding equality). When the selector is unregistered or no candidate round-trips, `decodedCall` carries `selector` only and the caller falls back to `rawInput`.

`args` is JSON-friendly: bigints stringified as decimal, addresses preserved as `0x` hex, fixed/dynamic bytes as `0x` hex, tuples as nested arrays/objects. Order matches the parameter order in `signature`.

## Why

The issue's blocker was the OZ `TimelockController` `schedule` → `execute` flow: to build `execute(target, value, payload, predecessor, salt)` the agent needs the same args from the prior `schedule(...)` call. Today `explain_tx` returns the narrative `"Top-level schedule call"` and balance/event deltas, but no calldata or decoded args — forcing the user to paste the raw input from Etherscan mid-flow.

## Implementation notes

- New `src/modules/postmortem/decode-call.ts` helper: 4byte fetch + iterate candidates + viem `decodeFunctionData` + re-encode equality gate (mirrors the integrity check `verify-decode.ts` uses for signing flows).
- Shares the module-level cache surface (`4byte-sigs:<selector>` keys with the same 24h TTL) so a repeat `explain_tx` on the same selector pays one HTTP round-trip total. Runs in parallel with the existing `resolveSelectors` call inside `evmPostmortem`.
- Lossless round-trip is the integrity gate. Selector collisions are real (registry spam + genuinely identical parameter layouts like `(address,uint256)` vs `(address,address)` for any 64-byte payload), so the first candidate that decodes AND re-encodes to the exact original bytes wins; `ambiguous: true` flags multi-candidate cases.
- EVM-only in v1. TRON / Solana surfaces unchanged.

## Test plan

- [x] `npx vitest run test/postmortem.test.ts` — 11 passed (4 new, 7 pre-existing). New cases:
  - Real-world OZ `TimelockController.schedule(address,uint256,bytes,bytes32,bytes32,uint256)` round-trips through encode → decode → assertion on each arg.
  - 4byte returning multiple candidates → `ambiguous: true`, first round-tripping signature wins.
  - 4byte returning no entry → `decodedCall: { selector }` only, `rawInput` still set.
  - Native send with `input: "0x"` → `rawInput: "0x"`, `decodedCall` omitted.
- [x] `npm test` — 191 files / 2481 tests passed.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)