### PR TITLE
fix(skill-pin): bump to v15

### DIFF
--- a/src/diagnostics/skill-pin-drift.ts
+++ b/src/diagnostics/skill-pin-drift.ts
@@ -53,7 +53,7 @@ import { createHash } from "node:crypto";
  * literal a second time.
  */
 export const EXPECTED_SKILL_SHA256 =
-  "e44c66895fc150e905b295364610e0f834ec8ee6cbca6bcd8eea3db9455e1ddd";
+  "596224e8fb0529760a9c6094a204642d72f1b5e336151d5fa19cb841449908bd";
 
 /**
  * Sentinel fragments. Assembled from three pieces so the full literal
@@ -63,8 +63,8 @@ export const EXPECTED_SKILL_SHA256 =
  * search the `Skill` tool's result text for the assembled value.
  */
 export const EXPECTED_SKILL_SENTINEL_A = "VAULTPILOT_PREFLIGHT_INTEGRITY";
-export const EXPECTED_SKILL_SENTINEL_B = "_v12_";
-export const EXPECTED_SKILL_SENTINEL_C = "a4d5a75453658f63";
+export const EXPECTED_SKILL_SENTINEL_B = "_v15_";
+export const EXPECTED_SKILL_SENTINEL_C = "2d7e9c4f8b3a5e60";
 
 /** Raw GitHub URL of the canonical `SKILL.md` on `master`. */
 export const SKILL_MD_RAW_URL =

--- a/test/local-skill-drift.test.ts
+++ b/test/local-skill-drift.test.ts
@@ -71,13 +71,13 @@ describe("checkLocalSkillDrift — issue #613 finding 3", () => {
     // v4 was the example version that triggered the original report.
     const stale = `# preflight skill v4
 ${EXPECTED_SKILL_SENTINEL_A}_v4_7655818578c7a044
-content body that does not match the canonical v12 hash`;
+content body that does not match the canonical v15 hash`;
     writeFixture(stale);
     const result = checkLocalSkillDrift();
     expect(result.status).toBe("version-stale");
     if (result.status === "version-stale") {
       expect(result.localVersion).toBe("4");
-      expect(result.pinnedVersion).toBe("12");
+      expect(result.pinnedVersion).toBe("15");
       expect(result.pinnedHash).toBe(EXPECTED_SKILL_SHA256);
       expect(result.localHash).not.toBe(EXPECTED_SKILL_SHA256);
     }
@@ -93,7 +93,7 @@ content body`;
     expect(result.status).toBe("version-stale");
     if (result.status === "version-stale") {
       expect(result.localVersion).toBe("99");
-      expect(result.pinnedVersion).toBe("12");
+      expect(result.pinnedVersion).toBe("15");
     }
   });
 
@@ -115,7 +115,7 @@ content`;
   });
 
   it("does NOT return `version-stale` when local sentinel happens to be the SAME version (still hash mismatch)", () => {
-    // Sentinel matches version (`v12`), but content body differs from
+    // Sentinel matches version (`v15`), but content body differs from
     // canonical → hash mismatch but version-extraction yields the same
     // version. Should fall through to content-mismatch (the version
     // marker says "same version" so something else is wrong).
@@ -136,7 +136,7 @@ body`);
     expect(first).not.toBeNull();
     expect(first).toContain("VAULTPILOT NOTICE — Local preflight skill is out of date (not tampered)");
     expect(first).toContain("`v4`");
-    expect(first).toContain("`v12`");
+    expect(first).toContain("`v15`");
     expect(first).toContain("git pull --ff-only");
     // Second call: deduped.
     expect(getLocalSkillDriftNotice()).toBeNull();


### PR DESCRIPTION
Routine companion-skill pin bump to keep the startup drift detector and Step 0 self-check from halting signing flows on hash mismatch.

## Summary
- `EXPECTED_SKILL_SHA256` → `596224e8fb0529760a9c6094a204642d72f1b5e336151d5fa19cb841449908bd`
- `EXPECTED_SKILL_SENTINEL_B` → `_v15_`
- `EXPECTED_SKILL_SENTINEL_C` → `2d7e9c4f8b3a5e60`
- `test/local-skill-drift.test.ts` — bump three `v12` literals + `pinnedVersion` assertions to `v15` / `"15"` to match the new sentinel.

Live skill: [`vaultpilot-security-skill/SKILL.md@master`](https://github.com/szhygulin/vaultpilot-security-skill/blob/master/SKILL.md). Verified locally — `curl … | sha256sum` matches the new pin and `grep -oE "VAULTPILOT_PREFLIGHT_INTEGRITY[^[:space:]]*"` returns the new sentinel.

## Test plan
- [x] `npm test` — 2558 / 2558 pass
- [x] `npm run build` — clean tsc