### PR TITLE
feat(custom-call): selector classifier for value-exfil patterns (#652)

### DIFF
--- a/src/modules/custom-call/actions.ts
+++ b/src/modules/custom-call/actions.ts
@@ -1,6 +1,7 @@
 import { encodeFunctionData, type Abi } from "viem";
 import { resolveContractAbi } from "../../shared/contract-abi.js";
 import { lookupKnownSpender } from "../../security/known-spenders.js";
+import { applyCustomCallClassifier } from "../../security/custom-call-classifier.js";
 import type { SupportedChain, UnsignedTx } from "../../types/index.js";
 import { assertNotUnlimitedBurnApproval } from "../shared/approval.js";
 
@@ -14,6 +15,7 @@ export interface BuildCustomCallParams {
   abi?: readonly unknown[];
   acknowledgeBurnApproval?: boolean;
   acknowledgeRawApproveBypass?: boolean;
+  acknowledgeKnownExfilPattern?: boolean;
 }
 
 const APPROVE_SELECTOR = "0x095ea7b3";
@@ -113,6 +115,33 @@ export async function buildCustomCall(p: BuildCustomCallParams): Promise<Unsigne
     }
   }
 
+  // Issue #652 — selector classifier for known value-exfil patterns
+  // (transfer / transferFrom / NFT-transfer / setApprovalForAll). The
+  // approve(...) selector is intentionally OUT of the classifier's
+  // ruleset because the dedicated check above already gates it with
+  // protocol-spender resolution. The classifier handles the OTHER
+  // selectors that the user-side defenses (swiss-knife URL, on-device
+  // blind-sign hash) can't meaningfully gate when the user has been
+  // social-engineered into the call themselves.
+  //
+  // `transferFrom` with `from == wallet` is value-exfil via a
+  // pre-existing approval and is refused outright with no bypass —
+  // there's no legitimate flow where the user wants to pull their own
+  // tokens through allowance-spending machinery (use prepare_token_send
+  // instead, which doesn't require an approval).
+  let transferFromSelfAsFrom = false;
+  if (data.toLowerCase().startsWith("0x23b872dd") && p.args.length >= 1) {
+    const fromArg = String(p.args[0] ?? "").toLowerCase();
+    if (fromArg === p.wallet.toLowerCase()) {
+      transferFromSelfAsFrom = true;
+    }
+  }
+  const classifierVerdict = applyCustomCallClassifier(
+    data,
+    p.acknowledgeKnownExfilPattern,
+    transferFromSelfAsFrom,
+  );
+
   // Stringify args for the decoded preview. Caller-supplied shapes are
   // arbitrary (struct tuples, address arrays, decimal strings); the JSON
   // form is the most faithful agent-readable rendering without losing
@@ -123,6 +152,11 @@ export async function buildCustomCall(p: BuildCustomCallParams): Promise<Unsigne
   );
   const argsPreview = argsJson.length > 4096 ? `${argsJson.slice(0, 4096)}…` : argsJson;
 
+  const decodedArgs: Record<string, string> = { args: argsPreview };
+  if (classifierVerdict.annotation) {
+    decodedArgs._classifierWarning = classifierVerdict.annotation;
+  }
+
   return {
     chain: p.chain,
     to: p.contract,
@@ -132,7 +166,7 @@ export async function buildCustomCall(p: BuildCustomCallParams): Promise<Unsigne
     description: `Custom call: ${p.fn} on ${p.contract} (${p.chain})`,
     decoded: {
       functionName: p.fn,
-      args: { args: argsPreview },
+      args: decodedArgs,
     },
   };
 }

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2809,6 +2809,7 @@ export async function prepareCustomCall(
     abi: args.abi,
     acknowledgeBurnApproval: args.acknowledgeBurnApproval,
     acknowledgeRawApproveBypass: args.acknowledgeRawApproveBypass,
+    acknowledgeKnownExfilPattern: args.acknowledgeKnownExfilPattern,
   });
   // Stamp the affirmative-ack on the tx so `assertTransactionSafe`
   // (preview/send time) recognizes this handle as the explicit

