### PR TITLE
feat(curve): generalize prepare_curve_swap to stable_ng factory pools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,7 @@ import { getCompoundPositions } from "./modules/compound/index.js";
 import { getCurvePositions } from "./modules/curve/positions.js";
 import {
   buildCurveAddLiquidity,
-  buildCurveStethSwap,
+  buildCurveSwap,
 } from "./modules/curve/actions.js";
 import {
   getCurvePositionsInput,
@@ -5715,9 +5715,9 @@ async function main() {
     "prepare_curve_swap",
     {
       description:
-        "Build an unsigned Curve swap on the canonical legacy stETH/ETH pool (0xDC24316b9AE028F1497c275EB9192a3Ea0f67022) — historically the tightest-spread venue for stETH↔ETH conversions, beating LiFi/1inch aggregator routing on this pair. Issue #615. " +
-        "Two directions: `eth_to_steth` (sends native ETH as msg.value, no approval) and `steth_to_eth` (chains an stETH approval to the pool first). Slippage gate REQUIRED: pass either `slippageBps` (server reads `get_dy` and applies the cap) or `minOut` (explicit decimal-string uint256). The pool's `exchange()` accepts `min_dy=0` silently — defaulting to that would let MEV extract the entire output. " +
-        "v0.1 scope: this pool only. Other Curve pools use distinct ABIs (cryptoswap, tricrypto, stable_ng) and routing them through the same selector would silently encode wrong calldata; per-pool dispatch is a follow-up. For other Curve pairs, fall back to `prepare_swap` (LiFi).",
+        "Build an unsigned Curve swap on Ethereum. Issue #615. Supports the canonical legacy stETH/ETH pool (0xDC24316b9AE028F1497c275EB9192a3Ea0f67022 — historically the tightest-spread venue for stETH↔ETH) and any plain pool registered with the stable_ng factory (covers crvUSD/USDC, USDe/USDC, etc.). Pass `pool` + `fromToken` + `toToken`; the tool resolves coin indices from the pool's `coins` array. Use `fromToken: \"native\"` for the ETH leg of the stETH/ETH pool (the only currently-supported pool whose `coins(i)` returns the ETH sentinel). " +
+        "Slippage gate REQUIRED: `slippageBps` (server reads `get_dy` and applies the cap) or `minOut` (explicit decimal-string uint256). The pool's `exchange()` accepts `min_dy=0` silently — defaulting to that would let MEV extract the entire output. ERC-20 inputs chain an approval to the pool automatically. " +
+        "Rejected: meta pools (use `exchange_underlying` — different ABI), cryptoswap / tricrypto / older legacy stable pools (uint256 indices, `use_eth` flag — different selectors). For unsupported Curve pairs, fall back to `prepare_swap` (LiFi).",
       inputSchema: prepareCurveSwapInput.shape,
       annotations: {
         title: "Prepare Curve Swap",
@@ -5727,7 +5727,7 @@ async function main() {
         openWorldHint: false,
       },
     },
-    txHandler("prepare_curve_swap", buildCurveStethSwap)
+    txHandler("prepare_curve_swap", buildCurveSwap)
   );
 
   // ---- Module 9: Morpho Blue ----

--- a/src/modules/curve/actions.ts
+++ b/src/modules/curve/actions.ts
@@ -12,7 +12,7 @@
  * gate explicitly than to silently default to 0 and let the user lose
  * to MEV).
  */
-import { encodeFunctionData, formatUnits, parseUnits, type Address } from "viem";
+import { encodeFunctionData, formatUnits, getAddress, parseUnits, type Address } from "viem";
 import { getClient } from "../../data/rpc.js";
 import {
   buildApprovalTx,
@@ -33,14 +33,33 @@ import type {
 } from "./schemas.js";
 
 /**
- * Indices on the canonical Curve stETH/ETH legacy StableSwap pool
- * (`0xDC24316b9AE028F1497c275EB9192a3Ea0f67022`). Verified on
- * Etherscan: `coins(0)` returns the ETH sentinel
- * `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` and `coins(1)` returns
- * stETH `0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84`.
+ * Curve's universal sentinel for the chain's native asset, returned by
+ * `coins(i)` on pools whose i-th coin is native ETH (e.g. the legacy
+ * stETH/ETH pool returns this from `coins(0)`).
  */
-const STETH_POOL_COIN_ETH = 0;
-const STETH_POOL_COIN_STETH = 1;
+const CURVE_NATIVE_ETH_SENTINEL =
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+interface CuratedCurvePool {
+  /** Number of coins. Pinned because legacy pools may not expose `N_COINS()` as a callable getter. */
+  nCoins: number;
+  /** Receipt-friendly label. */
+  label: string;
+}
+
+/**
+ * Curated entries for Curve pools NOT registered with the stable_ng
+ * factory but still supported by `prepare_curve_swap`. Today: the
+ * canonical legacy StableSwap stETH/ETH pool. Every pool here MUST
+ * honor the legacy `exchange(int128 i, int128 j, uint256 dx, uint256
+ * min_dy)` selector (selector identical to stable_ng's `exchange`).
+ */
+const CURATED_CURVE_POOLS: ReadonlyMap<string, CuratedCurvePool> = new Map([
+  [
+    CONTRACTS.ethereum.curve.stEthEthPool.toLowerCase(),
+    { nCoins: 2, label: "legacy StableSwap stETH/ETH" },
+  ],
+]);
 
 /**
  * Build a `prepare_curve_add_liquidity` UnsignedTx (with bundled
@@ -179,39 +198,152 @@ export async function buildCurveAddLiquidity(
 }
 
 /**
- * Build a `prepare_curve_swap` UnsignedTx for the canonical Curve
- * stETH/ETH legacy StableSwap pool (issue #615). Pool coin order:
- * 0=ETH (native, payable), 1=stETH.
+ * Confirm `pool` is supported by the swap path: either a curated entry
+ * (today: legacy stETH/ETH) OR a stable_ng factory plain pool. Reject
+ * meta pools and pools outside both sets — silent dispatch onto an
+ * unrecognized pool is the failure mode (cryptoswap / tricrypto /
+ * older legacy stable have different `exchange` ABIs).
  *
- *   eth_to_steth: i=0, j=1, value=dx (native), no approval.
- *   steth_to_eth: i=1, j=0, value=0, prepended with stETH approval to
- *     the pool (USDT-style reset handled by `buildApprovalTx`).
+ * Returns a brief label used in the receipt's description.
+ */
+async function ensureSupportedCurvePool(
+  pool: Address,
+  client: ReturnType<typeof getClient>,
+): Promise<{ label: string; nCoins: number }> {
+  const curated = CURATED_CURVE_POOLS.get(pool.toLowerCase());
+  if (curated) return { label: curated.label, nCoins: curated.nCoins };
+
+  const factory = CONTRACTS.ethereum.curve.stableNgFactory as Address;
+  const [isMetaR, nCoinsR] = await client.multicall({
+    contracts: [
+      {
+        address: factory,
+        abi: curveStableNgFactoryAbi,
+        functionName: "is_meta",
+        args: [pool],
+      },
+      {
+        address: factory,
+        abi: curveStableNgFactoryAbi,
+        functionName: "get_n_coins",
+        args: [pool],
+      },
+    ],
+    allowFailure: true,
+  });
+  if (
+    nCoinsR.status !== "success" ||
+    (nCoinsR.result as bigint) === 0n
+  ) {
+    throw new Error(
+      `Pool ${pool} is not supported by prepare_curve_swap. Recognized: legacy ` +
+        `stETH/ETH at ${CONTRACTS.ethereum.curve.stEthEthPool}; any stable_ng plain ` +
+        `pool at factory ${factory}. Other Curve pool generations (cryptoswap, ` +
+        `tricrypto, older legacy stable) use distinct exchange ABIs and are not ` +
+        `supported — file an issue if you need one of them.`,
+    );
+  }
+  if (isMetaR.status !== "success" || isMetaR.result === true) {
+    throw new Error(
+      `Pool ${pool} is a stable_ng meta pool. Meta pools route swaps through ` +
+        `\`exchange_underlying\` against a base-pool LP token — different ABI, out ` +
+        `of scope for prepare_curve_swap.`,
+    );
+  }
+  const nCoins = Number(nCoinsR.result as bigint);
+  return { label: "stable_ng plain pool", nCoins };
+}
+
+/**
+ * Locate a token in the pool's `coins` array. Native ETH matches the
+ * Curve sentinel `0xeeee...eeee` — pools that don't carry the sentinel
+ * at any index simply don't accept native ETH and the call will error.
+ */
+function indexOfTokenInCoins(
+  token: "native" | string,
+  coins: readonly Address[],
+): number {
+  const target =
+    token === "native"
+      ? CURVE_NATIVE_ETH_SENTINEL
+      : token.toLowerCase();
+  for (let i = 0; i < coins.length; i++) {
+    if (coins[i].toLowerCase() === target) return i;
+  }
+  if (token === "native") {
+    throw new Error(
+      `Pool does not accept native ETH (no \`coins(i)\` returns the ETH sentinel ` +
+        `${CURVE_NATIVE_ETH_SENTINEL}). Pass an ERC-20 token address instead. ` +
+        `coins=[${coins.join(", ")}].`,
+    );
+  }
+  throw new Error(
+    `Token ${token} is not in the pool's coins array. coins=[${coins.join(", ")}]. ` +
+      `Pass an address that matches one of those entries (or "native" if the pool's ` +
+      `coins(i) returns the ETH sentinel at some index).`,
+  );
+}
+
+/**
+ * Build a `prepare_curve_swap` UnsignedTx (issue #615 v0.2). Supports
+ * the canonical legacy stETH/ETH pool plus any stable_ng factory plain
+ * pool. Same `exchange(int128,int128,uint256,uint256)` selector for
+ * both flavors — the only per-pool dispatch is whether `coins(i)`
+ * returns the ETH sentinel (then we send `value = dx`, no approval) or
+ * an ERC-20 (then we chain an approval to the pool).
  *
  * Slippage gate is required: caller passes `minOut` (explicit) or
- * `slippageBps` (server computes via `get_dy * (1 - bps/10000)`).
- * Refusing to default to zero protects against MEV — Curve's exchange
- * silently accepts `min_dy=0` and would deliver whatever the pool
- * state allows, including post-sandwich.
+ * `slippageBps` (server computes via `get_dy * (1 - bps/10000)`). The
+ * pool's exchange silently accepts `min_dy=0` — defaulting there would
+ * let MEV extract the entire output.
  *
- * Tighter spread than aggregators for stETH↔ETH: the pool is the
- * historical best venue for this pair (deeper liquidity, no aggregator
- * cut). Other Curve pools use distinct ABIs (cryptoswap, tricrypto,
- * stable_ng) and are NOT supported here — the schema's `direction`
- * enum is the entire surface. Adding a `pool` parameter without
- * per-pool ABI dispatch would silently encode wrong selectors.
+ * Pools NOT in this support set (cryptoswap, tricrypto, older legacy)
+ * are rejected with an actionable error in `ensureSupportedCurvePool`.
  */
-export async function buildCurveStethSwap(
+export async function buildCurveSwap(
   p: PrepareCurveSwapArgs,
 ): Promise<UnsignedTx> {
   const wallet = p.wallet as Address;
-  const pool = CONTRACTS.ethereum.curve.stEthEthPool as Address;
-  const stETH = CONTRACTS.ethereum.lido.stETH as Address;
+  const pool = getAddress(p.pool) as Address;
   const client = getClient("ethereum");
-  const dx = parseUnits(p.amount, 18);
 
-  const ethToSteth = p.direction === "eth_to_steth";
-  const i = ethToSteth ? STETH_POOL_COIN_ETH : STETH_POOL_COIN_STETH;
-  const j = ethToSteth ? STETH_POOL_COIN_STETH : STETH_POOL_COIN_ETH;
+  const { label: poolLabel, nCoins } = await ensureSupportedCurvePool(pool, client);
+  if (!Number.isFinite(nCoins) || nCoins < 2 || nCoins > 8) {
+    throw new Error(
+      `Pool ${pool} reported N_COINS=${nCoins}. Expected 2..8 — refusing to dispatch.`,
+    );
+  }
+  const coinsR = await client.multicall({
+    contracts: Array.from({ length: nCoins }, (_, idx) => ({
+      address: pool,
+      abi: curveLegacyStableSwapAbi as never,
+      functionName: "coins" as const,
+      args: [BigInt(idx)] as const,
+    })),
+    allowFailure: false,
+  });
+  const coins = coinsR as readonly Address[];
+
+  const i = indexOfTokenInCoins(p.fromToken, coins);
+  const j = indexOfTokenInCoins(p.toToken, coins);
+  if (i === j) {
+    throw new Error(
+      `fromToken and toToken resolve to the same coin index (${i}) on pool ${pool}. ` +
+        `Pick distinct tokens.`,
+    );
+  }
+
+  const fromIsNative = p.fromToken === "native";
+  const toIsNative = p.toToken === "native";
+
+  const fromMeta = fromIsNative
+    ? { symbol: "ETH", decimals: 18 }
+    : await resolveTokenMeta("ethereum", coins[i]);
+  const toMeta = toIsNative
+    ? { symbol: "ETH", decimals: 18 }
+    : await resolveTokenMeta("ethereum", coins[j]);
+
+  const dx = parseUnits(p.amount, fromMeta.decimals);
 
   // Resolve min_dy. Mirrors `prepare_curve_add_liquidity`'s gate.
   let minDy: bigint;
@@ -247,17 +379,15 @@ export async function buildCurveStethSwap(
     args: [BigInt(i), BigInt(j), dx, minDy],
   });
 
-  const fromSym = ethToSteth ? "ETH" : "stETH";
-  const toSym = ethToSteth ? "stETH" : "ETH";
-  const minOutFormatted = formatUnits(minDy, 18);
+  const minOutFormatted = formatUnits(minDy, toMeta.decimals);
   const description =
-    `Swap ${p.amount} ${fromSym} → ≥${minOutFormatted} ${toSym} via Curve stETH/ETH pool ${pool}`;
+    `Swap ${p.amount} ${fromMeta.symbol} → ≥${minOutFormatted} ${toMeta.symbol} via Curve ${poolLabel} (${pool})`;
 
   const swapTx: UnsignedTx = {
     chain: "ethereum",
     to: pool,
     data: exchangeData,
-    value: ethToSteth ? dx.toString() : "0",
+    value: fromIsNative ? dx.toString() : "0",
     from: wallet,
     description,
     decoded: {
@@ -266,51 +396,51 @@ export async function buildCurveStethSwap(
         pool,
         i: String(i),
         j: String(j),
-        dx: `${p.amount} ${fromSym}`,
-        minOut: `${minOutFormatted} ${toSym}`,
+        dx: `${p.amount} ${fromMeta.symbol}`,
+        minOut: `${minOutFormatted} ${toMeta.symbol}`,
         ...(p.slippageBps !== undefined ? { slippageBps: String(p.slippageBps) } : {}),
       },
     },
   };
 
-  if (ethToSteth) return swapTx;
+  if (fromIsNative) return swapTx;
 
-  // stETH → ETH: prepend ERC-20 approval of stETH to the pool. The pool
-  // address is NOT in the global approve-allowlist (Aave / Compound /
-  // Morpho / Lido Queue / EigenLayer / Uniswap NPM+Router / LiFi
-  // Diamond), so the user must opt in via
+  // ERC-20 input: prepend an approval to the pool. Curve pools (any
+  // generation) are NOT in the global approve-allowlist (Aave /
+  // Compound / Morpho / Lido Queue / EigenLayer / Uniswap NPM+Router /
+  // LiFi Diamond), so the user must opt in via
   // `acknowledgeNonAllowlistedSpender: true` BEFORE the prepare path
-  // mints a handle. The flag is the affirmative gate; without it, fail
-  // fast with a clear message so the agent knows to surface the
-  // trade-off to the user. With it, stamp the approval tx so
+  // mints a handle. With it, stamp the approval tx so
   // `assertTransactionSafe` skips the spender-allowlist refusal at
-  // preview/send time.
+  // preview/send time. The allowlist is a security recommendation, not
+  // a hard requirement (PR #618 / issue #617).
   if (p.acknowledgeNonAllowlistedSpender !== true) {
     throw new Error(
-      `prepare_curve_swap (steth_to_eth) builds an approve to the Curve stETH/ETH pool ` +
-        `(${pool}), which is NOT in the protocol approve-allowlist (Aave Pool, Compound Comet, ` +
-        `Morpho Blue, Lido Queue, EigenLayer, Uniswap NPM, Uniswap SwapRouter02, LiFi Diamond). ` +
-        `The allowlist is a security recommendation: it limits approvals to a small set of ` +
-        `well-known spenders to keep prompt-injection drains from sliding through. Curve's ` +
-        `stETH/ETH pool is a 5+ year immutable contract and the historical canonical venue ` +
-        `for this pair, but it sits outside that curated set. Surface the trade-off to the ` +
-        `user, then retry with \`acknowledgeNonAllowlistedSpender: true\` to opt in.`,
+      `prepare_curve_swap builds an approve to a Curve ${poolLabel} (${pool}), which is NOT ` +
+        `in the protocol approve-allowlist (Aave Pool, Compound Comet, Morpho Blue, Lido ` +
+        `Queue, EigenLayer, Uniswap NPM, Uniswap SwapRouter02, LiFi Diamond). The allowlist ` +
+        `is a security recommendation: it limits approvals to a small set of well-known ` +
+        `spenders to keep prompt-injection drains from sliding through. Curve pools are ` +
+        `well-vetted but sit outside that curated set. Surface the trade-off to the user, ` +
+        `then retry with \`acknowledgeNonAllowlistedSpender: true\` to opt in.`,
     );
   }
-  // stETH is a rebasing OpenZeppelin-style token, no USDT quirk, but
-  // buildApprovalTx still handles the reset path defensively.
-  const meta = await resolveTokenMeta("ethereum", stETH);
-  const { approvalAmount, display } = resolveApprovalCap(p.approvalCap, dx, meta.decimals);
+  const fromTokenAddress = coins[i];
+  const { approvalAmount, display } = resolveApprovalCap(
+    p.approvalCap,
+    dx,
+    fromMeta.decimals,
+  );
   const approval = await buildApprovalTx({
     chain: "ethereum",
     wallet,
-    asset: stETH,
+    asset: fromTokenAddress,
     spender: pool,
     amountWei: dx,
     approvalAmount,
     approvalDisplay: display,
-    symbol: meta.symbol,
-    spenderLabel: `Curve stETH/ETH pool ${pool}`,
+    symbol: fromMeta.symbol,
+    spenderLabel: `Curve ${poolLabel} ${pool}`,
   });
   if (approval !== null) {
     // Surface the advisory in the description so the prepare receipt
@@ -318,7 +448,7 @@ export async function buildCurveStethSwap(
     // — security recommendation, not a hard requirement, but worth
     // verifying before signing.
     approval.description =
-      `${approval.description} ⚠ ADVISORY: spender is the Curve stETH/ETH pool, NOT in the ` +
+      `${approval.description} ⚠ ADVISORY: spender is a Curve ${poolLabel}, NOT in the ` +
       `protocol approve-allowlist; user opted in via acknowledgeNonAllowlistedSpender. ` +
       `Verify the on-device approve target matches ${pool}.`;
     // Flow the affirmative-ack flag through to assertTransactionSafe.

--- a/src/modules/curve/schemas.ts
+++ b/src/modules/curve/schemas.ts
@@ -57,26 +57,42 @@ export type PrepareCurveAddLiquidityArgs = z.infer<
 >;
 
 /**
- * `prepare_curve_swap` — issue #615. v0.1 scope: the canonical Curve
- * stETH/ETH legacy StableSwap pool only (`0xDC24316b9AE028F1497c275EB9192a3Ea0f67022`).
- * Other Curve pools (cryptoswap / tricrypto / stable_ng) use distinct
- * ABIs and are deferred to follow-up PRs. The `direction` enum is the
- * full surface — no `pool` parameter — because exposing other pools
- * without per-pool ABI dispatch would silently encode wrong selectors.
+ * `prepare_curve_swap` — issue #615. v0.2 supports two pool sources:
+ *   1. Curated entries (the canonical legacy stETH/ETH pool today).
+ *   2. Any plain pool registered with the stable_ng factory (covers
+ *      crvUSD/USDC, USDe/USDC, etc.).
+ *
+ * Meta pools and other Curve generations (cryptoswap, tricrypto,
+ * older legacy plain pools) are explicitly rejected — their `exchange`
+ * ABIs differ (uint256 indices, `use_eth` flag, receiver param) and
+ * silent wrong-selector encoding is the failure mode to avoid.
+ *
+ * Native-ETH detection comes from `coins(i)` returning the ETH
+ * sentinel (`0xeeee...eeee`); pass `fromToken: "native"` for the ETH
+ * leg of the legacy stETH/ETH pool.
  */
+const curveTokenSchema = z.union([
+  z.literal("native"),
+  z.string().regex(EVM_ADDRESS),
+]);
+
 export const prepareCurveSwapInput = z.object({
   wallet: evmAddress.describe("0x EVM wallet address that will sign the tx."),
-  direction: z
-    .enum(["eth_to_steth", "steth_to_eth"])
-    .describe(
-      "Swap direction. `eth_to_steth` sends native ETH as msg.value (no approval); `steth_to_eth` requires an ERC-20 approval of stETH to the pool first (chained automatically).",
-    ),
+  pool: evmAddress.describe(
+    "Curve pool address. Must be the canonical legacy stETH/ETH pool (0xDC24316b9AE028F1497c275EB9192a3Ea0f67022) or a stable_ng factory plain pool. Meta pools, cryptoswap, tricrypto, and older legacy stable pools are rejected with a clear error.",
+  ),
+  fromToken: curveTokenSchema.describe(
+    "Token to spend. Pass `\"native\"` only for pools whose `coins(i)` returns the ETH sentinel (0xeeee...eeee) at some index — currently the legacy stETH/ETH pool. For ERC-20 inputs the tool chains an approval to the pool automatically.",
+  ),
+  toToken: curveTokenSchema.describe(
+    "Token to receive. Same rules as `fromToken`. Must differ from `fromToken` and both must appear in the pool's `coins` array.",
+  ),
   amount: z
     .string()
     .max(50)
     .regex(/^\d+(\.\d+)?$/)
     .describe(
-      'Human-readable decimal input amount in the from-token (e.g. "1.5" for 1.5 ETH or 1.5 stETH). Decimals = 18 for both legs.',
+      'Human-readable decimal input amount in the from-token (e.g. "1.5"). Decimals are read from the from-token contract; native = 18.',
     ),
   slippageBps: z
     .number()
@@ -85,7 +101,7 @@ export const prepareCurveSwapInput = z.object({
     .max(500)
     .optional()
     .describe(
-      "Slippage tolerance in basis points (50 = 0.5%). When set, `min_dy = get_dy(i,j,dx) * (1 - slippageBps/10000)`. Either `slippageBps` or `minOut` is required — the pool refuses without a slippage floor and silently defaulting to 0 would leak to MEV. Capped at 5% (500 bps).",
+      "Slippage tolerance in basis points (50 = 0.5%). When set, `min_dy = get_dy(i,j,dx) * (1 - slippageBps/10000)`. Either `slippageBps` or `minOut` is required — the pool's exchange() accepts `min_dy=0` silently and defaulting to that would let MEV extract the entire output. Capped at 5% (500 bps).",
     ),
   minOut: z
     .string()
@@ -104,14 +120,14 @@ export const prepareCurveSwapInput = z.object({
     .literal(true)
     .optional()
     .describe(
-      "AFFIRMATIVE GATE — required for `direction: \"steth_to_eth\"`. The approve step targets the canonical Curve stETH/ETH pool " +
-        "(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022), which is NOT in the global protocol approve-allowlist (Aave Pool, Compound " +
-        "Comet, Morpho Blue, Lido Queue, EigenLayer, Uniswap NPM, Uniswap SwapRouter02, LiFi Diamond). The allowlist is a security " +
-        "recommendation, not a hard requirement: it limits approvals to a small set of well-known spenders to keep prompt-injection " +
-        "drains from sliding through. Setting this flag is the user's affirmative ack that they understand the approval target sits " +
-        "outside that curated set — the on-device clear-sign of `approve(<curve-pool>, <amount>)` and the prepare-receipt warning " +
-        "advisory are the verification anchors. Do NOT default this to true silently; surface the trade-off to the user first. " +
-        "Ignored for `direction: \"eth_to_steth\"` (no approval; native ETH is sent as msg.value).",
+      "AFFIRMATIVE GATE — required whenever `fromToken` is an ERC-20 (the approve leg targets the Curve pool, which is NOT in the " +
+        "global protocol approve-allowlist: Aave Pool, Compound Comet, Morpho Blue, Lido Queue, EigenLayer, Uniswap NPM, Uniswap " +
+        "SwapRouter02, LiFi Diamond). The allowlist is a security recommendation, not a hard requirement: it limits approvals to a " +
+        "small set of well-known spenders to keep prompt-injection drains from sliding through. Setting this flag is the user's " +
+        "affirmative ack that they understand the approval target sits outside that curated set — the on-device clear-sign of " +
+        "`approve(<curve-pool>, <amount>)` and the prepare-receipt warning advisory are the verification anchors. Do NOT default " +
+        "this to true silently; surface the trade-off to the user first. Ignored when `fromToken: \"native\"` (no approval; native " +
+        "ETH is sent as msg.value).",
     ),
   approvalCap: approvalCapSchema.optional(),
 });

--- a/src/security/canonical-dispatch.ts
+++ b/src/security/canonical-dispatch.ts
@@ -67,9 +67,13 @@ const EXPECTED_TARGETS: Record<string, Partial<Record<SupportedChain, Set<string
   prepare_morpho_: chainSet({
     ethereum: [CONTRACTS.ethereum.morpho.blue],
   }),
-  prepare_curve_swap: chainSet({
-    ethereum: [CONTRACTS.ethereum.curve.stEthEthPool],
-  }),
+  // `prepare_curve_swap` intentionally has NO entry here. The supported
+  // pool set is dynamic (curated entries + every stable_ng factory plain
+  // pool) and can't be enumerated as a static address set. The
+  // equivalent dispatch-target validation lives in
+  // `ensureSupportedCurvePool` inside `src/modules/curve/actions.ts`,
+  // which runs before any swap tx is built and refuses pools outside
+  // the curated set + stable_ng factory.
   prepare_uniswap_swap: chainSet({
     ethereum: [CONTRACTS.ethereum.uniswap.swapRouter02],
     arbitrum: [CONTRACTS.arbitrum.uniswap.swapRouter02],

--- a/test/curve-v1.test.ts
+++ b/test/curve-v1.test.ts
@@ -329,79 +329,146 @@ describe("buildCurveAddLiquidity", () => {
 });
 
 /**
- * `prepare_curve_swap` — issue #615. Pool is hardcoded to the canonical
- * legacy stETH/ETH StableSwap pool. Tests pin: direction routing,
- * slippage gate, native-value placement on eth_to_steth, approval chain
- * on steth_to_eth, get_dy → min_dy math.
+ * `prepare_curve_swap` — issue #615 v0.2. Generalized to:
+ *   - the canonical legacy stETH/ETH pool (curated entry, ETH at index 0)
+ *   - any stable_ng factory plain pool (factory-resolved, ERC-20 only)
+ * Tests pin: index resolution from coins, native-value placement on
+ * native-in legs, approval chain on ERC-20-in legs, slippage gate,
+ * meta-pool rejection, unknown-pool rejection, mismatched-token error.
  */
 const STETH_POOL = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022" as const;
 const STETH_TOKEN = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" as const;
+const ETH_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
+const NG_POOL = "0xCCCCCcccCCCCcCcCCCCcCCCCcCCcCCccCCCCCCCC" as const;
+const NG_COIN_A = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const; // USDC
+const NG_COIN_B = "0xdAC17F958D2ee523a2206206994597C13D831ec7" as const; // USDT
 
-describe("buildCurveStethSwap (issue #615)", () => {
+describe("buildCurveSwap (issue #615 v0.2)", () => {
   beforeEach(() => vi.resetModules());
   afterEach(() => vi.restoreAllMocks());
 
-  function poolClient(opts: { allowance?: bigint; getDy?: bigint } = {}) {
+  /**
+   * Mock client tailored to the curated stETH/ETH path:
+   *   - readContract N_COINS → 2
+   *   - multicall coins(0..1) → [ETH_SENTINEL, stETH]
+   *   - readContract get_dy → opts.getDy
+   *   - readContract allowance → opts.allowance
+   *   - (CURATED — no factory multicall is fired)
+   */
+  function stethPoolClient(opts: { allowance?: bigint; getDy?: bigint } = {}) {
     return {
       readContract: vi.fn(async (call: { functionName: string }) => {
+        if (call.functionName === "N_COINS") return 2n;
         if (call.functionName === "get_dy") return opts.getDy ?? 10n ** 18n;
         if (call.functionName === "allowance") return opts.allowance ?? 0n;
         if (call.functionName === "decimals") return 18;
         if (call.functionName === "symbol") return "stETH";
         throw new Error(`unexpected readContract: ${call.functionName}`);
       }),
+      multicall: vi.fn(
+        async ({ contracts }: { contracts: MulticallCall[] }) => {
+          const fns = contracts.map((c) => c.functionName);
+          if (fns.every((f) => f === "coins")) {
+            return [ETH_SENTINEL, STETH_TOKEN];
+          }
+          throw new Error(`unexpected multicall: ${fns.join(",")}`);
+        },
+      ),
     };
   }
 
-  it("eth_to_steth: native value, no approval, min_dy from slippageBps", async () => {
-    const client = poolClient({ getDy: 10n ** 18n });
+  /**
+   * Mock client for a stable_ng factory plain pool (USDC/USDT-like):
+   *   - factory multicall {is_meta, get_n_coins} → {false, 2}
+   *   - readContract N_COINS → 2
+   *   - multicall coins(0..1) → [USDC, USDT]
+   * The dispatch fires THREE multicalls in this path (factory → coins).
+   * Distinguish by inspecting the contract list of each call.
+   */
+  function ngPoolClient(opts: {
+    isMeta?: boolean;
+    nCoinsFactory?: bigint;
+    getDy?: bigint;
+    allowance?: bigint;
+  } = {}) {
+    return {
+      readContract: vi.fn(async (call: { functionName: string }) => {
+        if (call.functionName === "N_COINS") return 2n;
+        if (call.functionName === "get_dy") return opts.getDy ?? 1_000_000n;
+        if (call.functionName === "allowance") return opts.allowance ?? 0n;
+        if (call.functionName === "decimals") return 6;
+        if (call.functionName === "symbol") return "USDC";
+        throw new Error(`unexpected readContract: ${call.functionName}`);
+      }),
+      multicall: vi.fn(
+        async ({ contracts }: { contracts: MulticallCall[] }) => {
+          const fns = contracts.map((c) => c.functionName);
+          if (fns.includes("is_meta") && fns.includes("get_n_coins")) {
+            return [
+              { status: "success", result: opts.isMeta ?? false },
+              { status: "success", result: opts.nCoinsFactory ?? 2n },
+            ];
+          }
+          if (fns.every((f) => f === "coins")) {
+            return [NG_COIN_A, NG_COIN_B];
+          }
+          throw new Error(`unexpected multicall: ${fns.join(",")}`);
+        },
+      ),
+    };
+  }
+
+  it("legacy stETH/ETH (curated): native ETH input emits value=dx, no approval", async () => {
+    const client = stethPoolClient({ getDy: 10n ** 18n });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
     vi.doMock("../src/modules/shared/token-meta.js", () => ({
       resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
     }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
-    const tx = await buildCurveStethSwap({
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
       wallet: WALLET,
-      direction: "eth_to_steth",
+      pool: STETH_POOL,
+      fromToken: "native",
+      toToken: STETH_TOKEN,
       amount: "1.0",
-      slippageBps: 50, // 0.5%
+      slippageBps: 50,
     });
 
     expect(tx.to).toBe(STETH_POOL);
     expect(tx.value).toBe((10n ** 18n).toString());
-    expect(tx.next).toBeUndefined(); // no approval leg for native input
+    expect(tx.next).toBeUndefined();
     expect(tx.decoded?.functionName).toBe("exchange");
     expect(tx.decoded?.args.i).toBe("0");
     expect(tx.decoded?.args.j).toBe("1");
-    // 1e18 * (10000 - 50) / 10000 = 0.995e18
     expect(tx.decoded?.args.minOut).toBe("0.995 stETH");
   });
 
-  it("steth_to_eth: chains stETH approval to the pool, value=0", async () => {
-    const client = poolClient({ getDy: 10n ** 18n, allowance: 0n });
+  it("legacy stETH/ETH (curated): stETH input chains an approval to the pool, value=0", async () => {
+    const client = stethPoolClient({ getDy: 10n ** 18n, allowance: 0n });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
     vi.doMock("../src/modules/shared/token-meta.js", () => ({
       resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
     }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
-    const tx = await buildCurveStethSwap({
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
       wallet: WALLET,
-      direction: "steth_to_eth",
+      pool: STETH_POOL,
+      fromToken: STETH_TOKEN,
+      toToken: "native",
       amount: "1.0",
       slippageBps: 50,
       acknowledgeNonAllowlistedSpender: true,
     });
 
-    // Head should be the approval; action sits at the tail.
     expect(tx.to).toBe(STETH_TOKEN);
     expect(tx.decoded?.functionName).toBe("approve");
     // The approval head must carry the affirmative-ack flag so
     // assertTransactionSafe accepts the non-allowlisted spender at
     // preview/send time.
     expect(tx.acknowledgedNonAllowlistedSpender).toBe(true);
-    expect(tx.description).toMatch(/ADVISORY.*Curve stETH\/ETH pool.*allowlist/i);
+    expect(tx.description).toMatch(/ADVISORY.*Curve.*stETH\/ETH.*allowlist/i);
     type WithNext = typeof tx & { next?: typeof tx };
     let cur: typeof tx = tx;
     while ((cur as WithNext).next !== undefined) cur = (cur as WithNext).next!;
@@ -412,88 +479,258 @@ describe("buildCurveStethSwap (issue #615)", () => {
     expect(cur.decoded?.args.j).toBe("0");
   });
 
-  it("steth_to_eth: refuses without acknowledgeNonAllowlistedSpender", async () => {
-    const client = poolClient({ getDy: 10n ** 18n, allowance: 0n });
+  it("ERC-20 input: refuses without acknowledgeNonAllowlistedSpender (Curve pool sits outside protocol allowlist)", async () => {
+    const client = stethPoolClient({ getDy: 10n ** 18n, allowance: 0n });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
     vi.doMock("../src/modules/shared/token-meta.js", () => ({
       resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
     }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
     await expect(
-      buildCurveStethSwap({
+      buildCurveSwap({
         wallet: WALLET,
-        direction: "steth_to_eth",
+        pool: STETH_POOL,
+        fromToken: STETH_TOKEN,
+        toToken: "native",
         amount: "1.0",
         slippageBps: 50,
+        // No ack — should fail.
       }),
     ).rejects.toThrow(/acknowledgeNonAllowlistedSpender|approve-allowlist|recommendation/i);
   });
 
-  it("eth_to_steth: ignores acknowledgeNonAllowlistedSpender (no approval is built)", async () => {
-    const client = poolClient({ getDy: 10n ** 18n });
+  it("native input: ignores acknowledgeNonAllowlistedSpender (no approval built)", async () => {
+    const client = stethPoolClient({ getDy: 10n ** 18n });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
     vi.doMock("../src/modules/shared/token-meta.js", () => ({
       resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
     }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
-    const tx = await buildCurveStethSwap({
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
       wallet: WALLET,
-      direction: "eth_to_steth",
+      pool: STETH_POOL,
+      fromToken: "native",
+      toToken: STETH_TOKEN,
       amount: "1.0",
       slippageBps: 50,
-      // No ack — eth_to_steth path does not build an approval, so the
-      // gate is irrelevant.
+      // No ack — native input path doesn't build an approval, gate is irrelevant.
     });
     expect(tx.acknowledgedNonAllowlistedSpender).toBeUndefined();
     expect(tx.next).toBeUndefined();
   });
 
-  it("requires slippage gate — refuses when neither slippageBps nor minOut is set", async () => {
-    const client = poolClient();
+  it("ERC-20 input + ack: approval description carries ADVISORY, ack flag flows to UnsignedTx", async () => {
+    const client = stethPoolClient({ getDy: 10n ** 18n, allowance: 0n });
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
+      wallet: WALLET,
+      pool: STETH_POOL,
+      fromToken: STETH_TOKEN,
+      toToken: "native",
+      amount: "1.0",
+      slippageBps: 50,
+      acknowledgeNonAllowlistedSpender: true,
+    });
+    // Head leg is the approval; assert the ADVISORY in its description and
+    // that the ack flag is stamped so `assertTransactionSafe` skips the
+    // spender-allowlist refusal at preview/send.
+    expect(tx.decoded?.functionName).toBe("approve");
+    expect(tx.description).toMatch(/ADVISORY/);
+    expect(tx.description).toMatch(/protocol approve-allowlist/i);
+    expect(tx.acknowledgedNonAllowlistedSpender).toBe(true);
+  });
+
+  it("stable_ng factory plain pool: ERC-20 ↔ ERC-20, indices resolved from coins", async () => {
+    const client = ngPoolClient({ getDy: 1_000_000n, allowance: 0n });
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "USDC", decimals: 6 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
+      wallet: WALLET,
+      pool: NG_POOL,
+      fromToken: NG_COIN_A,
+      toToken: NG_COIN_B,
+      amount: "1.0",
+      slippageBps: 50,
+      acknowledgeNonAllowlistedSpender: true,
+    });
+
+    // Approval head (USDC → pool) then exchange.
+    expect(tx.to.toLowerCase()).toBe(NG_COIN_A.toLowerCase());
+    type WithNext = typeof tx & { next?: typeof tx };
+    let cur: typeof tx = tx;
+    while ((cur as WithNext).next !== undefined) cur = (cur as WithNext).next!;
+    expect(cur.to.toLowerCase()).toBe(NG_POOL.toLowerCase());
+    expect(cur.value).toBe("0");
+    expect(cur.decoded?.functionName).toBe("exchange");
+    expect(cur.decoded?.args.i).toBe("0");
+    expect(cur.decoded?.args.j).toBe("1");
+    expect(cur.description).toMatch(/stable_ng plain pool/i);
+  });
+
+  it("rejects meta pools with an actionable error", async () => {
+    const client = ngPoolClient({ isMeta: true });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
     await expect(
-      buildCurveStethSwap({
+      buildCurveSwap({
         wallet: WALLET,
-        direction: "eth_to_steth",
+        pool: NG_POOL,
+        fromToken: NG_COIN_A,
+        toToken: NG_COIN_B,
+        amount: "1.0",
+        slippageBps: 50,
+        acknowledgeNonAllowlistedSpender: true,
+      }),
+    ).rejects.toThrow(/meta pool/i);
+  });
+
+  it("rejects pools outside curated set + stable_ng factory", async () => {
+    const client = ngPoolClient({ nCoinsFactory: 0n });
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    await expect(
+      buildCurveSwap({
+        wallet: WALLET,
+        pool: "0xDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef",
+        fromToken: NG_COIN_A,
+        toToken: NG_COIN_B,
+        amount: "1.0",
+        slippageBps: 50,
+      }),
+    ).rejects.toThrow(/not supported|not in.*set|cryptoswap/i);
+  });
+
+  it("rejects native fromToken when pool's coins carry no ETH sentinel", async () => {
+    const client = ngPoolClient();
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "USDC", decimals: 6 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    await expect(
+      buildCurveSwap({
+        wallet: WALLET,
+        pool: NG_POOL,
+        fromToken: "native",
+        toToken: NG_COIN_B,
+        amount: "1.0",
+        slippageBps: 50,
+      }),
+    ).rejects.toThrow(/does not accept native/i);
+  });
+
+  it("rejects fromToken that isn't in the pool's coins array", async () => {
+    const client = ngPoolClient();
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "USDC", decimals: 6 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    await expect(
+      buildCurveSwap({
+        wallet: WALLET,
+        pool: NG_POOL,
+        fromToken: "0x1111111111111111111111111111111111111111",
+        toToken: NG_COIN_B,
+        amount: "1.0",
+        slippageBps: 50,
+      }),
+    ).rejects.toThrow(/not in the pool's coins/i);
+  });
+
+  it("requires slippage gate — refuses when neither slippageBps nor minOut is set", async () => {
+    const client = stethPoolClient();
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    await expect(
+      buildCurveSwap({
+        wallet: WALLET,
+        pool: STETH_POOL,
+        fromToken: "native",
+        toToken: STETH_TOKEN,
         amount: "1.0",
       }),
     ).rejects.toThrow(/min_dy=0|min_out|slippage/i);
   });
 
   it("explicit minOut overrides slippageBps and skips get_dy read", async () => {
-    const client = poolClient();
+    const client = stethPoolClient();
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
+    }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
-    const tx = await buildCurveStethSwap({
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    const tx = await buildCurveSwap({
       wallet: WALLET,
-      direction: "eth_to_steth",
+      pool: STETH_POOL,
+      fromToken: "native",
+      toToken: STETH_TOKEN,
       amount: "1.0",
-      minOut: "990000000000000000", // 0.99e18 — well under the 1e18 mock
+      minOut: "990000000000000000",
     });
     expect(tx.decoded?.args.minOut).toBe("0.99 stETH");
-    // get_dy should not have been called
     expect(client.readContract).not.toHaveBeenCalledWith(
       expect.objectContaining({ functionName: "get_dy" }),
     );
   });
 
   it("rejects high slippage without acknowledgement", async () => {
-    const client = poolClient({ getDy: 10n ** 18n });
+    const client = stethPoolClient({ getDy: 10n ** 18n });
     vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
+    }));
 
-    const { buildCurveStethSwap } = await import("../src/modules/curve/actions.js");
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
     await expect(
-      buildCurveStethSwap({
+      buildCurveSwap({
         wallet: WALLET,
-        direction: "eth_to_steth",
+        pool: STETH_POOL,
+        fromToken: "native",
+        toToken: STETH_TOKEN,
         amount: "1.0",
-        slippageBps: 200, // 2%
+        slippageBps: 200,
       }),
     ).rejects.toThrow(/sandwich|acknowledgeHighSlippage/i);
+  });
+
+  it("rejects fromToken === toToken", async () => {
+    const client = stethPoolClient();
+    vi.doMock("../src/data/rpc.js", () => ({ getClient: () => client }));
+    vi.doMock("../src/modules/shared/token-meta.js", () => ({
+      resolveTokenMeta: async () => ({ symbol: "stETH", decimals: 18 }),
+    }));
+
+    const { buildCurveSwap } = await import("../src/modules/curve/actions.js");
+    await expect(
+      buildCurveSwap({
+        wallet: WALLET,
+        pool: STETH_POOL,
+        fromToken: STETH_TOKEN,
+        toToken: STETH_TOKEN,
+        amount: "1.0",
+        slippageBps: 50,
+      }),
+    ).rejects.toThrow(/same coin index|distinct tokens/i);
   });
 });


### PR DESCRIPTION
Follow-up to #616. Generalizes the `prepare_curve_swap` tool that shipped there from the canonical stETH/ETH pool only to any plain pool registered with the stable_ng factory.

## What changes

Schema replaces the `direction: "eth_to_steth" | "steth_to_eth"` enum with `pool` + `fromToken` + `toToken` (with `"native"` accepted). Dispatch supports two pool sources:

- **Curated entries** — `CURATED_CURVE_POOLS` map. Today: the canonical legacy stETH/ETH pool, pinned with its N_COINS because legacy Vyper pools don't expose `N_COINS()` as a callable getter.
- **stable_ng factory plain pools** — any pool where `factory.get_n_coins(pool) > 0` AND `is_meta == false`. Covers crvUSD/USDC, USDe/USDC, etc.

Same `exchange(int128, int128, uint256, uint256)` selector for both flavors (verified against `@curvefi/api` v2.69.0 `factory-stable-ng/plain-stableswap-ng.json`). Native-ETH detection comes from `coins(i)` matching the ETH sentinel `0xeeee...eeee` — no per-pool flag needed. ERC-20 inputs chain an approval to the pool automatically.

## Rejected with actionable errors

- Meta pools (use `exchange_underlying` — different semantics)
- Pools outside the curated set + stable_ng factory (cryptoswap / tricrypto / older legacy stable use distinct selectors)
- `fromToken` or `toToken` not in the pool's `coins`
- Native `fromToken` when the pool carries no ETH sentinel

## Canonical-dispatch allowlist

Removed the static `prepare_curve_swap` entry — the supported set is dynamic. The equivalent dispatch-target check lives in `ensureSupportedCurvePool` and runs before any swap tx is built.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` — 192 files, 2510 tests pass
  - 11 swap tests (was 5 in #616): legacy stETH/ETH both directions, stable_ng plain pool ERC-20↔ERC-20, meta rejection, unknown-pool rejection, native-on-non-ETH-pool rejection, mismatched-token, slippage gate variants, same-coin guard
- [ ] Live ledger smoke (manual): stable_ng pool swap (e.g. crvUSD/USDC), regression check that legacy stETH/ETH still works in both directions

## Out of scope

- Cryptoswap / tricrypto / twocrypto-NG pools (different exchange ABIs — uint256 indices, `use_eth` flag, receiver param). Per-flavor dispatch is a follow-up.
- Older legacy stable pools beyond stETH/ETH (e.g. 3pool, fraxbp). Easy additions to `CURATED_CURVE_POOLS` once we confirm each is non-meta and uses the legacy 4-arg `exchange` selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)