### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.14.0";
+const SERVER_VERSION = "0.14.1";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
## Summary

Patch release shipping the install-doc fix from #632 to npm + MCP Registry.

Three doc-only PRs merged since v0.14.0:

- #629 sync skill pin to v0.10
- #631 roadmap cleanup (link missing plans, fix broken links)
- #632 install docs — Step 0 host-client detection, Windows `cmd /c` wrapper

No code changes. The bump exists so agents fetching `AGENTS.md` from the latest npm tarball or reading vaultpilot-mcp metadata via the MCP Registry see the corrected Step 2 routing rather than the version bundled with v0.14.0.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 193 test files / 2529 tests pass
- [x] All four version strings synced (`package.json`, `server.json` top + `packages[0].version`, `src/modules/incident-report/index.ts`)
- [ ] After merge: tag `v0.14.1` on the merge commit, create GitHub Release; `publish.yml` (npm + MCP Registry) and `release-binaries.yml` fire on `release: published`
- [ ] Verify `npm view vaultpilot-mcp version` reports `0.14.1`
- [ ] Verify MCP Registry entry: `curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=vaultpilot-mcp&version=latest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)