--- a/src/modules/execution/schemas.ts
+++ b/src/modules/execution/schemas.ts
@@ -1123,6 +1123,21 @@ export const prepareCustomCallInput = z.object({
         "non-ERC-20 contract that exposes `approve(address,uint256)` for an unrelated " +
         "purpose (rare governance hooks, DAO-specific approvals). Do NOT default to true."
     ),
+  acknowledgeKnownExfilPattern: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override flag for the CUSTOM_CALL_REFUSED selector classifier (issue #652). The " +
+        "classifier hard-refuses obvious ERC-20 value-exfil selectors routed through this " +
+        "escape hatch — `transfer(address,uint256)` and `transferFrom(address,address,uint256)` " +
+        "— and points the agent at the safer protocol-specific tool (`prepare_token_send`, " +
+        "etc.). Set to true only when the user has explicitly asked for the raw selector " +
+        "via this escape hatch (e.g. testing a non-standard ERC-20 fork, calling through a " +
+        "contract whose `transfer` is unrelated to ERC-20). Pulling your own wallet via " +
+        "`transferFrom` (from = self) is refused outright and is NOT bypassable through " +
+        "this flag — use `prepare_token_send` instead. Do NOT default to true silently — " +
+        "the agent must surface the trade-off to the user before setting it."
+    ),
 });
 
 export const sendTransactionInput = z.object({

--- a/src/security/custom-call-classifier.ts
+++ b/src/security/custom-call-classifier.ts
@@ -1,0 +1,196 @@
+/**
+ * Selector classifier for `prepare_custom_call` value-exfil patterns
+ * (issue #652, deferred from #493 / PR #494).
+ *
+ * `prepare_custom_call` is the explicit escape hatch — it BYPASSES the
+ * canonical-dispatch allowlist on purpose, gated by
+ * `acknowledgeNonProtocolTarget: true`. The v1 user-side defenses
+ * (swiss-knife decoder URL, simulation revert reason, on-device
+ * blind-sign hash) cover the threat model where the attacker is the
+ * agent or a prompt-injection that rewrites args. They do NOT cover
+ * the threat model where the user themselves has been social-
+ * engineered into running a custom call that drains their wallet.
+ *
+ * The classifier inspects the encoded calldata's 4-byte selector
+ * against a hardcoded ruleset of known value-exfil patterns. Hard
+ * "refuse" matches throw a structured error pointing at the safer
+ * protocol-specific tool; soft "warn" matches attach a non-fatal
+ * annotation to the decoded preview so the user sees the warning
+ * before signing without the call being blocked outright.
+ *
+ * Approve(`0x095ea7b3`) is intentionally NOT in this ruleset — it's
+ * already gated by the dedicated `assertApproveRoutedToDedicatedTool`
+ * check (issue #556) which carries protocol-spender resolution and
+ * its own `acknowledgeRawApproveBypass` escape hatch.
+ *
+ * Out-of-scope (deferred): cross-contract reentrancy detection
+ * (claimAirdrop → transferFrom via pre-existing approval), arg-shape
+ * filtering against the contacts address-book, per-protocol
+ * allowlists for the target contract.
+ */
+
+export type ClassifierHardness = "refuse" | "warn";
+
+export interface ClassifierRule {
+  /** 4-byte function selector, lowercase hex with 0x prefix. */
+  selector: `0x${string}`;
+  /** Canonical function signature, used in error messages and the warning annotation. */
+  signature: string;
+  /** Hard refuse blocks the call; soft warn surfaces an annotation but allows the call. */
+  hardness: ClassifierHardness;
+  /** Human-readable error / annotation message — explains what to do instead. */
+  message: string;
+}
+
+/**
+ * Selectors and signatures verified against viem's keccak — see the
+ * test suite for bit-exact assertions.
+ *
+ * - `transfer(address,uint256)` 0xa9059cbb — ERC-20 transfer; bypasses
+ *   `prepare_token_send`'s recipient-label resolution and contacts-tamper
+ *   layer.
+ * - `transferFrom(address,address,uint256)` 0x23b872dd — ERC-20 pull;
+ *   wraps an existing allowance. Self-as-from is pull-style draining
+ *   with no per-protocol equivalent (refused outright by the wiring
+ *   layer); other-as-from is rare-but-legitimate (ack-bypassable).
+ * - `safeTransferFrom(address,address,uint256)` 0x42842e0e and
+ *   `safeTransferFrom(address,address,uint256,bytes)` 0xb88d4fde —
+ *   ERC-721 transfer. Less commonly abused than ERC-20 since each
+ *   tokenId is unique, but worth surfacing.
+ * - `setApprovalForAll(address,bool)` 0xa22cb465 — ERC-721 operator
+ *   approval. Known phishing vector ("collection-wide drain") but the
+ *   legitimate marketplace-listing flow still uses it; warn rather
+ *   than refuse. (Selector verified bit-exact against viem in the
+ *   test suite — the archive plan's 0xa22cba26 was a typo.)
+ */
+export const CUSTOM_CALL_CLASSIFIER_RULES: readonly ClassifierRule[] = [
+  {
+    selector: "0xa9059cbb",
+    signature: "transfer(address,uint256)",
+    hardness: "refuse",
+    message:
+      "ERC-20 transfer via prepare_custom_call bypasses prepare_token_send's recipient " +
+      "label resolution and contacts-tamper layer. Use prepare_token_send instead — it " +
+      "looks up the recipient against the address book, surfaces a friendly label, and " +
+      "applies the address-poisoning checks. If you genuinely need a raw transfer through " +
+      "this escape hatch (e.g. testing a non-standard ERC-20 fork), retry with " +
+      "`acknowledgeKnownExfilPattern: true`.",
+  },
+  {
+    selector: "0x23b872dd",
+    signature: "transferFrom(address,address,uint256)",
+    hardness: "refuse",
+    message:
+      "ERC-20 transferFrom via prepare_custom_call is pull-style draining when the `from` " +
+      "argument is your own wallet — a rogue agent or social-engineering attempt can use a " +
+      "pre-existing approval to drain the wallet through this call. If you intend to spend " +
+      "an existing allowance via a protocol contract, use the protocol-specific prepare_* " +
+      "tool (Aave Pool, Uniswap Router, etc.) instead. The escape-hatch override " +
+      "(`acknowledgeKnownExfilPattern: true`) is available only when `from` is NOT your " +
+      "wallet — pulling someone else's allowance to yourself is rare-but-legitimate; " +
+      "pulling your own wallet is refused outright.",
+  },
+  {
+    selector: "0x42842e0e",
+    signature: "safeTransferFrom(address,address,uint256)",
+    hardness: "warn",
+    message:
+      "ERC-721 transfer detected — the on-device blind-sign hash is your only verification " +
+      "anchor for the recipient and tokenId. Decode the calldata via the swiss-knife URL " +
+      "before signing.",
+  },
+  {
+    selector: "0xb88d4fde",
+    signature: "safeTransferFrom(address,address,uint256,bytes)",
+    hardness: "warn",
+    message:
+      "ERC-721 transfer with data detected — the trailing `bytes` arg can carry arbitrary " +
+      "executable payload to the recipient's onERC721Received hook. Decode the calldata " +
+      "via the swiss-knife URL before signing.",
+  },
+  {
+    selector: "0xa22cb465",
+    signature: "setApprovalForAll(address,bool)",
+    hardness: "warn",
+    message:
+      "ERC-721 setApprovalForAll detected — when the second arg is `true`, ALL NFTs of " +
+      "this collection become controllable by the operator. This is a well-known phishing " +
+      "vector (`Blur`/`OpenSea`-shaped fake-listing drains). Verify the operator address " +
+      "against your intended marketplace via the swiss-knife URL before signing.",
+  },
+];
+
+/**
+ * Classify the encoded calldata's 4-byte selector. Returns the matched
+ * rule or null. Pure function — no I/O, no async.
+ */
+export function classifyCustomCallSelector(
+  data: `0x${string}`,
+): ClassifierRule | null {
+  // Selector is 4 bytes = 8 hex chars + the leading "0x" = 10 chars
+  // total. Anything shorter has no selector to classify.
+  if (data.length < 10) return null;
+  const sel = data.slice(0, 10).toLowerCase() as `0x${string}`;
+  return CUSTOM_CALL_CLASSIFIER_RULES.find((r) => r.selector === sel) ?? null;
+}
+
+export interface ClassifierVerdict {
+  /** The matched rule, or null if no rule matched. */
+  rule: ClassifierRule | null;
+  /** Annotation text to attach to the decoded preview (warn case, or refuse-with-bypass). */
+  annotation?: string;
+}
+
+/**
+ * Apply the classifier verdict and either throw a refusal, return an
+ * annotation for the warn case, or return null for unmatched
+ * selectors. The caller decides what to do with the annotation.
+ *
+ * Bypass semantics:
+ *   - `acknowledgeKnownExfilPattern: true` downgrades a "refuse" verdict
+ *     to a warn-equivalent annotation (still surfaced, not blocked).
+ *   - `transferFromSelfAsFrom: true` (computed by the caller from the
+ *     decoded args) makes the `transferFrom` refusal NON-bypassable —
+ *     pulling your own wallet via a pre-existing approval is an
+ *     architectural mismatch with the user's intent, not a legitimate
+ *     advanced flow.
+ */
+export function applyCustomCallClassifier(
+  data: `0x${string}`,
+  ack: boolean | undefined,
+  transferFromSelfAsFrom: boolean,
+): ClassifierVerdict {
+  const rule = classifyCustomCallSelector(data);
+  if (!rule) return { rule: null };
+
+  if (rule.hardness === "refuse") {
+    const isTransferFrom = rule.selector === "0x23b872dd";
+    if (isTransferFrom && transferFromSelfAsFrom) {
+      throw new Error(
+        `CUSTOM_CALL_REFUSED [${rule.signature}]: pulling your own wallet via ` +
+          `transferFrom is value-exfil through a pre-existing approval and is NOT ` +
+          `bypassable through this escape hatch. If you intend to move tokens from ` +
+          `your own wallet, use prepare_token_send (no allowance required). If you're ` +
+          `revoking an approval, use prepare_revoke_approval.`,
+      );
+    }
+    if (ack !== true) {
+      throw new Error(
+        `CUSTOM_CALL_REFUSED [${rule.signature}]: ${rule.message}`,
+      );
+    }
+    // Ack-bypassed: surface the rule's message as a warning annotation
+    // so the verification block still shows the user what they're
+    // overriding.
+    return {
+      rule,
+      annotation: `[exfil-pattern bypassed via ack] ${rule.signature}: ${rule.message}`,
+    };
+  }
+
+  // Warn case — attach annotation, don't throw.
+  return {
+    rule,
+    annotation: `[warning] ${rule.signature}: ${rule.message}`,
+  };
+}

--- a/test/custom-call.test.ts
+++ b/test/custom-call.test.ts
@@ -426,3 +426,322 @@ describe("canonical-dispatch wiring (#483 / PR #489)", () => {
     expect(() => assertCanonicalDispatchOnTxChain("prepare_custom_call", tx)).not.toThrow();
   });
 });
