### PR TITLE
feat(bench): measure per-conversation MCP tool static-surface token cost

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "verify-personas": "node scripts/verify-personas.mjs",
+    "bench:tools": "node scripts/bench-tools.mjs",
     "bundle": "pkg .",
     "prepare": "patch-package"
   },

--- a/scripts/bench-tools.mjs
+++ b/scripts/bench-tools.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * MCP tool static-surface token-cost benchmark (issue #637).
+ *
+ * Spawns the built server (`dist/index.js`) over stdio, performs the
+ * MCP `initialize` handshake, requests `tools/list`, and feeds the
+ * response into `src/diagnostics/tool-cost.ts` to produce a ranked
+ * Markdown report of per-tool token cost.
+ *
+ * The point: identify which tool descriptions / input schemas eat the
+ * most agent context per session, so future trim PRs can target the
+ * heavy hitters with numbers (the analog of the README rewrite, but
+ * for tool surface).
+ *
+ * Scope: static surface only — what the agent loads via `tools/list`
+ * once per conversation. Response-side measurement (CHECKS PERFORMED
+ * blocks, NOTICE blocks, payload bodies that load on every tool call)
+ * is a follow-on; it requires fixtures or live RPC and is a separate
+ * harness.
+ *
+ * Usage:
+ *   npm run build               # produce dist/
+ *   npm run bench:tools         # print ranked table to stdout
+ *   npm run bench:tools -- --out bench/tool-cost.md  # save markdown
+ *   npm run bench:tools -- --top 20   # show top N (default 10)
+ *
+ * Exit codes: 0 ok, 1 bench failure (server crash, no tools, malformed
+ * response). Never modifies state — read-only via `tools/list`.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdir } from "node:fs/promises";
+
+import {
+  analyzeToolList,
+  formatRankingTable,
+} from "../dist/diagnostics/tool-cost.js";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const DIST_ENTRY = resolve(REPO_ROOT, "dist", "index.js");
+
+function parseArgs(argv) {
+  const args = { out: null, top: 10 };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--out") {
+      args.out = argv[++i];
+    } else if (a === "--top") {
+      const n = Number(argv[++i]);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`--top requires a positive integer, got: ${argv[i]}`);
+      }
+      args.top = Math.floor(n);
+    } else if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown flag: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      "bench-tools — measure MCP tool static-surface token cost",
+      "",
+      "Usage:",
+      "  npm run bench:tools                       Print ranked table to stdout",
+      "  npm run bench:tools -- --out FILE         Save markdown report to FILE",
+      "  npm run bench:tools -- --top N            Show top N tools (default 10)",
+      "  npm run bench:tools -- --help             This message",
+      "",
+    ].join("\n"),
+  );
+}
+
+/**
+ * Spawn the built server and run an MCP `initialize` + `tools/list`
+ * round-trip. Returns the array of tool descriptors.
+ */
+async function listTools() {
+  if (!existsSync(DIST_ENTRY)) {
+    throw new Error(
+      `dist/index.js not found at ${DIST_ENTRY} — run \`npm run build\` first`,
+    );
+  }
+
+  return new Promise((resolveList, rejectList) => {
+    // Force demo mode off and any chain scoping off so we measure the
+    // full registered surface, not a narrowed slice. Bench is the
+    // canonical "what does the unrestricted agent load?" snapshot.
+    const child = spawn(process.execPath, [DIST_ENTRY], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        VAULTPILOT_DEMO: "",
+        VAULTPILOT_SCOPE: "",
+      },
+    });
+
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      rejectList(
+        new Error(
+          `bench-tools timed out after 30s. server stderr tail:\n${stderrBuf.slice(-2000)}`,
+        ),
+      );
+    }, 30_000);
+
+    child.stderr.on("data", (chunk) => {
+      stderrBuf += chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rejectList(err);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rejectList(
+        new Error(
+          `server exited unexpectedly (code=${code}, signal=${signal}) before tools/list response. stderr tail:\n${stderrBuf.slice(-2000)}`,
+        ),
+      );
+    });
+
+    child.stdout.on("data", (chunk) => {
+      stdoutBuf += chunk.toString("utf8");
+      // JSON-RPC over stdio is newline-delimited.
+      let nl;
+      while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+        const line = stdoutBuf.slice(0, nl).trim();
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        if (!line) continue;
+        let msg;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          // Non-JSON lines on stdout shouldn't happen for an MCP
+          // server; skip and continue.
+          continue;
+        }
+        if (msg.id === 1 && msg.result) {
+          // initialize response — fire the initialized notification,
+          // then request tools/list.
+          send(child, {
+            jsonrpc: "2.0",
+            method: "notifications/initialized",
+          });
+          send(child, {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list",
+            params: {},
+          });
+        } else if (msg.id === 2) {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          if (msg.error) {
+            rejectList(
+              new Error(`tools/list returned error: ${JSON.stringify(msg.error)}`),
+            );
+          } else {
+            resolveList(msg.result?.tools ?? []);
+          }
+          // Polite shutdown — server has no graceful close hook for
+          // stdio, so SIGTERM is the right signal.
+          child.kill("SIGTERM");
+        }
+      }
+    });
+
+    // Kick off the handshake.
+    send(child, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "vaultpilot-bench-tools", version: "0.0.0" },
+      },
+    });
+  });
+}
+
+function send(child, msg) {
+  child.stdin.write(JSON.stringify(msg) + "\n");
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    process.stderr.write(`bench-tools: ${err.message}\n`);
+    printHelp();
+    process.exit(2);
+  }
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const tools = await listTools();
+  if (tools.length === 0) {
+    throw new Error("tools/list returned zero tools — server registered nothing");
+  }
+
+  const summary = analyzeToolList(tools);
+  const report = formatRankingTable(summary, { top: args.top });
+
+  process.stdout.write(report + "\n");
+
+  if (args.out) {
+    const outPath = resolve(REPO_ROOT, args.out);
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, report + "\n", "utf8");
+    process.stderr.write(`bench-tools: wrote report to ${outPath}\n`);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`bench-tools failed: ${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/src/diagnostics/tool-cost.ts
+++ b/src/diagnostics/tool-cost.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-tool token-cost analyzer for the static MCP surface (issue #637).
+ *
+ * The agent loads every registered tool's `name`, `description`, and
+ * `inputSchema` (JSON Schema) into context on every `tools/list` call —
+ * once per conversation, but persistent across every subsequent turn.
+ * That static surface is the largest single contributor to per-session
+ * Claude token spend on this server, and we have no measurement of it
+ * today.
+ *
+ * This module computes per-tool size breakdowns from a `tools/list`
+ * response and ranks them. It is deliberately runtime-free: callers
+ * pass in tool metadata they obtained however they want (spawned
+ * server, fixture, snapshot), and get back sized rows + a formatted
+ * table. The runner script in `scripts/bench-tools.mjs` does the
+ * actual server spawn.
+ *
+ * **Tokenizer choice**: Anthropic's tokenizer is closed-source. cl100k
+ * is the standard public proxy and would require ~5MB of BPE tables.
+ * For *relative ranking* — which is what this benchmark needs — raw
+ * character count works fine (the issue itself notes "cl100k is a
+ * serviceable proxy for relative ranking"; we go one step lighter by
+ * using char/4 as a proxy for cl100k). When absolute counts matter
+ * later (e.g. to ground a CI budget rule in real-tokenizer output),
+ * swap `approxTokens` for a `gpt-tokenizer` import. Until then, the
+ * `approxTokens` column is "tokens, approximately" — not a contract.
+ *
+ * **Scope**: static surface (description + inputSchema JSON). Response
+ * sizes (CHECKS PERFORMED blocks, NOTICE blocks, payload bodies) are a
+ * follow-on; they require fixtures or live RPC and live in a separate
+ * harness.
+ */
+
+/**
+ * Each registered tool, as it appears in an MCP `tools/list` response.
+ * Mirrors the SDK's `Tool` shape but keeps this module's types
+ * independent of the SDK so the analyzer can be exercised in tests
+ * without pulling the server in.
+ */
+export interface ToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+export interface ToolCostRow {
+  name: string;
+  /** Length in UTF-8 bytes — canonical, locale-free. */
+  nameBytes: number;
+  descriptionBytes: number;
+  inputSchemaBytes: number;
+  /** Sum of name + description + inputSchema bytes. */
+  totalBytes: number;
+  /** Approximate token count (chars/4 proxy — see module header). */
+  approxTokens: number;
+}
+
+export interface ToolCostSummary {
+  rows: ToolCostRow[];
+  totalBytes: number;
+  totalApproxTokens: number;
+  toolCount: number;
+}
+
+/** Approximate cl100k tokens. Chars / 4, rounded up. */
+export function approxTokens(s: string): number {
+  if (s.length === 0) return 0;
+  return Math.ceil(s.length / 4);
+}
+
+/** UTF-8 byte length, matching what the JSON-RPC transport puts on the wire. */
+export function utf8Bytes(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+/**
+ * Serialize the inputSchema the way the MCP SDK does on the wire — the
+ * canonical JSON form, no pretty-printing. This is what the agent
+ * actually sees in its tools/list payload.
+ */
+export function serializeInputSchema(schema: unknown): string {
+  if (schema === undefined || schema === null) return "";
+  return JSON.stringify(schema);
+}
+
+export function analyzeTool(tool: ToolDescriptor): ToolCostRow {
+  const nameBytes = utf8Bytes(tool.name);
+  const descriptionBytes = utf8Bytes(tool.description ?? "");
+  const inputSchemaJson = serializeInputSchema(tool.inputSchema);
+  const inputSchemaBytes = utf8Bytes(inputSchemaJson);
+  const totalBytes = nameBytes + descriptionBytes + inputSchemaBytes;
+  // Approx tokens computed off the combined char count, which matches
+  // how a tokenizer would chew the concatenated payload.
+  const totalChars =
+    tool.name.length + (tool.description ?? "").length + inputSchemaJson.length;
+  return {
+    name: tool.name,
+    nameBytes,
+    descriptionBytes,
+    inputSchemaBytes,
+    totalBytes,
+    approxTokens: approxTokens("x".repeat(totalChars)),
+  };
+}
+
+export function analyzeToolList(tools: ToolDescriptor[]): ToolCostSummary {
+  const rows = tools.map(analyzeTool).sort((a, b) => b.totalBytes - a.totalBytes);
+  const totalBytes = rows.reduce((acc, r) => acc + r.totalBytes, 0);
+  const totalApproxTokens = rows.reduce((acc, r) => acc + r.approxTokens, 0);
+  return {
+    rows,
+    totalBytes,
+    totalApproxTokens,
+    toolCount: rows.length,
+  };
+}
+
+/**
+ * Format the analyzer output as a Markdown report. Top-N tools are
+ * shown by total bytes (descending); summary footer carries the global
+ * static-surface total.
+ */
+export function formatRankingTable(
+  summary: ToolCostSummary,
+  options: { top?: number } = {},
+): string {
+  const top = options.top ?? 10;
+  const limited = summary.rows.slice(0, top);
+  const lines: string[] = [];
+  lines.push("# MCP tool static-surface token cost");
+  lines.push("");
+  lines.push(
+    `Generated: ${new Date().toISOString()} — ${summary.toolCount} tools registered`,
+  );
+  lines.push("");
+  lines.push(
+    `**Per-conversation static cost**: ${summary.totalBytes.toLocaleString()} bytes ≈ ${summary.totalApproxTokens.toLocaleString()} tokens (chars/4 proxy).`,
+  );
+  lines.push("");
+  lines.push(`## Top ${limited.length} by total bytes`);
+  lines.push("");
+  lines.push("| Rank | Tool | Total bytes | ≈ tokens | Description bytes | Schema bytes |");
+  lines.push("|-----:|------|------------:|---------:|------------------:|-------------:|");
+  for (const [i, row] of limited.entries()) {
+    lines.push(
+      `| ${i + 1} | \`${row.name}\` | ${row.totalBytes.toLocaleString()} | ${row.approxTokens.toLocaleString()} | ${row.descriptionBytes.toLocaleString()} | ${row.inputSchemaBytes.toLocaleString()} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Section breakdown across all tools");
+  lines.push("");
+  const totalDescBytes = summary.rows.reduce((a, r) => a + r.descriptionBytes, 0);
+  const totalSchemaBytes = summary.rows.reduce((a, r) => a + r.inputSchemaBytes, 0);
+  const totalNameBytes = summary.rows.reduce((a, r) => a + r.nameBytes, 0);
+  lines.push("| Section | Bytes | % of total |");
+  lines.push("|---------|------:|-----------:|");
+  const pct = (n: number): string =>
+    summary.totalBytes === 0 ? "0%" : `${((n / summary.totalBytes) * 100).toFixed(1)}%`;
+  lines.push(`| Tool names | ${totalNameBytes.toLocaleString()} | ${pct(totalNameBytes)} |`);
+  lines.push(
+    `| Descriptions | ${totalDescBytes.toLocaleString()} | ${pct(totalDescBytes)} |`,
+  );
+  lines.push(
+    `| Input schemas | ${totalSchemaBytes.toLocaleString()} | ${pct(totalSchemaBytes)} |`,
+  );
+  lines.push("");
+  lines.push(
+    "_Token counts are an approximation (chars/4) — accurate for relative ranking, not for absolute budget claims. See `src/diagnostics/tool-cost.ts` header for details._",
+  );
+  return lines.join("\n");
+}

--- a/test/tool-cost.test.ts
+++ b/test/tool-cost.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import {
+  approxTokens,
+  utf8Bytes,
+  serializeInputSchema,
+  analyzeTool,
+  analyzeToolList,
+  formatRankingTable,
+  type ToolDescriptor,
+} from "../src/diagnostics/tool-cost.ts";
+
+/**
+ * Pure-helper tests for the tool-cost analyzer (issue #637). The
+ * spawn/JSON-RPC plumbing in `scripts/bench-tools.mjs` is exercised
+ * separately via `npm run bench:tools` against the built server;
+ * unit tests cover only the deterministic analysis layer.
+ */
+
+describe("approxTokens", () => {
+  it("returns 0 for empty string", () => {
+    expect(approxTokens("")).toBe(0);
+  });
+
+  it("rounds chars/4 up", () => {
+    expect(approxTokens("abcd")).toBe(1);
+    expect(approxTokens("abcde")).toBe(2);
+    expect(approxTokens("a".repeat(100))).toBe(25);
+    expect(approxTokens("a".repeat(101))).toBe(26);
+  });
+});
+
+describe("utf8Bytes", () => {
+  it("counts UTF-8 bytes, not code units", () => {
+    expect(utf8Bytes("abc")).toBe(3);
+    // Multibyte characters — emoji is 4 bytes, accent is 2 bytes.
+    expect(utf8Bytes("é")).toBe(2);
+    // Bytes diverge from `.length` (code units): rocket emoji is 2
+    // surrogate pairs (`.length === 2`) but 4 UTF-8 bytes.
+    expect(utf8Bytes("🚀")).toBe(4);
+    expect("🚀".length).toBe(2);
+  });
+});
+
+describe("serializeInputSchema", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(serializeInputSchema(undefined)).toBe("");
+    expect(serializeInputSchema(null)).toBe("");
+  });
+
+  it("emits compact JSON (no pretty-printing)", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } } };
+    const out = serializeInputSchema(schema);
+    expect(out).toBe('{"type":"object","properties":{"a":{"type":"string"}}}');
+    expect(out).not.toContain("\n");
+  });
+});
+
+describe("analyzeTool", () => {
+  it("breaks down bytes by section", () => {
+    const tool: ToolDescriptor = {
+      name: "get_things",
+      description: "Fetch things.",
+      inputSchema: { type: "object" },
+    };
+    const row = analyzeTool(tool);
+    expect(row.name).toBe("get_things");
+    expect(row.nameBytes).toBe(10);
+    expect(row.descriptionBytes).toBe("Fetch things.".length);
+    expect(row.inputSchemaBytes).toBe('{"type":"object"}'.length);
+    expect(row.totalBytes).toBe(
+      row.nameBytes + row.descriptionBytes + row.inputSchemaBytes,
+    );
+    expect(row.approxTokens).toBeGreaterThan(0);
+  });
+
+  it("handles missing description and schema", () => {
+    const row = analyzeTool({ name: "x" });
+    expect(row.nameBytes).toBe(1);
+    expect(row.descriptionBytes).toBe(0);
+    expect(row.inputSchemaBytes).toBe(0);
+    expect(row.totalBytes).toBe(1);
+  });
+});
+
+describe("analyzeToolList", () => {
+  const tools: ToolDescriptor[] = [
+    { name: "small", description: "tiny", inputSchema: {} },
+    {
+      name: "big",
+      description: "a much longer description that takes more bytes",
+      inputSchema: { type: "object", properties: { a: { type: "string" } } },
+    },
+    { name: "mid", description: "medium length", inputSchema: { type: "object" } },
+  ];
+
+  it("sorts rows by totalBytes descending", () => {
+    const summary = analyzeToolList(tools);
+    expect(summary.rows[0].name).toBe("big");
+    expect(summary.rows[summary.rows.length - 1].name).toBe("small");
+    // Strict descending order.
+    for (let i = 1; i < summary.rows.length; i++) {
+      expect(summary.rows[i - 1].totalBytes).toBeGreaterThanOrEqual(
+        summary.rows[i].totalBytes,
+      );
+    }
+  });
+
+  it("computes consistent totals", () => {
+    const summary = analyzeToolList(tools);
+    const expectedBytes = summary.rows.reduce((acc, r) => acc + r.totalBytes, 0);
+    const expectedTokens = summary.rows.reduce((acc, r) => acc + r.approxTokens, 0);
+    expect(summary.totalBytes).toBe(expectedBytes);
+    expect(summary.totalApproxTokens).toBe(expectedTokens);
+    expect(summary.toolCount).toBe(3);
+  });
+
+  it("handles empty list", () => {
+    const summary = analyzeToolList([]);
+    expect(summary.rows).toEqual([]);
+    expect(summary.totalBytes).toBe(0);
+    expect(summary.totalApproxTokens).toBe(0);
+    expect(summary.toolCount).toBe(0);
+  });
+});
+
+describe("formatRankingTable", () => {
+  const summary = analyzeToolList([
+    { name: "a_tool", description: "A".repeat(100), inputSchema: {} },
+    { name: "b_tool", description: "B".repeat(50), inputSchema: {} },
+    { name: "c_tool", description: "C".repeat(10), inputSchema: {} },
+  ]);
+
+  it("includes every tool when fewer than top", () => {
+    const table = formatRankingTable(summary, { top: 10 });
+    expect(table).toContain("a_tool");
+    expect(table).toContain("b_tool");
+    expect(table).toContain("c_tool");
+  });
+
+  it("respects --top truncation", () => {
+    const table = formatRankingTable(summary, { top: 2 });
+    expect(table).toContain("a_tool");
+    expect(table).toContain("b_tool");
+    expect(table).not.toContain("c_tool");
+    expect(table).toContain("Top 2 by total bytes");
+  });
+
+  it("renders the section breakdown", () => {
+    const table = formatRankingTable(summary);
+    expect(table).toContain("## Section breakdown across all tools");
+    expect(table).toContain("Tool names");
+    expect(table).toContain("Descriptions");
+    expect(table).toContain("Input schemas");
+  });
+
+  it("declares the proxy nature of token counts", () => {
+    const table = formatRankingTable(summary);
+    expect(table.toLowerCase()).toContain("approximation");
+  });
+
+  it("formats summary footer with total stats", () => {
+    const table = formatRankingTable(summary);
+    expect(table).toContain("Per-conversation static cost");
+    expect(table).toMatch(/\d[\d,]*\s+bytes/);
+  });
+});


### PR DESCRIPTION
Closes #637

## Summary

Adds a measurement harness for the per-conversation static MCP surface — the `tools/list` payload the agent loads on every session. Run via `npm run bench:tools`.

The runner:
1. spawns the built server (`dist/index.js`) over stdio,
2. performs the `initialize` + `tools/list` round-trip,
3. feeds the result into a pure analyzer (`src/diagnostics/tool-cost.ts`),
4. prints a ranked Markdown table; `--out FILE` saves a copy.

Current build snapshot (188 tools registered):

| Section | Bytes | % of total |
|---|---:|---:|
| Tool names | 3,894 | 1.2% |
| Descriptions | 143,487 | 44.4% |
| Input schemas | 175,664 | 54.4% |

**Per-conversation static cost**: ~323 KB ≈ 80,500 tokens (chars/4 proxy).

Top 5 by total bytes: `prepare_swap`, `get_swap_quote`, `prepare_custom_call`, `get_portfolio_summary`, `send_transaction`. Input schemas are the bigger contributor, not descriptions — a finding I'd have guessed wrong without the numbers.

## Design choices

- **Pure analyzer + thin runner.** All sizing/formatting lives in `src/diagnostics/tool-cost.ts` (testable with vitest); the `.mjs` script is just spawn + JSON-RPC + report. Mirrors the existing `verify-personas.mjs` pattern.
- **Tokenizer proxy.** Anthropic's tokenizer is closed; cl100k would require a ~5MB BPE table; chars/4 is a serviceable proxy for *relative ranking* (which is what the issue asks for). Documented in the module header — swap in `gpt-tokenizer` if absolute counts ever matter.
- **Static surface only (v1).** The issue's "Scope: Measurement infrastructure only. Specific cuts come in follow-up PRs." Response-side cost (CHECKS PERFORMED / NOTICE / payload sections) is out of scope here — it needs fixtures or live RPC and lives in a separate harness. The bench script header calls this out.

## Issue questions, answered

- **Tokenizer**: chars/4 proxy. Cheap, dependency-free, good enough for ranking.
- **Where to run**: standalone runner in `scripts/`, analyzer in `src/diagnostics/`, tests in `test/`. Mirrors existing repo conventions; no new top-level dir.
- **Frequency**: ad-hoc via `npm run bench:tools`. Adding a CI budget rule would be a separate PR — the numbers need to settle before we know what the budget should be.

## Test plan

- [x] Unit tests for the analyzer (15 tests in `test/tool-cost.test.ts`) — `approxTokens`, `utf8Bytes` (multibyte), `serializeInputSchema`, `analyzeTool` (with/without description/schema), `analyzeToolList` (ordering, totals, empty), `formatRankingTable` (truncation, sections, proxy disclosure).
- [x] Full vitest run still green: 194 files / 2547 tests.
- [x] `npm run bench:tools` runs end-to-end against the built server.
- [x] `--top N` truncation and `--out FILE` markdown save both verified.

— Cook (agent-fe90)
