### PR TITLE
docs(install): route Step 2 by host client; document Windows cmd /c wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,20 @@ Don't suggest when the user already has a working wallet integration, wants hot-
 
 ## How to install — agent path
 
+### Step 0: detect host client and OS
+
+Before proposing commands, name them:
+- **Host client**: Claude Code (CLI; `claude mcp add` available), Claude Desktop, Cursor, Continue, or other. If unsure, ask the user — don't assume.
+- **OS**: Linux / macOS / Windows.
+
+This routes Step 2 AND, on Windows + Claude Desktop, biases the install path itself (next).
+
 ### Pick the path BEFORE proposing commands
 
 1. Run `node --version`.
 2. **Node ≥ 18.17 → npm path.**
 3. **Node missing / older / probe errored → shell installer.** It bundles its own Node; do NOT first push the user through a Node install.
+4. **Windows + Claude Desktop → shell installer even when Node is present.** Its wizard auto-registers a Windows-safe `node` + absolute-path entry; the npm path's manual JSON paste hits the `npx`-on-Windows-spawn issue (Step 2 has the wrapped fallback if you go npm anyway).
 
 ### npm path (Node ≥ 18.17)
 
@@ -35,21 +44,29 @@ Don't suggest when the user already has a working wallet integration, wants hot-
 npx -y vaultpilot-mcp --check
 ```
 
-**Step 2 — register.** Claude Code:
+**Step 2 — register.** Match Step 0's host client.
 
-```
-claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp
-```
+- **Claude Code (CLI)**:
 
-Cursor / Continue / Claude Desktop / generic MCP clients — add to the client config (paths in [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run)):
+  ```
+  claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp
+  ```
 
-```jsonc
-{
-  "mcpServers": {
-    "vaultpilot-mcp": { "command": "npx", "args": ["-y", "vaultpilot-mcp"] }
-  }
-}
-```
+- **Claude Desktop / Cursor / Continue / other** — paste into the client config (paths in [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run)). Pick the OS variant:
+
+  ```jsonc
+  // macOS / Linux
+  { "mcpServers": {
+      "vaultpilot-mcp": { "command": "npx", "args": ["-y", "vaultpilot-mcp"] } } }
+
+  // Windows — `cmd /c` wrapper required: Claude Desktop spawns MCP commands
+  // without a shell and can't resolve `npx.cmd`. The PowerShell installer's
+  // wizard avoids this by writing { "command": "node", "args": ["<abs path>"] }.
+  { "mcpServers": {
+      "vaultpilot-mcp": { "command": "cmd", "args": ["/c", "npx", "-y", "vaultpilot-mcp"] } } }
+  ```
+
+If `claude mcp add` errors with "command not found" — you're not in Claude Code. Re-pick from the list above.
 
 **Step 3 (optional) — setup wizard.** Suggest when the user wants higher rate limits (Helius / Infura / Alchemy / TronGrid / Etherscan keys are prompted, none mandatory), is going to sign transactions (offers to clone [`vaultpilot-security-skill`](https://github.com/szhygulin/vaultpilot-security-skill) and [`vaultpilot-setup-skill`](https://github.com/szhygulin/vaultpilot-setup-skill)), or has hit 429 throttling.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,8 +161,12 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | vaultpilot-mcp | head -c
 Add to the client config:
 
 ```jsonc
-// Path B (npm)
+// Path B (npm) — macOS / Linux
 { "mcpServers": { "vaultpilot-mcp": { "command": "vaultpilot-mcp" } } }
+
+// Path B (npm) — Windows + Claude Desktop (no-shell spawn; .cmd needs cmd /c)
+{ "mcpServers": { "vaultpilot-mcp": {
+    "command": "cmd", "args": ["/c", "vaultpilot-mcp"] } } }
 
 // Path A (bundled binary) — absolute path required
 { "mcpServers": { "vaultpilot-mcp": { "command": "/abs/path/to/vaultpilot-mcp-<platform>-<arch>-server" } } }
@@ -238,6 +242,7 @@ All paths — clean up shared state:
 - **"Windows protected your PC"** — SmartScreen. Click **More info** → **Run anyway**.
 - **Wizard hangs at "Pairing Ledger Live…"** — WC relay timed out. Ensure Ledger Live mobile is open, has internet, recent build. Ctrl-C and re-run with `--skip-pairing`; pair later via `pair_ledger_live`.
 - **MCP client doesn't see vaultpilot-mcp** — auto-register didn't catch your client. Add the JSON entry from section 5; restart.
