### PR TITLE
feat(diagnostics): surface Safe API key in get_vaultpilot_config_status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4171,7 +4171,7 @@ async function main() {
         "READ-ONLY — report what the server knows about its local config without revealing any " +
         "secret values. Returns the config-file path + existence, server version, per-chain RPC " +
         "URL source classification (env-var / provider-key / custom-url / public-fallback), " +
-        "API-key presence + source per service (Etherscan, 1inch, TronGrid, WalletConnect — " +
+        "API-key presence + source per service (Etherscan, 1inch, Safe, TronGrid, WalletConnect — " +
         "boolean + source enum, never values), counts of paired Ledger accounts (Solana / TRON), " +
         "the WC session-topic SUFFIX (last 8 chars only — same convention as get_ledger_status), " +
         "the agent-side preflight-skill install state, a `setupHints` array (each entry has a " +

--- a/src/modules/diagnostics/index.ts
+++ b/src/modules/diagnostics/index.ts
@@ -112,6 +112,7 @@ interface VaultPilotConfigStatus {
   apiKeys: {
     etherscan: { set: boolean; source: ApiKeySource };
     oneInch: { set: boolean; source: ApiKeySource };
+    safe: { set: boolean; source: ApiKeySource };
     tronGrid: { set: boolean; source: ApiKeySource };
     walletConnectProjectId: { set: boolean; source: ApiKeySource };
   };
@@ -268,6 +269,7 @@ export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): Va
   // pointing the user at a feature they're already in.
   const etherscanKey = classifyApiKey("ETHERSCAN_API_KEY", cfg?.etherscanApiKey);
   const oneInchKey = classifyApiKey("ONEINCH_API_KEY", cfg?.oneInchApiKey);
+  const safeKey = classifyApiKey("SAFE_API_KEY", cfg?.safeApiKey);
   const wcProjectKey = classifyApiKey(
     "WALLETCONNECT_PROJECT_ID",
     cfg?.walletConnect?.projectId,
@@ -275,6 +277,7 @@ export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): Va
   const noKeys =
     !etherscanKey.set &&
     !oneInchKey.set &&
+    !safeKey.set &&
     !tronGridKey.set &&
     !wcProjectKey.set;
   const noPairings =
@@ -317,6 +320,7 @@ export function getVaultPilotConfigStatus(_args: Record<string, never> = {}): Va
     apiKeys: {
       etherscan: etherscanKey,
       oneInch: oneInchKey,
+      safe: safeKey,
       tronGrid: tronGridKey,
       walletConnectProjectId: wcProjectKey,
     },

--- a/test/diagnostics-config-status.test.ts
+++ b/test/diagnostics-config-status.test.ts
@@ -37,6 +37,7 @@ beforeEach(async () => {
   delete process.env.RPC_API_KEY;
   delete process.env.ETHERSCAN_API_KEY;
   delete process.env.ONEINCH_API_KEY;
+  delete process.env.SAFE_API_KEY;
   delete process.env.TRON_API_KEY;
   delete process.env.WALLETCONNECT_PROJECT_ID;
   delete process.env.VAULTPILOT_SKILL_MARKER_PATH;
@@ -144,11 +145,29 @@ describe("get_vaultpilot_config_status — API key source classification", () =>
     const status = getVaultPilotConfigStatus();
     expect(status.apiKeys.etherscan).toEqual({ set: false, source: "unset" });
     expect(status.apiKeys.oneInch).toEqual({ set: false, source: "unset" });
+    expect(status.apiKeys.safe).toEqual({ set: false, source: "unset" });
     expect(status.apiKeys.tronGrid).toEqual({ set: false, source: "unset" });
     expect(status.apiKeys.walletConnectProjectId).toEqual({
       set: false,
       source: "unset",
     });
+  });
+
+  it("reports safe key from SAFE_API_KEY env var", async () => {
+    process.env.SAFE_API_KEY = "safe-env-secret";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.apiKeys.safe).toEqual({ set: true, source: "env-var" });
+  });
+
+  it("reports safe key from config file when env var unset", async () => {
+    writeConfig({
+      rpc: { provider: "infura", apiKey: "k" },
+      safeApiKey: "config-safe-secret",
+    });
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.apiKeys.safe).toEqual({ set: true, source: "config" });
   });
 
   it("env-var source wins over config", async () => {
@@ -256,6 +275,7 @@ describe("get_vaultpilot_config_status — strict no-secrets contract", () => {
     const SECRETS = {
       etherscan: "ETHSCAN-PLANT-SECRET-DO-NOT-LEAK",
       oneInch: "ONEINCH-PLANT-SECRET-DO-NOT-LEAK",
+      safe: "SAFE-PLANT-SECRET-DO-NOT-LEAK",
       tron: "TRON-PLANT-SECRET-DO-NOT-LEAK",
       wcProject: "WC-PLANT-SECRET-DO-NOT-LEAK",
       ethRpc: "https://mainnet.example.com/PLANT-RPC-SECRET",
@@ -265,6 +285,7 @@ describe("get_vaultpilot_config_status — strict no-secrets contract", () => {
     } as const;
     process.env.ETHERSCAN_API_KEY = SECRETS.etherscan;
     process.env.ONEINCH_API_KEY = SECRETS.oneInch;
+    process.env.SAFE_API_KEY = SECRETS.safe;
     process.env.TRON_API_KEY = SECRETS.tron;
     process.env.WALLETCONNECT_PROJECT_ID = SECRETS.wcProject;
     process.env.ETHEREUM_RPC_URL = SECRETS.ethRpc;
@@ -379,6 +400,13 @@ describe("get_vaultpilot_config_status — first-run demo-mode hint (issue #371 
 
   it("self-clears when the user adds an Etherscan API key", async () => {
     process.env.ETHERSCAN_API_KEY = "k";
+    const { getVaultPilotConfigStatus } = await loadFresh();
+    const status = getVaultPilotConfigStatus();
+    expect(status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode")).toBeUndefined();
+  });
+
+  it("self-clears when the user adds a Safe API key", async () => {
+    process.env.SAFE_API_KEY = "k";
     const { getVaultPilotConfigStatus } = await loadFresh();
     const status = getVaultPilotConfigStatus();
     expect(status.setupHints.find((h: { kind: string }) => h.kind === "demo-mode")).toBeUndefined();


### PR DESCRIPTION
Closes #604.

## Summary

`get_vaultpilot_config_status` is the canonical "is my server configured the way I think it is?" tool, but its `apiKeys` schema only tracked `etherscan` / `oneInch` / `tronGrid` / `walletConnectProjectId` — the Safe key was the lone outlier among five EVM-required keys, which contributed to the user-facing confusion in the issue.

The wizard side of option (a) already shipped in PR #261 (Apr 26): `configureSafe` is in the full-wizard and edit-menu paths, `safeApiKey` is on `UserConfig`, and `summarizeConfig` prints "Safe API key: set / not set". This PR closes the symmetry gap on the diagnostics side:

- Add `safe: { set, source }` to `VaultPilotConfigStatus.apiKeys` (env-var precedes config — mirrors `resolveSafeApiKey` in `src/modules/safe/sdk.ts`).
- Include the safe key in the fresh-install demo-mode-hint suppression check, so a user with only `SAFE_API_KEY` set is no longer mis-identified as "no setup detected".
- Mention "Safe" in the `get_vaultpilot_config_status` tool description so agents see it alongside the other four services.

The error string from `SafeApiKeyMissingError` ("Set the `SAFE_API_KEY` env var or run `vaultpilot-mcp-setup`") is now accurate as-is — the wizard does write that field, so no message change is needed.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 2535/2535 pass.
- [x] New unit tests cover the env-var path, the config-file path, the no-secrets sweep (planted Safe key never echoed), and demo-mode-hint self-clear when `SAFE_API_KEY` is set.

— Tu (agent-da91)
