### PR TITLE
feat(preview): surface pinned network fee + EIP-1559 breakdown at preview_send

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -531,6 +531,7 @@ import {
   renderCostPreviewBlock,
   renderLitecoinVerificationBlock,
   renderPrepareReceiptBlock,
+  renderPreviewCostBlock,
   renderPreviewVerifyAgentTaskBlock,
   renderSolanaAgentTaskBlock,
   renderSolanaPrepareAgentTaskBlock,
@@ -1315,7 +1316,10 @@ export function previewSendHandler(
       maxFeePerGas: string;
       maxPriorityFeePerGas: string;
       gas: string;
+      baseFeePerGas?: string;
     };
+    gasCostNative?: string;
+    gasCostUsd?: number;
     previewToken: string;
     decoderUrl?: string;
     clearSignOnly?: boolean;
@@ -1327,6 +1331,23 @@ export function previewSendHandler(
       const content: { type: "text"; text: string }[] = [
         { type: "text", text: JSON.stringify(result, bigintReplacer, 2) },
       ];
+      // Pinned-cost preview (issue #650) — surfaced FIRST among the human-
+      // readable blocks so a fee-spike since prepare time aborts the flow
+      // before the user spends attention on the hash-match + CHECKS PERFORMED
+      // surfaces. Returns null when the cost fields are absent (older
+      // envelope shape, or computePreviewCost was skipped); we silently
+      // omit rather than fabricate.
+      if (result.pinned.baseFeePerGas !== undefined) {
+        const cost = renderPreviewCostBlock({
+          chain: result.chain,
+          ...(result.gasCostNative ? { gasCostNative: result.gasCostNative } : {}),
+          ...(result.gasCostUsd !== undefined ? { gasCostUsd: result.gasCostUsd } : {}),
+          baseFeePerGas: result.pinned.baseFeePerGas,
+          maxPriorityFeePerGas: result.pinned.maxPriorityFeePerGas,
+          gas: result.pinned.gas,
+        });
+        if (cost) content.push({ type: "text", text: cost });
+      }
       const warning = missingPreflightSkillWarning();
       if (warning) content.push({ type: "text", text: warning });
       const demoNotice = missingDemoWalletNotice();

--- a/src/modules/execution/index.ts
+++ b/src/modules/execution/index.ts
@@ -2948,6 +2948,13 @@ async function pinSendFields(
   maxFeePerGas: bigint;
   maxPriorityFeePerGas: bigint;
   gas: bigint;
+  /**
+   * Live base fee from `latestBlock.baseFeePerGas`. Threaded out so the
+   * preview-time cost block (issue #650) can render `base fee X gwei`
+   * separately from the priority fee — recovering it from `maxFeePerGas`
+   * arithmetic would silently drift if `BASE_FEE_MULTIPLIER` ever changes.
+   */
+  baseFeePerGas: bigint;
 }> {
   const rpcClient = getClient(chain);
   const [nonceRaw, latestBlock, priorityEstimate, gasLimit] = await Promise.all([
@@ -2970,6 +2977,7 @@ async function pinSendFields(
     maxFeePerGas,
     maxPriorityFeePerGas,
     gas: gasLimit,
+    baseFeePerGas: baseFee,
   };
 }
 
@@ -3071,7 +3079,30 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     maxFeePerGas: string;
     maxPriorityFeePerGas: string;
     gas: string;
+    /**
+     * Live base fee from `latestBlock.baseFeePerGas` at pin time. Surfaced
+     * for the preview-time cost block's EIP-1559 breakdown (issue #650);
+     * not part of what `send_transaction` forwards to WalletConnect — the
+     * tx is signed against `maxFeePerGas` + `maxPriorityFeePerGas`.
+     */
+    baseFeePerGas: string;
   };
+  /**
+   * Native-currency cost computed at preview time from the pinned tuple
+   * (`gas * (baseFee + priority)` — the realistic-case cost; worst-case
+   * is bounded by `gas * maxFeePerGas`). Lets the preview-time render
+   * surface a fee-spike that happened between prepare and preview, without
+   * scrolling back through the verification + cross-check + agent-task
+   * surfaces. Always present on success — derived from values already in
+   * scope, no separate failure path. Issue #650.
+   */
+  gasCostNative: string;
+  /**
+   * USD-denominated equivalent of `gasCostNative`. Undefined when the
+   * native-token price lookup (DefiLlama) degraded. The render block falls
+   * back to native-only in that case rather than fabricating a number.
+   */
+  gasCostUsd?: number;
   previewToken: string;
   refreshed?: boolean;
   /**
@@ -3106,6 +3137,7 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
   const clearSignOnly = isClearSignOnlyTx(tx);
   const existing = getPinnedGas(args.handle);
   if (existing && !args.refresh) {
+    const cost = await computePreviewCost(tx.chain, existing);
     return {
       handle: args.handle,
       chain: tx.chain,
@@ -3117,7 +3149,10 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
         maxFeePerGas: existing.maxFeePerGas.toString(),
         maxPriorityFeePerGas: existing.maxPriorityFeePerGas.toString(),
         gas: existing.gas.toString(),
+        baseFeePerGas: existing.baseFeePerGas.toString(),
       },
+      gasCostNative: cost.native,
+      ...(cost.usd !== undefined ? { gasCostUsd: cost.usd } : {}),
       previewToken: existing.previewToken,
       ...(decoderUrl ? { decoderUrl } : {}),
       ...(clearSignOnly ? { clearSignOnly: true } : {}),
@@ -3161,11 +3196,13 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
     maxFeePerGas: pinned.maxFeePerGas,
     maxPriorityFeePerGas: pinned.maxPriorityFeePerGas,
     gas: pinned.gas,
+    baseFeePerGas: pinned.baseFeePerGas,
     preSignHash,
     pinnedAt: Date.now(),
     previewToken,
   };
   attachPinnedGas(args.handle, pin);
+  const cost = await computePreviewCost(tx.chain, pin);
   return {
     handle: args.handle,
     chain: tx.chain,
@@ -3177,12 +3214,42 @@ export async function previewSend(args: PreviewSendArgs): Promise<{
       maxFeePerGas: pinned.maxFeePerGas.toString(),
       maxPriorityFeePerGas: pinned.maxPriorityFeePerGas.toString(),
       gas: pinned.gas.toString(),
+      baseFeePerGas: pinned.baseFeePerGas.toString(),
     },
+    gasCostNative: cost.native,
+    ...(cost.usd !== undefined ? { gasCostUsd: cost.usd } : {}),
     previewToken,
     ...(existing ? { refreshed: true } : {}),
     ...(decoderUrl ? { decoderUrl } : {}),
     ...(clearSignOnly ? { clearSignOnly: true } : {}),
   };
+}
+
+/**
+ * Realistic-case fee estimate from a pinned EIP-1559 tuple. Uses
+ * `gas * (baseFee + priority)` rather than `gas * maxFeePerGas` because
+ * `maxFeePerGas` is `baseFee * 2 + priority` (a 4-block-rise headroom cap),
+ * not what the user actually pays. The on-chain effectiveGasPrice is
+ * `min(maxFeePerGas, baseFeeAtInclusion + priority)` — over the ~12s
+ * inclusion window `baseFeeAtInclusion` rarely diverges far from `baseFee`,
+ * so this is the right number to anchor abort decisions.
+ *
+ * Native is always returned (we have all the inputs); USD is undefined when
+ * DefiLlama price lookup degrades. Issue #650.
+ */
+async function computePreviewCost(
+  chain: SupportedChain,
+  pin: StashedPin,
+): Promise<{ native: string; usd?: number }> {
+  const effectiveGasPrice = pin.baseFeePerGas + pin.maxPriorityFeePerGas;
+  const gasWei = pin.gas * effectiveGasPrice;
+  const native = formatUnits(gasWei, 18);
+  const price = await getTokenPrice(chain, "native");
+  if (price === undefined) {
+    return { native };
+  }
+  const usd = round(Number(native) * price, 2);
+  return { native, usd };
 }
 
 /**

--- a/src/signing/render-verification.ts
+++ b/src/signing/render-verification.ts
@@ -138,6 +138,69 @@ export function renderCostPreviewBlock(
   return `Estimated network fee: ≈ ${nativeFmt} ${symbol} (USD price unavailable)`;
 }
 
+/**
+ * Trim a wei-denominated fee to a short gwei string. Single source of
+ * truth so the preview-cost breakdown line keeps consistent precision
+ * across base fee (typically 1–100 gwei) and priority fee (typically
+ * 0.01–5 gwei).
+ *
+ *   - n ≥ 10:    rounded to integer gwei (e.g. "18")
+ *   - 1 ≤ n < 10: 1 fractional digit, trailing 0 trimmed (e.g. "1.5")
+ *   - n < 1:     2 fractional digits, trailing zeros trimmed (e.g. "0.05")
+ *
+ * Number(BigInt) is safe here — typical gwei wei values are well under
+ * 2^53 (1000 gwei = 1e12 wei).
+ */
+function weiToGweiShort(wei: string): string {
+  const n = Number(BigInt(wei)) / 1e9;
+  if (!Number.isFinite(n) || n < 0) return wei;
+  if (n >= 10) return n.toFixed(0);
+  if (n >= 1) return n.toFixed(1).replace(/\.0$/, "");
+  return n.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+/**
+ * Preview-time cost block (issue #650). Surfaced as the FIRST content of
+ * every successful EVM `preview_send` so the user can abort on a fee spike
+ * that happened between prepare and preview, without scrolling back through
+ * the LEDGER BLIND-SIGN HASH + agent-task surfaces below.
+ *
+ * Differs from prepare-time `renderCostPreviewBlock`:
+ *   - values come from the SERVER-PINNED tuple (the exact maxFeePerGas /
+ *     maxPriorityFeePerGas / gas that go on-chain, not a prepare-time
+ *     estimate that may now be stale),
+ *   - adds a breakdown line (`base fee X gwei · priority Y gwei · gas N
+ *     units`) so the user sees what changed if the cost spiked,
+ *   - leads with "Pinned" rather than "Estimated" to communicate the
+ *     commitment — these are the values the user is signing for.
+ *
+ * Returns null when `gasCostNative` is missing — better silent than a
+ * fabricated number adjacent to a real device prompt. Native + breakdown
+ * always shown together when present; USD line is degraded silently when
+ * the price lookup failed.
+ */
+export function renderPreviewCostBlock(args: {
+  chain: SupportedChain;
+  gasCostNative?: string;
+  gasCostUsd?: number;
+  baseFeePerGas: string;
+  maxPriorityFeePerGas: string;
+  gas: string;
+}): string | null {
+  if (!args.gasCostNative) return null;
+  const symbol = NATIVE_SYMBOL[args.chain];
+  const nativeFmt = formatNativeShort(args.gasCostNative);
+  const headline =
+    args.gasCostUsd !== undefined
+      ? `Pinned network fee: ~$${args.gasCostUsd.toFixed(2)} (≈ ${nativeFmt} ${symbol})`
+      : `Pinned network fee: ≈ ${nativeFmt} ${symbol} (USD price unavailable)`;
+  const breakdown =
+    `  base fee ${weiToGweiShort(args.baseFeePerGas)} gwei` +
+    ` · priority ${weiToGweiShort(args.maxPriorityFeePerGas)} gwei` +
+    ` · gas ${args.gas} units`;
+  return `${headline}\n${breakdown}`;
+}
+
 function truncateHex(data: string, bytelenLabel: boolean): string {
   const normalized = data.startsWith("0x") ? data : `0x${data}`;
   if (normalized.length <= 26) return normalized;

--- a/src/signing/tx-store.ts
+++ b/src/signing/tx-store.ts
@@ -35,6 +35,15 @@ export interface StashedPin {
   maxFeePerGas: bigint;
   maxPriorityFeePerGas: bigint;
   gas: bigint;
+  /**
+   * Live base fee from `latestBlock.baseFeePerGas` at pin time. Stored so the
+   * preview-time cost block (issue #650) can render the EIP-1559 breakdown
+   * (`base fee X gwei · priority Y gwei`) without re-querying the chain on a
+   * cached re-pin. Not used by `send_transaction` — it's purely a UX field
+   * for the cost-preview render. `0n` when the chain doesn't expose a base
+   * fee (pre-London, but we reject those at simulation time anyway).
+   */
+  baseFeePerGas: bigint;
   preSignHash: `0x${string}`;
   pinnedAt: number;
   /**

--- a/test/send-hash-pin.test.ts
+++ b/test/send-hash-pin.test.ts
@@ -607,6 +607,75 @@ describe("previewSendHandler — LEDGER BLIND-SIGN HASH gating", () => {
     ).length;
     expect(hashBlockCount).toBe(1);
   });
+
+  // Issue #650 — preview-time pinned-cost block surfaced as the FIRST
+  // human-readable block (right after the JSON dump) so a fee-spike
+  // since prepare aborts the flow before the user invests attention in
+  // the LEDGER BLIND-SIGN HASH + CHECKS PERFORMED surfaces.
+  it("prepends the Pinned network fee block when cost fields are present (issue #650)", async () => {
+    const fakePreview = async () => ({
+      handle: "h",
+      chain: "ethereum" as const,
+      to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as `0x${string}`,
+      valueWei: "0",
+      preSignHash:
+        "0xdeadbeefcafef00dbabe0123456789abcdef0123456789abcdef0123456789ab" as `0x${string}`,
+      pinned: {
+        nonce: 1,
+        maxFeePerGas: "22000000000",
+        maxPriorityFeePerGas: "2000000000",
+        gas: "100000",
+        baseFeePerGas: "10000000000",
+      },
+      gasCostNative: "0.0012",
+      gasCostUsd: 4.2,
+      previewToken: "tok",
+    });
+    const out = await previewSendHandler(fakePreview)({ handle: "h" });
+    // content[0] is the JSON dump; the cost block sits at content[1].
+    expect(out.content.length).toBeGreaterThanOrEqual(3);
+    const costBlock = out.content[1].text;
+    expect(costBlock).toMatch(/^Pinned network fee: ~\$4\.20 \(≈ 0\.0012 ETH\)/);
+    expect(costBlock).toContain(
+      "base fee 10 gwei · priority 2 gwei · gas 100000 units",
+    );
+    // Must come BEFORE the LEDGER BLIND-SIGN HASH block.
+    const texts = out.content.map((c) => c.text);
+    const costIdx = texts.findIndex((t) => /^Pinned network fee:/.test(t));
+    const hashIdx = texts.findIndex((t) =>
+      /LEDGER BLIND-SIGN HASH — RELAY VERBATIM TO USER/.test(t),
+    );
+    expect(costIdx).toBeGreaterThanOrEqual(0);
+    expect(hashIdx).toBeGreaterThanOrEqual(0);
+    expect(costIdx).toBeLessThan(hashIdx);
+  });
+
+  // Back-compat: older envelope shape (no baseFeePerGas / gasCost*) must
+  // not regress — the handler should silently omit the cost block rather
+  // than throw or render a half-populated line.
+  it("omits the cost block when baseFeePerGas is absent (envelope back-compat)", async () => {
+    const fakePreview = async () => ({
+      handle: "h",
+      chain: "ethereum" as const,
+      to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as `0x${string}`,
+      valueWei: "0",
+      preSignHash:
+        "0xdeadbeefcafef00dbabe0123456789abcdef0123456789abcdef0123456789ab" as `0x${string}`,
+      pinned: {
+        nonce: 1,
+        maxFeePerGas: "22000000000",
+        maxPriorityFeePerGas: "2000000000",
+        gas: "100000",
+        // baseFeePerGas deliberately omitted (older envelope shape)
+      },
+      previewToken: "tok",
+    });
+    const out = await previewSendHandler(fakePreview)({ handle: "h" });
+    const texts = out.content.map((c) => c.text);
+    for (const t of texts) {
+      expect(t).not.toMatch(/^Pinned network fee:/);
+    }
+  });
 });
 
 describe("preview_send surfaces pin + hash; send_transaction consumes them", () => {

--- a/test/simulation.test.ts
+++ b/test/simulation.test.ts
@@ -193,6 +193,9 @@ describe("preview_send runs guards and pins fees; send_transaction consumes the 
       maxFeePerGas: 22_000_000_000n.toString(),
       maxPriorityFeePerGas: 2_000_000_000n.toString(),
       gas: 21_000n.toString(),
+      // Issue #650 — live base fee surfaced for the preview-time cost
+      // breakdown. The mock returns baseFeePerGas: 10 gwei.
+      baseFeePerGas: 10_000_000_000n.toString(),
     });
     expect(preview.previewToken).toMatch(/^[0-9a-f-]{36}$/);
 

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -12,6 +12,7 @@ import { decodeCalldata } from "../src/signing/decode-calldata.js";
 import {
   renderCostPreviewBlock,
   renderPostSendPollBlock,
+  renderPreviewCostBlock,
   renderTronAgentTaskBlock,
   renderTronVerificationBlock,
   renderVerificationBlock,
@@ -441,6 +442,72 @@ describe("renderCostPreviewBlock — issue #636 fee-shock abort signal", () => {
       gasCostNative: "0.5000",
     });
     expect(big).toContain("0.5 ETH");
+  });
+});
+
+describe("renderPreviewCostBlock — issue #650 preview-time fee surface", () => {
+  it("renders headline + EIP-1559 breakdown when all fields are populated", () => {
+    const out = renderPreviewCostBlock({
+      chain: "ethereum",
+      gasCostUsd: 4.12,
+      gasCostNative: "0.00195",
+      // 18 gwei base fee, 1.5 gwei priority, 100k gas
+      baseFeePerGas: "18000000000",
+      maxPriorityFeePerGas: "1500000000",
+      gas: "100000",
+    });
+    expect(out).toBe(
+      "Pinned network fee: ~$4.12 (≈ 0.00195 ETH)\n" +
+        "  base fee 18 gwei · priority 1.5 gwei · gas 100000 units",
+    );
+  });
+
+  it("falls back to native-only when USD price was unavailable", () => {
+    const out = renderPreviewCostBlock({
+      chain: "ethereum",
+      gasCostNative: "0.00195",
+      baseFeePerGas: "18000000000",
+      maxPriorityFeePerGas: "1500000000",
+      gas: "100000",
+    });
+    expect(out).toMatch(/^Pinned network fee: ≈ 0\.00195 ETH \(USD price unavailable\)/);
+    expect(out).toContain("base fee 18 gwei · priority 1.5 gwei · gas 100000 units");
+  });
+
+  it("returns null when gasCostNative is missing (silent over fabricated)", () => {
+    expect(
+      renderPreviewCostBlock({
+        chain: "ethereum",
+        baseFeePerGas: "18000000000",
+        maxPriorityFeePerGas: "1500000000",
+        gas: "100000",
+      }),
+    ).toBeNull();
+  });
+
+  it("formats sub-gwei priority fees with 2 fractional digits trimmed", () => {
+    // 0.5 gwei priority fee floor — still readable.
+    const out = renderPreviewCostBlock({
+      chain: "arbitrum",
+      gasCostUsd: 0.05,
+      gasCostNative: "0.0000234",
+      baseFeePerGas: "100000000",
+      maxPriorityFeePerGas: "500000000", // 0.5 gwei
+      gas: "200000",
+    });
+    expect(out).toContain("base fee 0.1 gwei · priority 0.5 gwei · gas 200000 units");
+  });
+
+  it("uses the chain's native symbol (POL/MATIC on polygon)", () => {
+    const out = renderPreviewCostBlock({
+      chain: "polygon",
+      gasCostUsd: 0.02,
+      gasCostNative: "0.04",
+      baseFeePerGas: "30000000000",
+      maxPriorityFeePerGas: "30000000000",
+      gas: "21000",
+    });
+    expect(out).toMatch(/Pinned network fee: ~\$0\.02 \(≈ 0\.04 (MATIC|POL)\)/);
   });
 });
 


### PR DESCRIPTION
Closes #650.

Follow-up to #648 (which closed #636 by surfacing the prepare-time cost block). Adds the same fee-shock abort signal at the **preview_send** boundary, where the values are the ones actually committed to: `nonce`, `maxFeePerGas`, `maxPriorityFeePerGas`, and `gas` are pinned server-side; `effectiveGasPrice = baseFee + priority` drives a fresh native + USD cost computed from the pinned tuple.

## What ships

- New `renderPreviewCostBlock` in `src/signing/render-verification.ts`. Produces `Pinned network fee: ~$X (≈ Y ETH)` followed by a `base fee A gwei · priority B gwei · gas N units` breakdown. Returns `null` when `gasCostNative` is missing (silent over fabricated). USD half is degraded silently when DefiLlama price lookup fails — native + breakdown still rendered.
- `previewSend` envelope extended:
  - `pinned.baseFeePerGas: string` (live `latestBlock.baseFeePerGas` at pin time)
  - `gasCostNative: string` (computed from `gas * (baseFeePerGas + maxPriorityFeePerGas)`)
  - `gasCostUsd?: number` (omitted when price lookup degrades)
- `StashedPin` and `pinSendFields` now thread `baseFeePerGas` so the cached re-pin path renders without re-querying the chain.
- `previewSendHandler` prepends the new block as the **FIRST** human-readable block (right after the JSON dump, before the missing-skill / demo notices, the `LEDGER BLIND-SIGN HASH`, and the `CHECKS PERFORMED` agent-task surface).

## Why "Pinned" rather than "Estimated"

The prepare-time block leads with `Estimated network fee:` (rough `gasPrice` × `gasEstimate`). At preview time the server has committed to specific EIP-1559 fields — leading with `Pinned` communicates the user is signing to **these** numbers, and any post-pin fee movement is captured by re-running `preview_send(refresh: true)`.

## Why the realistic cost (not `gas * maxFeePerGas`)

`maxFeePerGas = baseFee * 2 + priority` is a 4-block-rise headroom cap, not what the user pays. On-chain `effectiveGasPrice = min(maxFeePerGas, baseFeeAtInclusion + priority)`; over a typical 12s window `baseFeeAtInclusion ≈ baseFee`, so `gas * (baseFee + priority)` is the right anchor for an abort decision. The breakdown line lets the user see baseFee separately if they want the worst-case anchor.

## Tests

- `renderPreviewCostBlock` — 5 cases: full populated, USD-degraded, native-missing → null, sub-gwei priority formatting, non-ETH chain symbol.
- `previewSendHandler` — cost block prepended ahead of the LEDGER BLIND-SIGN HASH block; back-compat: no `baseFeePerGas` on the envelope → block silently omitted (no throw, no half-line).
- `simulation.test.ts` test that asserts the full pinned tuple now expects `baseFeePerGas`.

All 2565 tests pass.

## Out of scope

TRON / Solana / BTC / LTC have no equivalent EIP-1559 pinned-fee model and no shared `gasCostNative` path on their preview/send envelopes — same as #648.

— Alonzo (agent-92ff)
