### PR TITLE
fix(docker): repair Glama Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM node:20.20.2-alpine3.22 AS builder
 WORKDIR /app
+# Build toolchain for native modules (usb, node-hid) when no musl prebuild matches.
+RUN apk add --no-cache python3 make g++ linux-headers libusb-dev eudev-dev
 COPY package.json package-lock.json ./
+COPY vendor ./vendor
+COPY patches ./patches
 RUN npm ci
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
+RUN npm prune --omit=dev
 
 FROM node:20.20.2-alpine3.22
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+# Runtime .so deps for the native modules.
+RUN apk add --no-cache libusb eudev-libs
+COPY package.json ./
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 # The node:alpine image ships a pre-created unprivileged `node` user/group.
 # Running as root gives a compromise inside the process write access to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaultpilot-mcp",
-  "version": "0.13.0",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaultpilot-mcp",
-      "version": "0.13.0",
+      "version": "0.14.2",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -4197,6 +4197,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6221,6 +6236,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7084,6 +7106,21 @@
         "ws": "*"
       }
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7300,6 +7337,25 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/ledger-bitcoin": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
+      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
+      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^1.0.2",
+        "@bitcoinerlab/secp256k1": "^1.0.5",
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.1.3"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -9622,7 +9678,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary

The Glama-side Docker build was failing on `npm ci`. Investigation surfaced three stacked failures, only the first of which was reaching the user as the visible error:

1. **Lockfile drift** — `package-lock.json` was last regenerated on 2026-04-28 (commit `a18145c`). Transitive peer/optional pins for `fastestsmallesttextencoderdecoder`, `utf-8-validate`, and `ledger-bitcoin` shifted since, leaving `npm ci` (strict) refusing with `EUSAGE`. `npm install` in the working tree was silently re-resolving, hiding the drift locally.
2. **Missing `COPY vendor` / `COPY patches`** — `package.json` references `"@kamino-finance/kliquidity-sdk": "file:./vendor/kliquidity-stub"` (needs `vendor/` present at `npm ci`) and `"prepare": "patch-package"` (lifecycle runs during `npm ci`, needs `patches/`). Neither was copied. Would have surfaced as the next error once the lockfile sync was in.
3. **Native modules need a build toolchain** — `usb` and `node-hid` (via `@ledgerhq/hw-transport-node-hid`) fall through to `node-gyp rebuild` on alpine when the musl prebuild isn't picked up; the base alpine image has no Python / g++ / libusb headers.

Restructured the Dockerfile so:
- Builder stage installs the build toolchain (`python3 make g++ linux-headers libusb-dev eudev-dev`), runs `npm ci`, builds, then prunes with `npm prune --omit=dev`.
- Runtime stage just `COPY --from=builder` the pruned `node_modules` plus the runtime `.so` libs (`libusb`, `eudev-libs`). No second `npm ci`.

`USER node` is preserved.

## Test plan

- [x] `docker build .` succeeds end-to-end on a clean cache
- [x] Resulting image boots: `docker run --rm -i …` produces the expected `[vaultpilot-mcp] demo mode: ON` banner and exits cleanly
- [ ] Glama's next build picks up the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)