### PR TITLE
fix(deps): make Glama's pnpm build succeed alongside npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
+# Repo uses npm; pnpm-lock is only created by tools that default to pnpm
+# (e.g. glama). package-lock.json is the source of truth — don't commit a sibling.
+pnpm-lock.yaml
 dist/
 !vendor/**/dist/
 release/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,15 @@
+# Repo standardizes on npm (package-lock.json). This file only matters when a
+# tool defaults to pnpm — currently glama.ai's auto-generated Dockerfile forces
+# `pnpm install`, whose isolated node_modules layout breaks two things npm's
+# flat layout silently masks:
+#
+#   1. Phantom-dep imports (`bignumber.js`, `@coral-xyz/anchor`, `bs58`,
+#      `@noble/curves/secp256k1`, etc.) used in `src/*` but not declared in
+#      `dependencies`. pnpm hides them under `.pnpm/`, so `tsc` fails TS2307.
+#   2. patch-package — patches expect `node_modules/<pkg>`; pnpm puts them
+#      under `.pnpm/`.
+#
+# `node-linker=hoisted` + `shamefully-hoist=true` make pnpm produce an
+# npm-style flat layout. npm ignores both keys.
+node-linker=hoisted
+shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -194,6 +194,23 @@
       "bs58": "^5.0.0"
     }
   },
+  "pnpm": {
+    "overrides": {
+      "uuid": "^14.0.0",
+      "hono": "^4.12.14",
+      "@coral-xyz/anchor": "^0.30.1",
+      "@coral-xyz/borsh": "^0.30.1",
+      "bs58": "^6.0.0",
+      "@kamino-finance/kliquidity-sdk": "file:./vendor/kliquidity-stub",
+      "@marinade.finance/marinade-ts-sdk>@coral-xyz/anchor": "^0.28.0",
+      "@marinade.finance/marinade-ts-sdk>@coral-xyz/borsh": "^0.28.0",
+      "@marinade.finance/marinade-ts-sdk>bs58": "^5.0.0",
+      "@ledgerhq/hw-app-btc>bs58": "^5.0.0",
+      "bs58@5>base-x": "^3.0.0",
+      "bs58check@2>base-x": "^3.0.0",
+      "bs58check>bs58": "^5.0.0"
+    }
+  },
   "engines": {
     "node": ">=18.17.0"
   }


### PR DESCRIPTION
## Summary

Glama auto-generates a Dockerfile that hardcodes `pnpm install` — independent of this repo's own Dockerfile (fixed separately in #655). The repo standardizes on npm (`package-lock.json`), and pnpm's default isolated `node_modules` layout breaks two things npm's flat layout silently masks.

**Failing build:** [glama logs](https://glama.ai) show 17× TS2307 (`Cannot find module 'bignumber.js'`, `'@coral-xyz/anchor'`, `'bs58'`, `'@noble/curves/secp256k1'`, etc.) plus a `patch-package` failure on `bigint-buffer`.

## Root cause (two layers)

1. **Layout** — pnpm hides transitive deps under `node_modules/.pnpm/`. `src/*` imports ~9 phantom transitives, and `patches/<pkg>+<ver>.patch` files expect the package at `node_modules/<pkg>`.
2. **Override syntax** — `overrides` (top-level) is npm-specific; pnpm reads `pnpm.overrides`. Without the mirror, MarginFi's transitive `@coral-xyz/anchor@0.29.0` wins over the desired `^0.30.1`, breaking the v0.30+ IDL shape used in `src/modules/solana/marginfi.ts`.

## Fix

- **`.npmrc`** — `node-linker=hoisted` + `shamefully-hoist=true` make pnpm produce an npm-style flat layout. npm ignores both keys.
- **`pnpm.overrides`** — mirrors top-level `overrides`, with two adjustments:
  - pnpm's `parent>child` selector matches direct deps only, so the npm nested-object scoping for `@ledgerhq/hw-app-btc → base-x: ^3.0.0` doesn't translate 1:1. Versioned-parent form `bs58@5>base-x: ^3.0.0` + `bs58check@2>base-x: ^3.0.0` is what re-pins the BTC subtree's base-x to v3 (Buffer-returning) instead of v4 (Uint8Array — breaks `xpub.readUInt32BE`).
  - `@solana/web3.js: $@solana/web3.js` (npm self-reference) is dropped — pnpm doesn't need it once direct deps are normal.
- **`.gitignore`** — `pnpm-lock.yaml` so accidental pnpm runs in a clone don't leave a sibling lockfile.

## Verification

`pnpm install && pnpm run build && pnpm run test` green: 2558/2558 tests pass, including the `@ledgerhq/hw-app-btc bs58/base-x subtree` regression guard (test/btc-pair.test.ts:973).

## Test plan

- [ ] Glama re-build succeeds on next sync
- [x] `pnpm install` clean (patches apply)
- [x] `pnpm run build` (`tsc`) exits 0
- [x] `pnpm run test` 2558/2558 pass
- [x] npm flow undisturbed (`overrides`, `package-lock.json` unchanged; `.npmrc` keys are pnpm-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)