### PR TITLE
docs(agents): reframe Step 0 as hard refusal gate (MUST / MUST NOT)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,16 @@ Don't suggest when the user already has a working wallet integration, wants hot-
 
 ## How to install — agent path
 
-### Step 0: detect host client and OS
+### Step 0: REQUIRED — name host client and OS
 
-Before proposing commands, name them:
-- **Host client**: Claude Code (CLI; `claude mcp add` available), Claude Desktop, Cursor, Continue, or other. If unsure, ask the user — don't assume.
-- **OS**: Linux / macOS / Windows.
+You MUST NOT propose any install command in this turn unless your reply contains both:
 
-This routes Step 2 AND, on Windows + Claude Desktop, biases the install path itself (next).
+1. The user's host client (Claude Code CLI / Claude Desktop / Cursor / Continue / other), AND
+2. The user's OS (Linux / macOS / Windows).
+
+If either is unknown, your entire reply MUST be a single question asking for the missing fact. Do not list options, do not show commands, do not explain — just ask.
+
+This rule overrides any "be helpful, give the answer now" instinct. The wrong-client / wrong-OS install (e.g. `claude mcp add` recommended to a Claude Desktop user, or bare `npx` recommended to a Windows Claude Desktop user) is the most common failure mode in the wild.
 
 ### Pick the path BEFORE proposing commands
 


### PR DESCRIPTION
Closes #640

## Summary

Reframe `AGENTS.md` Step 0 from soft "ask the user — don't assume" prose to a hard refusal gate using `MUST NOT` / `MUST` language. Adds a named failure mode (wrong-client / wrong-OS install) so the agent has a reason to comply.

## Why

[#632](https://github.com/szhygulin/vaultpilot-mcp/pull/632) added Step 0 as prose. Empirical evidence in the field: agents fetching `AGENTS.md` summarized the soft directives away — fresh chat session assumed Claude Code as host, assumed Node ≥ 18.17 was present, and produced commands without asking either question.

Imperative phrasing + explicit failure mode survives doc summarization where soft directives don't. Same mechanism that makes `DO NOT XYZ` guard rails in `CLAUDE.md` / `AGENTS.md` hold under summarization.

## Diff shape

`AGENTS.md` only — Step 0 prose replaced with the proposal from the issue body verbatim. Subsequent sections ("Pick the path BEFORE proposing commands", npm path, shell installer) untouched.

## Acceptance criteria (from #640)

- [x] Step 0 uses MUST NOT / MUST language explicitly.
- [x] Step 0 names the failure mode (wrong-client / wrong-OS install).
- [ ] Re-test by fetching `AGENTS.md` from a fresh chat session — agent's first reply asks for host client + OS, contains zero commands. **(Manual verification, post-merge.)**

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 2532 / 2532 passed.
- [ ] Smoke-test post-merge: fresh chat asks for vaultpilot install via `AGENTS.md`; verify first reply is a single question naming neither commands nor lists.

— Lambert (agent-bf46)
