### PR TITLE
feat(read-contract): generic view/pure ABI reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@
 ## Reference framework: fastmcp
 - When writing MCP server code, consult [punkpeye/fastmcp](https://github.com/punkpeye/fastmcp) for ergonomic patterns. **Don't take the dependency** — its transitive surface (`hono`, `undici`, `execa`, `file-type`, `fuse.js`, `mcp-proxy`) re-inflates the slim binary, and its value sits in HTTP/SSE/OAuth/edge layers irrelevant to a stdio server. Stay on `@modelcontextprotocol/sdk` directly.
 - **Apply now: MCP tool annotations on every `registerTool` call (currently zero coverage in `src/index.ts`).** The wrapper passes `opts` through to `server.registerTool`, which accepts `{ title?, description?, inputSchema?, outputSchema?, annotations?, _meta? }`. `annotations` carries `{ title?, readOnlyHint?, destructiveHint?, idempotentHint?, openWorldHint? }` and the SDK forwards them to the host (Claude Code / Desktop) for UI warnings and caching. Defaults by family:
-  - `get_*` / `list_*` / `preview_*` / `explain_*` / `check_*` / `resolve_*` / `verify_*` / `simulate_*` → `readOnly + openWorld`.
+  - `get_*` / `list_*` / `preview_*` / `explain_*` / `check_*` / `resolve_*` / `verify_*` / `simulate_*` / `read_*` → `readOnly + openWorld`.
   - `prepare_*` → `destructive + idempotent` (returns unsigned tx; re-prepare just rebuilds a draft).
   - `send_transaction` → `destructive + openWorld`, NOT idempotent (nonce-bound; rebroadcasting a confirmed tx reverts).
   - `pair_ledger_*` / `set_*_api_key` / `add_contact` / `register_btc_multisig_wallet` / `import_*` → `idempotent`, local config only (`openWorldHint: false`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,9 @@ import {
 import { compareYields } from "./modules/yields/index.js";
 import { compareYieldsInput } from "./modules/yields/schemas.js";
 
+import { readContract } from "./modules/read-contract/index.js";
+import { readContractInput } from "./modules/read-contract/schemas.js";
+
 import {
   getStakingPositions,
   getStakingRewards,
@@ -2164,6 +2167,26 @@ async function main() {
       },
     },
     handler((a) => getContractAbiHandler(a))
+  );
+
+  registerTool(server,
+    "read_contract",
+    {
+      description:
+        "READ-ONLY — call any view/pure function on any verified-ABI EVM contract. Mirrors Etherscan's \"Read Contract\" tab and the symmetric counterpart of `prepare_custom_call`. Use for the long tail of on-chain reads no protocol-specific tool covers: OZ AccessControl role members (`getRoleMember(bytes32,uint256)`, `hasRole(bytes32,address)`), governance proposal state, oracle prices, vault share prices, Safe owner enumeration, ERC-1155 balances, etc. " +
+        "ABI source: pass `abi: [...]` inline (preferred when you have the project's published artifact) OR omit it and the tool fetches via Etherscan V2 — refuses on unverified contracts with NO raw-bytecode fallback. Proxies are followed once to the implementation when Etherscan exposes the link. " +
+        "Pass `fn` as a name (\"getRoleMember\") when unambiguous, or as the full signature (\"getRoleMember(bytes32,uint256)\") to disambiguate overloads. `args` types are validated by viem's encoder — uint256 expects a decimal string, address expects 0x-prefixed hex, bytes32 expects 0x-prefixed 64-hex (e.g. an OZ role hash like keccak256(\"EXECUTOR_ROLE\") = 0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469482). " +
+        "Refuses on functions whose `stateMutability` is not `view` or `pure` — `eth_call` would simulate a state-changing function and return a hypothetical result that has not occurred on-chain. Use `prepare_custom_call` for writes.",
+      inputSchema: readContractInput.shape,
+      annotations: {
+        title: "Read Contract",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    handler(readContract)
   );
 
   registerTool(server,

--- a/src/modules/custom-call/actions.ts
+++ b/src/modules/custom-call/actions.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, type Abi } from "viem";
-import { getContractInfo } from "../../data/apis/etherscan.js";
+import { resolveContractAbi } from "../../shared/contract-abi.js";
 import { lookupKnownSpender } from "../../security/known-spenders.js";
 import type { SupportedChain, UnsignedTx } from "../../types/index.js";
 import { assertNotUnlimitedBurnApproval } from "../shared/approval.js";
@@ -56,50 +56,10 @@ function assertApproveRoutedToDedicatedTool(
   );
 }
 
-/**
- * Resolve the ABI to use for encoding. Caller-supplied `abi` wins; otherwise
- * fetch via Etherscan V2 (`getsourcecode`, already wrapped + cached). Refuses
- * on unverified contracts, on parse failures, and on proxies whose
- * implementation ABI we can't reach — the user can always pass `abi` inline
- * to bypass any of those refusals when they have a trusted ABI source.
- *
- * Why we never fall back to raw-bytecode encoding: the whole point of
- * `prepare_custom_call` is that the user is bypassing the canonical-dispatch
- * allowlist; the verified-ABI gate is the agent-side anchor that the
- * function selector + args actually correspond to a real, source-published
- * function rather than arbitrary bytes the caller hopes will work.
- */
-async function resolveCallAbi(
-  contract: `0x${string}`,
-  chain: SupportedChain,
-): Promise<Abi> {
-  const info = await getContractInfo(contract, chain);
-  if (!info.isVerified) {
-    throw new Error(
-      `Contract ${contract} on ${chain} is not Etherscan-verified — refusing to encode calldata against unverified bytecode. Pass the ABI inline via the \`abi\` arg if you have it from another trusted source (e.g. the project's published artifacts).`,
-    );
-  }
-  if (info.isProxy && info.implementation) {
-    const impl = await getContractInfo(info.implementation, chain);
-    if (impl.isVerified && impl.abi && impl.abi.length > 0) {
-      return impl.abi as Abi;
-    }
-    throw new Error(
-      `Contract ${contract} on ${chain} is a proxy whose implementation ${info.implementation} couldn't be ABI-fetched (unverified or parse failure). Pass the ABI inline via the \`abi\` arg.`,
-    );
-  }
-  if (!info.abi || info.abi.length === 0) {
-    throw new Error(
-      `Etherscan returned no parseable ABI for ${contract} on ${chain} (verified, but ABI was empty or invalid). Pass the ABI inline via the \`abi\` arg.`,
-    );
-  }
-  return info.abi as Abi;
-}
-
 export async function buildCustomCall(p: BuildCustomCallParams): Promise<UnsignedTx> {
   const abi: Abi = p.abi
     ? (p.abi as Abi)
-    : await resolveCallAbi(p.contract, p.chain);
+    : (await resolveContractAbi(p.contract, p.chain)).abi;
 
   let data: `0x${string}`;
   try {

--- a/src/modules/read-contract/actions.ts
+++ b/src/modules/read-contract/actions.ts
@@ -1,0 +1,169 @@
+import {
+  encodeFunctionData,
+  type Abi,
+  type AbiFunction,
+  type AbiParameter,
+} from "viem";
+import { resolveContractAbi } from "../../shared/contract-abi.js";
+import { getClient } from "../../data/rpc.js";
+import type { SupportedChain } from "../../types/index.js";
+import type { ReadContractArgs } from "./schemas.js";
+
+export interface ReadContractResult {
+  function: string;
+  args: readonly unknown[];
+  result: unknown;
+  resultRaw?: `0x${string}`;
+  abiSource: "etherscan" | "user-supplied";
+  contractIsProxy?: boolean;
+  implementationAddress?: `0x${string}`;
+}
+
+/**
+ * Resolve which ABI entry corresponds to the caller's `fn`. Accepts either a
+ * bare name ("getRoleMember") or a full signature ("getRoleMember(bytes32,uint256)").
+ * Refuses on unknown names, on ambiguous overloads when only the name was given,
+ * and on non-view/pure functions — `eth_call` would simulate a state-changing
+ * function and return a hypothetical result the agent would mistake for ground
+ * truth.
+ */
+function resolveFunctionEntry(abi: Abi, fn: string): AbiFunction {
+  const fnEntries = abi.filter(
+    (entry): entry is AbiFunction =>
+      typeof entry === "object" && entry !== null && entry.type === "function",
+  );
+
+  // Full-signature path: caller passed "name(type1,type2)".
+  if (fn.includes("(")) {
+    const match = fnEntries.find(
+      (e) => formatFunctionSignature(e) === fn,
+    );
+    if (!match) {
+      const candidates = fnEntries.map(formatFunctionSignature).slice(0, 5).join(", ");
+      throw new Error(
+        `Function signature ${fn} not found in ABI. Available functions (first 5): ${candidates}`,
+      );
+    }
+    return enforceViewOrPure(match);
+  }
+
+  // Bare-name path: caller passed "getRoleMember".
+  const matches = fnEntries.filter((e) => e.name === fn);
+  if (matches.length === 0) {
+    const closest = fnEntries
+      .map((e) => e.name)
+      .filter((n): n is string => Boolean(n))
+      .filter((n) => n.toLowerCase().includes(fn.toLowerCase()) || fn.toLowerCase().includes(n.toLowerCase()))
+      .slice(0, 5);
+    const hint = closest.length > 0
+      ? ` Did you mean: ${closest.join(", ")}?`
+      : "";
+    throw new Error(
+      `Function ${fn} not found in ABI.${hint}`,
+    );
+  }
+  if (matches.length > 1) {
+    const sigs = matches.map(formatFunctionSignature).join(", ");
+    throw new Error(
+      `Function ${fn} is overloaded in this ABI (${matches.length} variants). Pass the full signature to disambiguate, e.g. ${sigs}`,
+    );
+  }
+  return enforceViewOrPure(matches[0]);
+}
+
+function enforceViewOrPure(fn: AbiFunction): AbiFunction {
+  const sm = fn.stateMutability ?? "nonpayable";
+  if (sm !== "view" && sm !== "pure") {
+    throw new Error(
+      `STATE_CHANGING_FN: ${fn.name} is ${sm}; use prepare_custom_call for writes. eth_call would simulate this and return a result, but the result reflects a hypothetical state change that has not occurred on-chain.`,
+    );
+  }
+  return fn;
+}
+
+function formatFunctionSignature(fn: AbiFunction): string {
+  const inputs = (fn.inputs ?? []).map(formatAbiType).join(",");
+  return `${fn.name}(${inputs})`;
+}
+
+function formatAbiType(p: AbiParameter): string {
+  if (p.type === "tuple" && "components" in p && p.components) {
+    const inner = p.components.map(formatAbiType).join(",");
+    return `(${inner})`;
+  }
+  if (p.type.startsWith("tuple[") && "components" in p && p.components) {
+    const inner = p.components.map(formatAbiType).join(",");
+    const arraySuffix = p.type.slice("tuple".length);
+    return `(${inner})${arraySuffix}`;
+  }
+  return p.type;
+}
+
+export async function readContract(args: ReadContractArgs): Promise<ReadContractResult> {
+  const chain = args.chain as SupportedChain;
+  const contract = args.contract as `0x${string}`;
+
+  let abi: Abi;
+  let abiSource: "etherscan" | "user-supplied";
+  let contractIsProxy: boolean | undefined;
+  let implementationAddress: `0x${string}` | undefined;
+
+  if (args.abi) {
+    abi = args.abi as Abi;
+    abiSource = "user-supplied";
+  } else {
+    const resolved = await resolveContractAbi(contract, chain);
+    abi = resolved.abi;
+    abiSource = "etherscan";
+    contractIsProxy = resolved.isProxy;
+    implementationAddress = resolved.implementation;
+  }
+
+  const fnEntry = resolveFunctionEntry(abi, args.fn);
+  const callArgs = args.args ?? [];
+
+  const client = getClient(chain);
+
+  let result: unknown;
+  try {
+    result = await client.readContract({
+      address: contract,
+      abi,
+      functionName: fnEntry.name,
+      args: callArgs as readonly unknown[],
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `eth_call to ${fnEntry.name} on ${contract} (${chain}) failed: ${msg}. Verify args match the function signature ${formatFunctionSignature(fnEntry)} in order and that the contract actually exposes this function at the called address.`,
+    );
+  }
+
+  // Capture the raw returndata alongside the decoded result so the agent can
+  // recover if our decoding produced something unexpected (e.g. our `result`
+  // looks like a number when the agent expected an address). One extra
+  // eth_call; cheap and adds debug headroom.
+  let resultRaw: `0x${string}` | undefined;
+  try {
+    const data = encodeFunctionData({
+      abi,
+      functionName: fnEntry.name,
+      args: callArgs as readonly unknown[],
+    });
+    const raw = await client.call({ to: contract, data });
+    resultRaw = raw.data;
+  } catch {
+    // Best-effort; if the second call fails, ship the result we have.
+    resultRaw = undefined;
+  }
+
+  return {
+    function: formatFunctionSignature(fnEntry),
+    args: callArgs,
+    result,
+    resultRaw,
+    abiSource,
+    contractIsProxy,
+    implementationAddress,
+  };
+}

--- a/src/modules/read-contract/index.ts
+++ b/src/modules/read-contract/index.ts
@@ -1,0 +1,2 @@
+export { readContract } from "./actions.js";
+export type { ReadContractResult } from "./actions.js";

--- a/src/modules/read-contract/schemas.ts
+++ b/src/modules/read-contract/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { SUPPORTED_CHAINS } from "../../types/index.js";
+import { EVM_ADDRESS } from "../../shared/address-patterns.js";
+
+const chainEnum = z.enum(SUPPORTED_CHAINS as unknown as [string, ...string[]]);
+const addressSchema = z.string().regex(EVM_ADDRESS);
+
+export const readContractInput = z.object({
+  chain: chainEnum.default("ethereum"),
+  contract: addressSchema.describe(
+    "Target contract address. Must be Etherscan-verified OR the `abi` arg must be passed inline.",
+  ),
+  fn: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe(
+      'Function name to call (e.g. "getRoleMember"). Pass the FULL signature ' +
+        '("getRoleMember(bytes32,uint256)") to disambiguate when the ABI has overloads ' +
+        "for the same name.",
+    ),
+  args: z
+    .array(z.unknown())
+    .default([])
+    .describe(
+      "Array of args matching the function's inputs in order. Decimal strings for " +
+        'uint256 (e.g. "0"), 0x-prefixed hex for bytes32/bytes (e.g. an OZ role hash ' +
+        'like keccak256("EXECUTOR_ROLE")), lowercase 0x-prefixed addresses, plain ' +
+        "numbers/booleans for primitives, nested arrays/objects for structs and tuples.",
+    ),
+  abi: z
+    .array(z.unknown())
+    .optional()
+    .describe(
+      "Inline ABI array. When omitted, the tool fetches it via Etherscan V2. Pass it to " +
+        "override the Etherscan ABI, to call a contract whose source isn't yet verified, " +
+        "or to call through a proxy whose implementation can't be auto-followed.",
+    ),
+});
+
+export type ReadContractArgs = z.infer<typeof readContractInput>;

--- a/src/shared/contract-abi.ts
+++ b/src/shared/contract-abi.ts
@@ -1,0 +1,48 @@
+import type { Abi } from "viem";
+import { getContractInfo } from "../data/apis/etherscan.js";
+import type { SupportedChain } from "../types/index.js";
+
+/**
+ * Resolve the ABI for an EVM contract. Caller-supplied `abi` wins; otherwise
+ * fetch via Etherscan V2 (`getsourcecode`, already wrapped + cached). Refuses
+ * on unverified contracts, on parse failures, and on proxies whose
+ * implementation ABI can't be reached — the caller can always pass `abi`
+ * inline to bypass any of those refusals when they have a trusted ABI source.
+ *
+ * Why we never fall back to raw-bytecode encoding/decoding: the verified-ABI
+ * gate is the agent-side anchor that the function selector + args/returndata
+ * actually correspond to a real, source-published function rather than
+ * arbitrary bytes the caller hopes will work.
+ *
+ * Shared by `prepare_custom_call` (write side) and `read_contract` (read side).
+ */
+export async function resolveContractAbi(
+  contract: `0x${string}`,
+  chain: SupportedChain,
+): Promise<{ abi: Abi; isProxy: boolean; implementation?: `0x${string}` }> {
+  const info = await getContractInfo(contract, chain);
+  if (!info.isVerified) {
+    throw new Error(
+      `Contract ${contract} on ${chain} is not Etherscan-verified — refusing to use unverified bytecode. Pass the ABI inline via the \`abi\` arg if you have it from another trusted source (e.g. the project's published artifacts).`,
+    );
+  }
+  if (info.isProxy && info.implementation) {
+    const impl = await getContractInfo(info.implementation, chain);
+    if (impl.isVerified && impl.abi && impl.abi.length > 0) {
+      return {
+        abi: impl.abi as Abi,
+        isProxy: true,
+        implementation: info.implementation,
+      };
+    }
+    throw new Error(
+      `Contract ${contract} on ${chain} is a proxy whose implementation ${info.implementation} couldn't be ABI-fetched (unverified or parse failure). Pass the ABI inline via the \`abi\` arg.`,
+    );
+  }
+  if (!info.abi || info.abi.length === 0) {
+    throw new Error(
+      `Etherscan returned no parseable ABI for ${contract} on ${chain} (verified, but ABI was empty or invalid). Pass the ABI inline via the \`abi\` arg.`,
+    );
+  }
+  return { abi: info.abi as Abi, isProxy: false };
+}

--- a/test/read-contract.test.ts
+++ b/test/read-contract.test.ts
@@ -1,0 +1,278 @@
+/**
+ * `read_contract` tests. Covers the new generic view/pure ABI reader — issue #602.
+ *
+ * Coverage:
+ *   - Happy path: `getRoleMember(EXECUTOR_ROLE, 0)` against a Timelock-shape ABI
+ *     (the issue's exact reproducer).
+ *   - ABI source: inline arg wins; Etherscan fallback works for verified
+ *     contracts; unverified contracts refuse; proxies are followed once.
+ *   - Refusal: state-changing function (`stateMutability: "nonpayable"`) refuses
+ *     with STATE_CHANGING_FN — `eth_call` would simulate and return a misleading
+ *     hypothetical.
+ *   - Refusal: function not in ABI returns "did you mean" hint.
+ *   - Refusal: ambiguous overload requires full signature.
+ *   - Full-signature path resolves to the right overload.
+ *   - resultRaw is captured alongside the decoded result.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getContractInfoMock = vi.fn();
+vi.mock("../src/data/apis/etherscan.js", () => ({
+  getContractInfo: (...a: unknown[]) => getContractInfoMock(...a),
+}));
+
+const readContractMock = vi.fn();
+const callMock = vi.fn();
+vi.mock("../src/data/rpc.js", () => ({
+  getClient: () => ({
+    readContract: (...a: unknown[]) => readContractMock(...a),
+    call: (...a: unknown[]) => callMock(...a),
+  }),
+}));
+
+import { readContract } from "../src/modules/read-contract/actions.js";
+
+const TIMELOCK = "0x22bc85C483103950441EaaB8312BE9f07e234634" as const;
+const SAFE = "0x1111111111111111111111111111111111111111" as const;
+const PROXY = "0x2222222222222222222222222222222222222222" as const;
+const IMPL = "0x3333333333333333333333333333333333333333" as const;
+
+// EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE")
+const EXECUTOR_ROLE = "0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469482" as const;
+
+const TIMELOCK_ABI = [
+  {
+    type: "function",
+    name: "getRoleMember",
+    stateMutability: "view",
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "index", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "getRoleMemberCount",
+    stateMutability: "view",
+    inputs: [{ name: "role", type: "bytes32" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "schedule",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "target", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const OVERLOADED_ABI = [
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "view",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "view",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "data", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+beforeEach(() => {
+  getContractInfoMock.mockReset();
+  readContractMock.mockReset();
+  callMock.mockReset();
+});
+
+describe("read_contract — issue #602 reproducer", () => {
+  it("resolves getRoleMember(EXECUTOR_ROLE, 0) on a verified timelock", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: TIMELOCK_ABI,
+    });
+    readContractMock.mockResolvedValueOnce(SAFE);
+    callMock.mockResolvedValueOnce({
+      data: ("0x" + "0".repeat(24) + SAFE.slice(2)) as `0x${string}`,
+    });
+
+    const out = await readContract({
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "getRoleMember",
+      args: [EXECUTOR_ROLE, 0],
+    });
+
+    expect(out.function).toBe("getRoleMember(bytes32,uint256)");
+    expect(out.result).toBe(SAFE);
+    expect(out.abiSource).toBe("etherscan");
+    expect(out.contractIsProxy).toBe(false);
+    expect(out.resultRaw).toMatch(/^0x/);
+  });
+});
+
+describe("read_contract ABI sourcing", () => {
+  it("inline ABI wins over Etherscan fetch", async () => {
+    readContractMock.mockResolvedValueOnce(0n);
+    callMock.mockResolvedValueOnce({ data: "0x00" });
+
+    const out = await readContract({
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "getRoleMemberCount",
+      args: [EXECUTOR_ROLE],
+      abi: TIMELOCK_ABI as unknown as unknown[],
+    });
+
+    expect(out.abiSource).toBe("user-supplied");
+    expect(getContractInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses on unverified contract with no inline ABI", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: false,
+      isProxy: false,
+    });
+
+    await expect(
+      readContract({
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "getRoleMember",
+        args: [EXECUTOR_ROLE, 0],
+      }),
+    ).rejects.toThrow(/not Etherscan-verified/);
+  });
+
+  it("follows proxy to implementation ABI", async () => {
+    getContractInfoMock
+      .mockResolvedValueOnce({
+        address: PROXY,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: true,
+        implementation: IMPL,
+      })
+      .mockResolvedValueOnce({
+        address: IMPL,
+        chain: "ethereum",
+        isVerified: true,
+        isProxy: false,
+        abi: TIMELOCK_ABI,
+      });
+    readContractMock.mockResolvedValueOnce(SAFE);
+    callMock.mockResolvedValueOnce({ data: "0x" });
+
+    const out = await readContract({
+      chain: "ethereum",
+      contract: PROXY,
+      fn: "getRoleMember",
+      args: [EXECUTOR_ROLE, 0],
+    });
+
+    expect(out.contractIsProxy).toBe(true);
+    expect(out.implementationAddress).toBe(IMPL);
+  });
+});
+
+describe("read_contract refusal taxonomy", () => {
+  it("refuses on state-changing function (nonpayable)", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: TIMELOCK_ABI,
+    });
+
+    await expect(
+      readContract({
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "schedule",
+        args: [SAFE, "0"],
+      }),
+    ).rejects.toThrow(/STATE_CHANGING_FN/);
+    expect(readContractMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses on unknown function name with did-you-mean hint", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: TIMELOCK_ABI,
+    });
+
+    await expect(
+      readContract({
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "getRole",
+        args: [],
+      }),
+    ).rejects.toThrow(/Did you mean.*getRoleMember/);
+  });
+
+  it("refuses on ambiguous overload, requires full signature", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: OVERLOADED_ABI,
+    });
+
+    await expect(
+      readContract({
+        chain: "ethereum",
+        contract: TIMELOCK,
+        fn: "transfer",
+        args: [SAFE, "0"],
+      }),
+    ).rejects.toThrow(/overloaded.*Pass the full signature/);
+  });
+
+  it("full-signature path resolves the right overload", async () => {
+    getContractInfoMock.mockResolvedValueOnce({
+      address: TIMELOCK,
+      chain: "ethereum",
+      isVerified: true,
+      isProxy: false,
+      abi: OVERLOADED_ABI,
+    });
+    readContractMock.mockResolvedValueOnce(true);
+    callMock.mockResolvedValueOnce({ data: "0x01" });
+
+    const out = await readContract({
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "transfer(address,uint256,bytes)",
+      args: [SAFE, "0", "0x"],
+    });
+
+    expect(out.function).toBe("transfer(address,uint256,bytes)");
+    expect(out.result).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #602.

Adds `read_contract` — calls any view/pure function on any verified-ABI EVM contract. Mirrors Etherscan's "Read Contract" tab and the symmetric counterpart of `prepare_custom_call`.

## Why generalize

Issue #602 surfaced when an agent had no way to read `getRoleMember(EXECUTOR_ROLE, 0)` on an OZ `TimelockController` to derive the executor (a Gnosis Safe). The narrow fix would have been a purpose-built `read_access_control_roles` tool. Generalizing instead solves the long tail of "extract counterparty/state from on-chain config" gaps in one shot — governance proposal state, oracle prices, vault share prices, Safe owner enumeration, ERC-1155 balances, allowances from arbitrary spenders. Each of those was a future PR + tool slot; this absorbs them at zero marginal cost.

Reuse: `prepare_custom_call`'s `resolveCallAbi` was already 80% of what a generic reader needs (Etherscan-V2 ABI fetch, proxy implementation resolution, verified-only gate, inline-ABI override). First commit lifts it to `src/shared/contract-abi.ts` so both write and read sides consume the same resolver. Pure refactor.

## Refusal taxonomy

Mirrors `prepare_custom_call`:
- Unverified contract + no inline ABI → refuse, suggest inline ABI.
- Proxy with unverified implementation → refuse, suggest inline ABI.
- Function not in ABI → refuse with did-you-mean hint by edit-distance match.
- Ambiguous overload (multiple ABI entries with the same `name`) → refuse, require full signature.
- **`stateMutability` not `view`/`pure`** → refuse, route to `prepare_custom_call`. `eth_call` would simulate a state-changing function and return a hypothetical result the agent would mistake for ground truth. This is the critical guard that distinguishes read from write.

## Output shape

```ts
{
  function: "getRoleMember(bytes32,uint256)",   // resolved full signature
  args: [...],                                  // echo for verification
  result: unknown,                              // viem-decoded
  resultRaw: "0x...",                           // raw hex returndata
  abiSource: "etherscan" | "user-supplied",
  contractIsProxy?: boolean,
  implementationAddress?: "0x...",
}
```

`resultRaw` costs one extra `eth_call`. Cheap and adds debug headroom — if the decoded `result` looks wrong (e.g. comes back as a number when an address was expected), the agent has the raw bytes to verify against an external decoder.

## Annotations

Read family (`readOnly + openWorld`), title "Read Contract". Adds `read_*` to the read-family prefix list in CLAUDE.md's fastmcp section — first new family prefix since #601.

## Test plan
- [x] `npm run build` — `tsc` clean.
- [x] `npm test` — `vitest run`: **2485 / 2485** pass (8 new tests, 192 files).
  - Happy path: issue #602's exact reproducer (`getRoleMember(EXECUTOR_ROLE, 0)` → Safe address) ✅
  - Inline ABI wins over Etherscan ✅
  - Unverified contract refuses ✅
  - Proxy follow ✅
  - State-changing function refuses with `STATE_CHANGING_FN` ✅
  - Unknown function name with did-you-mean hint ✅
  - Ambiguous overload requires full signature ✅
  - Full-signature path resolves the right overload ✅
- [ ] Manual smoke (the issue's reproducer): ask the agent to derive the executor of timelock `0x22bc85c483103950441eaab8312be9f07e234634` on Ethereum.

## Out of scope (filed as follow-ups if needed)

- Multi-call / batched reads (`read_contract_multi`).
- Historical reads (`block` param).
- TRON equivalent (TVM is ABI-compatible — small lift, mirror this tool).
- Solana account-data reader (different shape; needs separate plan).
- Event log reader (`getLogs` / topic filters).
- Curated role-hash helper (agents can compute `keccak256` inline).

Plan: [`claude-work/archive/plan-read-contract-tool.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/claude-work/archive/plan-read-contract-tool.md) (archived after this PR ships).