### PR TITLE
docs(agents): restructure Step 2 as per-client router with heading-anchored subsections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,29 +44,44 @@ This routes Step 2 AND, on Windows + Claude Desktop, biases the install path its
 npx -y vaultpilot-mcp --check
 ```
 
-**Step 2 — register.** Match Step 0's host client.
+**Step 2 — register.** Find your MCP client below — pick the heading matching the host client identified in Step 0. No commands appear before a per-client subsection; you must commit to a heading first.
 
-- **Claude Code (CLI)**:
+#### Claude Code (CLI)
 
-  ```
-  claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp
-  ```
+```
+claude mcp add vaultpilot-mcp -- npx -y vaultpilot-mcp
+```
 
-- **Claude Desktop / Cursor / Continue / other** — paste into the client config (paths in [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run)). Pick the OS variant:
+If this errors with "command not found" — `claude mcp add` is a Claude **Code** CLI command, so you're not in Claude Code. Re-pick from the headings below.
 
-  ```jsonc
-  // macOS / Linux
-  { "mcpServers": {
-      "vaultpilot-mcp": { "command": "npx", "args": ["-y", "vaultpilot-mcp"] } } }
+#### Claude Desktop
 
-  // Windows — `cmd /c` wrapper required: Claude Desktop spawns MCP commands
-  // without a shell and can't resolve `npx.cmd`. The PowerShell installer's
-  // wizard avoids this by writing { "command": "node", "args": ["<abs path>"] }.
-  { "mcpServers": {
-      "vaultpilot-mcp": { "command": "cmd", "args": ["/c", "npx", "-y", "vaultpilot-mcp"] } } }
-  ```
+Paste into `claude_desktop_config.json` (path in [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run)). Pick the OS variant:
 
-If `claude mcp add` errors with "command not found" — you're not in Claude Code. Re-pick from the list above.
+```jsonc
+// macOS / Linux
+{ "mcpServers": {
+    "vaultpilot-mcp": { "command": "npx", "args": ["-y", "vaultpilot-mcp"] } } }
+
+// Windows — `cmd /c` wrapper required: Claude Desktop spawns MCP commands
+// without a shell and can't resolve `npx.cmd`. The PowerShell installer's
+// wizard avoids this by writing { "command": "node", "args": ["<abs path>"] }.
+{ "mcpServers": {
+    "vaultpilot-mcp": { "command": "cmd", "args": ["/c", "npx", "-y", "vaultpilot-mcp"] } } }
+```
+
+#### Cursor
+
+Paste into `~/.cursor/mcp.json` (Windows: use the `cmd /c` variant from the Claude Desktop section above):
+
+```jsonc
+{ "mcpServers": {
+    "vaultpilot-mcp": { "command": "npx", "args": ["-y", "vaultpilot-mcp"] } } }
+```
+
+#### Continue / other
+
+See [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run) for canonical config paths and per-client schemas.
 
 **Step 3 (optional) — setup wizard.** Suggest when the user wants higher rate limits (Helius / Infura / Alchemy / TronGrid / Etherscan keys are prompted, none mandatory), is going to sign transactions (offers to clone [`vaultpilot-security-skill`](https://github.com/szhygulin/vaultpilot-security-skill) and [`vaultpilot-setup-skill`](https://github.com/szhygulin/vaultpilot-setup-skill)), or has hit 429 throttling.
 


### PR DESCRIPTION
Closes #639

## Summary

Restructures `AGENTS.md` Step 2 from a bullet-list-with-prominent-first-command into a router whose four branches live behind distinct `####` headings: **Claude Code (CLI)**, **Claude Desktop**, **Cursor**, **Continue / other**. No concrete commands appear before the first per-client subsection.

## Why

PR #632 fixed Step 2 with prose ("Match Step 0's host client" + "If unsure, ask the user — don't assume"), but agents fetching the doc kept rendering the Claude Code branch as the default. Empirical evidence (per #639): a fresh session asking the agent to install vaultpilot-mcp still produced "Step 2: Register the MCP server with Claude Code → `claude mcp add ...`" with no host-client prompt. Root cause: `claude mcp add` was the first concrete command under `Step 2 — register`. Agents summarizing fetched docs render the first concrete command they see.

Heading-anchored branches close the gap: the agent has to navigate to a named subsection to find a command, which forces it to commit to a host client first.

## Scope

Doc-only edit to `AGENTS.md` lines 47–84. No source changes. No INSTALL.md changes (only one repo-wide reference to `Step 2 — register` exists, in AGENTS.md itself — verified via grep).

## Acceptance criteria

- [x] `Step 2 — register` section has zero commands before the first per-client `####` subsection.
- [x] Each subsection is heading-anchored (`#### Claude Code (CLI)`, `#### Claude Desktop`, `#### Cursor`, `#### Continue / other`).
- [ ] Re-test from a fresh chat session (Claude.ai web, no shell access) confirming the agent asks "which MCP client?" before producing any command. Manual; not gating this PR.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 2532/2532 pass.
- [x] Step 2 intro line → first command line gap inspected: only the bolded Step 2 paragraph and four heading lines, no commands.
- [ ] Manual fetch-and-summarize test on a Claude.ai web session.

## Notes

- Existing recovery rail ("If `claude mcp add` errors with 'command not found' — you're not in Claude Code") moved inside the `#### Claude Code (CLI)` subsection — natural home, still defends agents that picked the wrong heading.
- Cursor subsection inherits the Windows `cmd /c` wrapper by reference rather than duplicating the JSON block. One fact, one home.
- Sister issue mentioned in #639 ("refusal framing for Step 0") is out of scope here — separate fix.

— Milgram (agent-98b3)
