### PR TITLE
feat(nft): add get_nft_listings for ranked floor-sweep candidates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -370,11 +370,13 @@ import { renderSetLevelEnumeration } from "./security/set-level-enumeration.js";
 import {
   getNftCollection,
   getNftHistory,
+  getNftListings,
   getNftPortfolio,
 } from "./modules/nft/index.js";
 import {
   getNftCollectionInput,
   getNftHistoryInput,
+  getNftListingsInput,
   getNftPortfolioInput,
 } from "./modules/nft/schemas.js";
 import {
@@ -5057,6 +5059,26 @@ async function main() {
       },
     },
     handler(getNftCollection)
+  );
+
+  registerTool(server,
+    "get_nft_listings",
+    {
+      description:
+        "Issue #569. Ranked individual listings (currently active asks) for a single EVM NFT collection on a single chain, sorted floor-ascending. Distinct from `get_nft_collection`, which exposes only collection-level metadata (floor / volume / holders) and so cannot ground a 'show me the N cheapest' question. Source: Reservoir `/orders/asks/v5?status=active&sortBy=price&sortDirection=asc`. " +
+        "Returns rows with `tokenId`, `priceEth` / `priceUsd`, `priceCurrency`, `listingSource` (marketplace domain — opensea.io / blur.io / x2y2.io / etc.), `makerAddress` (seller), `validUntil` (expiry), and `orderKind` (seaport-v1.6 / blur / etc.). Page size schema-capped at 10 (default 5) — small enough that the agent can validate every referenced row exists in the response. Single-token criteria only; collection-bid criteria orders are filtered out so every row names a concrete `tokenId`. " +
+        "SCOPE: read-only display tool. VaultPilot does NOT yet expose an NFT-buy preparation flow — Seaport / blur / x2y2 marketplace fills require EIP-712 typed-data signing, gated on the typed-data clear-sign defenses tracked at #453. Use these rows for research / candidate selection; execute any actual buy via the listing's marketplace UI (`listingSource` field) until the prepare flow lands. " +
+        "AGENT BEHAVIOR: do NOT extrapolate beyond `rows.length`. Validate that any `rows[i]` referenced in the answer actually exists in this response. The small page cap is the fabrication-resistance guard called out in #569. EVM-only in v1; Solana NFT marketplaces (Magic Eden / Tensor) deferred. Read-only.",
+      inputSchema: getNftListingsInput.shape,
+      annotations: {
+        title: "Get NFT Listings",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    handler(getNftListings)
   );
 
   registerTool(server,

--- a/src/modules/nft/index.ts
+++ b/src/modules/nft/index.ts
@@ -16,8 +16,10 @@ import {
   ReservoirRateLimitedError,
   RESERVOIR_SETUP_HINT,
   type ReservoirActivityItem,
+  type ReservoirAskOrder,
   type ReservoirCollection,
   type ReservoirCollectionsResponse,
+  type ReservoirOrdersAsksResponse,
   type ReservoirUserToken,
   type ReservoirUserTokensResponse,
   type ReservoirUsersActivityResponse,
@@ -30,11 +32,14 @@ import {
 import type {
   GetNftCollectionArgs,
   GetNftHistoryArgs,
+  GetNftListingsArgs,
   GetNftPortfolioArgs,
   NftCollectionInfo,
   NftHistoryItem,
   NftHistoryItemType,
   NftHistoryResult,
+  NftListingRow,
+  NftListingsResult,
   NftPortfolioResult,
   NftPortfolioRow,
 } from "./schemas.js";
@@ -475,6 +480,121 @@ export async function getNftCollection(
     );
   }
   return info;
+}
+
+// ---- get_nft_listings (issue #569) ---------------------------------
+
+function projectAsk(
+  chain: SupportedChain,
+  contractAddress: string,
+  o: ReservoirAskOrder,
+): NftListingRow | null {
+  const tokenId = o.criteria?.data?.token?.tokenId;
+  if (!tokenId) {
+    // Collection-bid criteria (no concrete tokenId) — drop. The "buy
+    // N cheapest" question only makes sense against single-token asks,
+    // and surfacing collection-criteria orders without a tokenId would
+    // give the agent rows it can't reference unambiguously.
+    return null;
+  }
+  const priceEth = o.price?.amount?.decimal;
+  const priceUsd = o.price?.amount?.usd;
+  const validUntil = o.validUntil;
+  return {
+    orderId: o.id,
+    contractAddress,
+    tokenId,
+    ...(typeof priceEth === "number" ? { priceEth } : {}),
+    ...(typeof priceUsd === "number" ? { priceUsd: round2(priceUsd) } : {}),
+    ...(o.price?.currency?.symbol ? { priceCurrency: o.price.currency.symbol } : {}),
+    ...(o.source?.domain ? { listingSource: o.source.domain } : {}),
+    ...(o.source?.name ? { listingSourceName: o.source.name } : {}),
+    makerAddress: o.maker,
+    ...(typeof validUntil === "number" ? { validUntil } : {}),
+    ...(typeof validUntil === "number"
+      ? { validUntilIso: new Date(validUntil * 1000).toISOString() }
+      : {}),
+    ...(o.kind ? { orderKind: o.kind } : {}),
+  };
+}
+
+export async function getNftListings(
+  args: GetNftListingsArgs,
+): Promise<NftListingsResult> {
+  const chain = args.chain as SupportedChain;
+  const contractAddress = args.contractAddress;
+  const limit = args.limit;
+
+  // Over-fetch by 1 so we can detect truncation when collection-bid
+  // criteria orders get filtered out: ask for `limit + 1` raw, return
+  // up to `limit` valid rows, mark `truncated` if Reservoir said there
+  // was more OR we filtered any out at the boundary.
+  const rawLimit = Math.min(limit + 1, 50);
+
+  let res: ReservoirOrdersAsksResponse;
+  try {
+    res = await reservoirFetch<ReservoirOrdersAsksResponse>({
+      chain,
+      path: `/orders/asks/v5`,
+      query: {
+        contracts: contractAddress,
+        status: "active",
+        sortBy: "price",
+        sortDirection: "asc",
+        limit: rawLimit,
+      },
+    });
+  } catch (e) {
+    if (e instanceof ReservoirRateLimitedError) {
+      throw new Error(
+        `Reservoir rate-limited the listings lookup. ${RESERVOIR_SETUP_HINT}`,
+      );
+    }
+    throw e;
+  }
+
+  const projected: NftListingRow[] = [];
+  for (const o of res.orders) {
+    const row = projectAsk(chain, contractAddress, o);
+    if (row) projected.push(row);
+    if (projected.length >= limit) break;
+  }
+
+  const truncated =
+    !!res.continuation || res.orders.length > projected.length;
+
+  const notes: string[] = [];
+  if (projected.length === 0) {
+    notes.push(
+      "No active listings for this collection on " +
+        chain +
+        ". The collection may exist on-chain but currently have no asks " +
+        "(Reservoir's `/orders/asks/v5` filtered to status=active returned 0 rows). " +
+        "Re-check after listings repopulate, or use `get_nft_collection` for " +
+        "collection-level vitals (floor / volume / holders) instead.",
+    );
+  }
+  notes.push(
+    "Read-only display tool. VaultPilot does not yet expose an NFT-buy " +
+      "preparation flow — Seaport / blur / x2y2 marketplace fills require " +
+      "EIP-712 typed-data signing, gated on the typed-data clear-sign " +
+      "defenses tracked at #453. Use these rows for research / candidate " +
+      "selection; execute the buy via the listing's marketplace UI " +
+      "(`listingSource` field) until the prepare flow lands.",
+  );
+  notes.push(
+    "Page size is schema-capped at 10. Validate that any `rows[i]` you " +
+      "reference exists in this response — do NOT extrapolate beyond " +
+      "`rows.length`. Issue #569 fabrication-resistance guard.",
+  );
+
+  return {
+    chain,
+    contractAddress,
+    rows: projected,
+    truncated,
+    notes,
+  };
 }
 
 // ---- get_nft_history -----------------------------------------------

--- a/src/modules/nft/reservoir.ts
+++ b/src/modules/nft/reservoir.ts
@@ -230,3 +230,53 @@ export interface ReservoirUsersActivityResponse {
   activities: ReservoirActivityItem[];
   continuation?: string;
 }
+
+/**
+ * `/orders/asks/v5` — active sell orders. Issue #569.
+ *
+ * `criteria.data.token.tokenId` carries the token id for single-token
+ * asks; collection-criteria asks (rare) leave it absent and the
+ * handler filters them out so per-row display always names a concrete
+ * tokenId.
+ */
+export interface ReservoirAskOrder {
+  id: string;
+  kind?: string;
+  side: "sell";
+  status?: string;
+  contract?: string;
+  maker: string;
+  taker?: string;
+  price?: {
+    currency?: { contract?: string; name?: string; symbol?: string; decimals?: number };
+    amount?: { raw?: string; decimal?: number; usd?: number; native?: number };
+    netAmount?: { raw?: string; decimal?: number; usd?: number; native?: number };
+  };
+  validFrom?: number;
+  validUntil?: number;
+  quantityFilled?: string;
+  quantityRemaining?: string;
+  criteria?: {
+    kind?: string;
+    data?: {
+      token?: { tokenId?: string };
+      collection?: { id?: string };
+    };
+  };
+  source?: {
+    id?: string;
+    domain?: string;
+    name?: string;
+    icon?: string;
+    url?: string;
+  };
+  feeBps?: number;
+  expiration?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReservoirOrdersAsksResponse {
+  orders: ReservoirAskOrder[];
+  continuation?: string;
+}

--- a/src/modules/nft/schemas.ts
+++ b/src/modules/nft/schemas.ts
@@ -98,6 +98,50 @@ export const getNftCollectionInput = z.object({
 export type GetNftCollectionArgs = z.infer<typeof getNftCollectionInput>;
 
 /**
+ * `get_nft_listings` — issue #569. Ranked individual asks (currently
+ * active listings) for a single EVM collection on a single chain,
+ * sorted floor-ascending. Distinct from `get_nft_collection` which
+ * exposes only collection-level metadata (floor / volume / holders)
+ * and so cannot ground a "show me the N cheapest" question.
+ *
+ * Read-only display tool. VaultPilot does not yet expose an NFT-buy
+ * preparation flow (Seaport / blur / etc. all require EIP-712 typed-
+ * data signing, which is gated on the typed-data clear-sign defenses
+ * tracked at #453). Surface the rows for research / planning; the
+ * agent must NOT fabricate a buy preparation off this output. Page
+ * size is capped at 10 by schema — small enough that the agent can
+ * validate every row exists in the response before referencing it,
+ * which is the smoke-test fabrication-resistance guard the issue's
+ * suggested-fix called out.
+ */
+export const getNftListingsInput = z.object({
+  contractAddress: z
+    .string()
+    .regex(EVM_ADDRESS)
+    .describe("EVM contract address of the NFT collection."),
+  chain: chainEnum
+    .default("ethereum")
+    .describe(
+      "EVM chain the collection is deployed on. Defaults to ethereum.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .default(5)
+    .describe(
+      "Max ranked listings to return (cheapest-first). Capped at 10 — " +
+        "small enough that the agent can validate every row index against " +
+        "the response before referencing it. The issue (#569) explicitly " +
+        "calls out the small cap as part of the fabrication-resistance " +
+        "defense.",
+    ),
+});
+
+export type GetNftListingsArgs = z.infer<typeof getNftListingsInput>;
+
+/**
  * `get_nft_history` — recent NFT activity for the wallet (mints, buys,
  * sells, transfers, listings). Mirrors the EVM `get_transaction_history`
  * shape but limited to NFT-relevant events.
@@ -177,6 +221,50 @@ export interface NftPortfolioResult {
   rows: NftPortfolioRow[];
   /** Per-chain coverage — `errored` flags which chains failed. */
   coverage: Array<{ chain: string; errored: boolean; reason?: string }>;
+  notes: string[];
+}
+
+/**
+ * One ranked listing row for `get_nft_listings`. Fields chosen to
+ * match what the issue (#569) calls out: token_id + price +
+ * listing_source + maker_address. `validUntil` is added because
+ * "active listing" is a moving target — the row is meaningful only
+ * until that timestamp.
+ */
+export interface NftListingRow {
+  /** Reservoir order id — opaque, useful for dedup / deep links. */
+  orderId: string;
+  /** EVM contract address of the NFT (echoed for explicit-display). */
+  contractAddress: string;
+  /** Token id within the collection. Absent on collection-bid criteria (filtered out). */
+  tokenId?: string;
+  /** Price in the listing's native currency (typically ETH). */
+  priceEth?: number;
+  /** Price in USD via Reservoir's pricing. */
+  priceUsd?: number;
+  /** Currency symbol — e.g. "ETH" / "WETH" / "USDC". */
+  priceCurrency?: string;
+  /** Marketplace domain — "opensea.io" / "blur.io" / "x2y2.io" etc. Useful provenance. */
+  listingSource?: string;
+  /** Friendly source name when Reservoir provides one. */
+  listingSourceName?: string;
+  /** Seller address. */
+  makerAddress: string;
+  /** Unix-seconds expiry of the order. */
+  validUntil?: number;
+  /** ISO mirror of `validUntil` for chat display. */
+  validUntilIso?: string;
+  /** Order kind — "seaport-v1.6" / "blur" / "x2y2" / etc. */
+  orderKind?: string;
+}
+
+export interface NftListingsResult {
+  chain: string;
+  contractAddress: string;
+  /** Ranked floor-ascending. Length is bounded by the schema-capped `limit`. */
+  rows: NftListingRow[];
+  /** True when Reservoir has more active asks beyond the requested limit. */
+  truncated: boolean;
   notes: string[];
 }
 

--- a/test/nft.test.ts
+++ b/test/nft.test.ts
@@ -421,6 +421,196 @@ describe("get_nft_collection", () => {
   });
 });
 
+describe("get_nft_listings (issue #569)", () => {
+  it("returns ranked listings sorted floor-ascending with tokenId / price / source / maker", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      // Verify the request shape — caller must hit /orders/asks/v5
+      // with status=active, sortBy=price, sortDirection=asc.
+      expect(url).toContain("/orders/asks/v5");
+      expect(url).toContain("status=active");
+      expect(url).toContain("sortBy=price");
+      expect(url).toContain("sortDirection=asc");
+      return fakeResponse({
+        status: 200,
+        body: {
+          orders: [
+            {
+              id: "order-1",
+              kind: "seaport-v1.6",
+              side: "sell",
+              status: "active",
+              contract: BAYC,
+              maker: "0xseller1",
+              price: {
+                currency: { symbol: "ETH" },
+                amount: { decimal: 24.5, usd: 63700 },
+              },
+              validUntil: 1_800_000_000,
+              criteria: { kind: "token", data: { token: { tokenId: "100" } } },
+              source: { domain: "opensea.io", name: "OpenSea" },
+            },
+            {
+              id: "order-2",
+              kind: "blur",
+              side: "sell",
+              status: "active",
+              contract: BAYC,
+              maker: "0xseller2",
+              price: {
+                currency: { symbol: "ETH" },
+                amount: { decimal: 25.1, usd: 65260 },
+              },
+              validUntil: 1_800_100_000,
+              criteria: { kind: "token", data: { token: { tokenId: "200" } } },
+              source: { domain: "blur.io", name: "Blur" },
+            },
+          ],
+        },
+      });
+    });
+
+    const { getNftListings } = await import("../src/modules/nft/index.ts");
+    const r = await getNftListings({
+      contractAddress: BAYC,
+      chain: "ethereum",
+      limit: 5,
+    });
+
+    expect(r.chain).toBe("ethereum");
+    expect(r.contractAddress).toBe(BAYC);
+    expect(r.rows).toHaveLength(2);
+
+    expect(r.rows[0]).toMatchObject({
+      orderId: "order-1",
+      tokenId: "100",
+      priceEth: 24.5,
+      priceUsd: 63700,
+      priceCurrency: "ETH",
+      listingSource: "opensea.io",
+      listingSourceName: "OpenSea",
+      makerAddress: "0xseller1",
+      orderKind: "seaport-v1.6",
+    });
+    expect(r.rows[0].validUntilIso).toMatch(/^20/);
+
+    expect(r.rows[1]).toMatchObject({
+      tokenId: "200",
+      listingSource: "blur.io",
+      orderKind: "blur",
+    });
+
+    // Read-only / no-buy-flow note must always be surfaced — the agent
+    // needs to know not to attempt a Seaport/blur fill prep off this
+    // output.
+    expect(r.notes.some((n) => /read-only display tool/i.test(n))).toBe(true);
+    expect(r.notes.some((n) => /#453/.test(n))).toBe(true);
+    // Fabrication-resistance reminder must be present.
+    expect(r.notes.some((n) => /fabrication-resistance|do NOT extrapolate/i.test(n))).toBe(true);
+  });
+
+  it("filters out collection-bid criteria orders (no concrete tokenId)", async () => {
+    fetchMock.mockImplementation(async () =>
+      fakeResponse({
+        status: 200,
+        body: {
+          orders: [
+            {
+              id: "order-collection",
+              kind: "seaport-v1.6",
+              side: "sell",
+              status: "active",
+              contract: BAYC,
+              maker: "0xseller-x",
+              price: { currency: { symbol: "ETH" }, amount: { decimal: 24, usd: 62400 } },
+              criteria: { kind: "collection", data: { collection: { id: BAYC } } },
+              source: { domain: "opensea.io" },
+            },
+            {
+              id: "order-token",
+              kind: "seaport-v1.6",
+              side: "sell",
+              status: "active",
+              contract: BAYC,
+              maker: "0xseller-y",
+              price: { currency: { symbol: "ETH" }, amount: { decimal: 25, usd: 65000 } },
+              validUntil: 1_800_000_000,
+              criteria: { kind: "token", data: { token: { tokenId: "300" } } },
+              source: { domain: "opensea.io" },
+            },
+          ],
+        },
+      }),
+    );
+    const { getNftListings } = await import("../src/modules/nft/index.ts");
+    const r = await getNftListings({
+      contractAddress: BAYC,
+      chain: "ethereum",
+      limit: 5,
+    });
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0].tokenId).toBe("300");
+  });
+
+  it("flags an empty-listings collection in notes", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ status: 200, body: { orders: [] } }),
+    );
+    const { getNftListings } = await import("../src/modules/nft/index.ts");
+    const r = await getNftListings({
+      contractAddress: BAYC,
+      chain: "ethereum",
+      limit: 5,
+    });
+    expect(r.rows).toHaveLength(0);
+    expect(r.notes.some((n) => /no active listings/i.test(n))).toBe(true);
+  });
+
+  it("flags truncated:true when Reservoir signals a continuation", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        status: 200,
+        body: {
+          orders: [
+            {
+              id: "o1",
+              kind: "seaport-v1.6",
+              side: "sell",
+              status: "active",
+              contract: BAYC,
+              maker: "0xseller",
+              price: { currency: { symbol: "ETH" }, amount: { decimal: 25, usd: 65000 } },
+              criteria: { kind: "token", data: { token: { tokenId: "1" } } },
+              source: { domain: "opensea.io" },
+            },
+          ],
+          continuation: "next-page-cursor",
+        },
+      }),
+    );
+    const { getNftListings } = await import("../src/modules/nft/index.ts");
+    const r = await getNftListings({
+      contractAddress: BAYC,
+      chain: "ethereum",
+      limit: 5,
+    });
+    expect(r.truncated).toBe(true);
+  });
+
+  it("re-throws a structured rate-limit error with the setup hint", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ status: 429, body: { message: "Rate limited" } }),
+    );
+    const { getNftListings } = await import("../src/modules/nft/index.ts");
+    await expect(
+      getNftListings({
+        contractAddress: BAYC,
+        chain: "ethereum",
+        limit: 5,
+      }),
+    ).rejects.toThrow(/RESERVOIR_API_KEY/);
+  });
+});
+
 describe("get_nft_history", () => {
   it("merges 2-chain activity, sorts desc by timestamp, caps at limit", async () => {
     fetchMock.mockImplementation(async (url: string) => {


### PR DESCRIPTION
Closes #569.

## Summary
Adds `get_nft_listings` — ranked individual asks for an EVM NFT collection, sorted floor-ascending. Source: Reservoir `/orders/asks/v5?status=active&sortBy=price&sortDirection=asc`. Distinct from `get_nft_collection`, which exposes only collection-level metadata (floor / volume / holders) and so cannot ground a "show me the N cheapest" question.

Returns rows with `tokenId`, `priceEth` / `priceUsd`, `priceCurrency`, `listingSource` (marketplace domain — opensea.io / blur.io / x2y2.io), `listingSourceName`, `makerAddress`, `validUntil` + ISO mirror, and `orderKind`. Collection-bid criteria orders are filtered out so every row names a concrete `tokenId`.

## Why this scope
The smoke-test (x110-A.3) confirmed the agent correctly refuses to fabricate listings against a metadata-only source. The issue's signal was the **fabrication pressure**, not a security defect. The fix removes the pressure by giving the agent a real ranked-listings source it can reference verbatim.

Page size is schema-capped at **10** (default 5), per the issue's recommendation — small enough that the agent can validate every referenced `rows[i]` exists in the response. The cap is part of the fabrication-resistance defense, not a UX nicety.

## What this does NOT do
- **No buy preparation.** VaultPilot has no `prepare_nft_buy_*` flow today — Seaport / blur / x2y2 fills require EIP-712 typed-data signing, which is gated on the typed-data clear-sign defenses tracked at #453 (Inv #1b decode + Inv #2b digest recompute). The tool's `notes[]` surfaces this scope verbatim so the agent does not attempt a marketplace-fill prep off this output. The agent should route the user to the listing's marketplace UI (the `listingSource` domain) until the prepare flow lands.
- **No Solana.** Magic Eden / Tensor integration is the same deferred follow-up that gates Solana floor pricing in `get_nft_portfolio` (#433).

## Files
- `src/modules/nft/schemas.ts` — `getNftListingsInput`, `NftListingRow`, `NftListingsResult`.
- `src/modules/nft/reservoir.ts` — `ReservoirAskOrder`, `ReservoirOrdersAsksResponse` typed projections.
- `src/modules/nft/index.ts` — `getNftListings` handler with `projectAsk` row projection.
- `src/index.ts` — registers `get_nft_listings` with `readOnly + idempotent + openWorld` annotations.
- `test/nft.test.ts` — 5 new cases: happy path (ordering, fields, source/maker), collection-bid filter, empty-listings note, truncation flag, rate-limit setup-hint passthrough.

## Test plan
- [x] `npm run build` — clean.
- [x] `npm test` — 2563 / 2563 pass (5 new in this PR).
- [ ] Live smoke (post-merge) — `get_nft_listings({ contractAddress: "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D", chain: "ethereum", limit: 5 })` against BAYC; verify rows are floor-ascending and `listingSource` is populated.

— Milgram (agent-98b3)
