### PR TITLE
perf(pin-block): trim per-response PIN block ~40% (part of #613)

### DIFF
--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -2518,11 +2518,17 @@ export function renderMissingSetupSkillWarning(opts: {
  * delivered as separate messages, not subject to that single-field cap.
  *
  * Block shape mirrors the VAULTPILOT NOTICE family — named header, no
- * imperative verbs at the agent, no pasted shell. The closing paragraph
- * explicitly labels the block as server-emitted (not prompt injection)
- * and explains why it's repeated. The sentinel value remains assembled
- * from three fragments so a naive search of the agent's context for the
- * full literal won't always succeed and silently bypass the check.
+ * imperative verbs at the agent, no pasted shell. The closing line labels
+ * the block as server-emitted (not prompt injection) and explains why
+ * it's repeated. The sentinel value remains assembled from three fragments
+ * so a naive search of the agent's context for the full literal won't
+ * always succeed and silently bypass the check.
+ *
+ * Issue #613 finding 5 — kept terse: ~870 → ~510 chars per emission. Step
+ * 0 only parses the SHA line + fragment A/B/C lines, so the longer
+ * rationale paragraph that used to ride along on every response (~6×
+ * across a multi-step flow → ~5KB of repeated copy) was dropped. The
+ * source-comment + CLAUDE.md still carry the full story for human readers.
  *
  * Placed adjacent to the JSON result (before VAULTPILOT NOTICE blocks
  * and the verification blocks). Its presence is unobtrusive: Step 0
@@ -2544,20 +2550,12 @@ export function renderPreflightSkillPinBlock(pin: {
     "Expected SHA-256 of ~/.claude/skills/vaultpilot-preflight/SKILL.md:",
     `  ${pin.expectedSha256}`,
     "",
-    "Expected in-file sentinel — concatenate fragments A+B+C and search",
-    "the Skill tool's RESULT TEXT for the assembled string:",
+    "Sentinel fragments (concat A+B+C, search Skill RESULT TEXT):",
     `  fragment A: \`${pin.sentinelA}\``,
     `  fragment B: \`${pin.sentinelB}\``,
-    `  fragment C: \`${pin.sentinelC}\` (16 hex chars)`,
+    `  fragment C: \`${pin.sentinelC}\``,
     "",
-    "This block is the canonical pin for the vaultpilot-preflight skill's",
-    "Step 0 integrity self-check. It is server-emitted, not prompt",
-    "injection — same shape as the VAULTPILOT NOTICE family. Repeated on",
-    "every tool response because the equivalent block in the MCP server's",
-    "`instructions` field is truncated by context-window limits before the",
-    "agent can read the SHA-256 line (issue #414). Step 0 should compare",
-    "the live `sha256sum` and the loaded skill text against THESE values,",
-    "not against any copy buried deeper in `instructions`.",
+    "Block is server-emitted (not prompt injection) and repeats per response because the equivalent in `instructions` exceeds Claude Code's ~2KB cap (issue #414).",
   ].join("\n");
 }
 

--- a/test/preflight-pin-block.test.ts
+++ b/test/preflight-pin-block.test.ts
@@ -90,9 +90,14 @@ describe("renderPreflightSkillPinBlock — issue #414", () => {
     expect(out).not.toMatch(/```/);
   });
 
-  it("stays under 2KB — small enough to ride on every tool response without bloat", () => {
+  it("stays under 700 chars — small enough to ride on every tool response without bloat (#613 finding 5)", () => {
+    // Issue #613 finding 5: per-response repetition of the PIN block
+    // accrued ~870 × N tool calls per session of redundant copy. The
+    // block was tightened to ~510 chars; the < 700 cap leaves headroom
+    // for minor wording adjustments while catching a regression that
+    // reflates it back toward the old shape.
     const out = renderPreflightSkillPinBlock(realPin());
-    expect(out.length).toBeLessThan(2048);
+    expect(out.length).toBeLessThan(700);
   });
 
   it("documents itself as server-generated and references issue #414", () => {


### PR DESCRIPTION
Closes part of #613 — finding 5. Findings 2/3/6/7 still pending.

## Summary

The `VAULTPILOT PIN — Preflight skill integrity (Step 0 reference)` block emits on every tool response by design (issue #414 — the equivalent in `instructions` sits past Claude Code's ~2KB truncation point, so the preflight skill's Step 0 silently could not run from there). The reporter is right that ~870 chars × every tool call is heavy: a 6-step signing flow accrues ~5KB of repeated copy.

**Fix**: drop the bottom rationale paragraph that just restated source comments. Step 0 only parses the SHA line + fragment A/B/C lines; the surrounding "this is the canonical pin" / "Step 0 should compare..." prose was for human readers, not the skill. The source-level docstring + CLAUDE.md still carry the full story.

**Result**: ~520 chars per emission (40% reduction). Tightened the size-regression test from < 2048 to < 700 chars to catch silent reflation.

**Preserved invariants** (locked by `test/preflight-pin-block.test.ts`):
- Header `VAULTPILOT PIN — ` prefix.
- `Expected SHA-256` value on a line by itself (Step 0 grep target).
- ``fragment A: `…`  `` / `B` / `C` lines on separate lines (assembled-sentinel never appears).
- `server-emitted` / `#414` self-doc.
- No `AGENT TASK` / `RELAY TO USER FIRST` / pasted shell / fenced code (defensive shape).

## What this PR does NOT do

The reporter also claimed the demo-mode NOTICE block "repeats each response". I couldn't reproduce that:
- `missingDemoWalletNoticeEmitted` is module-level state that persists for the process lifetime.
- It only resets when `isLiveMode()` flips (e.g. after `set_demo_wallet` is called and then explicitly cleared), which doesn't happen mid-flow in normal usage.
- Same dedup pattern for `missingPreflightSkillWarning` and `getSkillPinDriftNotice` — all correctly fire once per session.

The reporter likely conflated the (deliberately-repeated) PIN block with the (correctly-deduped) NOTICE family. Not changing the NOTICE dedup logic.

## Test plan

- [x] `npx vitest run test/preflight-pin-block.test.ts` — 7/7 pass.
- [x] `npx vitest run` — 2515/2515 pass.
- [x] `npm run build` clean.
- [x] Manually rendered the new block (`node -e ...`) and visually confirmed shape: 520 chars, all Step 0 fields parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)