### PR TITLE
docs(CLAUDE): Install-State-Aware Recommendations discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,17 @@
 - Format: smallest fix + what the larger proposal adds + which scope to pursue. If the issue/plan author specified the heavy approach, surface the lighter one explicitly — don't silently downscope either.
 - If the user says the larger scope is intended, proceed.
 
+## Install-State-Aware Recommendations
+- **Before recommending a command that depends on how a tool is installed (npm-global vs local clone vs pipx vs system-package vs MCP-server registration), verify the actual install state first.** This is the `rnd` skill's "name the source before you name the fact" applied to recommendations: the source of truth is the user's actual installed state, not a plausible guess about how they installed it. One cheap read (`which <bin>`, `claude mcp get <name>`, `cat <config>`, `ls <expected dir>`) costs less than a command that silently switches the user off their dev build, points at the wrong binary, or installs a duplicate alongside the real one. Generalizes: any recommendation whose correctness depends on user-side state — shell, package manager, version, scope, env — verifies that state before naming the command.
+- Tells you're about to recommend without verifying:
+  - `npx -y <pkg>` for a tool the user runs from `node /path/to/dist/index.js`.
+  - `pip install` when the user has it under pipx / conda / system-package.
+  - `brew` on Linux, `apt` on macOS, or any pkg-manager that doesn't match the platform.
+  - `claude mcp add <name>` without `claude mcp get <name>` first to capture existing scope, command, args, env.
+  - `~/.bashrc` edits when the user runs zsh (or vice versa).
+- Format: lead with one observation line ("`claude mcp get` shows scope=local, launches via `node /path/dist/index.js`, no env vars set"), then the command tailored to that state. The observation line lets the user catch mismatches you missed.
+- Past incident 2026-04-29: drafted `claude mcp add vaultpilot-mcp --env SAFE_API_KEY=<key> -- npx -y vaultpilot-mcp` for a `SAFE_API_KEY` setup, assuming the published npm package. User actually runs a local dev clone at `/home/szhygulin/dev/recon-mcp/dist/index.js`. The recommended command would have switched their MCP off the dev build onto npm-latest, silently dropping unmerged local work. Caught only because the user asked for the exact command, forcing me to read `claude mcp get` first. Right move: read first, recommend second.
+
 ## Typed-Data Signing Discipline
 - **No typed-data signing tool ships without paired Inv #1b (typed-data tree decode) + Inv #2b (digest recompute) in the same release.** Tools: `prepare_eip2612_permit`, `prepare_permit2_*`, `prepare_cowswap_order`, `sign_typed_data_v4`, any `eth_signTypedData_v4` exposure. Tracked at [#453](https://github.com/szhygulin/vaultpilot-mcp/issues/453).
 - Why: hash-recompute alone passes tautologically over a tampered tree — a rogue MCP swaps `spender` inside `Permit{owner, spender, value, nonce, deadline}` and the digest still matches because it's computed over the swap. Worst blast radius in EVM signing: ONE permit signature → perpetual transfer authority for `deadline`'s lifetime (Permit2 batch with 5-year USDT expiration, smoke-test 126, irrevocable once signed).


### PR DESCRIPTION
## Summary

- New CLAUDE.md section: **Install-State-Aware Recommendations**.
- Generalizes the `rnd` skill's "name the source before you name the fact" rule to *recommendations*, not just claims: any command whose correctness depends on user-side state (shell, package manager, version, scope, env) verifies that state before being named.
- Inserted between Smallest-Solution Discipline and Typed-Data Signing Discipline — sits with the other before-acting checks.

## Why now

Earlier this session I drafted `claude mcp add vaultpilot-mcp --env SAFE_API_KEY=<key> -- npx -y vaultpilot-mcp`, assuming the user ran the published npm package. They actually run a local dev clone at `/home/szhygulin/dev/recon-mcp/dist/index.js`. Running the suggested command would have silently switched their MCP off the dev build onto npm-latest, dropping any unmerged local work. Caught only because the user asked for the *exact* command, which forced me to read `claude mcp get` first. The discipline gap was: extrapolating an install assumption instead of reading the actual registration. Memorialized as a "Past incident" line in the new section.

## Test plan

- [ ] Read top-to-bottom — section fits the surrounding terse-bullet style (rule + Tells + Format + Past incident).
- [ ] Cross-reference the `rnd` skill's "name the source" rule reads cleanly without re-implementing it.
- [ ] No churn elsewhere in the file.