### PR TITLE
docs: flag Claude.ai chat sandbox limitation for local stdio MCP

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -187,6 +187,18 @@ Per-client config locations:
 
 If `mcpServers` already exists, **merge** — don't overwrite. Back up before editing.
 
+### Claude.ai chat — won't reach external RPCs today
+
+The wizard registers vaultpilot-mcp with the Claude.ai native desktop app, but the host environment's outbound-HTTP allowlist blocks chain RPC providers (`publicnode.com`, `mainnet-beta.solana.com`, Alchemy, Helius, Etherscan, etc.). The stdio handshake succeeds — the MCP initializes, lists tools, accepts calls — and every read that hits an external RPC then returns `403 Host not in allowlist`. The same applies to Claude Code running inside Claude.ai's cloud sandbox.
+
+Working surfaces today:
+
+- **Claude Code CLI in your terminal** (`claude` from a shell) — no sandbox.
+- **Cursor** — runs MCP as a child process on your machine.
+- **Any MCP client** on a host with unrestricted outbound HTTP.
+
+A [hosted MCP endpoint](./ROADMAP.md#deployment-modes) is on the roadmap and will give Claude.ai chat a network-unrestricted backend (EVM-only for v1, OAuth 2.1). Not yet shipped. TRON / Solana / Bitcoin / Litecoin signing needs a local USB-HID connection to your Ledger and will continue to require terminal CLI or Cursor regardless of what the hosted backend covers.
+
 ## 6. Pair Ledger (only if signing)
 
 VaultPilot is self-custodial; signing pairs once per chain.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-custodial DeFi for AI agents. The agent proposes, you approve on your Ledge
 
 ![VaultPilot MCP demo](./demo.gif)
 
-Read on-chain positions and prepare transactions across **Ethereum, Arbitrum, Polygon, Base, Optimism, TRON, Solana, Bitcoin, and Litecoin**. Supported protocols: **Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido, EigenLayer** on EVM, **MarginFi** on Solana, plus **LiFi** (EVM swap/bridge) and **Jupiter v6** (Solana swap), with **1inch** as an optional EVM quote cross-check. EVM signs over WalletConnect → Ledger Live; TRON and Solana sign over USB HID directly to the device (Ledger Live's WalletConnect bridge does not support either namespace today). Works with Claude Desktop, Claude Code, Cursor, and any MCP-compatible client.
+Read on-chain positions and prepare transactions across **Ethereum, Arbitrum, Polygon, Base, Optimism, TRON, Solana, Bitcoin, and Litecoin**. Supported protocols: **Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido, EigenLayer** on EVM, **MarginFi** on Solana, plus **LiFi** (EVM swap/bridge) and **Jupiter v6** (Solana swap), with **1inch** as an optional EVM quote cross-check. EVM signs over WalletConnect → Ledger Live; TRON and Solana sign over USB HID directly to the device (Ledger Live's WalletConnect bridge does not support either namespace today). Works with **Claude Code** (CLI/terminal), **Cursor**, and any MCP-compatible client over stdio. **Claude.ai chat (web + native desktop app) needs a hosted MCP endpoint** — [on the roadmap](./ROADMAP.md#deployment-modes), not yet shipped.
 
 > Agents: read **[AGENTS.md](./AGENTS.md)**. One-line prompt to paste into Claude Code / Cursor / any MCP-capable agent:
 > ```
@@ -163,9 +163,11 @@ claude mcp add vaultpilot-mcp --env VAULTPILOT_DEMO=true -- npx -y vaultpilot-mc
 
 For Solana RPC throttling under multi-tool fan-out, inject a [Helius](https://helius.dev) key at runtime: `set_helius_api_key({ key })`. Demo mode nudges proactively after 10 public-RPC throttle errors.
 
-## Use with Claude Desktop / Claude Code / Cursor
+## Use with Claude Code (CLI) / Cursor / Claude Desktop
 
 `vaultpilot-mcp setup` detects installed clients and registers vaultpilot-mcp with each (existing configs backed up to `<file>.vaultpilot.bak`). Per-project / per-workspace configs are skipped — the wizard runs from arbitrary CWD. For manual wiring or the per-client config paths, see [INSTALL.md §5](./INSTALL.md#5-manual-mcp-client-wiring-if-auto-register-didnt-run).
+
+> **Claude.ai chat — limitation.** Local stdio MCP installed via the wizard registers cleanly with the Claude.ai native desktop app, but the host environment's outbound-HTTP allowlist blocks chain RPC providers (PublicNode, public Solana mainnet, Alchemy, Helius, etc.). The MCP initializes and processes tool calls, but every read that hits an external RPC fails with 403 / "Host not in allowlist". The same applies to Claude Code running inside Claude.ai's cloud sandbox. **Working today**: Claude Code CLI in your terminal, Cursor, Claude Desktop on a host with unrestricted outbound HTTP. **Future**: a hosted MCP endpoint ([roadmap](./ROADMAP.md#deployment-modes), not yet shipped) will give Claude.ai chat a network-unrestricted backend; TRON / Solana / Bitcoin / Litecoin USB-HID signing requires a local Ledger and stays on the terminal CLI / Cursor path regardless.
 
 ## Environment variables
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,7 +73,7 @@ Deferred per CLAUDE.md fastmcp section's "Defer until a real 'feels stuck' repor
 
 **Deployment modes**
 
-- **Hosted MCP endpoint** — OAuth 2.1 + bearer tokens for headless users, operator-supplied API keys, EVM-only for v1. TRON / Solana USB HID tools stay local.
+- **Hosted MCP endpoint** — OAuth 2.1 + bearer tokens, operator-supplied API keys, EVM-only for v1. **Unblocks Claude.ai chat (web + native desktop app)**, where the host environment's outbound-HTTP allowlist blocks chain RPC providers (PublicNode, public Solana mainnet, Alchemy, Helius, etc.) and the local stdio MCP can't complete reads. Headless users get the same backend. TRON / Solana / Bitcoin / Litecoin USB-HID signing requires a local Ledger connection and stays on the terminal CLI / Cursor path regardless.
 
 **Security hardening**
 


### PR DESCRIPTION
## Summary

Document that local stdio MCP (the path the wizard installs) doesn't reach external chain RPCs from inside Claude.ai chat — both the native desktop app and the cloud sandbox that hosts Claude Code inside Claude.ai have an outbound-HTTP allowlist that returns 403 on `publicnode.com`, `mainnet-beta.solana.com`, Alchemy, Helius, Etherscan, etc. The MCP itself initializes and lists tools fine; only reads that egress fail.

This was raised against a real session where a user followed the install path, hit the 403s, and asked whether the chat-app failure was a bug. It isn't — it's the expected sandbox behavior — but the docs gave them no way to know that up front.

## What changed

- **README.md** — tagline now names the working surfaces (Claude Code CLI, Cursor, any stdio client) and calls out the Claude.ai chat gap with a link to the roadmap entry. Heading renamed `Use with Claude Code (CLI) / Cursor / Claude Desktop` to lead with the working surfaces; added a one-paragraph callout under it linking to the canonical INSTALL.md note.
- **INSTALL.md §5** — new "Claude.ai chat — won't reach external RPCs today" subsection placed where users wire client config; canonical home for the detailed note (per "state each idea once").
- **ROADMAP.md "Hosted MCP endpoint"** — reframed with the WHY (unblocks Claude.ai chat) instead of just "for headless users". Explicit not-yet-shipped framing.

Scope confirmed with the user before editing — they picked "All Claude.ai surfaces (web + desktop chat)" rather than the narrower "only Claude.ai cloud sandbox" framing. USB-HID signing (TRON / Solana / Bitcoin / Litecoin) is called out separately as a hard local requirement that won't be solved by the hosted endpoint either.

## Test plan

- [ ] Render README.md, INSTALL.md, ROADMAP.md on the GitHub branch view; verify the new callout boxes don't break adjacent table rendering.
- [ ] Click each new in-doc link (`./ROADMAP.md#deployment-modes`, `./INSTALL.md#5-...`) on the GitHub PR view to confirm the anchors resolve.
- [ ] Diff against `origin/main` is purely additive prose — no source/build changes; `npm test` not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)