### PR TITLE
chore(release): 0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "mcpName": "io.github.szhygulin/vaultpilot-mcp",
   "description": "Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.szhygulin/vaultpilot-mcp",
   "title": "VaultPilot MCP",
   "description": "Self-custodial crypto + DeFi MCP for AI agents. Ledger-signed. EVM, TRON, Solana, BTC, LTC.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "websiteUrl": "https://github.com/szhygulin/vaultpilot-mcp",
   "repository": {
     "url": "https://github.com/szhygulin/vaultpilot-mcp",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vaultpilot-mcp",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/src/modules/incident-report/index.ts
+++ b/src/modules/incident-report/index.ts
@@ -37,7 +37,7 @@ import { redactEnvelope, type RedactionMode } from "./redact.js";
  * a specific release. Static import (vs reading package.json at
  * runtime) keeps the snapshot consistent with the build artifact.
  */
-const SERVER_VERSION = "0.14.1";
+const SERVER_VERSION = "0.14.2";
 
 interface PairingSummary {
   chain: "solana" | "tron" | "bitcoin" | "litecoin";


### PR DESCRIPTION
## Summary

Patch release bundling 9 PRs merged since v0.14.1.

## Highlights

- **Pre-sign UX** — estimated network fee surfaced before pre-sign checks (#648); SCOPE + AGENT BEHAVIOR clauses on data-surfacing tools (#646); Safe API key visible in `get_vaultpilot_config_status` (#644).
- **Bug fixes** — `read_contract` EXECUTOR_ROLE hash typo corrected (#634); Safe STS submit errors enriched with diagnostic read probe (#635); skill-pin bumped to v15 (#653).
- **Docs** — AGENTS.md Step 0 reframed as hard refusal gate (#642); Step 2 restructured as per-client router (#643).
- **Tooling** — per-conversation MCP static-surface token-cost benchmark (#647).

## Included PRs

- #634 fix(read_contract): correct EXECUTOR_ROLE hash in description and test fixture
- #635 fix(safe): enrich opaque STS submit errors with diagnostic read probe
- #642 docs(agents): reframe Step 0 as hard refusal gate (MUST / MUST NOT)
- #643 docs(agents): restructure Step 2 as per-client router with heading-anchored subsections
- #644 feat(diagnostics): surface Safe API key in get_vaultpilot_config_status
- #646 Add SCOPE + AGENT BEHAVIOR clauses to data-surfacing tools (#599)
- #647 feat(bench): measure per-conversation MCP tool static-surface token cost
- #648 feat(prepare): surface estimated network fee before pre-sign checks
- #653 fix(skill-pin): bump to v15

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 194 test files / 2558 tests pass
- [x] All four version strings synced (`package.json`, `server.json` top + `packages[0].version`, `src/modules/incident-report/index.ts`)
- [ ] After merge: tag `v0.14.2` on the merge commit, create GitHub Release; `publish.yml` (npm + MCP Registry) and `release-binaries.yml` fire on `release: published`
- [ ] Verify `npm view vaultpilot-mcp version` reports `0.14.2`
- [ ] Verify MCP Registry: \`curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=vaultpilot-mcp&version=latest"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)