+
+// ------- Selector classifier (issue #652) -------
+// Defense in depth on the prepare_custom_call escape hatch — refuses
+// obvious value-exfil selectors and routes the agent to the safer
+// protocol-specific tool. Approve(0x095ea7b3) is intentionally NOT in
+// the classifier (already handled by the dedicated #556 check above).
+
+const ERC20_TRANSFER_ABI = [
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const ERC20_TRANSFER_FROM_ABI = [
+  {
+    type: "function",
+    name: "transferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const ERC721_SAFE_TRANSFER_FROM_ABI = [
+  {
+    type: "function",
+    name: "safeTransferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const ERC721_SET_APPROVAL_FOR_ALL_ABI = [
+  {
+    type: "function",
+    name: "setApprovalForAll",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "operator", type: "address" },
+      { name: "approved", type: "bool" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const ATTACKER = "0x000000000000000000000000000000000000dEaD" as const;
+const ANOTHER_WALLET = "0x1111111111111111111111111111111111111111" as const;
+
+describe("buildCustomCall — selector classifier (issue #652)", () => {
+  it("refuses ERC-20 transfer(...) and points at prepare_token_send", async () => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "transfer",
+        args: [ATTACKER, "1000000"],
+        value: "0",
+        abi: ERC20_TRANSFER_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/CUSTOM_CALL_REFUSED[\s\S]*transfer\(address,uint256\)[\s\S]*prepare_token_send/);
+  });
+
+  it("refuses ERC-20 transferFrom(...) and points at the safer flow", async () => {
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "transferFrom",
+        args: [ANOTHER_WALLET, ATTACKER, "1000000"],
+        value: "0",
+        abi: ERC20_TRANSFER_FROM_ABI as unknown as readonly unknown[],
+      }),
+    ).rejects.toThrow(/CUSTOM_CALL_REFUSED[\s\S]*transferFrom/);
+  });
+
+  it("refuses transferFrom(self, ...) outright with NO bypass available", async () => {
+    // Self-as-from is pull-style draining via a pre-existing approval —
+    // there's no legitimate flow where the user wants this through the
+    // escape hatch (use prepare_token_send instead, which doesn't need
+    // an allowance). The ack flag MUST NOT downgrade this verdict.
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "transferFrom",
+        args: [WALLET, ATTACKER, "1000000"],
+        value: "0",
+        abi: ERC20_TRANSFER_FROM_ABI as unknown as readonly unknown[],
+        acknowledgeKnownExfilPattern: true,
+      }),
+    ).rejects.toThrow(/NOT[\s\S]*bypassable/);
+  });
+
+  it("self-as-from comparison is case-insensitive on the wallet hex", async () => {
+    // Wallet is a checksummed 0xC0f5… address; from-arg is the same
+    // hex lowercased. The check must canonicalize both sides.
+    await expect(
+      buildCustomCall({
+        wallet: WALLET,
+        chain: "ethereum",
+        contract: USDC,
+        fn: "transferFrom",
+        args: [WALLET.toLowerCase(), ATTACKER, "1000000"],
+        value: "0",
+        abi: ERC20_TRANSFER_FROM_ABI as unknown as readonly unknown[],
+        acknowledgeKnownExfilPattern: true,
+      }),
+    ).rejects.toThrow(/NOT[\s\S]*bypassable/);
+  });
+
+  it("acknowledgeKnownExfilPattern=true downgrades transfer refusal to a warn annotation", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "transfer",
+      args: [ATTACKER, "1000000"],
+      value: "0",
+      abi: ERC20_TRANSFER_ABI as unknown as readonly unknown[],
+      acknowledgeKnownExfilPattern: true,
+    });
+    expect(tx.data.startsWith("0xa9059cbb")).toBe(true);
+    expect(tx.decoded?.args._classifierWarning).toBeDefined();
+    expect(tx.decoded?.args._classifierWarning).toMatch(/exfil-pattern bypassed/);
+  });
+
+  it("acknowledgeKnownExfilPattern=true downgrades transferFrom(other, ...) refusal", async () => {
+    // Other-as-from is rare-but-legitimate (pulling someone else's
+    // pre-existing allowance to yourself). Bypass IS allowed here.
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "transferFrom",
+      args: [ANOTHER_WALLET, WALLET, "1000000"],
+      value: "0",
+      abi: ERC20_TRANSFER_FROM_ABI as unknown as readonly unknown[],
+      acknowledgeKnownExfilPattern: true,
+    });
+    expect(tx.data.startsWith("0x23b872dd")).toBe(true);
+    expect(tx.decoded?.args._classifierWarning).toMatch(/exfil-pattern bypassed/);
+  });
+
+  it("attaches a soft-warn annotation to ERC-721 safeTransferFrom (no refusal)", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC, // contract addr is irrelevant — selector match is the gate
+      fn: "safeTransferFrom",
+      args: [WALLET, ANOTHER_WALLET, "42"],
+      value: "0",
+      abi: ERC721_SAFE_TRANSFER_FROM_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.data.startsWith("0x42842e0e")).toBe(true);
+    expect(tx.decoded?.args._classifierWarning).toMatch(/\[warning\][\s\S]*safeTransferFrom/);
+  });
+
+  it("attaches a soft-warn annotation to setApprovalForAll (no refusal)", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: USDC,
+      fn: "setApprovalForAll",
+      args: [ANOTHER_WALLET, true],
+      value: "0",
+      abi: ERC721_SET_APPROVAL_FOR_ALL_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.data.startsWith("0xa22cb465")).toBe(true);
+    expect(tx.decoded?.args._classifierWarning).toMatch(/\[warning\][\s\S]*setApprovalForAll/);
+  });
+
+  it("does not attach a warning for unrelated selectors (Timelock schedule)", async () => {
+    const tx = await buildCustomCall({
+      wallet: WALLET,
+      chain: "ethereum",
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0",
+        "0x",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "172800",
+      ],
+      value: "0",
+      abi: TIMELOCK_ABI as unknown as readonly unknown[],
+    });
+    expect(tx.data.startsWith("0x01d5062a")).toBe(true);
+    expect(tx.decoded?.args._classifierWarning).toBeUndefined();
+  });
+});
+
+describe("classifier rule selectors (#652) — bit-exact against viem", () => {
+  // Verify the hard-coded selectors in CUSTOM_CALL_CLASSIFIER_RULES
+  // match what viem encodes for the canonical signatures. Per the
+  // project rule on verifying cryptographic constants independently.
+  it("ERC-20 transfer", () => {
+    const data = encodeFunctionData({
+      abi: ERC20_TRANSFER_ABI,
+      functionName: "transfer",
+      args: ["0x0000000000000000000000000000000000000001", 0n],
+    });
+    expect(data.slice(0, 10)).toBe("0xa9059cbb");
+  });
+
+  it("ERC-20 transferFrom", () => {
+    const data = encodeFunctionData({
+      abi: ERC20_TRANSFER_FROM_ABI,
+      functionName: "transferFrom",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        0n,
+      ],
+    });
+    expect(data.slice(0, 10)).toBe("0x23b872dd");
+  });
+
+  it("ERC-721 safeTransferFrom (3-arg)", () => {
+    const data = encodeFunctionData({
+      abi: ERC721_SAFE_TRANSFER_FROM_ABI,
+      functionName: "safeTransferFrom",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        0n,
+      ],
+    });
+    expect(data.slice(0, 10)).toBe("0x42842e0e");
+  });
+
+  it("ERC-721 setApprovalForAll", () => {
+    const data = encodeFunctionData({
+      abi: ERC721_SET_APPROVAL_FOR_ALL_ABI,
+      functionName: "setApprovalForAll",
+      args: ["0x0000000000000000000000000000000000000001", true],
+    });
+    expect(data.slice(0, 10)).toBe("0xa22cb465");
+  });
+
+  it("ERC-721 safeTransferFrom (4-arg with bytes)", () => {
+    const ABI_WITH_BYTES = [
+      {
+        type: "function",
+        name: "safeTransferFrom",
+        stateMutability: "nonpayable",
+        inputs: [
+          { name: "from", type: "address" },
+          { name: "to", type: "address" },
+          { name: "tokenId", type: "uint256" },
+          { name: "data", type: "bytes" },
+        ],
+        outputs: [],
+      },
+    ] as const;
+    const data = encodeFunctionData({
+      abi: ABI_WITH_BYTES,
+      functionName: "safeTransferFrom",
+      args: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        0n,
+        "0x",
+      ],
+    });
+    expect(data.slice(0, 10)).toBe("0xb88d4fde");
+  });
+});
+
+describe("prepareCustomCallInput schema — acknowledgeKnownExfilPattern (#652)", () => {
+  it("accepts boolean true / false / undefined", () => {
+    const ok1 = prepareCustomCallInput.parse({
+      wallet: WALLET,
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [],
+      acknowledgeNonProtocolTarget: true,
+      acknowledgeKnownExfilPattern: true,
+    });
+    expect(ok1.acknowledgeKnownExfilPattern).toBe(true);
+    const ok2 = prepareCustomCallInput.parse({
+      wallet: WALLET,
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [],
+      acknowledgeNonProtocolTarget: true,
+      acknowledgeKnownExfilPattern: false,
+    });
+    expect(ok2.acknowledgeKnownExfilPattern).toBe(false);
+    const ok3 = prepareCustomCallInput.parse({
+      wallet: WALLET,
+      contract: TIMELOCK,
+      fn: "schedule",
+      args: [],
+      acknowledgeNonProtocolTarget: true,
+    });
+    expect(ok3.acknowledgeKnownExfilPattern).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #652.

Defense in depth on the `prepare_custom_call` escape hatch — refuses obvious ERC-20 value-exfil selectors at prepare time and routes the agent to the safer protocol-specific tool. NFT-shaped patterns (`safeTransferFrom`, `setApprovalForAll`) attach a soft-warn annotation rather than blocking outright.

## Threat model

`prepare_custom_call` intentionally bypasses the canonical-dispatch allowlist (block 4 of `assertTransactionSafe`) when the agent stamps `acknowledgeNonProtocolTarget: true`. The v1 user-side defenses (swiss-knife decoder URL, simulation revert reason, on-device blind-sign hash) cover the agent-as-attacker threat model. They do NOT cover the user-as-target threat model where the user has been social-engineered into running a custom call that drains their wallet — a Discord-pasted "run this `prepare_custom_call({ contract: USDC, fn: 'transfer', args: [attacker, max] })`" defeats every defense above because the user is volunteering the call.

## Classifier ruleset

| Selector | Signature | Verdict | Bypass |
|---|---|---|---|
| `0xa9059cbb` | `transfer(address,uint256)` | refuse → `prepare_token_send` | `acknowledgeKnownExfilPattern: true` |
| `0x23b872dd` | `transferFrom(address,address,uint256)` | refuse → protocol-specific `prepare_*` | `acknowledgeKnownExfilPattern: true` (only when `from != self`) |
| `0x42842e0e` | `safeTransferFrom(address,address,uint256)` | warn (annotation) | n/a |
| `0xb88d4fde` | `safeTransferFrom(address,address,uint256,bytes)` | warn (annotation) | n/a |
| `0xa22cb465` | `setApprovalForAll(address,bool)` | warn (annotation) | n/a |

`approve(0x095ea7b3)` is intentionally NOT in the classifier — already handled by the dedicated #556 check (which carries protocol-spender resolution and its own `acknowledgeRawApproveBypass` flag). Adding a parallel classifier rule would duplicate that logic.

## Why `transferFrom(self, ...)` is refused outright

The "self-as-from" case is value-exfil through a pre-existing approval — there's no legitimate flow where the user wants this through the escape hatch (use `prepare_token_send` instead, which doesn't require an allowance). The `acknowledgeKnownExfilPattern` flag MUST NOT downgrade this verdict. Other-as-from (pulling someone else's allowance to yourself) is rare-but-legitimate and remains ack-bypassable.

## Files changed

- `src/security/custom-call-classifier.ts` (new) — rules + `applyCustomCallClassifier`
- `src/modules/custom-call/actions.ts` — wire the classifier after `encodeFunctionData`
- `src/modules/execution/schemas.ts` — `acknowledgeKnownExfilPattern` ack flag
- `src/modules/execution/index.ts` — pass the ack through to `buildCustomCall`
- `test/custom-call.test.ts` — refusals, bypass, soft-warn annotations, schema, selector bit-exactness

## Crypto-constant verification

All 5 selectors verified bit-exact against `viem.encodeFunctionData` in the test suite. The archive plan's `setApprovalForAll` selector `0xa22cba26` was a typo — the actual selector is `0xa22cb465` (caught by the test on first run; per project rule on verifying cryptographic constants independently).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 2573 passed (194 files), of which 31 in `test/custom-call.test.ts`
- [ ] Maintainer reviews the refusal-message wording (esp. the "use `prepare_token_send` instead" pointer)
- [ ] Maintainer confirms the `transferFrom(self, ...)` no-bypass policy is the right call

## Out of scope (deferred per the issue body)

- Cross-contract reentrancy detection (e.g. `claimAirdrop` → internal `transferFrom` via pre-existing approval). Requires simulation-state-trace inspection — a separate, much heavier feature.
- Arg-shape filtering against the contacts address book (recipient = known-contact's complement). The current `_classifierWarning` field gives the skill a hook to layer that in later if needed.
- Per-protocol allowlists for the target contract.

— Aryabhata (agent-a642)
