### PR TITLE
fix(pre-sign): accept prepare_safe_tx_* handles

### DIFF
--- a/src/modules/safe/actions.ts
+++ b/src/modules/safe/actions.ts
@@ -85,6 +85,10 @@ function buildApproveHashTx(args: {
       functionName: "approveHash",
       args: { hashToApprove: args.safeTxHash },
     },
+    // Safe addresses are user-specific and never appear in the
+    // canonical-dispatch allowlist. Tag the handle so `assertTransactionSafe`
+    // skips ONLY its catch-all unknown-destination refusal. Issue #609.
+    safeTxOrigin: true,
   };
 }
 

--- a/src/modules/safe/execute.ts
+++ b/src/modules/safe/execute.ts
@@ -208,5 +208,9 @@ export async function prepareSafeTxExecute(
         signaturesLength: String((signatures.length - 2) / 2),
       },
     },
+    // Safe addresses are user-specific and never appear in the
+    // canonical-dispatch allowlist. Tag the handle so `assertTransactionSafe`
+    // skips ONLY its catch-all unknown-destination refusal. Issue #609.
+    safeTxOrigin: true,
   };
 }

--- a/src/signing/pre-sign-check.ts
+++ b/src/signing/pre-sign-check.ts
@@ -284,17 +284,26 @@ export async function assertTransactionSafe(tx: UnsignedTx): Promise<void> {
 
   // 4) Every other selector: must be a known protocol destination — UNLESS
   //    this handle came through `prepare_custom_call`'s affirmative-ack
-  //    path (`acknowledgeNonProtocolTarget: true`). The schema-enforced
-  //    gate at build time already covered consent for the non-protocol
-  //    target; refusing here would render the escape hatch dead-on-arrival
-  //    at the very next step (the bug from issue #496). Note this skips
+  //    path (`acknowledgeNonProtocolTarget: true`) OR through one of the
+  //    `prepare_safe_tx_*` builders (`safeTxOrigin: true`, issue #609 —
+  //    Safe addresses are user-specific and can never appear in any
+  //    canonical allowlist; the OUTER calldata is always `approveHash` or
+  //    `execTransaction`, neither of which carries transferable authority
+  //    on its own). The schema-enforced gate at build time (custom_call)
+  //    or the tool semantics (safe_tx_*) already covered consent for the
+  //    non-protocol target; refusing here would render the escape hatch
+  //    dead-on-arrival (the bug from #496) and break the documented
+  //    `prepare_safe_tx_propose → send_transaction` flow. Note this skips
   //    ONLY the catch-all unknown-destination refusal — the approve()
   //    spender-allowlist (block 2 above), the transfer()-on-unknown-token
   //    refusal (block 3), and the per-destination ABI-selector check
   //    (block 5 below) all stay active because they protect against
-  //    distinct attack shapes that the ack does not subsume.
+  //    distinct attack shapes the ack does not subsume.
   if (!dest) {
-    if (tx.acknowledgedNonProtocolTarget === true) {
+    if (
+      tx.acknowledgedNonProtocolTarget === true ||
+      tx.safeTxOrigin === true
+    ) {
       // Pre-sign defenses #2 (approve spender allowlist) and #3 (transfer
       // on unknown token) are already past; this catch-all is the right
       // place to cleanly accept the call.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1300,6 +1300,26 @@ export interface UnsignedTx {
    */
   acknowledgedNonProtocolTarget?: boolean;
   /**
+   * Set when the tx was built by `prepare_safe_tx_propose`,
+   * `prepare_safe_tx_approve`, or `prepare_safe_tx_execute`. Read by
+   * `assertTransactionSafe` to skip ONLY the catch-all "unknown destination"
+   * refusal — the OUTER `to` is the user's own Safe contract, which is by
+   * definition not in any canonical allowlist. Issue #609.
+   *
+   * Why this is safe: the OUTER calldata is always a Safe-specific selector
+   * (`approveHash(bytes32)` or `execTransaction(...)`) — neither carries
+   * transferable authority on its own, and Ledger Live shows the
+   * destination address on-device. The inner-action defense (binding the
+   * SafeTx body to the safeTxHash) is upstream of this check.
+   *
+   * Trust note: like `acknowledgedNonProtocolTarget`, this flag flows
+   * through the handle store keyed by the server-minted UUID. The agent
+   * cannot fabricate it on a tx that didn't come through one of the three
+   * prepare paths above. Setting it on any other prepare path is a server
+   * bug, not a user-controllable lever.
+   */
+  safeTxOrigin?: boolean;
+  /**
    * Invariant #14 — durable-binding source-of-truth verification (issue
    * #460). When the tx binds funds to a durable on-chain object selected
    * from a multi-candidate set (Compound Comet, Morpho marketId, Uniswap

--- a/test/pre-sign-check.test.ts
+++ b/test/pre-sign-check.test.ts
@@ -637,3 +637,89 @@ describe("Pre-sign check: prepare_custom_call escape hatch (issue #496)", () => 
     void zeroAddress;
   });
 });
+
+describe("Pre-sign check: prepare_safe_tx_* origin flag (issue #609)", () => {
+  // A user-specific Safe Multisig contract — by definition never in any
+  // canonical-dispatch allowlist. The bug from #609: `preview_send` /
+  // `send_transaction` refused every approveHash / execTransaction handle
+  // produced by `prepare_safe_tx_propose|approve|execute` because the Safe
+  // address didn't match a known destination. The fix: those builders
+  // stamp `safeTxOrigin: true` on the UnsignedTx, and this check skips
+  // ONLY the catch-all unknown-destination refusal — every other defense
+  // stays active.
+  const SAFE_ADDRESS = "0xC9844d6cecebc0498e533118Cd886C0d05d4B537" as const;
+  // approveHash(bytes32) selector + zero hash arg
+  const APPROVE_HASH_CALLDATA =
+    ("0xd4d9bdcd" +
+      "0000000000000000000000000000000000000000000000000000000000000000") as `0x${string}`;
+
+  it("WITHOUT the safeTxOrigin flag — refuses unknown Safe address (current behavior)", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: SAFE_ADDRESS as `0x${string}`,
+        data: APPROVE_HASH_CALLDATA,
+        value: "0",
+        from: WALLET,
+        description: "approveHash on user Safe",
+      }),
+    ).rejects.toThrow(/refusing to sign against unknown contract/);
+  });
+
+  it("WITH safeTxOrigin=true — accepts approveHash on the user's Safe", async () => {
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: SAFE_ADDRESS as `0x${string}`,
+        data: APPROVE_HASH_CALLDATA,
+        value: "0",
+        from: WALLET,
+        description: "prepare_safe_tx_propose: approveHash",
+        safeTxOrigin: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("WITH safeTxOrigin=true — accepts execTransaction on the user's Safe", async () => {
+    // execTransaction selector (0x6a761202); calldata body irrelevant to the
+    // catch-all branch — the destination + selector class are what's tested.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = ("0x6a761202" + "00".repeat(32 * 10)) as `0x${string}`;
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: SAFE_ADDRESS as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "prepare_safe_tx_execute: execTransaction",
+        safeTxOrigin: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("the flag does NOT bypass the approve() spender allowlist", async () => {
+    // Defense in depth: even if a builder stamped safeTxOrigin on a tx
+    // whose calldata happens to be approve(attacker, max), block 2 still
+    // refuses. The Safe-origin bypass only opens the catch-all branch.
+    const { assertTransactionSafe } = await import("../src/signing/pre-sign-check.js");
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [ATTACKER as `0x${string}`, maxUint256],
+    });
+    await expect(
+      assertTransactionSafe({
+        chain: "ethereum",
+        to: USDC_ETH as `0x${string}`,
+        data,
+        value: "0",
+        from: WALLET,
+        description: "[malicious] safeTxOrigin-tagged approve",
+        safeTxOrigin: true,
+      }),
+    ).rejects.toThrow(/spender is not in the protocol allowlist/);
+  });
+});


### PR DESCRIPTION
Closes #609.

`preview_send` / `send_transaction` refused every handle produced by `prepare_safe_tx_propose|approve|execute` because the user's Safe address is by definition not in the canonical-dispatch allowlist. The documented `prepare_safe_tx_propose → send_transaction` flow was therefore unreachable; the only workaround was re-encoding the same `approveHash` calldata via `prepare_custom_call` with `acknowledgeNonProtocolTarget: true` — defeating the point of the first-class tool and breaking the integration with `submit_safe_tx_signature`.

## Approach (issue's option a, smallest fix)

- Add `safeTxOrigin?: boolean` to `UnsignedTx` (mirrors the existing `acknowledgedNonProtocolTarget` pattern; flag is server-set and travels through the handle store keyed by a server-minted UUID, so an agent cannot fabricate it on a non-Safe handle).
- Stamp `safeTxOrigin: true` in `buildApproveHashTx` (covers `prepareSafeTxPropose` + `prepareSafeTxApprove`) and on the `prepareSafeTxExecute` return value.
- In `assertTransactionSafe`, when the catch-all unknown-destination branch fires, accept on `safeTxOrigin === true` (alongside the existing `acknowledgedNonProtocolTarget` ack).

## Defense-in-depth preserved

The Safe-origin bypass opens **only** the catch-all unknown-destination refusal. Every other pre-sign defense stays active:

- `approve()` spender allowlist (block 2)
- `transfer()` on unknown token (block 3)
- Per-destination ABI-selector check (block 5)

The OUTER calldata is always `approveHash(bytes32)` or `execTransaction(...)` — neither carries transferable authority on its own — and Ledger Live shows the destination address on-device. The inner-action defense (binding the SafeTx body to the safeTxHash) is upstream.

## Tests

`test/pre-sign-check.test.ts`: four new cases covering the bypass shape (without flag → still refuses; with flag → accepts approveHash + execTransaction; flag does NOT bypass approve-spender allowlist). Full suite: 2493/2493 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)