### PR TITLE
feat(prepare): surface estimated network fee before pre-sign checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -528,6 +528,7 @@ import {
   renderPostBroadcastBlock,
   renderPostSendPollBlock,
   renderBitcoinVerificationBlock,
+  renderCostPreviewBlock,
   renderLitecoinVerificationBlock,
   renderPrepareReceiptBlock,
   renderPreviewVerifyAgentTaskBlock,
@@ -820,6 +821,13 @@ export async function collectVerificationBlocks(
     // ERC-20 approvals clear-sign on Ledger's Ethereum app — skip rendering
     // (the send-time payload-hash guard still runs, using tx.verification).
     if (shouldRenderVerificationBlock(tx)) {
+      // Estimated network fee (issue #636) — surfaced FIRST so the user can
+      // abort on fee shock before reading the verification + cross-check +
+      // agent-task surfaces. `renderCostPreviewBlock` returns null when
+      // `enrichTx` couldn't estimate gas (network blip / sim revert), in
+      // which case we silently omit rather than fabricate a number.
+      const cost = renderCostPreviewBlock(tx);
+      if (cost) blocks.push(cost);
       blocks.push(renderVerificationBlock(tx));
       // Auto-emit the independent 4byte.directory cross-check. If the network
       // call fails, verifyEvmCalldata returns an "error" summary — we still

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2249,6 +2249,11 @@ async function enrichTx(tx: UnsignedTx): Promise<UnsignedTx> {
 
     const gasPrice = await client.getGasPrice();
     const gasWei = gas * gasPrice;
+    // Always populate the native-fee field (issue #636) — the cost preview
+    // block can render even when USD pricing degrades, which keeps the
+    // fee-shock abort signal alive on cold chains and during DefiLlama
+    // outages.
+    tx.gasCostNative = formatUnits(gasWei, 18);
     const ethPrice = await getTokenPrice(tx.chain, "native");
     if (ethPrice) {
       const gasEth = Number(formatUnits(gasWei, 18));

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -8,6 +8,7 @@ import type {
   UnsignedTronTx,
   UnsignedTx,
 } from "../types/index.js";
+import { NATIVE_SYMBOL } from "../config/contracts.js";
 import { solanaLedgerMessageHash } from "./verification.js";
 
 /**
@@ -88,6 +89,53 @@ export function isClearSignOnlyTx(tx: Pick<UnsignedTx, "data">): boolean {
   if (data.startsWith(ERC20_APPROVE_SELECTOR)) return true;
   if (data.startsWith(ERC20_TRANSFER_SELECTOR)) return true;
   return false;
+}
+
+/**
+ * Trim a native-fee decimal string ("0.00114523000…") to a small number of
+ * significant fractional digits without trailing zeros. Cheap UX layer over
+ * `formatUnits(_, 18)`; not meant for accounting accuracy. The thresholds
+ * track typical L1/L2 gas magnitudes (~$0.01–$50 of gas → 1e-7 to 1e-2 of
+ * native).
+ */
+function formatNativeShort(native: string): string {
+  const n = Number(native);
+  if (!Number.isFinite(n) || n <= 0) return native;
+  const fixed = n < 0.001 ? n.toFixed(8) : n < 0.1 ? n.toFixed(6) : n.toFixed(4);
+  return fixed.replace(/0+$/, "").replace(/\.$/, "");
+}
+
+/**
+ * One-line "Estimated network fee" header emitted ahead of every EVM
+ * VERIFY-BEFORE-SIGNING block (issue #636). Lets the user abort on fee shock
+ * before they spend attention on the verification + cross-check + agent-task
+ * surfaces below — a $40 gas estimate should kill the flow without further
+ * scrutiny.
+ *
+ * Returns `null` when `enrichTx` couldn't estimate gas (the field stays
+ * undefined). Better silent than fabricated: a wrong number rendered next
+ * to a real device prompt is a worse failure mode than no number.
+ *
+ * USD half is omitted when the native price lookup degraded; the native half
+ * is always shown when the field is present so the user still has a
+ * comparison anchor against their wallet balance.
+ *
+ * Scope: EVM only. TRON / Solana / BTC / LTC carry no equivalent
+ * precomputed cost field today (different fee models — bandwidth/energy,
+ * lamports + priority, sat/vB × vsize). Tracked as a follow-up.
+ */
+export function renderCostPreviewBlock(
+  tx: Pick<UnsignedTx, "chain" | "gasCostUsd" | "gasCostNative">,
+): string | null {
+  const native = tx.gasCostNative;
+  if (!native) return null;
+  const symbol = NATIVE_SYMBOL[tx.chain];
+  const nativeFmt = formatNativeShort(native);
+  const usd = tx.gasCostUsd;
+  if (usd !== undefined) {
+    return `Estimated network fee: ~$${usd.toFixed(2)} (≈ ${nativeFmt} ${symbol})`;
+  }
+  return `Estimated network fee: ≈ ${nativeFmt} ${symbol} (USD price unavailable)`;
 }
 
 function truncateHex(data: string, bytelenLabel: boolean): string {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1222,6 +1222,16 @@ export interface UnsignedTx {
   /** Estimated gas cost in USD. */
   gasCostUsd?: number;
   /**
+   * Estimated gas cost denominated in the chain's native asset (ETH on
+   * ethereum/arbitrum/base/optimism, MATIC/POL on polygon), as a string
+   * formatted at 18 decimals. Stored alongside `gasCostUsd` so the cost
+   * preview block (issue #636) can render the native fee even when the
+   * USD price lookup degrades (no network / DefiLlama miss). Both halves
+   * are populated by `enrichTx` when gas estimation succeeds; both stay
+   * undefined when it fails.
+   */
+  gasCostNative?: string;
+  /**
    * Result of an eth_call simulation against the current chain state. `ok:false`
    * with a revertReason is expected on the follow-up tx of an approve→action
    * pair at prepare time (the approve hasn't been mined yet). At sign time, the

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/signing/verification.js";
 import { decodeCalldata } from "../src/signing/decode-calldata.js";
 import {
+  renderCostPreviewBlock,
   renderPostSendPollBlock,
   renderTronAgentTaskBlock,
   renderTronVerificationBlock,
@@ -377,6 +378,148 @@ describe("collectVerificationBlocks — approve→action chain only renders the 
     expect(rendered).not.toContain(longHex);
     // Instead we get a head…tail (N bytes) preview.
     expect(rendered).toMatch(/0x(?:ab)+…(?:ab)+ \(1024 bytes\)/);
+  });
+});
+
+describe("renderCostPreviewBlock — issue #636 fee-shock abort signal", () => {
+  it("renders ~$ + native amount when both fields are populated", () => {
+    const out = renderCostPreviewBlock({
+      chain: "ethereum",
+      gasCostUsd: 3.42,
+      gasCostNative: "0.00114",
+    });
+    expect(out).toBe("Estimated network fee: ~$3.42 (≈ 0.00114 ETH)");
+  });
+
+  it("falls back to native-only when USD price was unavailable", () => {
+    const out = renderCostPreviewBlock({
+      chain: "ethereum",
+      gasCostNative: "0.00114",
+    });
+    expect(out).toBe("Estimated network fee: ≈ 0.00114 ETH (USD price unavailable)");
+  });
+
+  it("uses the chain's native symbol (POL on polygon)", () => {
+    const out = renderCostPreviewBlock({
+      chain: "polygon",
+      gasCostUsd: 0.02,
+      gasCostNative: "0.04",
+    });
+    // NATIVE_SYMBOL.polygon currently spells the asset MATIC; the test
+    // pins whatever the central map declares so the cost block stays in
+    // sync if/when that flips to POL.
+    expect(out).toMatch(/Estimated network fee: ~\$0\.02 \(≈ 0\.04 (MATIC|POL)\)/);
+  });
+
+  it("returns null when gas estimation failed (no native field)", () => {
+    expect(
+      renderCostPreviewBlock({
+        chain: "ethereum",
+      }),
+    ).toBeNull();
+  });
+
+  it("trims trailing zeros and picks fractional precision by magnitude", () => {
+    // Mid-range fee (0.001 ≤ n < 0.1): 6 fractional digits, trailing zeros trimmed.
+    const mid = renderCostPreviewBlock({
+      chain: "ethereum",
+      gasCostUsd: 41.5,
+      gasCostNative: "0.012000",
+    });
+    expect(mid).toContain("0.012 ETH");
+    // Tiny fee (n < 0.001): 8 fractional digits to keep significant precision.
+    const small = renderCostPreviewBlock({
+      chain: "arbitrum",
+      gasCostUsd: 0.05,
+      gasCostNative: "0.0000234",
+    });
+    expect(small).toContain("0.0000234 ETH");
+    // Big fee (n ≥ 0.1): 4 fractional digits, trailing zeros trimmed.
+    const big = renderCostPreviewBlock({
+      chain: "ethereum",
+      gasCostUsd: 1234.5,
+      gasCostNative: "0.5000",
+    });
+    expect(big).toContain("0.5 ETH");
+  });
+});
+
+describe("collectVerificationBlocks — cost preview prepended (issue #636)", () => {
+  it("renders cost as the FIRST block when gasCostNative is populated", async () => {
+    const supply: UnsignedTx = {
+      chain: "ethereum",
+      to: CONTRACTS.ethereum.aave.pool as `0x${string}`,
+      data: "0x617ba0370000" as `0x${string}`,
+      value: "0",
+      from: SENDER,
+      description: "Aave supply",
+      gasEstimate: "150000",
+      gasCostUsd: 3.42,
+      gasCostNative: "0.00114",
+    };
+    const stamped = issueHandles(supply);
+    const blocks = await collectVerificationBlocks(stamped, { verify: stubVerify });
+    // 4 blocks now: cost preview + verification + cross-check + agent task.
+    expect(blocks).toHaveLength(4);
+    expect(blocks[0]).toMatch(/^Estimated network fee:/);
+    expect(blocks[1]).toContain("VERIFY BEFORE SIGNING");
+    expect(blocks[2]).toContain("[CROSS-CHECK SUMMARY");
+    expect(blocks[3]).toContain("[AGENT TASK");
+  });
+
+  it("omits the cost block when enrichTx couldn't estimate gas", async () => {
+    const supply: UnsignedTx = {
+      chain: "ethereum",
+      to: CONTRACTS.ethereum.aave.pool as `0x${string}`,
+      data: "0x617ba0370000" as `0x${string}`,
+      value: "0",
+      from: SENDER,
+      description: "Aave supply",
+      // Deliberately no gasCostNative — enrichTx swallowed the failure.
+    };
+    const stamped = issueHandles(supply);
+    const blocks = await collectVerificationBlocks(stamped, { verify: stubVerify });
+    // Same 3-block shape as before issue #636 — defends against double-counting.
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toContain("VERIFY BEFORE SIGNING");
+  });
+
+  it("approve→action chain: cost block fires for the action node only", async () => {
+    const swap: UnsignedTx = {
+      chain: "ethereum",
+      to: getAddress("0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"),
+      data: "0x2c57e88400000000" as `0x${string}`,
+      value: "0",
+      from: SENDER,
+      description: "LiFi swap",
+      gasCostUsd: 12.5,
+      gasCostNative: "0.004",
+    };
+    const approve: UnsignedTx = {
+      chain: "ethereum",
+      to: USDC,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [getAddress("0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"), 100_000_000n],
+      }),
+      value: "0",
+      from: SENDER,
+      description: "Approve USDC to LiFi",
+      // Approve also has a cost in reality, but the verification block is
+      // suppressed for clear-sign-only approves and we keep cost paired
+      // with verification for a quiet response shape.
+      gasCostUsd: 1.2,
+      gasCostNative: "0.0004",
+      next: swap,
+    };
+    const stamped = issueHandles(approve);
+    const blocks = await collectVerificationBlocks(stamped, { verify: stubVerify });
+    expect(blocks).toHaveLength(4);
+    expect(blocks[0]).toMatch(/^Estimated network fee:/);
+    expect(blocks[0]).toContain("12.50");
+    expect(blocks[1]).toContain("VERIFY BEFORE SIGNING");
+    expect(blocks[1]).toContain("0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE");
   });
 });
 


### PR DESCRIPTION
Closes #636

## Summary

Surface estimated network fee at the top of every EVM `prepare_*` response, ahead of VERIFY BEFORE SIGNING and the cross-check / agent-task surfaces. Lets the user abort on fee shock before they spend attention on the verification stack below.

Single-line shape:

```
Estimated network fee: ~$3.42 (≈ 0.00114 ETH)
```

## What changed

- `UnsignedTx.gasCostNative?: string` — new field on the prepared-tx envelope, formatted at 18 decimals via the central `NATIVE_SYMBOL` map. `enrichTx` populates it whenever gas estimation succeeds, regardless of whether the USD price lookup also succeeds.
- `renderCostPreviewBlock(tx)` in `src/signing/render-verification.ts` — returns the one-line block, or `null` when `gasCostNative` is absent (gas estimation failed). Better silent than a fabricated number under a real device prompt.
- `collectVerificationBlocks` in `src/index.ts` prepends the cost block to the EVM render path when `shouldRenderVerificationBlock(tx)` is true. Cost is paired with the verification surface — clear-sign-only approves stay quiet (their cost rolls into the paired action's block via `next`).
- USD half is omitted when `getTokenPrice` returned undefined; native half is always shown so the user keeps a comparison anchor against their wallet balance.

## Out of scope (follow-ups)

- **TRON / Solana / BTC / LTC** (filed as #649): different fee models (bandwidth/energy, lamports + priority, sat/vB × vsize) and currently no equivalent precomputed cost field on the prepared-tx envelopes. Each chain needs its own enrichment + render — separate work.
- **`preview_send` cost block** (filed as #650): the issue mentions surfacing cost ahead of the `CHECKS PERFORMED` template at preview time too. The pinned EIP-1559 fees there give a more accurate number with base+priority breakdown. Not addressed in this PR — keeps the diff small and the prepare-time slice ships value standalone.
- **Cost-vs-value gate / refusal**: the issue's "Questions to resolve" lists a possible "warn when cost exceeds some fraction of tx value" gate. Per the issue's explicit "Cost preview only. Not a new gate" scope statement, that's deliberately out.

## Test plan

- [x] `renderCostPreviewBlock` unit tests — populated, USD-degraded, polygon symbol, gas-estimate-failure → null, fractional-precision tiers.
- [x] `collectVerificationBlocks` integration tests — cost is prepended as `blocks[0]`, omitted when `gasCostNative` is absent, fires on the action node only in approve→action chains.
- [x] Full suite: 2540/2540 pass (no regressions in existing `blocks).toHaveLength(3)` assertions because tests don't run `enrichTx` and so `gasCostNative` stays undefined → cost block is skipped → existing 3-block shape holds).

— Alonzo (agent-92ff)

