### PR TITLE
fix(skill-pin): bump to v12 (strategy share/import + crypto constants)

### DIFF
--- a/src/diagnostics/local-skill-drift.ts
+++ b/src/diagnostics/local-skill-drift.ts
@@ -76,7 +76,7 @@ function extractLocalSentinelVersion(content: string): {
   };
 }
 
-/** MCP-pinned version, parsed once from the sentinel B fragment (e.g. `_v10_` → `10`). */
+/** MCP-pinned version, parsed once from the sentinel B fragment (e.g. `_v12_` → `12`). */
 function pinnedVersion(): string | null {
   const m = EXPECTED_SKILL_SENTINEL_B.match(/^_v(\d+)_$/);
   return m ? m[1] : null;

--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "18ca800d2696720de9ca22e3a037a89a788ef069a17cfcdcd6649fa2f62b11cb";
+  "e44c66895fc150e905b295364610e0f834ec8ee6cbca6bcd8eea3db9455e1ddd";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v10_";
-export const EXPECTED_SKILL_SENTINEL_C = "3f4d8e2a6c9b1057";
+export const EXPECTED_SKILL_SENTINEL_B = "_v12_";
+export const EXPECTED_SKILL_SENTINEL_C = "a4d5a75453658f63";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =

--- a/test/local-skill-drift.test.ts
+++ b/test/local-skill-drift.test.ts
@@ -71,13 +71,13 @@ describe("checkLocalSkillDrift — issue #613 finding 3", () => {
     // v4 was the example version that triggered the original report.
     const stale = `# preflight skill v4
 ${EXPECTED_SKILL_SENTINEL_A}_v4_7655818578c7a044
-content body that does not match the canonical v10 hash`;
+content body that does not match the canonical v12 hash`;
     writeFixture(stale);
     const result = checkLocalSkillDrift();
     expect(result.status).toBe("version-stale");
     if (result.status === "version-stale") {
       expect(result.localVersion).toBe("4");
-      expect(result.pinnedVersion).toBe("10");
+      expect(result.pinnedVersion).toBe("12");
       expect(result.pinnedHash).toBe(EXPECTED_SKILL_SHA256);
       expect(result.localHash).not.toBe(EXPECTED_SKILL_SHA256);
     }
@@ -93,7 +93,7 @@ content body`;
     expect(result.status).toBe("version-stale");
     if (result.status === "version-stale") {
       expect(result.localVersion).toBe("99");
-      expect(result.pinnedVersion).toBe("10");
+      expect(result.pinnedVersion).toBe("12");
     }
   });
 
@@ -115,7 +115,7 @@ content`;
   });
 
   it("does NOT return `version-stale` when local sentinel happens to be the SAME version (still hash mismatch)", () => {
-    // Sentinel matches version (`v10`), but content body differs from
+    // Sentinel matches version (`v12`), but content body differs from
     // canonical → hash mismatch but version-extraction yields the same
     // version. Should fall through to content-mismatch (the version
     // marker says "same version" so something else is wrong).
@@ -136,7 +136,7 @@ body`);
     expect(first).not.toBeNull();
     expect(first).toContain("VAULTPILOT NOTICE — Local preflight skill is out of date (not tampered)");
     expect(first).toContain("`v4`");
-    expect(first).toContain("`v10`");
+    expect(first).toContain("`v12`");
     expect(first).toContain("git pull --ff-only");
     // Second call: deduped.
     expect(getLocalSkillDriftNotice()).toBeNull();


### PR DESCRIPTION
Coordinated MCP-side companion to two skill releases that landed back-to-back:

- [vaultpilot-security-skill#29](https://github.com/szhygulin/vaultpilot-security-skill/pull/29) — v0.9.0 strategy share/import integrity rules.
- [vaultpilot-security-skill#30](https://github.com/szhygulin/vaultpilot-security-skill/pull/30) — v0.10.0 cryptographic constant verification rule.

## Summary
- `EXPECTED_SKILL_SHA256`: `18ca800d…b11cb` → `e44c66895fc150e905b295364610e0f834ec8ee6cbca6bcd8eea3db9455e1ddd`
- `EXPECTED_SKILL_SENTINEL_B`: `_v10_` → `_v12_`
- `EXPECTED_SKILL_SENTINEL_C`: `3f4d8e2a6c9b1057` → `a4d5a75453658f63`

The pin jumps two skill versions (v10 → v12, skipping v11) because the MCP-side companion was deferred until both skill PRs landed.

## What the skill versions add

**Skill v0.9.0 — strategy share/import integrity** (sentinel `v11_5919abc208e8de9a`). Contact re-derivation around `share_strategy` (call `list_contacts` for the named recipient, surface the resolved address with bold + inline-code, refuse on no-match), CHECKS PERFORMED block on share + import (schema-validation pointer at MCP-side `STRATEGY_UNKNOWN_KEY_REJECTED` gate from [#571](https://github.com/szhygulin/vaultpilot-mcp/pull/571), redaction scan refusing payloads with embedded wallet addresses / tx hashes / ENS names). Explicit non-goal: no skill-side registry of allowed strategy fields, protocols, or smart contracts.

**Skill v0.10.0 — cryptographic constant verification** (sentinel `v12_a4d5a75453658f63`). Specializes the `rnd` skill's "name the source before you name the fact" principle for cryptographic constants. Agent must verify role hashes, function selectors, EIP-712 type hashes, canonical contract addresses, and source-pin SHA-256s via independent computation (`cast keccak`, viem `keccak256`, Python `eth_utils.keccak`) or canonical-source cross-check (OpenZeppelin source, EIP text, Etherscan "Read Contract", vendor-published registry) before passing them into tool calls. Closes the failure mode that surfaced 2026-04-29 when a wrong `EXECUTOR_ROLE` hash in `read_contract`'s docstring made `hasRole` return `false` uniformly (typo fix tracked at [#608](https://github.com/szhygulin/vaultpilot-mcp/issues/608)).

## Scope
Both new sections are explicit cooperating-agent guidance — a rogue agent reads any rule and ignores it; the architectural defense for that case lives at model-safety-tuning or chat-client output-filter, per the Rogue-Agent-Only Finding Triage rubric. Bytes-level defense for tampered strategy shapes lives in the existing `STRATEGY_UNKNOWN_KEY_REJECTED` gate; on-device clear-sign at any downstream signing step remains the load-bearing defense.

## Test plan
- [x] `npx vitest run test/local-skill-drift.test.ts test/preflight-pin-block.test.ts` — 18/18 passing.
- [x] `npx tsc --noEmit` — clean.
- [ ] After merge, users running an older skill clone will see the `Local preflight skill is out of date (not tampered)` notice with `v<old>` → `v12`; recovery path unchanged (`cd ~/.claude/skills/vaultpilot-preflight && git pull --ff-only`).
- [ ] After publish, users on the older `vaultpilot-mcp` package against v0.10.0 skill will see the same notice from the other side until they `npm update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)