### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.13.1";
+const SERVER_VERSION = "0.14.0";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
## Highlights

- **New tool — `read_contract`**: generic view/pure ABI reader, paving the way for explain-and-replay flows ([#606](https://github.com/szhygulin/vaultpilot-mcp/pull/606)). `explain_tx` now exposes `rawInput` + `decodedCall` args to feed it ([#605](https://github.com/szhygulin/vaultpilot-mcp/pull/605)).
- **New tool — `prepare_token_approve`**: dedicated path for ERC-20 approvals; routes `approve(...)` out of `prepare_custom_call` and refuses unlimited approve to canonical burn addresses (#564, plus earlier work).
- **Curve swap support**: `prepare_curve_swap` for stETH/ETH with direct 1inch `/swap` fallback ([#616](https://github.com/szhygulin/vaultpilot-mcp/pull/616)); generalized to `stable_ng` factory pools ([#619](https://github.com/szhygulin/vaultpilot-mcp/pull/619)); swap leg now stamps `acknowledgedNonProtocolTarget` ([#628](https://github.com/szhygulin/vaultpilot-mcp/pull/628)).
- **Tool annotations** on all 186 `registerTool` sites — readOnlyHint / destructiveHint / idempotentHint / openWorldHint surfaced to hosts ([#601](https://github.com/szhygulin/vaultpilot-mcp/pull/601)).
- **Approve-allowlist softened to advisory**: non-canonical spender becomes a `⚠ NON-CANONICAL SPENDER` recommendation instead of a hard refusal; rogue-spender protection still in place ([#618](https://github.com/szhygulin/vaultpilot-mcp/pull/618)).
- **Pre-sign gate accepts Safe handles**: `prepare_safe_tx_*` flows no longer trip the spender allowlist ([#611](https://github.com/szhygulin/vaultpilot-mcp/pull/611)).
- **Local-skill drift notice**: distinguishes stale (user clone behind MCP-pinned) vs. tampered (hash mismatch) ([#623](https://github.com/szhygulin/vaultpilot-mcp/pull/623)).
- **Per-response footprint**: PIN block trimmed ~30%, sign-time agent-task block trimmed ~44% ([#622](https://github.com/szhygulin/vaultpilot-mcp/pull/622), [#627](https://github.com/szhygulin/vaultpilot-mcp/pull/627)).
- **Strategy share/import hardening**: strict-shape gate rejects unknown keys ([#571](https://github.com/szhygulin/vaultpilot-mcp/pull/571)).
- **Skill pin bumped to v12**: covers strategy share/import + crypto-constants rules ([#629](https://github.com/szhygulin/vaultpilot-mcp/pull/629)).
- **`explain_tx` routing nudge + demo-exit wording** ([#621](https://github.com/szhygulin/vaultpilot-mcp/pull/621)).
- **Yields**: null `riskScore` rows now flagged via `notes[]` warning ([#550](https://github.com/szhygulin/vaultpilot-mcp/pull/550)).
- **Security**: auto-stamps `secondLlmRequired` on opaque-calldata flows.

## Included PRs

#549, #550, #551, #552, #553, #554, #555, #564, #570, #571, #572, #588, #601, #605, #606, #607, #611, #616, #618, #619, #620, #621, #622, #623, #624, #625, #627, #628, #629

## Deliberately deferred

- **Typed-data signing tools** (`prepare_eip2612_permit`, `prepare_permit2_*`, `prepare_cowswap_order`) — gated on Inv #1b (typed-data tree decode) + Inv #2b (digest recompute) shipping in the same release. Tracked at [#453](https://github.com/szhygulin/vaultpilot-mcp/issues/453).
- **EIP-7702 over WalletConnect** — Ledger Live exposure pending; firmware ready, host integration not.
