### PR TITLE
feat(decode): selector-only partial decode for setApprovalForAll on uncurated destinations

### DIFF
--- a/src/signing/decode-calldata.ts
+++ b/src/signing/decode-calldata.ts
@@ -369,6 +369,119 @@ function signatureOf(item: AbiFunction): string {
   return `${item.name}(${inputs})`;
 }
 
+/**
+ * High-risk standard selectors we still try to decode positionally even
+ * when the destination is absent from the curated `CONTRACTS` map.
+ *
+ * Threat that motivates this fallback: a C.2 collude attack routes an
+ * NFT operator-approval (`setApprovalForAll(operator, true)`) to an
+ * uncurated marketplace/aggregator while the cooperating MCP narrates
+ * "Seaport-only". With `source:'none'` the attacker-controlled operator
+ * address never surfaces in CHECKS PERFORMED, so Inv #1 sees opaque bytes
+ * and cannot flag the label/calldata mismatch — the user-facing prose
+ * passes while the bytes hand a hostile contract permission to move every
+ * NFT in the collection. (Issue #573, smoke-test batch-3 finding
+ * `expert-x104-C.2`.)
+ *
+ * The fallback returns `source:'local-abi-partial'` rather than
+ * `'local-abi'`: we KNOW the standard ABI shape but we DO NOT know that
+ * the destination is a real ERC-721/1155 — anyone can ship a contract
+ * with a matching selector. The partial label tells the cross-check NOT
+ * to compare function names against 4byte (4byte's signature for this
+ * selector IS canonical, so the re-encode check still anchors the args
+ * — matching the existing LiFi-bridge partial-decode pattern).
+ *
+ * Scope is intentionally narrow: standardized selectors whose blast
+ * radius justifies decoding even on contracts we don't know. Adding
+ * more selectors here is fine; using this list as an allowlist for
+ * destination trust is NOT — the partial source label IS the warning.
+ *
+ * Each entry's `abi` is a single-function ABI tuple ready for
+ * `decodeFunctionData`. We assert the selector matches at module load
+ * (see `assertSelectorMatches` below) so a mistyped selector or signature
+ * fails fast at server startup instead of silently mis-decoding.
+ */
+interface HighRiskSelector {
+  selector: `0x${string}`;
+  signature: string;
+  abi: AbiFunction;
+}
+
+const HIGH_RISK_STANDARD_SELECTORS: readonly HighRiskSelector[] = [
+  {
+    // ERC-721 / ERC-1155 setApprovalForAll(address operator, bool approved).
+    // A single signed call grants/revokes operator authority for ALL tokens
+    // of the collection — highest blast radius outside typed-data signing.
+    selector: "0xa22cb465",
+    signature: "setApprovalForAll(address,bool)",
+    abi: {
+      type: "function",
+      name: "setApprovalForAll",
+      stateMutability: "nonpayable",
+      inputs: [
+        { name: "operator", type: "address" },
+        { name: "approved", type: "bool" },
+      ],
+      outputs: [],
+    },
+  },
+];
+
+function decodeHighRiskStandardSelector(
+  data: `0x${string}`,
+): HumanDecode | null {
+  if (data.length < 10) return null;
+  const selector = data.slice(0, 10).toLowerCase() as `0x${string}`;
+  const entry = HIGH_RISK_STANDARD_SELECTORS.find((e) => e.selector === selector);
+  if (!entry) return null;
+
+  // ABI sanity: every standard selector listed here takes a fixed-size
+  // head with no dynamic tails (address + bool packs to exactly 64 bytes
+  // = 128 hex chars after the 4-byte selector). Reject calldata of the
+  // wrong length to avoid surfacing a spuriously-decoded args list when
+  // a different function with a coincidentally-matching selector prefix
+  // was intended.
+  const expectedHexLen = 10 + entry.abi.inputs.length * 64;
+  if (data.length !== expectedHexLen) return null;
+
+  let decoded: { functionName: string; args?: readonly unknown[] };
+  try {
+    decoded = decodeFunctionData({ abi: [entry.abi], data });
+  } catch {
+    return null;
+  }
+
+  const rawArgs = decoded.args ?? [];
+  const args: DecodedArg[] = entry.abi.inputs.map((input, idx) => {
+    const raw = rawArgs[idx];
+    const base: DecodedArg = {
+      name: input.name ?? `arg${idx}`,
+      type: input.type,
+      value: stringifyArg(raw),
+    };
+    if (input.type === "address" && typeof raw === "string") {
+      try {
+        base.value = getAddress(raw);
+      } catch {
+        // Keep raw string if checksum fails.
+      }
+    }
+    return base;
+  });
+
+  return {
+    functionName: entry.abi.name,
+    signature: entry.signature,
+    args,
+    // Partial: we know the standard ABI shape, but we DO NOT know the
+    // destination is a real ERC-721/1155 — name-equality with 4byte is
+    // not safe to claim from this side (the destination could be an
+    // attacker contract that re-uses the selector). The cross-check's
+    // re-encode anchor still validates the args.
+    source: "local-abi-partial",
+  };
+}
+
 export function decodeCalldata(
   chain: SupportedChain,
   to: `0x${string}`,
@@ -381,6 +494,12 @@ export function decodeCalldata(
 
   const dest = classifyDestination(chain, to);
   if (!dest || !dest.abi) {
+    // Before giving up on `source:'none'`, attempt a selector-only
+    // partial decode for high-risk standard selectors (ERC-721/1155
+    // operator approvals, etc.). Surfaces operator/spender addresses in
+    // CHECKS PERFORMED so Inv #1 can flag a label/calldata mismatch.
+    const partial = decodeHighRiskStandardSelector(data);
+    if (partial) return partial;
     return {
       functionName: "unknown",
       args: [],

--- a/test/nft-operator-approval-decode.test.ts
+++ b/test/nft-operator-approval-decode.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
+import { decodeCalldata } from "../src/signing/decode-calldata.js";
+
+/**
+ * Regression coverage for issue #573 — `decodeCalldata` must surface
+ * the operator address on `setApprovalForAll(address,bool)` even when
+ * the destination is absent from the curated `CONTRACTS` map. A C.2
+ * collude attack (smoke-test batch-3 finding `expert-x104-C.2`) routes
+ * an NFT operator-approval to an uncurated marketplace/aggregator while
+ * the cooperating MCP narrates a benign label; without this fallback
+ * the operator field is invisible to the user and Inv #1 cannot flag
+ * the label/calldata mismatch.
+ */
+
+const SET_APPROVAL_FOR_ALL_ABI = [
+  {
+    type: "function",
+    name: "setApprovalForAll",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "operator", type: "address" },
+      { name: "approved", type: "bool" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const UNCURATED_DESTINATION = getAddress(
+  "0xdeaDBEefDEadBEefdEAdbeefdEAdbeEFdeaDbeEf",
+);
+const ATTACKER_OPERATOR = getAddress(
+  "0xBaDC0DeBADc0DeBaDc0DeBaDc0DeBaDc0DeBaDc0",
+);
+
+describe("decodeCalldata — high-risk standard selector fallback (issue #573)", () => {
+  it("decodes setApprovalForAll(operator, true) on an uncurated destination as local-abi-partial", () => {
+    const data = encodeFunctionData({
+      abi: SET_APPROVAL_FOR_ALL_ABI,
+      functionName: "setApprovalForAll",
+      args: [ATTACKER_OPERATOR, true],
+    });
+    expect(data.slice(0, 10)).toBe("0xa22cb465");
+
+    const decoded = decodeCalldata("ethereum", UNCURATED_DESTINATION, data, "0");
+
+    // Partial — we know the standard ABI shape, but the destination is
+    // uncurated, so name-equality with 4byte is not safe to claim.
+    expect(decoded.source).toBe("local-abi-partial");
+    expect(decoded.functionName).toBe("setApprovalForAll");
+    expect(decoded.signature).toBe("setApprovalForAll(address,bool)");
+
+    // The whole point: the operator address surfaces in CHECKS PERFORMED.
+    const named = Object.fromEntries(decoded.args.map((a) => [a.name, a]));
+    expect(named.operator).toBeDefined();
+    expect(named.operator.type).toBe("address");
+    expect(named.operator.value).toBe(ATTACKER_OPERATOR);
+    expect(named.approved.type).toBe("bool");
+    expect(named.approved.value).toBe("true");
+  });
+
+  it("decodes setApprovalForAll(operator, false) — revoke flow surfaces operator too", () => {
+    // The revoke variant must also decode: a malicious agent could route
+    // a `revoke` UI to a `false` calldata while having previously sent a
+    // `true` to a different (attacker) operator. Surfacing the operator
+    // on revoke lets the user sanity-check that the revoke targets the
+    // contract they thought.
+    const data = encodeFunctionData({
+      abi: SET_APPROVAL_FOR_ALL_ABI,
+      functionName: "setApprovalForAll",
+      args: [ATTACKER_OPERATOR, false],
+    });
+    const decoded = decodeCalldata("ethereum", UNCURATED_DESTINATION, data, "0");
+    expect(decoded.source).toBe("local-abi-partial");
+    const named = Object.fromEntries(decoded.args.map((a) => [a.name, a]));
+    expect(named.operator.value).toBe(ATTACKER_OPERATOR);
+    expect(named.approved.value).toBe("false");
+  });
+
+  it("operator address is checksum-cased so it matches the swiss-knife render", () => {
+    // viem's encodeFunctionData accepts lowercase, but our decode pipeline
+    // re-applies EIP-55 casing on address args. The user compares the
+    // value rendered in chat against the swiss-knife browser decode — both
+    // should be checksummed identically.
+    const lowercaseOperator =
+      "0xbadc0debadc0debadc0debadc0debadc0debadc0" as `0x${string}`;
+    const data = encodeFunctionData({
+      abi: SET_APPROVAL_FOR_ALL_ABI,
+      functionName: "setApprovalForAll",
+      args: [lowercaseOperator, true],
+    });
+    const decoded = decodeCalldata("ethereum", UNCURATED_DESTINATION, data, "0");
+    const named = Object.fromEntries(decoded.args.map((a) => [a.name, a]));
+    expect(named.operator.value).toBe(getAddress(lowercaseOperator));
+  });
+
+  it("rejects truncated setApprovalForAll calldata (length guard, no silent decode)", () => {
+    // Selector + only one 32-byte word is not a valid (address, bool)
+    // payload. The fallback must NOT swallow this — it should fall through
+    // to source:'none' rather than fabricate args.
+    const truncated = ("0xa22cb465" + "00".repeat(32)) as `0x${string}`;
+    const decoded = decodeCalldata(
+      "ethereum",
+      UNCURATED_DESTINATION,
+      truncated,
+      "0",
+    );
+    expect(decoded.source).toBe("none");
+    expect(decoded.functionName).toBe("unknown");
+  });
+
+  it("rejects setApprovalForAll calldata with trailing junk (length guard)", () => {
+    // Real fixed-shape ABI calldata for this selector is exactly 4 + 64
+    // bytes. Trailing bytes mean either a different function with a
+    // coincidentally-matching selector prefix, or a malformed attacker
+    // payload — either way, refuse to surface a "decoded" args list.
+    const validData = encodeFunctionData({
+      abi: SET_APPROVAL_FOR_ALL_ABI,
+      functionName: "setApprovalForAll",
+      args: [ATTACKER_OPERATOR, true],
+    });
+    const padded = (validData + "deadbeef") as `0x${string}`;
+    const decoded = decodeCalldata("ethereum", UNCURATED_DESTINATION, padded, "0");
+    expect(decoded.source).toBe("none");
+    expect(decoded.functionName).toBe("unknown");
+  });
+
+  it("uncurated destination + non-listed selector still falls through to source:none", () => {
+    // Unknown selector on an unknown destination — the fallback must not
+    // pretend to decode anything. Pre-fix behavior is the safe default
+    // here; we only WIDEN to local-abi-partial when the selector matches
+    // a high-risk standard.
+    const decoded = decodeCalldata(
+      "ethereum",
+      UNCURATED_DESTINATION,
+      "0xdeadbeef00000000" as `0x${string}`,
+      "0",
+    );
+    expect(decoded.source).toBe("none");
+    expect(decoded.functionName).toBe("unknown");
+  });
+
+  it("preserves full local-abi decode when destination is curated (regression pin)", async () => {
+    // setApprovalForAll on a curated destination should still be processed
+    // by the existing classifyDestination path — but no curated contract
+    // in our registry exposes `setApprovalForAll`, so we instead pin the
+    // adjacent regression: a curated ERC-20 transfer call still produces
+    // source: 'local-abi' (NOT 'local-abi-partial'), proving the new
+    // fallback only fires on the uncurated branch.
+    const { CONTRACTS } = await import("../src/config/contracts.js");
+    const { erc20Abi } = await import("../src/abis/erc20.js");
+    const usdc = CONTRACTS.ethereum.tokens.USDC as `0x${string}`;
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [
+        getAddress("0x1111111111111111111111111111111111111111"),
+        1_000_000n,
+      ],
+    });
+    const decoded = decodeCalldata("ethereum", usdc, data, "0");
+    expect(decoded.source).toBe("local-abi");
+  });
+});


### PR DESCRIPTION
Closes #573.

## Summary

Extends `decodeCalldata` with a selector-only partial decode for high-risk standard selectors on uncurated destinations. Currently covers `setApprovalForAll(address operator, bool approved)` (`0xa22cb465`) — the operator-grant selector shared by ERC-721 and ERC-1155.

## Threat addressed

C.2 collude attack from smoke-test batch-3 finding `expert-x104-C.2`: agent routes an NFT operator-approval to an uncurated marketplace/aggregator while narrating "Seaport-only". With `source:'none'` the attacker-controlled operator address never reached CHECKS PERFORMED, so Inv #1 (independent calldata cross-check) saw opaque bytes and could not flag the label/calldata mismatch. After this change, the operator address surfaces in CHECKS PERFORMED with EIP-55 checksum casing — the user (and the second-LLM check) can compare it against the MCP-claimed label.

## Design

- Adds `HIGH_RISK_STANDARD_SELECTORS` registry keyed by 4-byte selector. Each entry carries the canonical signature + a single-function ABI tuple ready for `decodeFunctionData`.
- New `decodeHighRiskStandardSelector(data)` runs in the `!dest` branch of `decodeCalldata`, BEFORE the early-exit on `source:'none'`. Length-guards reject truncated payloads and trailing junk so the fallback never fabricates args.
- Returns `source:'local-abi-partial'` (matches the existing LiFi-bridge fallback): we know the standard ABI shape, but we don't know the destination is a real ERC-721/1155, so name-equality with 4byte is not safe to claim from this side. The cross-check's re-encode anchor still validates the args.
- Scope intentionally narrow: standardized selectors whose blast radius justifies decoding even on contracts we don't curate. ERC-721 `approve(address,uint256)` is deliberately omitted — its selector collides with ERC-20 `approve` and the verification block already special-cases the latter (Ledger clear-signs); reconciling that collision is its own design call.

## Tests

7 new tests in `test/nft-operator-approval-decode.test.ts`:
- decodes `setApprovalForAll(operator, true)` on uncurated destination → `local-abi-partial`
- revoke variant (`setApprovalForAll(operator, false)`) also surfaces the operator
- operator address is EIP-55 checksum-cased to match swiss-knife render
- truncated calldata → falls through to `source:'none'`
- trailing-junk calldata → falls through to `source:'none'`
- unknown selector on uncurated destination → still `source:'none'`
- regression pin: curated ERC-20 transfer still produces `source:'local-abi'`

Full suite: 2565/2565 passing.

## Compromise model / out of scope

Defense-in-depth for the cooperating-MCP case. A compromised MCP can synthesize whatever `humanDecode` it likes — the load-bearing rogue-MCP defense (decode calldata independently in the skill, refuse on operator-vs-label mismatch) belongs in `vaultpilot-security-skill` and is a separate cross-repo issue per CLAUDE.md §Cross-Repo Scope Splits.

— Calldata Decode (agent-d0eb)
