### PR TITLE
feat(pair_ledger): mandate per-address device verification in instructions

### DIFF
--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -260,7 +260,17 @@ export async function pairLedgerLive(): Promise<{
   return {
     uri,
     qr,
-    instructions: ledgerLivePairingInstructions(cachedVersion),
+    instructions:
+      ledgerLivePairingInstructions(cachedVersion) +
+      " VERIFY BEFORE FIRST USE: once pairing completes, the EVM addresses " +
+      "Ledger Live shares are exposed via `get_ledger_status`. Before any " +
+      "`prepare_*` uses one of those addresses, surface its FULL string (no " +
+      "truncation) and have the user cross-check it against (a) Ledger Live " +
+      "→ Settings → Connected Apps (the WC session entry shows the shared " +
+      "accounts), and (b) the on-device 'Display address' screen for the " +
+      "matching account in the Ethereum / chain-specific app. " +
+      "On any mismatch, abort — a compromised middle layer may have " +
+      "substituted addresses.",
     waitingForApproval: true,
   };
 }
@@ -308,7 +318,11 @@ export async function pairLedgerTron(args: PairLedgerTronArgs = {}): Promise<{
       "TRON account paired. You can now call `prepare_tron_*` with this address and " +
       "forward the handle via `send_transaction`. Keep the Ledger plugged in with the " +
       "TRON app open — each sign re-opens USB and re-verifies the device address. " +
-      "To pair a different slot, call `pair_ledger_tron` again with another `accountIndex`.",
+      "To pair a different slot, call `pair_ledger_tron` again with another `accountIndex`. " +
+      "VERIFY BEFORE FIRST USE: surface this FULL address (no truncation) and have " +
+      "the user verify it character-by-character against the device's 'Receive' / " +
+      "'Show address' screen on the TRON app. On any mismatch, abort — a " +
+      "compromised middle layer may have substituted the address.",
   };
 }
 
@@ -437,7 +451,13 @@ export async function pairLedgerBitcoin(args: PairLedgerBitcoinArgs = {}): Promi
       "`get_btc_account_balance({ accountIndex })` to sum across the cached set " +
       "for this account, or `get_btc_balance` against any single cached address. " +
       "Re-run `pair_ledger_btc` to refresh the cache; previously-cached entries " +
-      "for this accountIndex are dropped before the new scan persists.",
+      "for this accountIndex are dropped before the new scan persists. " +
+      "VERIFY BEFORE FIRST USE: before any `prepare_btc_*_send` or " +
+      "`send_transaction` uses one of these addresses, surface its FULL string " +
+      "(no truncation) and have the user verify it character-by-character against " +
+      "the device's 'Display address' screen (Bitcoin app → Display address → " +
+      "select the matching BIP path). On any mismatch, abort — a compromised " +
+      "middle layer may have substituted addresses.",
   };
 }
 
@@ -480,7 +500,12 @@ export async function pairLedgerSolana(
       "'Message Hash' instead of decoded fields. For SPL: (1) enable 'Allow " +
       "blind signing' in Solana app → Settings, (2) match the Message Hash " +
       "surfaced in the preview against the on-device value. To pair another " +
-      "slot, call `pair_ledger_solana` again with a different `accountIndex`.",
+      "slot, call `pair_ledger_solana` again with a different `accountIndex`. " +
+      "VERIFY BEFORE FIRST USE: surface this FULL address (no truncation) " +
+      "and have the user verify it character-by-character against the " +
+      "device's 'Public Key' / 'Show address' screen on the Solana app. " +
+      "On any mismatch, abort — a compromised middle layer may have " +
+      "substituted the address.",
   };
 }
 
@@ -1508,7 +1533,13 @@ export async function pairLedgerLitecoin(
       gapLimit +
       " consecutive empty addresses were observed. Use `get_ltc_balance` against " +
       "any cached address. Re-run `pair_ledger_ltc` to refresh; previously-cached " +
-      "entries for this accountIndex are dropped before the new scan persists." +
+      "entries for this accountIndex are dropped before the new scan persists. " +
+      "VERIFY BEFORE FIRST USE: before any `prepare_litecoin_*_send` or " +
+      "`send_transaction` uses one of these addresses, surface its FULL string " +
+      "(no truncation) and have the user verify it character-by-character " +
+      "against the device's 'Display address' screen (Litecoin app → Display " +
+      "address → select the matching BIP path). On any mismatch, abort — a " +
+      "compromised middle layer may have substituted addresses." +
       skippedNote,
   };
 }

--- a/test/security-audit.test.ts
+++ b/test/security-audit.test.ts
@@ -130,6 +130,32 @@ describe("C2+M10: WalletConnect peer identity", () => {
     expect(topicHits).toBeGreaterThanOrEqual(2);
   });
 