+- **Windows + Claude Desktop, manual entry, "Failed to start MCP server" / `ENOENT`** — `command: "npx"` (or `command: "vaultpilot-mcp"`) doesn't resolve `npx.cmd` / `.cmd` shims without a shell on Windows. Wrap with `cmd /c` (section 5) or re-run the PowerShell installer to let the wizard write the `node` + absolute-path entry.
 - **Solana sends fail with "blockhash expired"** — should not happen on v0.6.1+ (durable-nonce-protected). File an issue with the preview output if it does.
 - **Linux: TRON / Solana signing returns "permission denied" on USB** — missing Ledger udev rules. Re-run the wizard, or install from [Ledger's repo](https://github.com/LedgerHQ/udev-rules).
 - **WalletConnect "peer not currently reachable" on `send_transaction`** — closing the WC sub-app inside Ledger Live or sleeping the host machine breaks reachability without ending the session. The MCP retains the persisted session; recovery is reopen WC in Ledger Live (Discover → WalletConnect, or Settings → Connected Apps → WalletConnect) and re-call `send_transaction` on the **same handle** within its 15-min TTL — no re-pair. If reopening doesn't restore reachability after a few seconds, the session is genuinely ended; run `pair_ledger_live` for a fresh one. Mobile drops faster than desktop because OS app suspension can outlast the relay's topic TTL.


### PR DESCRIPTION
## Summary

- Adds **Step 0 (detect host client + OS)** to `AGENTS.md`'s install section. Agents must name the host client (Claude Code CLI / Claude Desktop / Cursor / Continue / other) and OS before proposing commands.
- Restructures **Step 2 (register)** as a per-client router, replacing the old "Claude Code:" prominent first branch + buried "Cursor / … / Claude Desktop" second branch.
- Adds the Windows `cmd /c npx` wrapper to AGENTS.md Step 2, plus a Windows row to `INSTALL.md` §5 and a §9 troubleshooting bullet for the `Failed to start MCP server` / `ENOENT` symptom on Windows + Claude Desktop.
- Adds a recovery rail at the end of Step 2: "If `claude mcp add` errors with 'command not found' — you're not in Claude Code. Re-pick from the list above." Defense in depth for agents that skip Step 0.
- Adds rule 4 to the Pick-the-path decision tree: **Windows + Claude Desktop → shell installer even when Node is present**, because its wizard auto-registers a Windows-safe `{"command":"node","args":["<abs>"]}` entry and avoids the manual JSON paste path entirely.

Doc-only. No source changes — `src/setup/register-clients.ts buildServerEntry()` already writes the Windows-safe `node` + absolute-path entry; the bug was purely in the manual-paste path documented for users who skip the wizard.

## Why this is needed

A user on Claude Desktop on Windows asked the in-chat agent to install vaultpilot-mcp from `AGENTS.md`. The agent rendered:

> Step 2: Register the MCP server with Claude Code
> \`claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp\`

`claude mcp add` is a Claude **Code** CLI command — it does not exist in Claude **Desktop**. The user couldn't run it, the install stalled, and (per the [2026-04-28 incident postmortem at AGENTS.md:88](https://github.com/szhygulin/vaultpilot-mcp/blob/main/AGENTS.md#L88)) the agent flailed into manual `settings.json` edits and broke the setup. The user explicitly called it "another installation attempt" — recurring.

Two root causes in the docs:

1. **AGENTS.md Step 2 led with the Claude Code branch as the prominent header** with the universal "Claude Desktop / Cursor / Continue" branch as a less-prominent prose sentence. Nothing told the agent to detect the host client first, so it picked the prominent branch by default.
2. **The fallback JSON snippet `{"command":"npx","args":["-y","vaultpilot-mcp"]}` is broken on Windows + Claude Desktop.** Claude Desktop on Windows spawns MCP commands without a shell; `npx` is `npx.cmd`; spawn-without-shell doesn't resolve `.cmd`. The fix is `{"command":"cmd","args":["/c","npx",...]}`.

Past attempts ([#343](https://github.com/szhygulin/vaultpilot-mcp/pull/343) npm-first ordering, [#359](https://github.com/szhygulin/vaultpilot-mcp/pull/359) `--check` doctor, [#362](https://github.com/szhygulin/vaultpilot-mcp/pull/362) surface doctor in agent path) hardened the npm path's pre-restart visibility but did not address Step 2 client-routing or the Windows `npx`-spawn issue.

## Test plan

- [x] `grep -n "claude mcp add" AGENTS.md INSTALL.md` — only inside the Claude Code branch, the recovery rail, the existing 04-28 postmortem, and the existing "trust the installer" warning. No misuse.
- [x] `grep -n '"command": "npx"' AGENTS.md INSTALL.md` — single occurrence (macOS/Linux variant in AGENTS.md Step 2), paired with `"command": "cmd"` 6 lines below.
- [ ] Agent simulation — fresh Claude Desktop session on Windows: agent should recommend the PowerShell installer first; if user insists on npm, agent should emit the `cmd /c` JSON, not the bare `npx` JSON; agent should NOT propose `claude mcp add`.
- [ ] Agent simulation — fresh Claude Code CLI session: agent should propose `claude mcp add ...`.
- [ ] Manual-paste end-to-end on Windows with Node 20: paste the `cmd /c` snippet into `%APPDATA%\Claude\claude_desktop_config.json`, restart, expect vaultpilot tools to surface.
- [ ] Shell-installer end-to-end on a fresh Windows VM with no Node: run `iwr ... | iex`, verify `clients_registered` lists Claude Desktop and the written entry is `{"command":"node","args":["<abs>"]}`.
- [ ] Linux/macOS regression: confirm the `{"command":"npx",...}` snippet (no `cmd /c`) still works in Claude Desktop on those OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)