+  it("pair_ledger_* runtime instructions mandate per-address device verification (issue #577 / Inv #18)", async () => {
+    // Threat: a rogue MCP returns an attacker-controlled address as 'primary'
+    // from pair_ledger_*; the agent's prose framing surfaces it without the
+    // user noticing the device shows a different address. The actual rogue-MCP
+    // defense lives skill-side (forced user-echo of device-displayed chars);
+    // this MCP-side instructions text is defense-in-depth for the cooperating-
+    // MCP case so the agent's first response after pairing reminds the user
+    // to verify against the device screen. If anyone softens the verification
+    // mandate to plain "address paired, you can now send" prose, the rogue-
+    // MCP attack regresses to "user trusts whatever the agent surfaced."
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../src/modules/execution/index.ts", import.meta.url),
+      "utf8",
+    );
+    // One instance per pair_ledger_* tool (btc, ltc, tron, solana, live).
+    const verifyHits = src.match(/VERIFY BEFORE FIRST USE/g)?.length ?? 0;
+    expect(verifyHits).toBeGreaterThanOrEqual(5);
+    // Each must call out the FULL address (no truncation) requirement.
+    const fullHits = src.match(/FULL (string|address)/g)?.length ?? 0;
+    expect(fullHits).toBeGreaterThanOrEqual(5);
+    // Each must instruct the agent to abort on mismatch.
+    const abortHits = src.match(/On any mismatch, abort/g)?.length ?? 0;
+    expect(abortHits).toBeGreaterThanOrEqual(5);
+  });
+
   it("isKnownLedgerPeer gates the warning — Ledger hosts pass, everything else trips", async () => {
     // Only when the peer URL is NOT a ledger.com host does the server ship the
     // warning. This keeps the common case (pairing with real Ledger Live) quiet


### PR DESCRIPTION
Closes #577.

## Summary

Update the runtime `instructions` field of every `pair_ledger_*` tool (btc, ltc, tron, solana, live) to mandate that the cooperating agent surface the FULL paired address (no truncation) and force the user to verify it character-by-character against the device's address-display screen before any subsequent `prepare_*` / `send_transaction` may consume the paired address.

## Threat / scope split

**Threat:** rogue MCP returns an attacker-controlled address from `pair_ledger_*`. Caught in matrix-sampled smoke-test batch-3 (`newcomer-n192-C.2`).

**Why this is mostly a skill-side fix:** the actual rogue-MCP defense is the user reading the *Ledger device screen* (out-of-band trust anchor outside the MCP boundary) and typing back chars to the agent. A rogue MCP fabricates both the address and any "verification proof" it might emit — MCP-side advisory text alone is structurally circular under rogue-MCP per the project's [tautological-mitigation rule](https://github.com/szhygulin/recon-mcp/blob/main/CLAUDE.md). The binding rule has to live skill-side so a cooperating agent drives the user-verification flow even when the MCP omits the advisory.

**This MCP-side change is defense-in-depth for the cooperating-MCP case.** The skill-side companion is filed at [vaultpilot-security-skill#42](https://github.com/szhygulin/vaultpilot-security-skill/issues/42) with the full Inv #18 rule (force user echo-back of first 6 + last 6 chars from device, refuse on mismatch) and an explicit cooperating-agent scope statement. Together they cover Role-B (rogue-MCP + cooperating agent); rogue-agent remains an architectural gap per the Rogue-Agent-Only Triage rule (skill text is in agent context — a hostile agent ignores it).

## Pre-sign gate sweep

Per the project's surface-sweep rule, this change does not modify any `assertTransactionSafe` block. It only adds advisory text to `pair_ledger_*` runtime responses. No `prepare_*` paths are gated.

## Regression test

`test/security-audit.test.ts` (mirrors the existing `Connected Apps` topic-cross-check pattern):

- ≥5 occurrences of `VERIFY BEFORE FIRST USE` (one per `pair_ledger_*`)
- ≥5 occurrences of `FULL string|address`
- ≥5 occurrences of `On any mismatch, abort`

A future "address paired, you can now send" softening fails CI loudly.

## What is intentionally NOT in scope

- **No `display=true` on USB pair calls.** Adding it would force a device prompt at pair time, but a rogue MCP just doesn't pass `display=true` — UX cost without rogue-MCP benefit. Skipped.
- **No structured `verificationRequired: true` field.** Same tautological-mitigation argument: rogue MCP omits it. Plain text in the `instructions` field is enough for the cooperating-MCP case the skill-side rule already covers more rigorously.
- **No state machine gating subsequent `prepare_*` calls.** A rogue MCP doesn't enforce the gate on itself. The agent-bound enforcement lives skill-side.

## Test plan

- [x] `npm run build` (tsc, no errors)
- [x] `npm test` (2559 / 2559 tests pass)
- [ ] Manual: `pair_ledger_btc` against a real device — confirm the new `instructions` text surfaces in the response
- [ ] Smoke-test re-run of `newcomer-n192-C.2` — confirm the verification mandate is what the agent surfaces (cooperating-agent regression check)

— Rogue-MCP Trust Boundary (agent-5ade)
